### PR TITLE
Add guild texture support and graphics helper

### DIFF
--- a/Documentation/GuildUpgradeTasks.md
+++ b/Documentation/GuildUpgradeTasks.md
@@ -1,0 +1,40 @@
+# Guild Upgrade System Implementation Plan
+
+This document outlines tasks required to integrate the guild upgrade system based on the reference commits from Joak1ngglb/Intersect-Engine.
+
+## 1. Guild Creation Interface
+- Add a new window `GuildCreationInterface` allowing players to design a guild logo with customizable background and symbol ([ad681d8](https://github.com/Joak1ngglb/Intersect-Engine/commit/ad681d827b5fbe9037ec5f6e2300fcad4ee49c4f)).
+- Provide color sliders for background and symbol as well as preview components.
+- Extend `GameInterface` with methods to open/close this window and update the game loop accordingly.
+- Extend content loading to include a new `Guild` texture group and implement pixel editing utilities (`SetColor`, `GraphicsHelper.Compose`, `GraphicsHelper.Recolor`).
+
+## 2. Guild Logo Networking and Storage
+- Introduce packets for guild creation and guild data updates (`CreateGuildPacket`, `GuildUpdate`, etc.) ([dfb4d27](https://github.com/Joak1ngglb/Intersect-Engine/commit/dfb4d273825c2a214cd7746cf1fef3a10cf60826)).
+- Update `PacketHandler` and `PacketSender` on both client and server to handle logo information.
+- Modify player and guild database models to store logo files and RGB values.
+- Add migrations to create the new columns for logo data.
+- Display the composed guild logo in the `GuildWindow` and associate it with player name labels.
+
+## 3. GUI Improvements
+- Replace logo selection panels with scrollable containers and adjust control positions (`b485d6a1`).
+- Show guild logos next to player labels (`2b70aa45`) and tweak sizes (`b04b6d06`).
+- Allow the guild creation window to be opened via in‑game events by sending a `GuildCreationWindowPacket` (`4865d4f6`).
+
+## 4. Guild Levels and Experience
+- Track guild experience and level server‑side, including initial configuration values for base XP and growth factor.
+- Update guild members when experience changes and show level/EXP in the guild window (`ca878d3`, `9ff28732`).
+- Implement player commands to donate experience and adjust personal contribution percentage.
+
+## 5. Guild Upgrades
+- Add support for guild points and upgrade types (`GuildUpgradeType`).
+- Implement client UI to view and purchase upgrades and server logic to apply them (`9085b269`).
+- Store spent points and upgrade levels in the database with a migration.
+
+## 6. Maintenance and Fixes
+- Reset contribution variables for new or removed members (`169101c`).
+- Remove unused symbol scaling and Y‑offset properties from packets and UI (`981719fe`).
+- Ensure guild members are attached correctly when loaded from the database (`01369e523`).
+
+Each of these steps corresponds to features introduced in the reference commits and should be ported while respecting the existing code style and architecture of this repository.
+
+Referenced commits: `ad681d8`, `dfb4d27`, `9ff2873`, `b485d6a1`, `ca878d3`, `2b70aa45`, `b04b6d06`, `9085b269`, `4865d4f6`, `169101c`, `981719fe`, `01369e523`.

--- a/Intersect.Client.Core/Interface/Game/GameInterface.cs
+++ b/Intersect.Client.Core/Interface/Game/GameInterface.cs
@@ -56,6 +56,9 @@ public partial class GameInterface : MutableInterface
 
     private SpellDescriptionWindow? _spellDescriptionWindow;
 
+    private GuildCreationWindow? _guildCreationWindow;
+    private bool _shouldOpenGuildCreation;
+
     private bool mShouldCloseBag;
 
     private bool _shouldCloseBank;
@@ -289,6 +292,29 @@ public partial class GameInterface : MutableInterface
         mCraftJournal = false;
     }
 
+    // Guild Creation
+    public void NotifyOpenGuildCreation()
+    {
+        _shouldOpenGuildCreation = true;
+    }
+
+    public void NotifyCloseGuildCreation()
+    {
+        if (_guildCreationWindow != null)
+        {
+            _guildCreationWindow.Close();
+            _guildCreationWindow = null;
+        }
+        _shouldOpenGuildCreation = false;
+    }
+
+    private void OpenGuildCreation()
+    {
+        _guildCreationWindow?.Close();
+        _guildCreationWindow = new GuildCreationWindow(GameCanvas);
+        _shouldOpenGuildCreation = false;
+    }
+
     public void OpenCraftingTable()
     {
         if (mCraftingWindow != null)
@@ -463,6 +489,23 @@ public partial class GameInterface : MutableInterface
         }
 
         mShouldCloseCraftingTable = false;
+
+        if (_shouldOpenGuildCreation)
+        {
+            OpenGuildCreation();
+        }
+
+        if (_guildCreationWindow != null)
+        {
+            if (!_guildCreationWindow.IsVisibleInTree)
+            {
+                _guildCreationWindow = null;
+            }
+            else
+            {
+                _guildCreationWindow.Update();
+            }
+        }
 
         //Trading update
         if (mShouldOpenTrading)

--- a/Intersect.Client.Core/Interface/Game/GuildCreationWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/GuildCreationWindow.cs
@@ -1,0 +1,105 @@
+using Intersect.Client.Core;
+using Intersect.Client.Framework.Content;
+using Intersect.Client.Framework.File_Management;
+using Intersect.Client.Framework.Graphics;
+using Intersect.Client.Framework.Gwen;
+using Intersect.Client.Framework.Gwen.Control;
+using Intersect.Client.Localization;
+
+namespace Intersect.Client.Interface.Game;
+
+public partial class GuildCreationWindow : Window
+{
+    private readonly ImagePanel _preview;
+    private readonly LabeledSlider _bgR;
+    private readonly LabeledSlider _bgG;
+    private readonly LabeledSlider _bgB;
+    private readonly LabeledSlider _symbolR;
+    private readonly LabeledSlider _symbolG;
+    private readonly LabeledSlider _symbolB;
+    private readonly Button _createButton;
+    private readonly Button _cancelButton;
+
+    private IGameTexture? _background;
+    private IGameTexture? _symbol;
+
+    public GuildCreationWindow(Canvas gameCanvas) : base(gameCanvas, "Create Guild", false, nameof(GuildCreationWindow))
+    {
+        IsResizable = false;
+        Alignment = [Alignments.Center];
+        MinimumSize = new Point(360, 240);
+        IsClosable = true;
+
+        _preview = new ImagePanel(this, nameof(_preview));
+
+        _bgR = CreateSlider(nameof(_bgR), "Red");
+        _bgG = CreateSlider(nameof(_bgG), "Green");
+        _bgB = CreateSlider(nameof(_bgB), "Blue");
+
+        _symbolR = CreateSlider(nameof(_symbolR), "Red");
+        _symbolG = CreateSlider(nameof(_symbolG), "Green");
+        _symbolB = CreateSlider(nameof(_symbolB), "Blue");
+
+        _createButton = new Button(this, nameof(_createButton))
+        {
+            Text = "Create"
+        };
+        _cancelButton = new Button(this, nameof(_cancelButton))
+        {
+            Text = "Cancel"
+        };
+
+        _createButton.Clicked += (s, e) => OnCreate?.Invoke(this, EventArgs.Empty);
+        _cancelButton.Clicked += (s, e) => Close();
+    }
+
+    public event EventHandler? OnCreate;
+
+    protected override void EnsureInitialized()
+    {
+        LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer?.GetResolutionString());
+    }
+
+    public void SetTextures(IGameTexture background, IGameTexture symbol)
+    {
+        _background = background;
+        _symbol = symbol;
+        UpdatePreview();
+    }
+
+    private Color SliderColor(LabeledSlider r, LabeledSlider g, LabeledSlider b)
+    {
+        return GraphicsHelper.SetColor((byte)r.Value, (byte)g.Value, (byte)b.Value);
+    }
+
+    private void UpdatePreview()
+    {
+        if (_background == null || _symbol == null)
+        {
+            return;
+        }
+
+        var composed = GraphicsHelper.Compose(
+            _background,
+            _symbol,
+            SliderColor(_bgR, _bgG, _bgB),
+            SliderColor(_symbolR, _symbolG, _symbolB)
+        );
+
+        _preview.Texture = composed;
+    }
+
+    private LabeledSlider CreateSlider(string name, string label)
+    {
+        var slider = new LabeledSlider(this, name)
+        {
+            Label = label,
+            Orientation = Orientation.LeftToRight,
+            Minimum = 0,
+            Maximum = 255,
+            Rounding = 0
+        };
+        slider.ValueChanged += (_, _) => UpdatePreview();
+        return slider;
+    }
+}

--- a/Intersect.Client.Core/MonoGame/File Management/MonoContentManager.cs
+++ b/Intersect.Client.Core/MonoGame/File Management/MonoContentManager.cs
@@ -193,6 +193,11 @@ public partial class MonoContentManager : GameContentManager
         LoadTextureGroup("paperdolls", mPaperdollDict);
     }
 
+    public override void LoadGuilds()
+    {
+        LoadTextureGroup("guilds", mGuildDict);
+    }
+
     public override void LoadGui()
     {
         LoadTextureGroup("gui", mGuiDict);

--- a/Intersect.Client.Core/Utilities/GraphicsHelper.cs
+++ b/Intersect.Client.Core/Utilities/GraphicsHelper.cs
@@ -1,0 +1,64 @@
+using Intersect.Client.Framework.Graphics;
+using Intersect.Client.Core;
+
+namespace Intersect.Client.Utilities;
+
+public static partial class GraphicsHelper
+{
+    public static IGameTexture Compose(
+        IGameTexture background,
+        IGameTexture symbol,
+        Color backgroundColor,
+        Color symbolColor
+    )
+    {
+        var renderer = Graphics.Renderer;
+        var renderTexture = renderer.CreateRenderTexture(background.Width, background.Height);
+
+        if (renderTexture.Begin())
+        {
+            renderTexture.Clear(Color.Transparent);
+            renderer.DrawTexture(
+                background,
+                0,
+                0,
+                background.Width,
+                background.Height,
+                0,
+                0,
+                background.Width,
+                background.Height,
+                backgroundColor,
+                renderTexture
+            );
+
+            renderer.DrawTexture(
+                symbol,
+                0,
+                0,
+                symbol.Width,
+                symbol.Height,
+                0,
+                0,
+                symbol.Width,
+                symbol.Height,
+                symbolColor,
+                renderTexture
+            );
+
+            renderTexture.End();
+        }
+
+        return renderTexture;
+    }
+
+    public static Color SetColor(byte r, byte g, byte b, byte a = 255)
+    {
+        return new Color(a, r, g, b);
+    }
+
+    public static IGameTexture Recolor(IGameTexture texture, Color color)
+    {
+        return Compose(texture, texture, color, Color.White);
+    }
+}

--- a/Intersect.Client.Framework/Content/ContentType.cs
+++ b/Intersect.Client.Framework/Content/ContentType.cs
@@ -52,6 +52,9 @@ public enum ContentType
     Spell,
 
     [AssetType(typeof(IGameTexture))]
+    Guild,
+
+    [AssetType(typeof(IGameTexture))]
     TextureAtlas,
 
     [AssetType(typeof(IGameTexture))]

--- a/Intersect.Client.Framework/Content/TextureType.cs
+++ b/Intersect.Client.Framework/Content/TextureType.cs
@@ -27,4 +27,5 @@ public enum TextureType
 
     Misc,
 
+    Guild,
 }

--- a/Intersect.Client.Framework/File Management/GameContentManager.cs
+++ b/Intersect.Client.Framework/File Management/GameContentManager.cs
@@ -51,6 +51,8 @@ public abstract partial class GameContentManager : IContentManager
 
     protected readonly Dictionary<string, IAsset> mMusicDict = [];
 
+    protected readonly Dictionary<string, IAsset> mGuildDict = [];
+
     protected readonly Dictionary<string, IAsset> mPaperdollDict = [];
 
     protected readonly Dictionary<string, IAsset> mResourceDict = [];
@@ -81,6 +83,7 @@ public abstract partial class GameContentManager : IContentManager
         { ContentType.Interface, mGuiDict.Values },
         { ContentType.Item, mItemDict.Values },
         { ContentType.Miscellaneous, mMiscDict.Values },
+        { ContentType.Guild, mGuildDict.Values },
         { ContentType.Paperdoll, mPaperdollDict.Values },
         { ContentType.Resource, mResourceDict.Values },
         { ContentType.Spell, mSpellDict.Values },
@@ -119,6 +122,7 @@ public abstract partial class GameContentManager : IContentManager
         LoadFogs();
         LoadResources();
         LoadPaperdolls();
+        LoadGuilds();
         LoadMisc();
         LoadGui();
         LoadFonts();
@@ -146,6 +150,8 @@ public abstract partial class GameContentManager : IContentManager
     public abstract void LoadResources();
 
     public abstract void LoadPaperdolls();
+
+    public abstract void LoadGuilds();
 
     public abstract void LoadGui();
 
@@ -212,6 +218,9 @@ public abstract partial class GameContentManager : IContentManager
 
             case TextureType.Paperdoll:
                 return mPaperdollDict.Keys.ToArray();
+
+            case TextureType.Guild:
+                return mGuildDict.Keys.ToArray();
 
             case TextureType.Gui:
                 return mGuiDict.Keys.ToArray();
@@ -287,6 +296,11 @@ public abstract partial class GameContentManager : IContentManager
 
             case TextureType.Paperdoll:
                 textureDict = mPaperdollDict;
+
+                break;
+
+            case TextureType.Guild:
+                textureDict = mGuildDict;
 
                 break;
 
@@ -560,6 +574,9 @@ public abstract partial class GameContentManager : IContentManager
 
             case ContentType.Miscellaneous:
                 return mMiscDict;
+
+            case ContentType.Guild:
+                return mGuildDict;
 
             case ContentType.Paperdoll:
                 return mPaperdollDict;


### PR DESCRIPTION
## Summary
- extend texture types with Guild
- load guild textures via GameContentManager
- add GraphicsHelper for logo composition and recoloring
- implement GuildCreationWindow and open/close logic

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853848280888324acd3dbd0950bc7da