### PR TITLE
Add DamageProfile structure

### DIFF
--- a/Framework/Intersect.Framework.Core/GameObjects/DamageProfile.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/DamageProfile.cs
@@ -1,0 +1,3 @@
+namespace Intersect.GameObjects;
+
+public readonly record struct DamageProfile(Enums.DamageType DamageType, int Amount);

--- a/Framework/Intersect.Framework.Core/GameObjects/Items/ItemDescriptor.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Items/ItemDescriptor.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Diagnostics.CodeAnalysis;
 using Intersect.Enums;
@@ -122,9 +123,16 @@ public partial class ItemDescriptor : DatabaseObject<ItemDescriptor>, IFolderabl
     /// </summary>
     public bool IgnoreCooldownReduction { get; set; } = false;
 
-    public int Damage { get; set; }
+    [NotMapped]
+    public List<DamageProfile> Damage { get; set; } = new();
 
-    public int DamageType { get; set; }
+    [Column("Damage")]
+    [JsonIgnore]
+    public string DamageJson
+    {
+        get => DatabaseUtils.SaveDamageProfiles(Damage);
+        set => Damage = DatabaseUtils.LoadDamageProfiles(value);
+    }
 
     public int AttackSpeedModifier { get; set; }
 

--- a/Framework/Intersect.Framework.Core/GameObjects/NPCs/NPCDescriptor.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/NPCs/NPCDescriptor.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations.Schema;
 using Intersect.Enums;
 using Intersect.Framework.Core.GameObjects.Animations;
@@ -187,10 +188,17 @@ public partial class NPCDescriptor : DatabaseObject<NPCDescriptor>, IFolderable
     }
 
     //Combat
-    public int Damage { get; set; } = 1;
 
-    public int DamageType { get; set; }
+    [NotMapped]
+    public List<DamageProfile> Damage { get; set; } = new();
 
+    [Column("Damage")]
+    [JsonIgnore]
+    public string DamageJson
+    {
+        get => DatabaseUtils.SaveDamageProfiles(Damage);
+        set => Damage = DatabaseUtils.LoadDamageProfiles(value);
+    }
     public int CritChance { get; set; }
 
     public double CritMultiplier { get; set; } = 1.5;

--- a/Framework/Intersect.Framework.Core/GameObjects/PlayerClass/ClassDescriptor.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/PlayerClass/ClassDescriptor.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations.Schema;
 using Intersect.Enums;
 using Intersect.Framework.Core.GameObjects.Animations;
@@ -168,9 +169,16 @@ public partial class ClassDescriptor : DatabaseObject<ClassDescriptor>, IFoldera
     public double CritMultiplier { get; set; } = 1.5;
 
     //Combat
-    public int Damage { get; set; } = 1;
+    [NotMapped]
+    public List<DamageProfile> Damage { get; set; } = new();
 
-    public int DamageType { get; set; }
+    [Column("Damage")]
+    [JsonIgnore]
+    public string DamageJson
+    {
+        get => DatabaseUtils.SaveDamageProfiles(Damage);
+        set => Damage = DatabaseUtils.LoadDamageProfiles(value);
+    }
 
     public int AttackSpeedModifier { get; set; }
 

--- a/Framework/Intersect.Framework.Core/GameObjects/Spells/SpellCombatDescriptor.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Spells/SpellCombatDescriptor.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 ﻿using System.ComponentModel.DataAnnotations.Schema;
 using Intersect.Enums;
 using Intersect.Utilities;
@@ -16,8 +17,17 @@ public partial class SpellCombatDescriptor
 
     public double CritMultiplier { get; set; } = 1.5;
 
-    public int DamageType { get; set; } = 1;
 
+    [NotMapped]
+    public List<DamageProfile> Damage { get; set; } = new();
+
+    [Column("Damage")]
+    [JsonIgnore]
+    public string DamageJson
+    {
+        get => DatabaseUtils.SaveDamageProfiles(Damage);
+        set => Damage = DatabaseUtils.LoadDamageProfiles(value);
+    }
     public int HitRadius { get; set; }
 
     public bool Friendly { get; set; }

--- a/Framework/Intersect.Framework.Core/Memory/DatabaseUtils.cs
+++ b/Framework/Intersect.Framework.Core/Memory/DatabaseUtils.cs
@@ -112,4 +112,8 @@ public static partial class DatabaseUtils
         return color;
     }
 
+    public static string SaveDamageProfiles(List<Intersect.GameObjects.DamageProfile> profiles) => JsonConvert.SerializeObject(profiles ?? new());
+
+    public static List<Intersect.GameObjects.DamageProfile> LoadDamageProfiles(string json) => json != null ? JsonConvert.DeserializeObject<List<Intersect.GameObjects.DamageProfile>>(json) ?? new() : new();
+
 }

--- a/Intersect.Client.Core/Interface/Game/DescriptionWindows/ItemDescriptionWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/DescriptionWindows/ItemDescriptionWindow.cs
@@ -293,10 +293,11 @@ public partial class ItemDescriptionWindow() : DescriptionWindowBase(Interface.G
         if (_itemDescriptor.EquipmentSlot == Options.Instance.Equipment.WeaponSlot)
         {
             // Base Damage:
-            rows.AddKeyValueRow(Strings.ItemDescription.BaseDamage, _itemDescriptor.Damage.ToString());
+            var dmg = _itemDescriptor.Damage.FirstOrDefault();
+            rows.AddKeyValueRow(Strings.ItemDescription.BaseDamage, dmg.Amount.ToString());
 
             // Damage Type:
-            Strings.ItemDescription.DamageTypes.TryGetValue(_itemDescriptor.DamageType, out var damageType);
+            Strings.ItemDescription.DamageTypes.TryGetValue((int)dmg.DamageType, out var damageType);
             rows.AddKeyValueRow(Strings.ItemDescription.BaseDamageType, damageType);
 
             if (_itemDescriptor.Scaling > 0)

--- a/Intersect.Client.Core/Interface/Game/DescriptionWindows/SpellDescriptionWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/DescriptionWindows/SpellDescriptionWindow.cs
@@ -235,7 +235,8 @@ public partial class SpellDescriptionWindow() : DescriptionWindowBase(Interface.
         }
 
         // Damage Type:
-        Strings.SpellDescription.DamageTypes.TryGetValue(_spellDescriptor.Combat.DamageType, out var damageType);
+        var dmg = _spellDescriptor.Combat.Damage.FirstOrDefault();
+        Strings.SpellDescription.DamageTypes.TryGetValue((int)dmg.DamageType, out var damageType);
         rows.AddKeyValueRow(Strings.SpellDescription.DamageType, damageType);
 
         if (_spellDescriptor.Combat.Scaling > 0)

--- a/Intersect.Server.Core/Entities/Entity.cs
+++ b/Intersect.Server.Core/Entities/Entity.cs
@@ -1646,9 +1646,19 @@ public abstract partial class Entity : IEntity
 
         if (parentSpell == null)
         {
+            var dmg = parentItem.Damage.FirstOrDefault();
             Attack(
-                target, parentItem.Damage, 0, (DamageType)parentItem.DamageType, (Stat)parentItem.ScalingStat,
-                parentItem.Scaling, parentItem.CritChance, parentItem.CritMultiplier, null, null, true
+                target,
+                dmg.Amount,
+                0,
+                dmg.DamageType,
+                (Stat)parentItem.ScalingStat,
+                parentItem.Scaling,
+                parentItem.CritChance,
+                parentItem.CritMultiplier,
+                null,
+                null,
+                true
             );
         }
 
@@ -1873,14 +1883,23 @@ public abstract partial class Entity : IEntity
 
         var damageHealth = spellDescriptor.Combat.VitalDiff[(int)Vital.Health];
         var damageMana = spellDescriptor.Combat.VitalDiff[(int)Vital.Mana];
+        var spellDmg = spellDescriptor.Combat.Damage.FirstOrDefault();
 
         if ((spellDescriptor.Combat.Effect != SpellEffect.OnHit || onHitTrigger) &&
             spellDescriptor.Combat.Effect != SpellEffect.Shield)
         {
             Attack(
-                target, damageHealth, damageMana, (DamageType)spellDescriptor.Combat.DamageType,
-                (Stat)spellDescriptor.Combat.ScalingStat, spellDescriptor.Combat.Scaling, spellDescriptor.Combat.CritChance,
-                spellDescriptor.Combat.CritMultiplier, deadAnimations, aliveAnimations, false
+                target,
+                damageHealth,
+                damageMana,
+                spellDmg.DamageType,
+                (Stat)spellDescriptor.Combat.ScalingStat,
+                spellDescriptor.Combat.Scaling,
+                spellDescriptor.Combat.CritChance,
+                spellDescriptor.Combat.CritMultiplier,
+                deadAnimations,
+                aliveAnimations,
+                false
             );
         }
 

--- a/Intersect.Server.Core/Entities/Npc.cs
+++ b/Intersect.Server.Core/Entities/Npc.cs
@@ -430,9 +430,17 @@ public partial class Npc : Entity
             );
         }
 
+        var dmg = Descriptor.Damage.FirstOrDefault();
         base.TryAttack(
-            target, Descriptor.Damage, (DamageType)Descriptor.DamageType, (Stat)Descriptor.ScalingStat, Descriptor.Scaling,
-            Descriptor.CritChance, Descriptor.CritMultiplier, deadAnimations, aliveAnimations
+            target,
+            dmg.Amount,
+            dmg.DamageType,
+            (Stat)Descriptor.ScalingStat,
+            Descriptor.Scaling,
+            Descriptor.CritChance,
+            Descriptor.CritMultiplier,
+            deadAnimations,
+            aliveAnimations
         );
 
         PacketSender.SendEntityAttack(this, CalculateAttackTime());

--- a/Intersect.Server.Core/Entities/Player.cs
+++ b/Intersect.Server.Core/Entities/Player.cs
@@ -1772,9 +1772,18 @@ public partial class Player : Entity
 
         if (weapon != null)
         {
+            var dmg = weapon.Damage.FirstOrDefault();
             base.TryAttack(
-                target, weapon.Damage, (DamageType)weapon.DamageType, (Stat)weapon.ScalingStat, weapon.Scaling,
-                weapon.CritChance, weapon.CritMultiplier, null, null, weapon
+                target,
+                dmg.Amount,
+                dmg.DamageType,
+                (Stat)weapon.ScalingStat,
+                weapon.Scaling,
+                weapon.CritChance,
+                weapon.CritMultiplier,
+                null,
+                null,
+                weapon
             );
         }
         else
@@ -1782,9 +1791,15 @@ public partial class Player : Entity
             var classBase = ClassDescriptor.Get(ClassId);
             if (classBase != null)
             {
+                var dmg = classBase.Damage.FirstOrDefault();
                 base.TryAttack(
-                    target, classBase.Damage, (DamageType)classBase.DamageType, (Stat)classBase.ScalingStat,
-                    classBase.Scaling, classBase.CritChance, classBase.CritMultiplier
+                    target,
+                    dmg.Amount,
+                    dmg.DamageType,
+                    (Stat)classBase.ScalingStat,
+                    classBase.Scaling,
+                    classBase.CritChance,
+                    classBase.CritMultiplier
                 );
             }
             else
@@ -3901,7 +3916,7 @@ public partial class Player : Entity
             return 0;
         }
 
-        return item.Descriptor.Damage;
+        return item.Descriptor.Damage.FirstOrDefault().Amount;
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- define DamageProfile struct
- store damage profiles as JSON in descriptors
- extend DatabaseUtils for DamageProfile lists
- adapt server/client logic to use damage profiles

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e12cfd65c8324a9a5f1678dfcf1fe