### PR TITLE
Fix double disposal in ClearChildren

### DIFF
--- a/Intersect.Client.Framework/Gwen/Control/Base.cs
+++ b/Intersect.Client.Framework/Gwen/Control/Base.cs
@@ -2236,7 +2236,9 @@ public partial class Base : IDisposable
         {
             foreach (var child in @this.HostedChildren)
             {
-                child.Dispose();
+                // Dispose is deferred to avoid double disposal when the
+                // child has already been scheduled for delayed deletion.
+                child.DelayedDelete();
             }
         }
 


### PR DESCRIPTION
## Summary
- avoid immediate disposal of children when clearing them
- schedule them for delayed deletion instead, preventing repeated `Dispose` calls

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f9968f73c8324a9dcfe3ac1d55769