### PR TITLE
Integrate trade chat from DEv-nuevo

### DIFF
--- a/Framework/Intersect.Framework.Core/Chatting/ChatMessageType.cs
+++ b/Framework/Intersect.Framework.Core/Chatting/ChatMessageType.cs
@@ -13,6 +13,8 @@ public enum ChatMessageType
 
     Global,
 
+    Trade,
+
     PM,
 
     Admin,

--- a/Intersect (Core)/CustomColors.cs
+++ b/Intersect (Core)/CustomColors.cs
@@ -83,6 +83,7 @@ public static partial class CustomColors
             {"Hostile", new LabelColor(new Color(255, 255, 81, 0), Color.Black, new Color(180, 0, 0, 0))},
             {"Moderator", new LabelColor(new Color(255, 0, 255, 255), Color.Black, new Color(180, 0, 0, 0))},
             {"Admin", new LabelColor(new Color(255, 255, 255, 0), Color.Black, new Color(180, 0, 0, 0))},
+            { "Market",     new LabelColor(new Color(255, 255, 191, 0),   Color.Black, new Color(180, 0, 0, 0)) } // 🔶 Canal de comercio
         };
 
     }
@@ -124,6 +125,7 @@ public static partial class CustomColors
 
         public Color GuildChat = new Color(255, 255, 165, 0);
 
+        public Color TradeChat = new Color(255, 255, 191, 0);
     }
 
     public sealed partial class QuestAlertNamespace

--- a/Intersect (Core)/Enums/ChatboxTab.cs
+++ b/Intersect (Core)/Enums/ChatboxTab.cs
@@ -13,6 +13,8 @@ public enum ChatboxTab
 
     Guild,
 
+    Trade,
+
     Global,
 
     System,

--- a/Intersect.Client.Core/Entities/Entity.cs
+++ b/Intersect.Client.Core/Entities/Entity.cs
@@ -283,6 +283,8 @@ public partial class Entity : IEntity
     //     set => Position = Position with { Y = Y + (value / TileHeight) };
     // }
 
+    public bool HasPermissionToTrade { get; }
+
     public Entity(Guid id, EntityPacket? packet, EntityType entityType)
     {
         Id = id;

--- a/Intersect.Client.Core/Interface/Game/Chat/Chatbox.cs
+++ b/Intersect.Client.Core/Interface/Game/Chat/Chatbox.cs
@@ -140,7 +140,7 @@ public partial class Chatbox
         mChannelLabel.IsHidden = true;
 
         mChannelCombobox = new ComboBox(mChatboxWindow, "ChatChannelCombobox");
-        for (var i = 0; i < 4; i++)
+        for (var i = 0; i < 5; i++)
         {
             var menuItem = mChannelCombobox.AddItem(Strings.Chatbox.Channels[i]);
             menuItem.UserData = i;
@@ -151,7 +151,7 @@ public partial class Chatbox
         if (Globals.Me.Type > 0)
         {
             var menuItem = mChannelCombobox.AddItem(Strings.Chatbox.ChannelAdmin);
-            menuItem.UserData = 4;
+            menuItem.UserData = 5;
             menuItem.Selected += MenuItem_Selected;
         }
 
@@ -346,6 +346,10 @@ public partial class Chatbox
 
             case ChatboxTab.Guild:
                 mChannelCombobox.SelectByUserData(3);
+                break;
+
+            case ChatboxTab.Trade:
+                mChannelCombobox.SelectByUserData(4);
                 break;
 
             default:
@@ -575,6 +579,7 @@ public partial class Chatbox
         mTabButtons[ChatboxTab.Local].Show();
         mTabButtons[ChatboxTab.Party].Show();
         mTabButtons[ChatboxTab.Guild].Show();
+        mTabButtons[ChatboxTab.Trade].Show();
         mTabButtons[ChatboxTab.Global].Show();
         mTabButtons[ChatboxTab.System].Show();
         mChatboxMessages.Show();
@@ -587,6 +592,7 @@ public partial class Chatbox
         mTabButtons[ChatboxTab.Local].Hide();
         mTabButtons[ChatboxTab.Party].Hide();
         mTabButtons[ChatboxTab.Guild].Hide();
+        mTabButtons[ChatboxTab.Trade].Hide();
         mTabButtons[ChatboxTab.Global].Hide();
         mTabButtons[ChatboxTab.System].Hide();
         mChatboxMessages.Hide();

--- a/Intersect.Client.Core/Interface/Game/Chat/ChatboxMsg.cs
+++ b/Intersect.Client.Core/Interface/Game/Chat/ChatboxMsg.cs
@@ -18,6 +18,7 @@ public partial class ChatboxMsg
         { ChatboxTab.Party, new ChatMessageType[] { ChatMessageType.Party, ChatMessageType.PM, ChatMessageType.Admin } },
         { ChatboxTab.Global, new ChatMessageType[] { ChatMessageType.Global, ChatMessageType.PM, ChatMessageType.Admin } },
         { ChatboxTab.Guild, new ChatMessageType[] { ChatMessageType.Guild, ChatMessageType.PM, ChatMessageType.Admin } },
+        { ChatboxTab.Trade, new ChatMessageType[] { ChatMessageType.Trade, ChatMessageType.PM, ChatMessageType.Admin } },
         { ChatboxTab.System, new ChatMessageType[] { 
             ChatMessageType.Experience, ChatMessageType.Loot, ChatMessageType.Inventory, ChatMessageType.Bank, 
             ChatMessageType.Combat, ChatMessageType.Quest, ChatMessageType.Crafting, ChatMessageType.Trading, 

--- a/Intersect.Client.Core/Localization/Strings.cs
+++ b/Intersect.Client.Core/Localization/Strings.cs
@@ -762,7 +762,8 @@ public static partial class Strings
             {0, @"local"},
             {1, @"global"},
             {2, @"party"},
-            {3, @"guild"}
+            {3, @"guild"},
+            {4, @"trade"},
         };
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
@@ -775,6 +776,7 @@ public static partial class Strings
             { ChatboxTab.Party, @"Party" },
             { ChatboxTab.Global, @"Global" },
             { ChatboxTab.Guild, @"Guild" },
+            { ChatboxTab.Trade, @"Trade" },
             { ChatboxTab.System, @"System" },
         };
 
@@ -2764,6 +2766,24 @@ If you are sure you want to hand over your guild enter '\c{{#ff8080}}{02}\c{{}}'
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public static LocalizedString YourOffer = @"Your Offer:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString OtherPlayer = @"The other player has accepted the trade.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString TooFast = @"You are sending messages too quickly! Please wait.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Muted = @"You cannot send trade messages while muted.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Format = @"[Trade] {00}: {01}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString SELL = @"[SELL]";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString BUY = @"[BUY]";
     }
 
     public partial struct EscapeMenu

--- a/Intersect.Client.Core/Networking/PacketSender.cs
+++ b/Intersect.Client.Core/Networking/PacketSender.cs
@@ -3,6 +3,8 @@ using Intersect.Client.Framework.Gwen.Control;
 using Intersect.Client.Framework.Gwen.Control.EventArguments;
 using Intersect.Client.Framework.Gwen.Control.EventArguments.InputSubmissionEvent;
 using Intersect.Client.General;
+using Intersect.Client.Interface.Game;
+using Intersect.Client.Interface.Game.Chat;
 using Intersect.Client.Interface.Shared;
 using Intersect.Client.Maps;
 using Intersect.Enums;

--- a/Intersect.Server.Core/Localization/Strings.cs
+++ b/Intersect.Server.Core/Localization/Strings.cs
@@ -220,6 +220,15 @@ public static partial class Strings
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public readonly LocalizedString TooFast = @"You are chatting too fast!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString Trade = @"[MARKET] {00}: {01}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString TradeCommand = @"/trade";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString TradeNotAllowed = @"You cannot trade yet!";
     }
 
     public sealed partial class ClassNamespace : LocaleNamespace

--- a/Intersect.Server.Core/Networking/PacketHandler.cs
+++ b/Intersect.Server.Core/Networking/PacketHandler.cs
@@ -910,14 +910,20 @@ internal sealed partial class PacketHandler
 
                 case 3:
                     cmd = Strings.Guilds.GuildCommand;
+
                     break;
 
-                case 4: //admin
+                case 4: //trade
+                    cmd = Strings.Chat.TradeCommand;
+                    
+                    break;
+
+                case 5: //admin
                     cmd = Strings.Chat.AdminCommand;
 
                     break;
 
-                case 5: //private
+                case 6: //private
                     PacketSender.SendChatMsg(player, msg, ChatMessageType.Local);
 
                     return;
@@ -1121,6 +1127,18 @@ internal sealed partial class PacketHandler
             {
                 PacketSender.SendChatMsg(player, Strings.Player.Offline, ChatMessageType.PM, CustomColors.Alerts.Error);
             }
+        }
+        else if (cmd == Strings.Chat.TradeCommand){
+            if (msg.Trim().Length == 0)
+            {
+                return;
+            }
+            else
+            {
+                PacketSender.SendTradeMsg(player, Strings.Chat.Trade.ToString(player.Name, msg), CustomColors.Chat.TradeChat);
+                ChatHistory.LogMessage(player, msg.Trim(), ChatMessageType.Trade,Guid.Empty);
+            }
+
         }
         else
         {

--- a/Intersect.Server.Core/Networking/PacketSender.cs
+++ b/Intersect.Server.Core/Networking/PacketSender.cs
@@ -2261,6 +2261,12 @@ public static partial class PacketSender
         }
     }
 
+    public static void SendTradeMsg(Player player, string message, Color color, string target = "", ChatMessageType type = ChatMessageType.Trade)
+    {
+        //SendChatMsg(player, message, ChatMessageType.Trade, clr, target);
+        SendDataToAllPlayers(new ChatMsgPacket(message, type, color, target));
+    }
+
     /// <summary>
     /// Send a player their guild member list.
     /// </summary>


### PR DESCRIPTION
## Summary
- add trade chat tab and message type
- update client chatbox to show/hide trade tab
- support trade chat server-side
- add new localized strings and color
- fix handler logic

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845c35d7fec8324aa54078298791c2a