### PR TITLE
Load guild assets from nested folders

### DIFF
--- a/Intersect.Client.Core/Interface/Game/Guilds/GuildCreationWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Guilds/GuildCreationWindow.cs
@@ -134,14 +134,14 @@ public partial class GuildCreationWindow : Window
         var path = Path.Combine(ClientConfiguration.ResourcesDirectory, "Guild", "Background");
         if (!Directory.Exists(path)) Directory.CreateDirectory(path);
 
-        var files = Directory.GetFiles(path, "*.png");
+        var files = Directory.GetFiles(path, "*.png", SearchOption.AllDirectories);
         const int size = 48;
         int x = 5, y = 5;
         int maxW = _backgroundPanel.Width;
 
         foreach (var file in files)
         {
-            var fn = Path.GetFileName(file);
+            var fn = Path.GetRelativePath(path, file).Replace("\\", "/");
          
             var tex = Globals.ContentManager.GetTexture(Framework.Content.TextureType.Guild, fn);
             if (tex == null) continue;
@@ -170,7 +170,8 @@ public partial class GuildCreationWindow : Window
             BackgroundIconPanel.Clicked += (_, _) =>
             {
                 _logoElements[0] = tex;
-           
+                _selectedBackgroundFile = fn;
+
                 UpdateLogoPreview();
             };
 
@@ -186,7 +187,7 @@ public partial class GuildCreationWindow : Window
         var path = Path.Combine(ClientConfiguration.ResourcesDirectory, "Guild", "Symbols");
         if (!Directory.Exists(path)) Directory.CreateDirectory(path);
 
-        var files = Directory.GetFiles(path, "*.png");
+        var files = Directory.GetFiles(path, "*.png", SearchOption.AllDirectories);
     
         const int size = 48;
         int x = 5, y = 5;
@@ -194,7 +195,7 @@ public partial class GuildCreationWindow : Window
 
         foreach (var file in files)
         {
-            var fn = Path.GetFileName(file);
+            var fn = Path.GetRelativePath(path, file).Replace("\\", "/");
         
             var tex = Globals.ContentManager.GetTexture(Framework.Content.TextureType.Guild, fn);
             if (tex == null) continue;
@@ -222,7 +223,8 @@ public partial class GuildCreationWindow : Window
             SymbolIconPanel.Clicked += (_, _) =>
             {
                 _logoElements[1] = tex;
-                
+                _selectedSymbolFile = fn;
+
                 UpdateLogoPreview();
             };
 

--- a/Intersect.Client.Core/MonoGame/File Management/MonoContentManager.cs
+++ b/Intersect.Client.Core/MonoGame/File Management/MonoContentManager.cs
@@ -204,7 +204,61 @@ public partial class MonoContentManager : GameContentManager
     }
     public override void LoadGuild()
     {
-        LoadTextureGroup("Guild", mGuildDict);
+        mGuildDict.Clear();
+
+        // Load guild backgrounds
+        AppendTextureGroup(Path.Combine("Guild", "Background"), mGuildDict);
+
+        // Load guild symbols
+        AppendTextureGroup(Path.Combine("Guild", "Symbols"), mGuildDict);
+    }
+
+    private void AppendTextureGroup(string directory, Dictionary<string, IAsset> dict)
+    {
+        var dir = Path.Combine(ClientConfiguration.ResourcesDirectory, directory);
+        if (!Directory.Exists(dir))
+        {
+            if (!Directory.Exists(Path.Combine(ClientConfiguration.ResourcesDirectory, "packs")))
+            {
+                Directory.CreateDirectory(dir);
+            }
+        }
+        else
+        {
+            var items = Directory.GetFiles(dir, "*.png", SearchOption.AllDirectories);
+            foreach (var item in items)
+            {
+                var filename = Path.GetRelativePath(dir, item).Replace("\\", "/").ToLower();
+                if (dict.ContainsKey(filename))
+                {
+                    continue;
+                }
+
+                dict.Add(
+                    filename,
+                    Core.Graphics.Renderer.LoadTexture(
+                        Path.Combine(dir, filename),
+                        Path.Combine(dir, item.Replace(dir, string.Empty).TrimStart(Path.DirectorySeparatorChar))
+                    )
+                );
+            }
+        }
+
+        var packItems = AtlasReference.GetAllFor(directory);
+        foreach (var itm in packItems)
+        {
+            var filename = Path.GetFileName(itm.Name.ToLower().Replace("\\", "/"));
+            if (!dict.ContainsKey(filename))
+            {
+                dict.Add(
+                    filename,
+                    Core.Graphics.Renderer.LoadTexture(
+                        Path.Combine(dir, filename),
+                        Path.Combine(dir, Path.Combine(dir, filename))
+                    )
+                );
+            }
+        }
     }
 
 


### PR DESCRIPTION
## Summary
- support recursive asset search for guild backgrounds and symbols
- store relative paths for selected guild assets

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859b36fa80c8324a645b3d02854d077