### PR TITLE
Switch attack calculations to agility

### DIFF
--- a/Intersect.Client.Core/Entities/Entity.cs
+++ b/Intersect.Client.Core/Entities/Entity.cs
@@ -1016,7 +1016,7 @@ public partial class Entity : IEntity
         //Otherwise return the legacy attack speed calculation
         return (int)(Options.Instance.Combat.MaxAttackRate +
                      (Options.Instance.Combat.MinAttackRate - Options.Instance.Combat.MaxAttackRate) *
-                     (((float)Options.Instance.Player.MaxStat - Stat[(int)Enums.Stat.Speed]) /
+                     (((float)Options.Instance.Player.MaxStat - Stat[(int)Enums.Stat.Agility]) /
                       Options.Instance.Player.MaxStat));
     }
 

--- a/Intersect.Client.Core/Entities/Player.cs
+++ b/Intersect.Client.Core/Entities/Player.cs
@@ -2421,15 +2421,15 @@ public partial class Player : Entity, IPlayer
     }
 
     /// <summary>
-    /// Calculate the attack time for the player as if they have a specified speed stat.
+    /// Calculate the attack time for the player as if they have a specified agility stat.
     /// </summary>
-    /// <param name="speed"></param>
+    /// <param name="agility"></param>
     /// <returns></returns>
-    public virtual int CalculateAttackTime(int speed)
+    public virtual int CalculateAttackTime(int agility)
     {
         return (int)(Options.Instance.Combat.MaxAttackRate +
                       (Options.Instance.Combat.MinAttackRate - Options.Instance.Combat.MaxAttackRate) *
-                      (((float)Options.Instance.Player.MaxStat - speed) /
+                      (((float)Options.Instance.Player.MaxStat - agility) /
                        Options.Instance.Player.MaxStat));
     }
 

--- a/Intersect.Client.Core/Interface/Game/DescriptionWindows/ItemDescriptionWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/DescriptionWindows/ItemDescriptionWindow.cs
@@ -366,8 +366,8 @@ public partial class ItemDescriptionWindow() : DescriptionWindowBase(Interface.G
             // Are we supposed to change our attack time based on a modifier?
             if (_itemDescriptor.AttackSpeedModifier == 0)
             {
-                // No modifier, assuming base attack rate? We have to calculate the speed stat manually here though..!
-                var speed = player.Stat[(int)Stat.Speed];
+                // No modifier, assuming base attack rate? We have to calculate the agility stat manually here though..!
+                var agility = player.Stat[(int)Stat.Agility];
 
                 // Remove currently equipped weapon stats.. We want to create a fair display!
                 var weaponSlot = player.MyEquipment[Options.Instance.Equipment.WeaponSlot];
@@ -377,22 +377,22 @@ public partial class ItemDescriptionWindow() : DescriptionWindowBase(Interface.G
                     var weapon = ItemDescriptor.Get(player.Inventory[weaponSlot].ItemId);
                     if (weapon != null && randomStats != null)
                     {
-                        speed = (int)Math.Round(speed / ((100 + weapon.PercentageStatsGiven[(int)Stat.Speed]) / 100f));
-                        speed -= weapon.StatsGiven[(int)Stat.Speed];
-                        speed -= randomStats[(int)Stat.Speed];
+                        agility = (int)Math.Round(agility / ((100 + weapon.PercentageStatsGiven[(int)Stat.Agility]) / 100f));
+                        agility -= weapon.StatsGiven[(int)Stat.Agility];
+                        agility -= randomStats[(int)Stat.Agility];
                     }
                 }
 
-                // Add current item's speed stats!
+                // Add current item's agility stats!
                 if (_itemProperties?.StatModifiers != default)
                 {
-                    speed += _itemDescriptor.StatsGiven[(int)Stat.Speed];
-                    speed += _itemProperties.StatModifiers[(int)Stat.Speed];
-                    speed += (int)Math.Floor(speed * (_itemDescriptor.PercentageStatsGiven[(int)Stat.Speed] / 100f));
+                    agility += _itemDescriptor.StatsGiven[(int)Stat.Agility];
+                    agility += _itemProperties.StatModifiers[(int)Stat.Agility];
+                    agility += (int)Math.Floor(agility * (_itemDescriptor.PercentageStatsGiven[(int)Stat.Agility] / 100f));
                 }
 
-                // Display the actual speed this weapon would have based off of our calculated speed stat.
-                rows.AddKeyValueRow(Strings.ItemDescription.AttackSpeed, TimeSpan.FromMilliseconds(player.CalculateAttackTime(speed)).WithSuffix());
+                // Display the actual agility this weapon would have based off of our calculated agility stat.
+                rows.AddKeyValueRow(Strings.ItemDescription.AttackSpeed, TimeSpan.FromMilliseconds(player.CalculateAttackTime(agility)).WithSuffix());
             }
             else if (_itemDescriptor.AttackSpeedModifier == 1)
             {

--- a/Intersect.Server.Core/Entities/Entity.cs
+++ b/Intersect.Server.Core/Entities/Entity.cs
@@ -1395,7 +1395,7 @@ public abstract partial class Entity : IEntity
     {
         return (int)(Options.Instance.Combat.MaxAttackRate +
                       (Options.Instance.Combat.MinAttackRate - Options.Instance.Combat.MaxAttackRate) *
-                      (((float)Options.Instance.Player.MaxStat - Stat[(int)Enums.Stat.Speed].Value()) /
+                      (((float)Options.Instance.Player.MaxStat - Stat[(int)Enums.Stat.Agility].Value()) /
                        Options.Instance.Player.MaxStat));
     }
 

--- a/Intersect.Server.Core/General/Formulas.cs
+++ b/Intersect.Server.Core/General/Formulas.cs
@@ -106,13 +106,15 @@ public partial class Formulas
             expression.Parameters["CritMultiplier"] = critMultiplier;
             expression.Parameters["A_Attack"] = attacker.Stat[(int)Stat.Attack].Value();
             expression.Parameters["A_Defense"] = attacker.Stat[(int)Stat.Defense].Value();
-            expression.Parameters["A_Speed"] = attacker.Stat[(int)Stat.Speed].Value();
+            // Use agility in place of speed for combat calculations
+            expression.Parameters["A_Speed"] = attacker.Stat[(int)Stat.Agility].Value();
             expression.Parameters["A_AbilityPwr"] = attacker.Stat[(int)Stat.Intelligence].Value();
             expression.Parameters["A_MagicResist"] = attacker.Stat[(int)Stat.Vitality].Value();
             expression.Parameters["A_Level"] = attacker.Level;
             expression.Parameters["V_Attack"] = victim.Stat[(int)Stat.Attack].Value();
             expression.Parameters["V_Defense"] = victim.Stat[(int)Stat.Defense].Value();
-            expression.Parameters["V_Speed"] = victim.Stat[(int)Stat.Speed].Value();
+            // Use agility in place of speed for combat calculations
+            expression.Parameters["V_Speed"] = victim.Stat[(int)Stat.Agility].Value();
             expression.Parameters["V_AbilityPwr"] = victim.Stat[(int)Stat.Intelligence].Value();
             expression.Parameters["V_MagicResist"] = victim.Stat[(int)Stat.Vitality].Value();
             expression.Parameters["V_Level"] = victim.Level;


### PR DESCRIPTION
## Summary
- calculate attack speed using Agility instead of Speed
- update item description window to use Agility when previewing attack speed
- update server formulas to use agility for combat variables

## Testing
- `dotnet build Intersect.Tests/Intersect.Tests.csproj -v minimal` *(fails: CS0121 in AuthorsTests.cs)*

------
https://chatgpt.com/codex/tasks/task_e_687722899a188324871ddbb208e44ccf