### PR TITLE
Fix event commands not opening in editor

### DIFF
--- a/Intersect.Editor/Forms/Editors/Events/frmEvent.cs
+++ b/Intersect.Editor/Forms/Editors/Events/frmEvent.cs
@@ -797,9 +797,26 @@ public partial class FrmEvent : Form
     public FrmEvent(MapDescriptor currentMap)
     {
         InitializeComponent();
+        SetNodeTags(lstCommands.Nodes);
         Icon = Program.Icon;
 
         mCurrentMap = currentMap;
+    }
+
+    private static void SetNodeTags(TreeNodeCollection nodes)
+    {
+        foreach (TreeNode node in nodes)
+        {
+            if (Enum.TryParse<EventCommandType>(node.Name, true, out var type))
+            {
+                node.Tag = (int)type;
+            }
+
+            if (node.Nodes.Count > 0)
+            {
+                SetNodeTags(node.Nodes);
+            }
+        }
     }
 
     private Size _defaultFormSize;


### PR DESCRIPTION
## Summary
- restore tagging of event command tree nodes at runtime so tree nodes are selectable in the editor

## Testing
- `dotnet build Intersect.sln -c Release` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6856c86b61c483249fb189e31d9a44f8