### PR TITLE
Fix attachment removal when multiple identical items exist

### DIFF
--- a/Intersect.Client.Core/Interface/Game/Mail/MailItem.cs
+++ b/Intersect.Client.Core/Interface/Game/Mail/MailItem.cs
@@ -211,7 +211,7 @@ public void FinalizeAttachment(Item item, int inventoryIndex)
 {
     SetItem(item);
 
-    SendMailBoxWindow.Instance.AddAttachment(item.ItemId, item.Quantity, item.ItemProperties);
+    SendMailBoxWindow.Instance.AddAttachment(this, item.ItemId, item.Quantity, item.ItemProperties);
 
     // Ajustar inventario
     var inventorySlot = Globals.Me.Inventory[inventoryIndex];


### PR DESCRIPTION
## Summary
- track attachments by their MailItem source
- remove the correct attachment when a slot is cleared

## Testing
- `dotnet test --no-build` *(fails: project references missing)*

------
https://chatgpt.com/codex/tasks/task_e_688677d87c088324bc118c5d3f9b82ec