### PR TITLE
Add stat based vital scaling

### DIFF
--- a/Framework/Intersect.Framework.Core/Config/Options.cs
+++ b/Framework/Intersect.Framework.Core/Config/Options.cs
@@ -228,6 +228,14 @@ public partial record Options
 
     #endregion Configuration Properties
 
+    #region Player Stat Scaling Helpers
+
+    public static int VitalityHealthmultiplier => Instance.Player.VitalityHealthmultiplier;
+
+    public static int IntelligenceManaMultiplier => Instance.Player.IntelligenceManaMultiplier;
+
+    #endregion
+
     public void FixAnimatedSprites()
     {
         for (var i = 0; i < AnimatedSprites.Count; i++)

--- a/Framework/Intersect.Framework.Core/Config/PlayerOptions.cs
+++ b/Framework/Intersect.Framework.Core/Config/PlayerOptions.cs
@@ -88,6 +88,16 @@ public partial class PlayerOptions
     public int MaxStat { get; set; } = 255;
 
     /// <summary>
+    /// Health gained per point of <see cref="Stat.Vitality"/>.
+    /// </summary>
+    public int VitalityHealthmultiplier { get; set; } = 3;
+
+    /// <summary>
+    /// Mana gained per point of <see cref="Stat.Intelligence"/>.
+    /// </summary>
+    public int IntelligenceManaMultiplier { get; set; } = 3;
+
+    /// <summary>
     /// How long a player must wait before sending a trade/party/friend.
     /// </summary>
     public int RequestTimeout { get; set; } = 300000;

--- a/Intersect.Server.Core/Entities/Player.cs
+++ b/Intersect.Server.Core/Entities/Player.cs
@@ -1209,6 +1209,21 @@ public partial class Player : Entity
         }
     }
 
+    public int GetStatValue(Stat stat)
+    {
+        return BaseStats[(int)stat] + StatPointAllocations[(int)stat];
+    }
+
+    private long CalculateVitalStatBonus(Vital vital)
+    {
+        return vital switch
+        {
+            Vital.Health => GetStatValue(Stat.Vitality) * Options.VitalityHealthmultiplier,
+            Vital.Mana => GetStatValue(Stat.Intelligence) * Options.IntelligenceManaMultiplier,
+            _ => 0,
+        };
+    }
+
     public override long GetMaxVital(int vital)
     {
         var classDescriptor = ClassDescriptor.Get(this.ClassId);
@@ -1246,6 +1261,8 @@ public partial class Player : Entity
         {
             classVital = Math.Max(classVital, 0);
         }
+
+        classVital += CalculateVitalStatBonus((Vital)vital);
 
         return classVital;
     }


### PR DESCRIPTION
## Summary
- add `VitalityHealthmultiplier` and `IntelligenceManaMultiplier` options
- expose new multipliers through `Options`
- compute bonus vitals from stats in `Player`

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: project files missing)*

------
https://chatgpt.com/codex/tasks/task_e_6886704b49c48324b1e1c3ec76f402c8