### PR TITLE
Add item subtype defaults

### DIFF
--- a/Framework/Intersect.Framework.Core/Config/ItemOptions.cs
+++ b/Framework/Intersect.Framework.Core/Config/ItemOptions.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using Intersect.Framework.Core.GameObjects.Items;
 using Newtonsoft.Json;
 
 namespace Intersect.Config;
@@ -23,9 +24,26 @@ public class ItemOptions
         @"Legendary",
     ];
 
+    [JsonProperty(ObjectCreationHandling = ObjectCreationHandling.Replace)]
+    public Dictionary<ItemType, List<string>> ItemSubtypes { get; set; } = new()
+    {
+        { ItemType.Equipment, [ "Weapon", "Armor", "Tool", "Accessory" ] },
+        { ItemType.Consumable, [ "Food", "Potion" ] },
+        { ItemType.Currency, [ "Money" ] },
+        { ItemType.Spell, [ "Scroll" ] },
+        { ItemType.Event, [] },
+        { ItemType.Bag, [ "Inventory", "Bank" ] },
+        { ItemType.Resource, [ "Ore", "Wood", "Herb", "Fish" ] },
+    };
+
     public bool TryGetRarityName(int rarityLevel, [NotNullWhen(true)] out string? rarityName)
     {
         rarityName = RarityTiers.Skip(rarityLevel).FirstOrDefault();
         return rarityName != default;
+    }
+
+    public IReadOnlyList<string> GetSubtypesFor(ItemType itemType)
+    {
+        return ItemSubtypes.TryGetValue(itemType, out var subtypes) ? subtypes : [];
     }
 }

--- a/Framework/Intersect.Framework.Core/GameObjects/Items/ItemDescriptor.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Items/ItemDescriptor.cs
@@ -8,6 +8,7 @@ using Intersect.GameObjects;
 using Intersect.GameObjects.Ranges;
 using Intersect.Models;
 using Intersect.Utilities;
+using Intersect.Config;
 using Newtonsoft.Json;
 
 namespace Intersect.Framework.Core.GameObjects.Items;
@@ -174,6 +175,26 @@ public partial class ItemDescriptor : DatabaseObject<ItemDescriptor>, IFolderabl
     public string FemalePaperdoll { get; set; } = string.Empty;
 
     public ItemType ItemType { get; set; }
+
+    public string Subtype { get; set; } = string.Empty;
+
+    public bool SetSubtype(string subtype)
+    {
+        var validSubtypes = Options.Instance.Items.GetSubtypesFor(ItemType);
+        if (string.IsNullOrWhiteSpace(subtype))
+        {
+            Subtype = string.Empty;
+            return true;
+        }
+
+        if (validSubtypes.Contains(subtype))
+        {
+            Subtype = subtype;
+            return true;
+        }
+
+        return false;
+    }
 
     public string MalePaperdoll { get; set; } = string.Empty;
 

--- a/Framework/Intersect.Framework.Core/GameObjects/Items/ItemType.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Items/ItemType.cs
@@ -15,4 +15,6 @@ public enum ItemType
     Event = 5,
 
     Bag = 6,
+
+    Resource = 7,
 }

--- a/Intersect.Client.Core/Items/Item.cs
+++ b/Intersect.Client.Core/Items/Item.cs
@@ -19,6 +19,8 @@ public class Item : IItem
 
     public ItemDescriptor Descriptor => ItemDescriptor.Get(ItemId);
 
+    public string Subtype => Descriptor.Subtype;
+
     public void Load(Guid id, int quantity, Guid? bagId, ItemProperties itemProperties)
     {
         ItemId = id;

--- a/Intersect.Client.Framework/Items/IItem.cs
+++ b/Intersect.Client.Framework/Items/IItem.cs
@@ -9,6 +9,7 @@ public interface IItem
     ItemDescriptor Descriptor { get; }
     Guid ItemId { get; set; }
     int Quantity { get; set; }
+    string Subtype { get; }
     ItemProperties ItemProperties { get; set; }
 
     void Load(Guid id, int quantity, Guid? bagId, ItemProperties itemProperties);

--- a/Intersect.Server.Core/Database/Item.cs
+++ b/Intersect.Server.Core/Database/Item.cs
@@ -93,6 +93,8 @@ public class Item : IItem
 
     [JsonIgnore, NotMapped] public ItemDescriptor Descriptor => ItemDescriptor.Get(ItemId);
 
+    [JsonIgnore, NotMapped] public string Subtype => Descriptor.Subtype;
+
     public static Item None => new();
 
     public Item Clone()

--- a/Intersect.Server.Framework/Items/IItem.cs
+++ b/Intersect.Server.Framework/Items/IItem.cs
@@ -9,5 +9,6 @@ public interface IItem
     ItemDescriptor Descriptor { get; }
     int Quantity { get; }
     string ItemName { get; }
+    string Subtype { get; }
     double DropChance { get; }
 }


### PR DESCRIPTION
## Summary
- add default subtype mapping per item type

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68523386b2408324bdf8ab63b0f3cb48