### PR TITLE
Adjust event node names for enchant windows

### DIFF
--- a/Intersect.Editor/Forms/Editors/Events/frmEvent.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/Events/frmEvent.Designer.cs
@@ -988,11 +988,11 @@ namespace Intersect.Editor.Forms.Editors.Events
             treeNode68.Text = "Give Job Experience";
             treeNode69.Name = "jobs";
             treeNode69.Text = "Jobs";
-            treeNode70.Name = "openenchantwindow";
+            treeNode70.Name = "openenchantment";
             treeNode70.Text = "Open Enchant Window";
-            treeNode71.Name = "openmagewindow";
+            treeNode71.Name = "openmage";
             treeNode71.Text = "Open Mage Window";
-            treeNode72.Name = "openbrokewindow";
+            treeNode72.Name = "openbrokeitem";
             treeNode72.Text = "Open Broke Items Window";
             treeNode73.Name = "Enchantment";
             treeNode73.Text = "Enchantment";

--- a/Intersect.Editor/Localization/Strings.cs
+++ b/Intersect.Editor/Localization/Strings.cs
@@ -2443,9 +2443,9 @@ Tick timer saved in server config.json.";
             {"fade", @"Screen Fade"},
             {"jobs",@"Jobs" },
             {"givejobexperience", @"Give Job Experience"},
-            {"openenchantwindow", @"Open Enchant Window"},
-{"openmagewindow", @"Open Mage Window"},
-{"openbrokewindow", @"Open Broke Items Window"},
+            {"openenchantment", @"Open Enchant Window"},
+{"openmage", @"Open Mage Window"},
+{"openbrokeitem", @"Open Broke Items Window"},
 {"Enchantment", @"Enchantment"},
 
         };


### PR DESCRIPTION
## Summary
- fix the tree node names for enchantment related event commands
- update localization dictionary keys

## Testing
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_687d444dd4548324a18dddb3f8a70313