### PR TITLE
Add preliminary job system infrastructure

### DIFF
--- a/Framework/Intersect.Framework.Core/Config/JobOptions.cs
+++ b/Framework/Intersect.Framework.Core/Config/JobOptions.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+using Intersect.Enums;
+
+namespace Intersect.Framework.Core.Config;
+
+/// <summary>
+/// Options related to the job system.
+/// </summary>
+public class JobOptions
+{
+    /// <summary>Maximum level for jobs.</summary>
+    public int MaxJobLevel { get; set; } = 100;
+
+    /// <summary>Base job experience.</summary>
+    public long BaseJobExp { get; set; } = 100;
+
+    /// <summary>Show progress notifications.</summary>
+    public bool ShowJobProgressNotifications { get; set; } = true;
+
+    /// <summary>Automatically level up jobs.</summary>
+    public bool AutoJobLevelUp { get; set; } = true;
+
+    /// <summary>Maximum active jobs.</summary>
+    public int MaxActiveJobs { get; set; } = 3;
+
+    /// <summary>Lose job experience on death.</summary>
+    public bool JobExpLossOnDeath { get; set; } = false;
+
+    /// <summary>Percent of experience lost on death.</summary>
+    public int JobExpLossPercent { get; set; } = 10;
+
+    /// <summary>Base experience per job type.</summary>
+    public Dictionary<JobType, long> JobBaseExp { get; set; } = new();
+}
+
+public enum JobType
+{
+    None,
+    Farming,
+    Mining,
+    Fishing,
+    Lumberjack,
+    Cooking,
+    Alchemy,
+    Crafting,
+    Smithing,
+    Hunter,
+    JobCount
+}

--- a/Framework/Intersect.Framework.Core/Config/Options.cs
+++ b/Framework/Intersect.Framework.Core/Config/Options.cs
@@ -3,6 +3,7 @@ using Intersect.Config;
 using Intersect.Config.Guilds;
 using Intersect.Core;
 using Intersect.Framework.Annotations;
+using Intersect.Framework.Core.Config;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 
@@ -224,6 +225,11 @@ public partial record Options
 
     public ItemOptions Items { get; set; } = new();
 
+    /// <summary>
+    /// Configuration for the job system.
+    /// </summary>
+    public JobOptions Jobs { get; set; } = new();
+
     #endregion Other Game Properties
 
     #endregion Configuration Properties
@@ -315,6 +321,11 @@ public partial record Options
     }
 
     public static event OptionsLoadedEventHandler? OptionsLoaded;
+
+    /// <summary>
+    /// Provides easy access to job configuration.
+    /// </summary>
+    public static JobOptions JobOptions => Instance.Jobs;
 
     public Options DeepClone() => JsonConvert.DeserializeObject<Options>(
         JsonConvert.SerializeObject(this, PrivateSerializerSettings)

--- a/Framework/Intersect.Framework.Core/GameObjects/Events/Commands/GiveJobExperienceCommand.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Events/Commands/GiveJobExperienceCommand.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using Intersect.Enums;
+using Intersect.Framework.Core.Config;
+
+namespace Intersect.Framework.Core.GameObjects.Events.Commands;
+
+public partial class GiveJobExperienceCommand : EventCommand
+{
+    public override EventCommandType Type { get; } = EventCommandType.GiveJobExperience;
+
+    public Dictionary<JobType, long> JobExp { get; set; } = new();
+}

--- a/Framework/Intersect.Framework.Core/GameObjects/Events/EventCommandType.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Events/EventCommandType.cs
@@ -136,4 +136,6 @@ public enum EventCommandType
     CastSpellOn,
 
     Fade,
+
+    GiveJobExperience,
 }

--- a/Framework/Intersect.Framework.Core/Network/Packets/Server/JobSyncPacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Server/JobSyncPacket.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using Intersect.Enums;
+using Intersect.Framework.Core.Config;
+using MessagePack;
+
+namespace Intersect.Network.Packets.Server;
+
+[MessagePackObject]
+public partial class JobSyncPacket : IntersectPacket
+{
+    public JobSyncPacket()
+    {
+    }
+
+    public JobSyncPacket(Dictionary<JobType, JobData> jobs)
+    {
+        Jobs = jobs;
+    }
+
+    [Key(0)]
+    public Dictionary<JobType, JobData> Jobs { get; set; } = new();
+}
+
+[MessagePackObject]
+public class JobData
+{
+    [Key(0)]
+    public int Level { get; set; }
+
+    [Key(1)]
+    public long Experience { get; set; }
+
+    [Key(2)]
+    public long ExperienceToNextLevel { get; set; }
+}

--- a/Intersect.Client.Core/CustomChanges/Jobs.cs
+++ b/Intersect.Client.Core/CustomChanges/Jobs.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using Intersect.Framework.Core.Config;
+using Intersect.Network.Packets.Server;
+
+namespace Intersect.Client.Entities;
+
+public partial class Player
+{
+    public Dictionary<JobType, int> JobLevel { get; set; } = new();
+    public Dictionary<JobType, long> JobExp { get; set; } = new();
+    public Dictionary<JobType, long> JobExpToNextLevel { get; set; } = new();
+
+    public void UpdateJobsFromPacket(Dictionary<JobType, JobData> jobs)
+    {
+        foreach (var (jobType, data) in jobs)
+        {
+            JobLevel[jobType] = data.Level;
+            JobExp[jobType] = data.Experience;
+            JobExpToNextLevel[jobType] = data.ExperienceToNextLevel;
+        }
+    }
+}

--- a/Intersect.Client.Core/General/Globals.cs
+++ b/Intersect.Client.Core/General/Globals.cs
@@ -3,6 +3,7 @@ using Intersect.Client.Entities;
 using Intersect.Client.Entities.Events;
 using Intersect.Client.Framework.Database;
 using Intersect.Client.Framework.Entities;
+using System;
 using Intersect.Client.Framework.File_Management;
 using Intersect.Client.Framework.Graphics;
 using Intersect.Client.Framework.Input;
@@ -104,6 +105,7 @@ public static partial class Globals
 
     //Only need 1 table, and that is the one we see at a given moment in time.
     public static CraftingTableDescriptor? ActiveCraftingTable { get; set; }
+    public static Guid FixedCraftingTableId { get; set; } = Guid.Empty;
 
     public static int AnimationFrame { get; set; }
 

--- a/Intersect.Client.Core/Networking/PacketHandler.cs
+++ b/Intersect.Client.Core/Networking/PacketHandler.cs
@@ -2022,6 +2022,12 @@ internal sealed partial class PacketHandler
         }
     }
 
+    //JobSyncPacket
+    public void HandlePacket(IPacketSender packetSender, JobSyncPacket packet)
+    {
+        Globals.Me?.UpdateJobsFromPacket(packet.Jobs);
+    }
+
     //TradePacket
     public void HandlePacket(IPacketSender packetSender, TradePacket packet)
     {

--- a/Intersect.Server.Core/CustomChanges/Jobs.cs
+++ b/Intersect.Server.Core/CustomChanges/Jobs.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations.Schema;
+using Intersect.Enums;
+using Intersect.Framework.Core.Config;
+using Intersect.Server.Localization;
+using Intersect.Server.Networking;
+using Newtonsoft.Json;
+
+namespace Intersect.Server.Entities;
+
+public partial class Player
+{
+    [Column("JobsData")]
+    public string JobsJson
+    {
+        get => JsonConvert.SerializeObject(Jobs);
+        set => Jobs = string.IsNullOrWhiteSpace(value)
+            ? new Dictionary<JobType, PlayerJob>()
+            : JsonConvert.DeserializeObject<Dictionary<JobType, PlayerJob>>(value) ?? new();
+    }
+
+    [NotMapped]
+    public Dictionary<JobType, PlayerJob> Jobs { get; set; } = new();
+
+    public void InitializeJobs()
+    {
+        for (var i = (int)JobType.Farming; i < (int)JobType.JobCount; i++)
+        {
+            var jt = (JobType)i;
+            if (!Jobs.ContainsKey(jt))
+            {
+                Jobs[jt] = new PlayerJob(jt);
+            }
+        }
+    }
+
+    public void GiveJobExperience(JobType jobType, long experience)
+    {
+        InitializeJobs();
+        if (Jobs.TryGetValue(jobType, out var job))
+        {
+            job.AddExperience(experience, this);
+        }
+    }
+
+    public PlayerJob? GetJob(JobType jobType)
+    {
+        InitializeJobs();
+        Jobs.TryGetValue(jobType, out var job);
+        return job;
+    }
+}
+
+public class PlayerJob
+{
+    public PlayerJob()
+    {
+    }
+
+    public PlayerJob(JobType type)
+    {
+        JobType = type;
+    }
+
+    public JobType JobType { get; set; }
+    public int Level { get; set; } = 1;
+    public long Experience { get; set; } = 0;
+
+    public void AddExperience(long amount, Player player)
+    {
+        Experience += amount;
+        while (Experience >= GetExperienceToNextLevel() && Level < Options.JobOptions.MaxJobLevel)
+        {
+            Experience -= GetExperienceToNextLevel();
+            Level++;
+            var msg = Strings.Player.LevelUp;
+            PacketSender.SendChatMsg(player, string.Format(msg, Level), ChatMessageType.Experience);
+        }
+        PacketSender.SendJobSync(player);
+    }
+
+    public long GetExperienceToNextLevel()
+    {
+        var baseExp = Options.JobOptions.BaseJobExp;
+        if (Options.JobOptions.JobBaseExp.TryGetValue(JobType, out var value))
+        {
+            baseExp = value;
+        }
+        return baseExp * Level;
+    }
+}

--- a/Intersect.Server.Core/Database/PlayerData/SeedData/SeedUsers.cs
+++ b/Intersect.Server.Core/Database/PlayerData/SeedData/SeedUsers.cs
@@ -123,6 +123,8 @@ public partial class SeedUsers : SeedData<User>
                     player.Stat[i].BaseStat = 0;
                 }
 
+                player.InitializeJobs();
+
                 user.Players?.Add(player);
                 player.ValidateLists();
             }

--- a/Intersect.Server.Core/Entities/Events/CommandProcessing.cs
+++ b/Intersect.Server.Core/Entities/Events/CommandProcessing.cs
@@ -1979,6 +1979,23 @@ public static partial class CommandProcessing
         }
     }
 
+    private static void ProcessCommand(
+        GiveJobExperienceCommand command,
+        Player player,
+        Event instance,
+        CommandInstance stackInfo,
+        Stack<CommandInstance> callStack
+    )
+    {
+        foreach (var (jobType, exp) in command.JobExp)
+        {
+            if (exp != 0)
+            {
+                player.GiveJobExperience(jobType, exp);
+            }
+        }
+    }
+
     private static void ProcessVariableModification(
         SetVariableCommand command,
         IntegerVariableMod mod,

--- a/Intersect.Server.Core/Localization/Strings.cs
+++ b/Intersect.Server.Core/Localization/Strings.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using Intersect.Config;
+using Intersect.Framework.Core.Config;
 using Intersect.Core;
 using Intersect.Localization;
 using Intersect.Server.Core;
@@ -1114,6 +1115,16 @@ public static partial class Strings
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public readonly LocalizedString LevelUp = @"You have leveled up! You are now level {00}!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly Dictionary<JobType, LocalizedString> JobLevelUpMessages = new()
+        {
+            { JobType.Farming, @"Your Farming job is now level {00}!" },
+            { JobType.Mining, @"Your Mining job is now level {00}!" }
+        };
+
+        public LocalizedString GetJobLevelUpMessage(JobType jobType) =>
+            JobLevelUpMessages.TryGetValue(jobType, out var msg) ? msg : @"";
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public readonly LocalizedString Moderator = @"{00} has been given moderation powers!";

--- a/Intersect.Server.Core/Migrations/Sqlite/Player/20250104055212_AddJobSystem.cs
+++ b/Intersect.Server.Core/Migrations/Sqlite/Player/20250104055212_AddJobSystem.cs
@@ -1,0 +1,22 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Intersect.Server.Migrations.Sqlite.Player;
+
+public partial class AddJobSystem : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AddColumn<string>(
+            name: "JobsData",
+            table: "Players",
+            type: "TEXT",
+            nullable: true);
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropColumn(
+            name: "JobsData",
+            table: "Players");
+    }
+}

--- a/Intersect.Server.Core/Networking/PacketSender.cs
+++ b/Intersect.Server.Core/Networking/PacketSender.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using Intersect.Core;
 using Intersect.Enums;
 using Intersect.Framework.Core;
@@ -415,6 +416,7 @@ public static partial class PacketSender
             SendQuestsProgress(player);
             SendItemCooldowns(player);
             SendSpellCooldowns(player);
+            SendJobSync(player);
         }
 
         switch (entity)
@@ -1581,6 +1583,22 @@ public static partial class PacketSender
     public static void SendExperience(Player player)
     {
         player.SendPacket(new ExperiencePacket(player.Exp, player.ExperienceToNextLevel), TransmissionMode.Any);
+    }
+
+    public static void SendJobSync(Player player)
+    {
+        var jobs = new Dictionary<JobType, JobData>();
+        foreach (var (type, job) in player.Jobs)
+        {
+            jobs[type] = new JobData
+            {
+                Level = job.Level,
+                Experience = job.Experience,
+                ExperienceToNextLevel = job.GetExperienceToNextLevel()
+            };
+        }
+
+        player.SendPacket(new JobSyncPacket(jobs), TransmissionMode.Any);
     }
 
     //PlayAnimationPacket


### PR DESCRIPTION
## Summary
- add JobOptions config and JobType enum
- enable job syncing with new JobSyncPacket
- integrate job dictionaries for players on client and server
- seed default jobs for users and send updates
- basic migration for storing job data

## Testing
- `dotnet build Intersect.sln -c Release` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6845cb6016c083249c4280d773d61a1e