### PR TITLE
Add equipment slot options

### DIFF
--- a/Framework/Intersect.Framework.Core/Config/EquipmentOptions.cs
+++ b/Framework/Intersect.Framework.Core/Config/EquipmentOptions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Runtime.Serialization;
+using System.Linq;
 
 namespace Intersect.Config;
 
@@ -8,14 +9,20 @@ public partial class EquipmentOptions
 
     public int ShieldSlot { get; set; } = 3;
 
-    public List<string> Slots { get; set; } =
+    public List<EquipmentSlotOptions> EquipmentSlots { get; set; } =
     [
-        "Helmet",
-        "Armor",
-        "Weapon",
-        "Shield",
-        "Boots",
+        new("Helmet"),
+        new("Armor"),
+        new("Weapon"),
+        new("Shield"),
+        new("Boots"),
+        new("Ring", 2),
+        new("Trophy", 5),
     ];
+
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonIgnore]
+    public List<string> Slots => [..EquipmentSlots.Select(es => es.Name)];
 
     public List<string> ToolTypes { get; set; } =
     [
@@ -30,26 +37,38 @@ public partial class EquipmentOptions
     [OnDeserializing]
     internal void OnDeserializingMethod(StreamingContext context)
     {
-        Slots.Clear();
+        EquipmentSlots.Clear();
         ToolTypes.Clear();
     }
 
     [OnDeserialized]
     internal void OnDeserializedMethod(StreamingContext context)
     {
+        if (EquipmentSlots.Count == 0 && Slots?.Count > 0)
+        {
+            foreach (var name in Slots)
+            {
+                EquipmentSlots.Add(new EquipmentSlotOptions(name));
+            }
+        }
+
         Validate();
     }
 
     public void Validate()
     {
-        Slots = [..Slots.Distinct()];
+        EquipmentSlots = [..EquipmentSlots.DistinctBy(es => es.Name)];
+        foreach (var slot in EquipmentSlots)
+        {
+            slot.Validate();
+        }
         ToolTypes = [..ToolTypes.Distinct()];
-        if (WeaponSlot < -1 || WeaponSlot > Slots.Count - 1)
+        if (WeaponSlot < -1 || WeaponSlot > EquipmentSlots.Count - 1)
         {
             throw new Exception("Config Error: (WeaponSlot) was out of bounds!");
         }
 
-        if (ShieldSlot < -1 || ShieldSlot > Slots.Count - 1)
+        if (ShieldSlot < -1 || ShieldSlot > EquipmentSlots.Count - 1)
         {
             throw new Exception("Config Error: (ShieldSlot) was out of bounds!");
         }

--- a/Framework/Intersect.Framework.Core/Config/EquipmentSlotOptions.cs
+++ b/Framework/Intersect.Framework.Core/Config/EquipmentSlotOptions.cs
@@ -1,0 +1,28 @@
+using System;
+
+namespace Intersect.Config;
+
+public partial class EquipmentSlotOptions
+{
+    public EquipmentSlotOptions()
+    {
+    }
+
+    public EquipmentSlotOptions(string name, int maxItems = 1)
+    {
+        Name = name;
+        MaxItems = maxItems;
+    }
+
+    public string Name { get; set; } = string.Empty;
+
+    public int MaxItems { get; set; } = 1;
+
+    public void Validate()
+    {
+        if (MaxItems < 1)
+        {
+            throw new Exception($"Config Error: Equipment slot '{Name}' must allow at least one item.");
+        }
+    }
+}

--- a/Framework/Intersect.Framework.Core/Config/PaperdollOptions.cs
+++ b/Framework/Intersect.Framework.Core/Config/PaperdollOptions.cs
@@ -18,6 +18,8 @@ public partial class PaperdollOptions
         "Weapon",
         "Shield",
         "Boots",
+        "Ring",
+        "Trophy",
     ];
 
     public List<string> Left { get; set; } =
@@ -28,6 +30,8 @@ public partial class PaperdollOptions
         "Weapon",
         "Shield",
         "Boots",
+        "Ring",
+        "Trophy",
     ];
 
     public List<string> Right { get; set; } =
@@ -38,6 +42,8 @@ public partial class PaperdollOptions
         "Weapon",
         "Shield",
         "Boots",
+        "Ring",
+        "Trophy",
     ];
 
     public List<string> Up { get; set; } =
@@ -48,6 +54,8 @@ public partial class PaperdollOptions
         "Weapon",
         "Shield",
         "Boots",
+        "Ring",
+        "Trophy",
     ];
 
     public PaperdollOptions()

--- a/Framework/Intersect.Framework.Core/Network/Packets/Server/EquipmentPacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Server/EquipmentPacket.cs
@@ -11,7 +11,7 @@ public partial class EquipmentPacket : IntersectPacket
     }
 
     //We send item ids for the equipment of others, but we send the correlating inventory slots for wearers because we want the equipped icons to show in the inventory.
-    public EquipmentPacket(Guid entityId, int[] invSlots, Guid[] itemIds)
+    public EquipmentPacket(Guid entityId, Dictionary<int, List<int>>? invSlots, Dictionary<int, List<Guid>>? itemIds)
     {
         EntityId = entityId;
         InventorySlots = invSlots;
@@ -22,9 +22,9 @@ public partial class EquipmentPacket : IntersectPacket
     public Guid EntityId { get; set; }
 
     [Key(1)]
-    public int[] InventorySlots { get; set; }
+    public Dictionary<int, List<int>>? InventorySlots { get; set; }
 
     [Key(2)]
-    public Guid[] ItemIds { get; set; }
+    public Dictionary<int, List<Guid>>? ItemIds { get; set; }
 
 }

--- a/Intersect.Client.Core/Entities/Player.cs
+++ b/Intersect.Client.Core/Entities/Player.cs
@@ -627,9 +627,9 @@ public partial class Player : Entity, IPlayer
 
     public bool IsEquipped(int slot)
     {
-        for (var i = 0; i < Options.Instance.Equipment.Slots.Count; i++)
+        foreach (var list in MyEquipment.Values)
         {
-            if (MyEquipment[i] == slot)
+            if (list.Contains(slot))
             {
                 return true;
             }
@@ -1988,7 +1988,7 @@ public partial class Player : Entity, IPlayer
     public bool TryBlock()
     {
         var shieldIndex = Options.Instance.Equipment.ShieldSlot;
-        var myShieldIndex = MyEquipment[shieldIndex];
+        var myShieldIndex = MyEquipment.GetValueOrDefault(shieldIndex).FirstOrDefault(-1);
 
         // Return false if character is attacking, or blocking or if they don't have a shield equipped.
         if (IsAttacking || IsBlocking || shieldIndex < 0 || myShieldIndex < 0)
@@ -2435,19 +2435,25 @@ public partial class Player : Entity, IPlayer
         if (this == Globals.Me)
         {
             if (Options.Instance.Equipment.WeaponSlot > -1 &&
-                Options.Instance.Equipment.WeaponSlot < Equipment.Length &&
-                MyEquipment[Options.Instance.Equipment.WeaponSlot] >= 0)
+                Options.Instance.Equipment.WeaponSlot < Equipment.Count)
             {
-                weapon = ItemDescriptor.Get(Inventory[MyEquipment[Options.Instance.Equipment.WeaponSlot]].ItemId);
+                var invList = MyEquipment.GetValueOrDefault(Options.Instance.Equipment.WeaponSlot);
+                if (invList.Count > 0)
+                {
+                    weapon = ItemDescriptor.Get(Inventory[invList[0]].ItemId);
+                }
             }
         }
         else
         {
             if (Options.Instance.Equipment.WeaponSlot > -1 &&
-                Options.Instance.Equipment.WeaponSlot < Equipment.Length &&
-                Equipment[Options.Instance.Equipment.WeaponSlot] != Guid.Empty)
+                Options.Instance.Equipment.WeaponSlot < Equipment.Count)
             {
-                weapon = ItemDescriptor.Get(Equipment[Options.Instance.Equipment.WeaponSlot]);
+                var equipList = Equipment.GetValueOrDefault(Options.Instance.Equipment.WeaponSlot);
+                if (equipList.Count > 0)
+                {
+                    weapon = ItemDescriptor.Get(equipList[0]);
+                }
             }
         }
 

--- a/Intersect.Client.Core/Interface/Game/Character/CharacterWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Character/CharacterWindow.cs
@@ -387,25 +387,31 @@ public partial class CharacterWindow
 
         for (var i = 0; i < Options.Instance.Equipment.Slots.Count; i++)
         {
-            var invSlot = player.MyEquipment[i];
-            if (invSlot < 0 || invSlot >= Options.Instance.Player.MaxInventory)
+            var slots = player.MyEquipment.GetValueOrDefault(i);
+            var itemIds = new List<Guid>();
+            var props = new List<ItemProperties>();
+            foreach (var slot in slots)
             {
-                Items[i].Update(Guid.Empty, mItemProperties);
-                continue;
+                if (slot < 0 || slot >= Options.Instance.Player.MaxInventory)
+                {
+                    continue;
+                }
+
+                var item = player.Inventory[slot];
+                if (item.ItemId == Guid.Empty)
+                {
+                    continue;
+                }
+
+                itemIds.Add(item.ItemId);
+                props.Add(item.ItemProperties);
+                if (updateExtraBuffs)
+                {
+                    UpdateExtraBuffs(item.ItemId);
+                }
             }
 
-            var item = player.Inventory[invSlot];
-            if (item.ItemId == Guid.Empty)
-            {
-                Items[i].Update(Guid.Empty, mItemProperties);
-                continue;
-            }
-
-            Items[i].Update(item.ItemId, item.ItemProperties);
-            if (updateExtraBuffs)
-            {
-                UpdateExtraBuffs(item.ItemId);
-            }
+            Items[i].Update(itemIds, props);
         }
     }
 


### PR DESCRIPTION
## Summary
- introduce `EquipmentSlotOptions` defining name and item count per equipment slot
- update `EquipmentOptions` to use these slot definitions and expose a list of slot names
- expand defaults with a multi-item `Ring` slot and a five-item `Trophy` slot
- validate each slot's `MaxItems`
- update `PaperdollOptions` with the new slots
- handle multiple equipped items in player entities, character window and equipment packet

## Testing
- `dotnet test --no-build` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_688680d4afcc8324ad3f59b217c15fd6