### PR TITLE
Add equipment stat comparison

### DIFF
--- a/Intersect.Client.Core/Interface/Game/DescriptionWindows/Components/RowContainerComponent.cs
+++ b/Intersect.Client.Core/Interface/Game/DescriptionWindows/Components/RowContainerComponent.cs
@@ -42,6 +42,11 @@ public partial class RowContainerComponent : ComponentBase
     /// <returns>Returns a new instance of <see cref="KeyValueRowComponent"/> with the provided settings.</returns>
     public KeyValueRowComponent AddKeyValueRow(string key, string value)
     {
+        return AddKeyValueRow(key, value, CustomColors.ItemDesc.Muted, CustomColors.ItemDesc.Muted);
+    }
+
+    public KeyValueRowComponent AddKeyValueRow(string key, string value, Color keyColor, Color valueColor)
+    {
         var row = new KeyValueRowComponent(this, key, value);
 
         // Since we're pulling some trickery here, catch any errors doing this ourselves and log them.
@@ -55,6 +60,8 @@ public partial class RowContainerComponent : ComponentBase
         }
 
         row.SizeToChildren(true, false);
+        row.SetKeyTextColor(keyColor);
+        row.SetValueTextColor(valueColor);
         PositionComponent(row);
         return row;
     }

--- a/Intersect.Client.Core/Localization/Strings.cs
+++ b/Intersect.Client.Core/Localization/Strings.cs
@@ -1877,6 +1877,9 @@ If you are sure you want to hand over your guild enter '\c{{#ff8080}}{02}\c{{}}'
         public static LocalizedString AttackSpeed = @"Attack Speed:";
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString AttackSpeedComparison = @"Attack Speed: {00} ({01})";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public static LocalizedString BagSlots = @"Bag Slots:";
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]


### PR DESCRIPTION
## Summary
- allow specifying text colors for key-value rows
- compute stat, vitals and attack-speed differences for equipment
- display differences when showing item descriptions
- add localization string for attack speed comparison

## Testing
- `dotnet test --no-build` *(fails: project references missing)*

------
https://chatgpt.com/codex/tasks/task_e_68867fe579e48324b311da2521c9c937