### PR TITLE
Add achievements tables and descriptors

### DIFF
--- a/Framework/Intersect.Framework.Core/Descriptors/GameObjectType.cs
+++ b/Framework/Intersect.Framework.Core/Descriptors/GameObjectType.cs
@@ -7,6 +7,7 @@ using Intersect.Framework.Core.GameObjects.Mapping.Tilesets;
 using Intersect.Framework.Core.GameObjects.Maps;
 using Intersect.Framework.Core.GameObjects.NPCs;
 using Intersect.Framework.Core.GameObjects.PlayerClass;
+using Intersect.Framework.Core.GameObjects.Achievements;
 using Intersect.Framework.Core.GameObjects.Resources;
 using Intersect.Framework.Core.GameObjects.Variables;
 using Intersect.GameObjects;
@@ -32,6 +33,9 @@ public enum GameObjectType
 
     [GameObjectInfo(typeof(QuestDescriptor), "quests")]
     Quest,
+
+    [GameObjectInfo(typeof(AchievementDescriptor), "achievements")]
+    Achievement,
 
     [GameObjectInfo(typeof(ResourceDescriptor), "resources")]
     Resource,

--- a/Framework/Intersect.Framework.Core/GameObjects/Achievements/AchievementDescriptor.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Achievements/AchievementDescriptor.cs
@@ -1,0 +1,40 @@
+using System.ComponentModel.DataAnnotations.Schema;
+using Intersect.Framework.Core.GameObjects.Conditions;
+using Intersect.Framework.Core.Serialization;
+using Intersect.Models;
+using Newtonsoft.Json;
+
+namespace Intersect.GameObjects;
+
+public partial class AchievementDescriptor : DatabaseObject<AchievementDescriptor>, IFolderable
+{
+    [JsonConstructor]
+    public AchievementDescriptor(Guid id) : base(id)
+    {
+        Name = "New Achievement";
+    }
+
+    public AchievementDescriptor()
+    {
+        Name = "New Achievement";
+    }
+
+    public string Category { get; set; } = string.Empty;
+
+    public int Difficulty { get; set; }
+
+    [Column("Requirements")]
+    [JsonIgnore]
+    public string JsonRequirements
+    {
+        get => Requirements.Data();
+        set => Requirements.Load(value);
+    }
+
+    [NotMapped]
+    public ConditionLists Requirements { get; set; } = new();
+
+    public string Rewards { get; set; } = string.Empty;
+
+    public string Folder { get; set; } = string.Empty;
+}

--- a/Intersect.Server.Core/Database/GameData/GameContext.cs
+++ b/Intersect.Server.Core/Database/GameData/GameContext.cs
@@ -7,6 +7,7 @@ using Intersect.Framework.Core.GameObjects.Mapping.Tilesets;
 using Intersect.Framework.Core.GameObjects.Maps.MapList;
 using Intersect.Framework.Core.GameObjects.NPCs;
 using Intersect.Framework.Core.GameObjects.PlayerClass;
+using Intersect.Framework.Core.GameObjects.Achievements;
 using Intersect.Framework.Core.GameObjects.Resources;
 using Intersect.Framework.Core.GameObjects.Variables;
 using Intersect.GameObjects;
@@ -57,6 +58,9 @@ public abstract partial class GameContext : IntersectDbContext<GameContext>, IGa
 
     //Quests
     public DbSet<QuestDescriptor> Quests { get; set; }
+
+    //Achievements
+    public DbSet<AchievementDescriptor> Achievements { get; set; }
 
     //Resources
     public DbSet<ResourceDescriptor> Resources { get; set; }

--- a/Intersect.Server.Core/Database/GameData/IGameContext.cs
+++ b/Intersect.Server.Core/Database/GameData/IGameContext.cs
@@ -6,6 +6,7 @@ using Intersect.Framework.Core.GameObjects.Mapping.Tilesets;
 using Intersect.Framework.Core.GameObjects.Maps.MapList;
 using Intersect.Framework.Core.GameObjects.NPCs;
 using Intersect.Framework.Core.GameObjects.PlayerClass;
+using Intersect.Framework.Core.GameObjects.Achievements;
 using Intersect.Framework.Core.GameObjects.Resources;
 using Intersect.Framework.Core.GameObjects.Variables;
 using Intersect.GameObjects;
@@ -39,6 +40,8 @@ public interface IGameContext : IDbContext
     DbSet<ProjectileDescriptor> Projectiles { get; set; }
 
     DbSet<QuestDescriptor> Quests { get; set; }
+
+    DbSet<AchievementDescriptor> Achievements { get; set; }
 
     DbSet<ResourceDescriptor> Resources { get; set; }
 

--- a/Intersect.Server.Core/Database/PlayerData/IPlayerContext.cs
+++ b/Intersect.Server.Core/Database/PlayerData/IPlayerContext.cs
@@ -27,6 +27,8 @@ public interface IPlayerContext : IDbContext
 
     DbSet<Quest> Player_Quests { get; set; }
 
+    DbSet<Achievement> Player_Achievements { get; set; }
+
     DbSet<SpellSlot> Player_Spells { get; set; }
 
     DbSet<PlayerVariable> Player_Variables { get; set; }

--- a/Intersect.Server.Core/Database/PlayerData/PlayerContext.cs
+++ b/Intersect.Server.Core/Database/PlayerData/PlayerContext.cs
@@ -33,6 +33,8 @@ public abstract partial class PlayerContext : IntersectDbContext<PlayerContext>,
 
     public DbSet<Quest> Player_Quests { get; set; }
 
+    public DbSet<Achievement> Player_Achievements { get; set; }
+
     public DbSet<SpellSlot> Player_Spells { get; set; }
 
     public DbSet<PlayerVariable> Player_Variables { get; set; }
@@ -99,6 +101,9 @@ public abstract partial class PlayerContext : IntersectDbContext<PlayerContext>,
 
         modelBuilder.Entity<Player>().HasMany(b => b.Quests).WithOne(p => p.Player);
         modelBuilder.Entity<Quest>().HasIndex(p => new { p.QuestId, p.PlayerId }).IsUnique();
+
+        modelBuilder.Entity<Player>().HasMany(b => b.Achievements).WithOne(p => p.Player);
+        modelBuilder.Entity<Achievement>().HasIndex(p => new { p.AchievementId, p.PlayerId }).IsUnique();
 
         modelBuilder.Entity<Player>().HasMany(b => b.Bank).WithOne(p => p.Player);
 
@@ -187,6 +192,9 @@ public abstract partial class PlayerContext : IntersectDbContext<PlayerContext>,
             Entry(itm).State = EntityState.Detached;
 
         foreach (var itm in player.Quests)
+            Entry(itm).State = EntityState.Detached;
+
+        foreach (var itm in player.Achievements)
             Entry(itm).State = EntityState.Detached;
 
         foreach (var itm in player.Bank)

--- a/Intersect.Server.Core/Database/PlayerData/Players/Achievement.cs
+++ b/Intersect.Server.Core/Database/PlayerData/Players/Achievement.cs
@@ -1,0 +1,37 @@
+using System.ComponentModel.DataAnnotations.Schema;
+using Intersect.Server.Entities;
+using Newtonsoft.Json;
+
+namespace Intersect.Server.Database.PlayerData.Players;
+
+public partial class Achievement : IPlayerOwned
+{
+    public Achievement() { }
+
+    public Achievement(Guid id)
+    {
+        AchievementId = id;
+    }
+
+    [DatabaseGenerated(DatabaseGeneratedOption.Identity), JsonIgnore]
+    public Guid Id { get; private set; }
+
+    [JsonIgnore]
+    public Guid AchievementId { get; private set; }
+
+    public int Progress { get; set; }
+
+    public bool Completed { get; set; }
+
+    [JsonIgnore]
+    public Guid PlayerId { get; private set; }
+
+    [JsonIgnore]
+    [ForeignKey(nameof(PlayerId))]
+    public virtual Player Player { get; private set; }
+
+    public string Data()
+    {
+        return JsonConvert.SerializeObject(this);
+    }
+}

--- a/Intersect.Server.Core/Entities/Player.cs
+++ b/Intersect.Server.Core/Entities/Player.cs
@@ -18,6 +18,7 @@ using Intersect.Framework.Core.GameObjects.Maps.Attributes;
 using Intersect.Framework.Core.GameObjects.NPCs;
 using Intersect.Framework.Core.GameObjects.PlayerClass;
 using Intersect.Framework.Core.GameObjects.Quests;
+using Intersect.Framework.Core.GameObjects.Achievements;
 using Intersect.Framework.Core.GameObjects.Variables;
 using Intersect.GameObjects;
 using Intersect.Network;
@@ -169,6 +170,9 @@ public partial class Player : Entity
 
     //Quests
     public virtual List<Quest> Quests { get; set; } = [];
+
+    //Achievements
+    public virtual List<Achievement> Achievements { get; set; } = [];
 
     //Variables
     public virtual List<PlayerVariable> Variables { get; set; } = [];

--- a/Intersect.Server.Core/Migrations/Sqlite/Game/20250701000000_AddAchievements.cs
+++ b/Intersect.Server.Core/Migrations/Sqlite/Game/20250701000000_AddAchievements.cs
@@ -1,0 +1,34 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Intersect.Server.Migrations.Sqlite.Game;
+
+public partial class AddAchievements : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.CreateTable(
+            name: "Achievements",
+            columns: table => new
+            {
+                Id = table.Column<Guid>(type: "TEXT", nullable: false),
+                TimeCreated = table.Column<long>(type: "INTEGER", nullable: false),
+                Name = table.Column<string>(type: "TEXT", nullable: true),
+                Category = table.Column<string>(type: "TEXT", nullable: true),
+                Difficulty = table.Column<int>(type: "INTEGER", nullable: false),
+                Requirements = table.Column<string>(type: "TEXT", nullable: true),
+                Rewards = table.Column<string>(type: "TEXT", nullable: true),
+                Folder = table.Column<string>(type: "TEXT", nullable: true)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_Achievements", x => x.Id);
+            });
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropTable(name: "Achievements");
+    }
+}

--- a/Intersect.Server.Core/Migrations/Sqlite/Game/SqliteGameContextModelSnapshot.cs
+++ b/Intersect.Server.Core/Migrations/Sqlite/Game/SqliteGameContextModelSnapshot.cs
@@ -1025,6 +1025,38 @@ namespace Intersect.Server.Migrations.Sqlite.Game
                     b.ToTable("Quests");
                 });
 
+            modelBuilder.Entity("Intersect.GameObjects.AchievementDescriptor", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .HasColumnType("TEXT");
+
+                    b.Property<string>("Category")
+                        .HasColumnType("TEXT");
+
+                    b.Property<int>("Difficulty")
+                        .HasColumnType("INTEGER");
+
+                    b.Property<string>("Folder")
+                        .HasColumnType("TEXT");
+
+                    b.Property<string>("Name")
+                        .HasColumnType("TEXT")
+                        .HasColumnOrder(0);
+
+                    b.Property<string>("Requirements")
+                        .HasColumnType("TEXT");
+
+                    b.Property<string>("Rewards")
+                        .HasColumnType("TEXT");
+
+                    b.Property<long>("TimeCreated")
+                        .HasColumnType("INTEGER");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("Achievements");
+                });
+
             modelBuilder.Entity("Intersect.GameObjects.ShopDescriptor", b =>
                 {
                     b.Property<Guid>("Id")

--- a/Intersect.Server.Core/Migrations/Sqlite/Player/20250701000000_AddAchievements.cs
+++ b/Intersect.Server.Core/Migrations/Sqlite/Player/20250701000000_AddAchievements.cs
@@ -1,0 +1,48 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Intersect.Server.Migrations.Sqlite.Player;
+
+public partial class AddAchievements : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.CreateTable(
+            name: "Player_Achievements",
+            columns: table => new
+            {
+                Id = table.Column<Guid>(type: "TEXT", nullable: false),
+                PlayerId = table.Column<Guid>(type: "TEXT", nullable: false),
+                AchievementId = table.Column<Guid>(type: "TEXT", nullable: false),
+                Progress = table.Column<int>(type: "INTEGER", nullable: false),
+                Completed = table.Column<bool>(type: "INTEGER", nullable: false)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_Player_Achievements", x => x.Id);
+                table.ForeignKey(
+                    name: "FK_Player_Achievements_Players_PlayerId",
+                    column: x => x.PlayerId,
+                    principalTable: "Players",
+                    principalColumn: "Id",
+                    onDelete: ReferentialAction.Cascade);
+            });
+
+        migrationBuilder.CreateIndex(
+            name: "IX_Player_Achievements_PlayerId",
+            table: "Player_Achievements",
+            column: "PlayerId");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_Player_Achievements_AchievementId_PlayerId",
+            table: "Player_Achievements",
+            columns: new[] { "AchievementId", "PlayerId" },
+            unique: true);
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropTable(name: "Player_Achievements");
+    }
+}

--- a/Intersect.Server.Core/Migrations/Sqlite/Player/SqlitePlayerContextModelSnapshot.cs
+++ b/Intersect.Server.Core/Migrations/Sqlite/Player/SqlitePlayerContextModelSnapshot.cs
@@ -421,6 +421,34 @@ namespace Intersect.Server.Migrations.Sqlite.Player
                     b.ToTable("Player_Quests");
                 });
 
+            modelBuilder.Entity("Intersect.Server.Database.PlayerData.Players.Achievement", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("TEXT");
+
+                    b.Property<Guid>("AchievementId")
+                        .HasColumnType("TEXT");
+
+                    b.Property<bool>("Completed")
+                        .HasColumnType("INTEGER");
+
+                    b.Property<int>("Progress")
+                        .HasColumnType("INTEGER");
+
+                    b.Property<Guid>("PlayerId")
+                        .HasColumnType("TEXT");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("PlayerId");
+
+                    b.HasIndex("AchievementId", "PlayerId")
+                        .IsUnique();
+
+                    b.ToTable("Player_Achievements");
+                });
+
             modelBuilder.Entity("Intersect.Server.Database.PlayerData.Players.SpellSlot", b =>
                 {
                     b.Property<Guid>("Id")

--- a/Intersect.Server/Migrations/MySql/Game/20250701000000_AddAchievements.cs
+++ b/Intersect.Server/Migrations/MySql/Game/20250701000000_AddAchievements.cs
@@ -1,0 +1,35 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Intersect.Server.Migrations.MySql.Game;
+
+public partial class AddAchievements : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.CreateTable(
+            name: "Achievements",
+            columns: table => new
+            {
+                Id = table.Column<Guid>(type: "char(36)", nullable: false)
+                    .Annotation("MySql:Collation", "ascii_general_ci"),
+                TimeCreated = table.Column<long>(type: "bigint", nullable: false),
+                Name = table.Column<string>(type: "longtext", nullable: true),
+                Category = table.Column<string>(type: "longtext", nullable: true),
+                Difficulty = table.Column<int>(type: "int", nullable: false),
+                Requirements = table.Column<string>(type: "longtext", nullable: true),
+                Rewards = table.Column<string>(type: "longtext", nullable: true),
+                Folder = table.Column<string>(type: "longtext", nullable: true)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_Achievements", x => x.Id);
+            });
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropTable(name: "Achievements");
+    }
+}

--- a/Intersect.Server/Migrations/MySql/Game/MySqlGameContextModelSnapshot.cs
+++ b/Intersect.Server/Migrations/MySql/Game/MySqlGameContextModelSnapshot.cs
@@ -1068,6 +1068,39 @@ namespace Intersect.Server.Migrations.MySql.Game
                     b.ToTable("Quests");
                 });
 
+            modelBuilder.Entity("Intersect.GameObjects.AchievementDescriptor", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .HasColumnType("char(36)")
+                        .UseCollation("ascii_general_ci");
+
+                    b.Property<string>("Category")
+                        .HasColumnType("longtext");
+
+                    b.Property<int>("Difficulty")
+                        .HasColumnType("int");
+
+                    b.Property<string>("Folder")
+                        .HasColumnType("longtext");
+
+                    b.Property<string>("Name")
+                        .HasColumnType("longtext")
+                        .HasColumnOrder(0);
+
+                    b.Property<string>("Requirements")
+                        .HasColumnType("longtext");
+
+                    b.Property<string>("Rewards")
+                        .HasColumnType("longtext");
+
+                    b.Property<long>("TimeCreated")
+                        .HasColumnType("bigint");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("Achievements");
+                });
+
             modelBuilder.Entity("Intersect.GameObjects.ShopDescriptor", b =>
                 {
                     b.Property<Guid>("Id")

--- a/Intersect.Server/Migrations/MySql/Player/20250701000000_AddAchievements.cs
+++ b/Intersect.Server/Migrations/MySql/Player/20250701000000_AddAchievements.cs
@@ -1,0 +1,51 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Intersect.Server.Migrations.MySql.Player;
+
+public partial class AddAchievements : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.CreateTable(
+            name: "Player_Achievements",
+            columns: table => new
+            {
+                Id = table.Column<Guid>(type: "char(36)", nullable: false)
+                    .Annotation("MySql:Collation", "ascii_general_ci"),
+                PlayerId = table.Column<Guid>(type: "char(36)", nullable: false)
+                    .Annotation("MySql:Collation", "ascii_general_ci"),
+                AchievementId = table.Column<Guid>(type: "char(36)", nullable: false)
+                    .Annotation("MySql:Collation", "ascii_general_ci"),
+                Progress = table.Column<int>(type: "int", nullable: false),
+                Completed = table.Column<bool>(type: "tinyint(1)", nullable: false)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_Player_Achievements", x => x.Id);
+                table.ForeignKey(
+                    name: "FK_Player_Achievements_Players_PlayerId",
+                    column: x => x.PlayerId,
+                    principalTable: "Players",
+                    principalColumn: "Id",
+                    onDelete: ReferentialAction.Cascade);
+            });
+
+        migrationBuilder.CreateIndex(
+            name: "IX_Player_Achievements_PlayerId",
+            table: "Player_Achievements",
+            column: "PlayerId");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_Player_Achievements_AchievementId_PlayerId",
+            table: "Player_Achievements",
+            columns: new[] { "AchievementId", "PlayerId" },
+            unique: true);
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropTable(name: "Player_Achievements");
+    }
+}

--- a/Intersect.Server/Migrations/MySql/Player/MySqlPlayerContextModelSnapshot.cs
+++ b/Intersect.Server/Migrations/MySql/Player/MySqlPlayerContextModelSnapshot.cs
@@ -469,6 +469,37 @@ namespace Intersect.Server.Migrations.MySql.Player
                     b.ToTable("Player_Quests");
                 });
 
+            modelBuilder.Entity("Intersect.Server.Database.PlayerData.Players.Achievement", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("char(36)")
+                        .UseCollation("ascii_general_ci");
+
+                    b.Property<Guid>("AchievementId")
+                        .HasColumnType("char(36)")
+                        .UseCollation("ascii_general_ci");
+
+                    b.Property<bool>("Completed")
+                        .HasColumnType("tinyint(1)");
+
+                    b.Property<int>("Progress")
+                        .HasColumnType("int");
+
+                    b.Property<Guid>("PlayerId")
+                        .HasColumnType("char(36)")
+                        .UseCollation("ascii_general_ci");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("PlayerId");
+
+                    b.HasIndex("AchievementId", "PlayerId")
+                        .IsUnique();
+
+                    b.ToTable("Player_Achievements");
+                });
+
             modelBuilder.Entity("Intersect.Server.Database.PlayerData.Players.SpellSlot", b =>
                 {
                     b.Property<Guid>("Id")


### PR DESCRIPTION
## Summary
- introduce AchievementDescriptor and enum entry
- track achievements per player
- update server contexts and player entity
- create EF migrations for Achievements and Player_Achievements tables

## Testing
- `dotnet` was not found so tests couldn't be run

------
https://chatgpt.com/codex/tasks/task_e_684e3f7a923483248e14b494168b1f2b