### PR TITLE
Fix item dropping and description window refresh

### DIFF
--- a/Intersect.Client.Core/Entities/Player.cs
+++ b/Intersect.Client.Core/Entities/Player.cs
@@ -511,7 +511,19 @@ public partial class Player : Entity, IPlayer
                 // Check if the item can be dropped in multiple quantities or if value is less than or equal to the quantity in the initial slot
                 if (!canDropMultiple || promptQuantity <= quantity)
                 {
-                    PacketSender.SendDropItem(slotIndex, !canDropMultiple ? 1 : promptQuantity);
+                    var dropAmount = !canDropMultiple ? 1 : promptQuantity;
+                    PacketSender.SendDropItem(slotIndex, dropAmount);
+
+                    var remaining = quantity - dropAmount;
+                    if (remaining > 0)
+                    {
+                        UpdateInventory(slotIndex, inventorySlot.ItemId, remaining, inventorySlot.BagId, inventorySlot.ItemProperties);
+                    }
+                    else
+                    {
+                        UpdateInventory(slotIndex, Guid.Empty, 0, null, null);
+                    }
+
                     return;
                 }
 
@@ -520,6 +532,7 @@ public partial class Player : Entity, IPlayer
 
                 // Send the drop item packet for the initial slot.
                 PacketSender.SendDropItem(slotIndex, quantity);
+                UpdateInventory(slotIndex, Guid.Empty, 0, null, null);
                 promptQuantity -= quantity;
                 _ = itemSlots.Remove(inventorySlot); // Remove the initial slot from the list of item slots
 
@@ -533,7 +546,19 @@ public partial class Player : Entity, IPlayer
                         break;
                     }
 
-                    PacketSender.SendDropItem(Inventory.IndexOf(slot), dropAmount);
+                    var slotIdx = Inventory.IndexOf(slot);
+                    PacketSender.SendDropItem(slotIdx, dropAmount);
+
+                    var remaining = slot.Quantity - dropAmount;
+                    if (remaining > 0)
+                    {
+                        UpdateInventory(slotIdx, slot.ItemId, remaining, slot.BagId, slot.ItemProperties);
+                    }
+                    else
+                    {
+                        UpdateInventory(slotIdx, Guid.Empty, 0, null, null);
+                    }
+
                     promptQuantity -= dropAmount;
                 }
             }

--- a/Intersect.Client.Core/Interface/Game/DescriptionWindows/DescriptionWindowBase.cs
+++ b/Intersect.Client.Core/Interface/Game/DescriptionWindows/DescriptionWindowBase.cs
@@ -14,6 +14,16 @@ public partial class DescriptionWindowBase : ComponentBase
     // Our internal list of components.
     private readonly List<ComponentBase> _components = [];
 
+    /// <summary>
+    /// Clears all child components and resets internal state so the window can be rebuilt.
+    /// </summary>
+    protected void ClearComponents()
+    {
+        ClearChildren(true);
+        _components.Clear();
+        _componentY = 0;
+    }
+
     public DescriptionWindowBase(Base parent, string name) : base(parent, name)
     {
         LoadJsonUi(Framework.File_Management.GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());

--- a/Intersect.Client.Core/Interface/Game/DescriptionWindows/ItemDescriptionWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/DescriptionWindows/ItemDescriptionWindow.cs
@@ -104,6 +104,8 @@ public partial class ItemDescriptionWindow() : DescriptionWindowBase(Interface.G
 
     protected void SetupDescriptionWindow()
     {
+        ClearComponents();
+
         if (_itemDescriptor == default)
         {
             return;

--- a/Intersect.Client.Core/Interface/Game/DescriptionWindows/SpellDescriptionWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/DescriptionWindows/SpellDescriptionWindow.cs
@@ -39,6 +39,8 @@ public partial class SpellDescriptionWindow() : DescriptionWindowBase(Interface.
 
     protected void SetupDescriptionWindow()
     {
+        ClearComponents();
+
         if (_spellDescriptor == default)
         {
             return;


### PR DESCRIPTION
## Summary
- Clear and rebuild item/spell description windows to fix equipment comparison issues
- Update local inventory immediately after dropping items

## Testing
- `dotnet build Intersect.Client.Core/Intersect.Client.Core.csproj` *(fails: NetLogLevel, NetPeer not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d4ec1e2d0832482e46875f3d0bb3e