### PR TITLE
Fix guild asset loading from subfolders

### DIFF
--- a/Intersect.Client.Core/Interface/Game/Guilds/GuildCreationWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Guilds/GuildCreationWindow.cs
@@ -170,7 +170,8 @@ public partial class GuildCreationWindow : Window
             BackgroundIconPanel.Clicked += (_, _) =>
             {
                 _logoElements[0] = tex;
-           
+                _selectedBackgroundFile = fn;
+
                 UpdateLogoPreview();
             };
 
@@ -222,7 +223,8 @@ public partial class GuildCreationWindow : Window
             SymbolIconPanel.Clicked += (_, _) =>
             {
                 _logoElements[1] = tex;
-                
+                _selectedSymbolFile = fn;
+
                 UpdateLogoPreview();
             };
 

--- a/Intersect.Client.Core/MonoGame/File Management/MonoContentManager.cs
+++ b/Intersect.Client.Core/MonoGame/File Management/MonoContentManager.cs
@@ -204,7 +204,61 @@ public partial class MonoContentManager : GameContentManager
     }
     public override void LoadGuild()
     {
-        LoadTextureGroup("Guild", mGuildDict);
+        mGuildDict.Clear();
+
+        // Load guild backgrounds
+        AppendTextureGroup(Path.Combine("Guild", "Background"), mGuildDict);
+
+        // Load guild symbols
+        AppendTextureGroup(Path.Combine("Guild", "Symbols"), mGuildDict);
+    }
+
+    private void AppendTextureGroup(string directory, Dictionary<string, IAsset> dict)
+    {
+        var dir = Path.Combine(ClientConfiguration.ResourcesDirectory, directory);
+        if (!Directory.Exists(dir))
+        {
+            if (!Directory.Exists(Path.Combine(ClientConfiguration.ResourcesDirectory, "packs")))
+            {
+                Directory.CreateDirectory(dir);
+            }
+        }
+        else
+        {
+            var items = Directory.GetFiles(dir, "*.png");
+            foreach (var item in items)
+            {
+                var filename = item.Replace(dir, string.Empty).TrimStart(Path.DirectorySeparatorChar).ToLower();
+                if (dict.ContainsKey(filename))
+                {
+                    continue;
+                }
+
+                dict.Add(
+                    filename,
+                    Core.Graphics.Renderer.LoadTexture(
+                        Path.Combine(dir, filename),
+                        Path.Combine(dir, item.Replace(dir, string.Empty).TrimStart(Path.DirectorySeparatorChar))
+                    )
+                );
+            }
+        }
+
+        var packItems = AtlasReference.GetAllFor(directory);
+        foreach (var itm in packItems)
+        {
+            var filename = Path.GetFileName(itm.Name.ToLower().Replace("\\", "/"));
+            if (!dict.ContainsKey(filename))
+            {
+                dict.Add(
+                    filename,
+                    Core.Graphics.Renderer.LoadTexture(
+                        Path.Combine(dir, filename),
+                        Path.Combine(dir, Path.Combine(dir, filename))
+                    )
+                );
+            }
+        }
     }
 
 


### PR DESCRIPTION
## Summary
- load guild assets from Background and Symbols folders
- remember selected asset filenames when creating a guild

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859b36fa80c8324a645b3d02854d077