### PR TITLE
feat: link items in chat

### DIFF
--- a/Framework/Intersect.Framework.Core/Network/Packets/ChatItem.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/ChatItem.cs
@@ -1,0 +1,25 @@
+using System;
+using Intersect.Framework.Core.GameObjects.Items;
+using MessagePack;
+
+namespace Intersect.Network.Packets;
+
+[MessagePackObject]
+public partial class ChatItem
+{
+    public ChatItem()
+    {
+    }
+
+    public ChatItem(Guid itemId, ItemProperties properties)
+    {
+        ItemId = itemId;
+        Properties = properties;
+    }
+
+    [Key(0)]
+    public Guid ItemId { get; set; }
+
+    [Key(1)]
+    public ItemProperties Properties { get; set; } = new ItemProperties();
+}

--- a/Framework/Intersect.Framework.Core/Network/Packets/Client/ChatMsgPacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Client/ChatMsgPacket.cs
@@ -1,4 +1,6 @@
-﻿using MessagePack;
+using System.Collections.Generic;
+using Intersect.Network.Packets;
+using MessagePack;
 
 namespace Intersect.Network.Packets.Client;
 
@@ -10,10 +12,11 @@ public partial class ChatMsgPacket : IntersectPacket
     {
     }
 
-    public ChatMsgPacket(string msg, byte channel)
+    public ChatMsgPacket(string msg, byte channel, List<ChatItem>? items = null)
     {
         Message = msg;
         Channel = channel;
+        Items = items ?? new List<ChatItem>();
     }
 
     [Key(0)]
@@ -22,4 +25,6 @@ public partial class ChatMsgPacket : IntersectPacket
     [Key(1)]
     public byte Channel { get; set; }
 
+    [Key(2)]
+    public List<ChatItem> Items { get; set; } = new List<ChatItem>();
 }

--- a/Framework/Intersect.Framework.Core/Network/Packets/Server/ChatMsgPacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Server/ChatMsgPacket.cs
@@ -1,4 +1,6 @@
-﻿using Intersect.Enums;
+using System.Collections.Generic;
+using Intersect.Enums;
+using Intersect.Network.Packets;
 using MessagePack;
 
 namespace Intersect.Network.Packets.Server;
@@ -6,13 +8,13 @@ namespace Intersect.Network.Packets.Server;
 [MessagePackObject]
 public partial class ChatMsgPacket : IntersectPacket
 {
-
-    public ChatMsgPacket(string message, ChatMessageType type, Color color, string target)
+    public ChatMsgPacket(string message, ChatMessageType type, Color color, string target, List<ChatItem>? items = null)
     {
         Message = message;
         Type = type;
         Color = color;
         Target = target;
+        Items = items ?? new List<ChatItem>();
     }
 
     [Key(0)]
@@ -27,4 +29,6 @@ public partial class ChatMsgPacket : IntersectPacket
     [Key(3)]
     public string Target { get; set; }
 
+    [Key(4)]
+    public List<ChatItem> Items { get; set; } = new List<ChatItem>();
 }

--- a/Intersect.Client.Core/Interface/Game/Bank/BankItem.cs
+++ b/Intersect.Client.Core/Interface/Game/Bank/BankItem.cs
@@ -26,6 +26,7 @@ public partial class BankItem : SlotItem
 
     // Context Menu Handling
     private MenuItem _withdrawContextItem;
+    private MenuItem _showItemContextItem;
 
     public BankItem(BankWindow bankWindow, Base parent, int index, ContextMenu contextMenu) :
         base(parent, nameof(BankItem), index, contextMenu)
@@ -52,6 +53,8 @@ public partial class BankItem : SlotItem
         contextMenu.ClearChildren();
         _withdrawContextItem = contextMenu.AddItem(Strings.BankContextMenu.Withdraw);
         _withdrawContextItem.Clicked += _withdrawMenuItem_Clicked;
+        _showItemContextItem = contextMenu.AddItem(Strings.ItemContextMenu.Show);
+        _showItemContextItem.Clicked += _showItemContextItem_Clicked;
         contextMenu.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
     }
 
@@ -73,6 +76,8 @@ public partial class BankItem : SlotItem
         contextMenu.ClearChildren();
         contextMenu.AddChild(_withdrawContextItem);
         _withdrawContextItem.SetText(Strings.BankContextMenu.Withdraw.ToString(item.Name));
+        contextMenu.AddChild(_showItemContextItem);
+        _showItemContextItem.SetText(Strings.ItemContextMenu.Show.ToString(item.Name));
 
         base.OnContextMenuOpening(contextMenu);
     }
@@ -80,6 +85,22 @@ public partial class BankItem : SlotItem
     private void _withdrawMenuItem_Clicked(Base sender, MouseButtonState arguments)
     {
         Globals.Me?.TryRetrieveItemFromBank(SlotIndex);
+    }
+
+    private void _showItemContextItem_Clicked(Base sender, MouseButtonState arguments)
+    {
+        if (Globals.BankSlots is not { Length: > 0 } bankSlots)
+        {
+            return;
+        }
+
+        var slot = bankSlots[SlotIndex];
+        if (!ItemDescriptor.TryGet(slot.ItemId, out var item))
+        {
+            return;
+        }
+
+        Interface.GameUi.AppendChatboxItem(item, slot.ItemProperties ?? new ItemProperties());
     }
 
     #endregion

--- a/Intersect.Client.Core/Interface/Game/Chat/Chatbox.cs
+++ b/Intersect.Client.Core/Interface/Game/Chat/Chatbox.cs
@@ -1,3 +1,7 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
 using Intersect.Client.Core;
 using Intersect.Client.Core.Controls;
 using Intersect.Client.Framework.File_Management;
@@ -15,9 +19,11 @@ using Intersect.Configuration;
 using Intersect.Core;
 using Intersect.Enums;
 using Intersect.Framework.Core;
+using Intersect.Framework.Core.GameObjects.Items;
 using Intersect.Localization;
 using Intersect.Utilities;
 using Microsoft.Extensions.Logging;
+using Intersect.Network.Packets;
 
 namespace Intersect.Client.Interface.Game.Chat;
 
@@ -64,6 +70,10 @@ public partial class Chatbox
     private int mMessageIndex;
 
     private bool mReceivedMessage;
+
+    private List<(string Name, ChatItem Item)> _pendingItemLinks = new List<(string Name, ChatItem Item)>();
+
+    private static readonly Dictionary<string, ChatItem> sLinkedItems = new Dictionary<string, ChatItem>();
 
     /// <summary>
     /// Defines which chat tab we are currently looking at.
@@ -379,6 +389,7 @@ public partial class Chatbox
         for (var i = mMessageIndex; i < messages.Count; i++)
         {
             var msg = messages[i];
+            RegisterItemLinks(msg.Items);
             string[] lines = [msg.Message];/*Text.WrapText(
                 msg.Message,
                 mChatboxMessages.Width - vScrollBar.Width - 8,
@@ -447,6 +458,45 @@ public partial class Chatbox
         Update();
     }
 
+    public string ChatboxText => mChatboxInput.Text;
+
+    public void AppendText(string text)
+    {
+        var current = mChatboxInput.Text;
+        if (string.Equals(current, GetDefaultInputText(), StringComparison.Ordinal))
+        {
+            current = string.Empty;
+        }
+
+        SetChatboxText(current + text);
+    }
+
+    public void AppendItem(ItemDescriptor descriptor, ItemProperties properties)
+    {
+        AppendText($"[{descriptor.Name}]");
+        var item = new ChatItem(descriptor.Id, new ItemProperties(properties));
+        _pendingItemLinks.Add((descriptor.Name, item));
+        sLinkedItems[descriptor.Name] = item;
+    }
+
+    public void RegisterItemLinks(IEnumerable<ChatItem>? items)
+    {
+        if (items == null)
+        {
+            return;
+        }
+
+        foreach (var item in items)
+        {
+            if (!ItemDescriptor.TryGet(item.ItemId, out var descriptor))
+            {
+                continue;
+            }
+
+            sLinkedItems[descriptor.Name] = item;
+        }
+    }
+
     public void SetChatboxText(string msg)
     {
         mChatboxInput.Text = msg;
@@ -458,6 +508,11 @@ public partial class Chatbox
     private void ChatboxRow_Clicked(Base sender, MouseButtonState arguments)
     {
         if (sender is not ListBoxRow row)
+        {
+            return;
+        }
+
+        if (arguments.MouseButton == MouseButton.Left && TryShowItemFromRow(row))
         {
             return;
         }
@@ -488,13 +543,44 @@ public partial class Chatbox
                 break;
         }
 
-        if (!string.IsNullOrWhiteSpace(target))
+        if (!string.IsNullOrWhiteSpace(target) && mGameUi.IsAdminWindowOpen)
         {
-            if (mGameUi.IsAdminWindowOpen)
+            mGameUi.AdminWindowSelectName(target);
+        }
+    }
+
+    private static bool TryShowItemFromRow(ListBoxRow row)
+    {
+        var matches = Regex.Matches(row.Text ?? string.Empty, "\\[(.+?)\\]");
+        foreach (Match match in matches)
+        {
+            var itemName = match.Groups[1].Value;
+            if (sLinkedItems.TryGetValue(itemName, out var linkedItem))
             {
-                mGameUi.AdminWindowSelectName(target);
+                if (ItemDescriptor.TryGet(linkedItem.ItemId, out var linkedDescriptor))
+                {
+                    Interface.GameUi.ItemDescriptionWindow?.Show(
+                        linkedDescriptor,
+                        1,
+                        linkedItem.Properties
+                    );
+                    return true;
+                }
+            }
+
+            var descriptor = ItemDescriptor.Lookup.Values
+                .OfType<ItemDescriptor>()
+                .FirstOrDefault(
+                    d => string.Equals(d.Name, itemName, StringComparison.OrdinalIgnoreCase)
+                );
+            if (descriptor != null)
+            {
+                Interface.GameUi.ItemDescriptionWindow?.Show(descriptor, 1);
+                return true;
             }
         }
+
+        return false;
     }
 
     //Extra Methods
@@ -614,10 +700,12 @@ public partial class Chatbox
 
         mLastChatTime = Timing.Global.MillisecondsUtc + Options.Instance.Chat.MinIntervalBetweenChats;
 
+        var itemsToSend = _pendingItemLinks.Select(l => l.Item).ToList();
         PacketSender.SendChatMsg(
-            msg, byte.Parse(mChannelCombobox.SelectedItem.UserData.ToString())
+            msg, byte.Parse(mChannelCombobox.SelectedItem.UserData.ToString()), itemsToSend
         );
 
+        _pendingItemLinks.Clear();
         mChatboxInput.Text = GetDefaultInputText();
     }
 

--- a/Intersect.Client.Core/Interface/Game/Chat/ChatboxMsg.cs
+++ b/Intersect.Client.Core/Interface/Game/Chat/ChatboxMsg.cs
@@ -1,7 +1,8 @@
-﻿using Intersect.Enums;
+using System.Collections.Generic;
+using Intersect.Enums;
+using Intersect.Network.Packets;
 
 namespace Intersect.Client.Interface.Game.Chat;
-
 
 public partial class ChatboxMsg
 {
@@ -33,6 +34,8 @@ public partial class ChatboxMsg
 
     private ChatMessageType mType;
 
+    private List<ChatItem> _items = new List<ChatItem>();
+
     /// <summary>
     /// Creates a new instance of the <see cref="ChatboxMsg"/> class.
     /// </summary>
@@ -40,12 +43,16 @@ public partial class ChatboxMsg
     /// <param name="clr">The color of the message.</param>
     /// <param name="type">The type of the message.</param>
     /// <param name="target">The target of the message.</param>
-    public ChatboxMsg(string msg, Color clr, ChatMessageType type, string target = "")
+    public ChatboxMsg(string msg, Color clr, ChatMessageType type, string target = "", IList<ChatItem>? items = null)
     {
         mMsg = msg;
         mMsgColor = clr;
         mTarget = target;
         mType = type;
+        if (items != null)
+        {
+            _items.AddRange(items);
+        }
     }
 
     /// <summary>
@@ -65,6 +72,8 @@ public partial class ChatboxMsg
     /// The type of this message.
     /// </summary>
     public ChatMessageType Type => mType;
+
+    public IReadOnlyList<ChatItem> Items => _items;
 
     /// <summary>
     /// Adds a new chat message to the stored list.

--- a/Intersect.Client.Core/Interface/Game/GameInterface.cs
+++ b/Intersect.Client.Core/Interface/Game/GameInterface.cs
@@ -22,6 +22,7 @@ using Intersect.Core;
 using Intersect.Enums;
 using Intersect.GameObjects;
 using Microsoft.Extensions.Logging;
+using Intersect.Framework.Core.GameObjects.Items;
 
 namespace Intersect.Client.Interface.Game;
 
@@ -208,6 +209,18 @@ public partial class GameInterface : MutableInterface
     {
         mChatBox.SetChatboxText(msg);
     }
+
+    public void AppendChatboxText(string text)
+    {
+        mChatBox.AppendText(text);
+    }
+
+    public void AppendChatboxItem(ItemDescriptor descriptor, ItemProperties properties)
+    {
+        mChatBox.AppendItem(descriptor, properties);
+    }
+
+    public string ChatboxText => mChatBox.ChatboxText;
 
     //Friends Window
     public void NotifyUpdateFriendsList()

--- a/Intersect.Client.Core/Interface/Game/Inventory/InventoryItem.cs
+++ b/Intersect.Client.Core/Interface/Game/Inventory/InventoryItem.cs
@@ -36,6 +36,7 @@ public partial class InventoryItem : SlotItem
     private readonly MenuItem _useItemMenuItem;
     private readonly MenuItem _actionItemMenuItem;
     private readonly MenuItem _dropItemMenuItem;
+    private readonly MenuItem _showItemMenuItem;
 
     public InventoryItem(InventoryWindow inventoryWindow, Base parent, int index, ContextMenu contextMenu)
         : base(parent, nameof(InventoryItem), index, contextMenu)
@@ -93,6 +94,8 @@ public partial class InventoryItem : SlotItem
         _dropItemMenuItem.Clicked += _dropItemContextItem_Clicked;
         _actionItemMenuItem = contextMenu.AddItem(Strings.ItemContextMenu.Bank);
         _actionItemMenuItem.Clicked += _actionItemContextItem_Clicked;
+        _showItemMenuItem = contextMenu.AddItem(Strings.ItemContextMenu.Show);
+        _showItemMenuItem.Clicked += _showItemContextItem_Clicked;
         contextMenu.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
 
         if (Globals.Me is { } player)
@@ -183,6 +186,9 @@ public partial class InventoryItem : SlotItem
             _dropItemMenuItem.SetText(Strings.ItemContextMenu.Drop.ToString(descriptor.Name));
         }
 
+        contextMenu.AddChild(_showItemMenuItem);
+        _showItemMenuItem.SetText(Strings.ItemContextMenu.Show.ToString(descriptor.Name));
+
         base.OnContextMenuOpening(contextMenu);
     }
 
@@ -209,6 +215,21 @@ public partial class InventoryItem : SlotItem
         {
             Globals.Me?.TryOfferItemToTrade(SlotIndex);
         }
+    }
+
+    private void _showItemContextItem_Clicked(Base sender, MouseButtonState arguments)
+    {
+        if (Globals.Me?.Inventory[SlotIndex] is not { } slot)
+        {
+            return;
+        }
+
+        if (!ItemDescriptor.TryGet(slot.ItemId, out var descriptor))
+        {
+            return;
+        }
+
+        Interface.GameUi.AppendChatboxItem(descriptor, slot.ItemProperties ?? new ItemProperties());
     }
 
     private void _dropItemContextItem_Clicked(Base sender, MouseButtonState arguments)

--- a/Intersect.Client.Core/Interface/Game/Shop/ShopItem.cs
+++ b/Intersect.Client.Core/Interface/Game/Shop/ShopItem.cs
@@ -18,6 +18,7 @@ public partial class ShopItem : SlotItem
     private readonly int _mySlot;
     private readonly ShopWindow _shopWindow;
     private readonly MenuItem _buyMenuItem;
+    private readonly MenuItem _showItemMenuItem;
 
     public ShopItem(ShopWindow shopWindow, Base parent, int index, ContextMenu contextMenu)
         : base(parent, nameof(ShopItem), index, contextMenu)
@@ -36,6 +37,8 @@ public partial class ShopItem : SlotItem
         contextMenu.ClearChildren();
         _buyMenuItem = contextMenu.AddItem(Strings.ShopContextMenu.Buy);
         _buyMenuItem.Clicked += _buyMenuItem_Clicked;
+        _showItemMenuItem = contextMenu.AddItem(Strings.ItemContextMenu.Show);
+        _showItemMenuItem.Clicked += _showItemMenuItem_Clicked;
         contextMenu.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
 
         LoadItem();
@@ -111,6 +114,26 @@ public partial class ShopItem : SlotItem
         Globals.Me?.TryBuyItem(_mySlot);
     }
 
+    private void _showItemMenuItem_Clicked(Base sender, Framework.Gwen.Control.EventArguments.MouseButtonState arguments)
+    {
+        if (Globals.GameShop is not { SellingItems.Count: > 0 } gameShop)
+        {
+            return;
+        }
+
+        if (!ItemDescriptor.TryGet(gameShop.SellingItems[_mySlot].ItemId, out var item))
+        {
+            return;
+        }
+
+        var itemProperties = new ItemProperties
+        {
+            StatModifiers = item.StatsGiven,
+        };
+
+        Interface.GameUi.AppendChatboxItem(item, itemProperties);
+    }
+
     protected override void OnContextMenuOpening(ContextMenu contextMenu)
     {
         if (Globals.GameShop is not { SellingItems.Count: > 0 } gameShop)
@@ -126,6 +149,8 @@ public partial class ShopItem : SlotItem
         contextMenu.ClearChildren();
         contextMenu.AddChild(_buyMenuItem);
         _buyMenuItem.SetText(Strings.ShopContextMenu.Buy.ToString(item.Name));
+        contextMenu.AddChild(_showItemMenuItem);
+        _showItemMenuItem.SetText(Strings.ItemContextMenu.Show.ToString(item.Name));
         base.OnContextMenuOpening(contextMenu);
     }
 

--- a/Intersect.Client.Core/Localization/Strings.cs
+++ b/Intersect.Client.Core/Localization/Strings.cs
@@ -1809,6 +1809,9 @@ If you are sure you want to hand over your guild enter '\c{{#ff8080}}{02}\c{{}}'
         public static LocalizedString Sell = @"Sell {00}";
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Show = @"Show {00}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public static LocalizedString Trade = @"Offer {00}";
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]

--- a/Intersect.Client.Core/Networking/PacketHandler.cs
+++ b/Intersect.Client.Core/Networking/PacketHandler.cs
@@ -613,7 +613,7 @@ internal sealed partial class PacketHandler
         ChatboxMsg.AddMessage(
             new ChatboxMsg(
                 packet.Message ?? "", new Color(packet.Color.A, packet.Color.R, packet.Color.G, packet.Color.B), packet.Type,
-                packet.Target
+                packet.Target, packet.Items
             )
         );
     }

--- a/Intersect.Client.Core/Networking/PacketSender.cs
+++ b/Intersect.Client.Core/Networking/PacketSender.cs
@@ -10,6 +10,8 @@ using Intersect.Framework;
 using Intersect.Framework.Core.GameObjects.Maps;
 using Intersect.Models;
 using Intersect.Network.Packets.Client;
+using System.Collections.Generic;
+using Intersect.Network.Packets;
 using AdminAction = Intersect.Admin.Actions.AdminAction;
 
 namespace Intersect.Client.Networking;
@@ -109,9 +111,9 @@ public static partial class PacketSender
         Network.SendPacket(new MovePacket(Globals.Me.MapId, Globals.Me.X, Globals.Me.Y, Globals.Me.DirectionFacing));
     }
 
-    public static void SendChatMsg(string msg, byte channel)
+    public static void SendChatMsg(string msg, byte channel, List<ChatItem>? items = null)
     {
-        Network.SendPacket(new ChatMsgPacket(msg, channel));
+        Network.SendPacket(new ChatMsgPacket(msg, channel, items));
     }
 
     public static void SendAttack(Guid targetId)

--- a/Intersect.Server.Core/Networking/PacketHandler.cs
+++ b/Intersect.Server.Core/Networking/PacketHandler.cs
@@ -951,7 +951,7 @@ internal sealed partial class PacketHandler
 
             PacketSender.SendProximityMsgToLayer(
                 Strings.Chat.Local.ToString(player.Name, msg), ChatMessageType.Local, player.MapId, player.MapInstanceId, chatColor,
-                player.Name
+                player.Name, packet.Items
             );
             PacketSender.SendChatBubble(player.Id, player.MapInstanceId, (int)EntityType.GlobalEntity, msg, player.MapId);
             ChatHistory.LogMessage(player, msg.Trim(), ChatMessageType.Local, Guid.Empty);
@@ -973,7 +973,7 @@ internal sealed partial class PacketHandler
                 chatColor = CustomColors.Chat.ModGlobalChat;
             }
 
-            PacketSender.SendGlobalMsg(Strings.Chat.Global.ToString(player.Name, msg), chatColor, player.Name);
+            PacketSender.SendGlobalMsg(Strings.Chat.Global.ToString(player.Name, msg), chatColor, player.Name, items: packet.Items);
             ChatHistory.LogMessage(player, msg.Trim(), ChatMessageType.Global, Guid.Empty);
         }
         else if (cmd == Strings.Chat.PartyCommand)
@@ -986,7 +986,7 @@ internal sealed partial class PacketHandler
             if (player.InParty(player))
             {
                 PacketSender.SendPartyMsg(
-                    player, Strings.Chat.Party.ToString(player.Name, msg), CustomColors.Chat.PartyChat, player.Name
+                    player, Strings.Chat.Party.ToString(player.Name, msg), CustomColors.Chat.PartyChat, player.Name, packet.Items
                 );
                 ChatHistory.LogMessage(player, msg.Trim(), ChatMessageType.Party, Guid.Empty);
             }
@@ -1005,7 +1005,7 @@ internal sealed partial class PacketHandler
             if (client?.Power.IsModerator ?? false)
             {
                 PacketSender.SendAdminMsg(
-                    Strings.Chat.Admin.ToString(player.Name, msg), CustomColors.Chat.AdminChat, player.Name
+                    Strings.Chat.Admin.ToString(player.Name, msg), CustomColors.Chat.AdminChat, player.Name, packet.Items
                 );
                 ChatHistory.LogMessage(player, msg.Trim(), ChatMessageType.Admin, Guid.Empty);
             }
@@ -1025,7 +1025,7 @@ internal sealed partial class PacketHandler
 
             //Normalize Rank
             var rank = Options.Instance.Guild.Ranks[Math.Max(0, Math.Min(player.GuildRank, Options.Instance.Guild.Ranks.Length - 1))].Title;
-            PacketSender.SendGuildMsg(player, Strings.Guilds.GuildChat.ToString(rank, player.Name, msg), CustomColors.Chat.GuildChat);
+            PacketSender.SendGuildMsg(player, Strings.Guilds.GuildChat.ToString(rank, player.Name, msg), CustomColors.Chat.GuildChat, items: packet.Items);
             ChatHistory.LogMessage(player, msg.Trim(), ChatMessageType.Guild, player.Guild.Id);
 
         }
@@ -1078,12 +1078,12 @@ internal sealed partial class PacketHandler
             {
                 PacketSender.SendChatMsg(
                     player, Strings.Chat.PrivateTo.ToString(target.Name, msg), ChatMessageType.PM, CustomColors.Chat.PrivateChatTo,
-                    player.Name
+                    player.Name, packet.Items
                 );
 
                 PacketSender.SendChatMsg(
                     target, Strings.Chat.PrivateFrom.ToString(player.Name, msg), ChatMessageType.PM,
-                    CustomColors.Chat.PrivateChatFrom, player.Name
+                    CustomColors.Chat.PrivateChatFrom, player.Name, packet.Items
                 );
 
                 target.ChatTarget = player;
@@ -1106,12 +1106,12 @@ internal sealed partial class PacketHandler
             {
                 PacketSender.SendChatMsg(
                     player, Strings.Chat.PrivateTo.ToString(player.ChatTarget.Name, msg), ChatMessageType.PM, CustomColors.Chat.PrivateChatTo,
-                    player.Name
+                    player.Name, packet.Items
                 );
 
                 PacketSender.SendChatMsg(
                     player.ChatTarget, Strings.Chat.PrivateFrom.ToString(player.Name, msg), ChatMessageType.PM,
-                    CustomColors.Chat.PrivateChatFrom, player.Name
+                    CustomColors.Chat.PrivateChatFrom, player.Name, packet.Items
                 );
 
                 player.ChatTarget.ChatTarget = player;

--- a/Intersect.Server.Core/Networking/PacketSender.cs
+++ b/Intersect.Server.Core/Networking/PacketSender.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using Intersect.Core;
 using Intersect.Enums;
 using Intersect.Framework.Core;
@@ -18,6 +19,7 @@ using Intersect.GameObjects;
 using Intersect.Models;
 using Intersect.Network;
 using Intersect.Network.Packets.Server;
+using Intersect.Network.Packets;
 using Intersect.Server.Database;
 using Intersect.Server.Database.Logging.Entities;
 using Intersect.Server.Database.PlayerData.Players;
@@ -692,9 +694,9 @@ public static partial class PacketSender
     /// <param name="message">The message to send.</param>
     /// <param name="type">The type of message we are sending.</param>
     /// <param name="target">The sender of this message, should we decide to respond from the client.</param>
-    public static void SendChatMsg(Player player, string message, ChatMessageType type, string target = "")
+    public static void SendChatMsg(Player player, string message, ChatMessageType type, string target = "", List<ChatItem>? items = null)
     {
-        SendChatMsg(player, message, type, CustomColors.Chat.PlayerMsg, target);
+        SendChatMsg(player, message, type, CustomColors.Chat.PlayerMsg, target, items);
     }
 
     /// <summary>
@@ -705,14 +707,14 @@ public static partial class PacketSender
     /// <param name="type">The type of message we are sending.</param>
     /// <param name="color">The color assigned to this message.</param>
     /// <param name="target">The sender of this message, should we decide to respond from the client.</param>
-    public static void SendChatMsg(Player player, string message, ChatMessageType type, Color color, string target = "")
+    public static void SendChatMsg(Player player, string message, ChatMessageType type, Color color, string target = "", List<ChatItem>? items = null)
     {
         if (player == null)
         {
             return;
         }
 
-        player.SendPacket(new ChatMsgPacket(message, type, color, target), TransmissionMode.All);
+        player.SendPacket(new ChatMsgPacket(message, type, color, target, items), TransmissionMode.All);
     }
 
     //GameDataPacket
@@ -802,9 +804,9 @@ public static partial class PacketSender
     /// <param name="color">The color assigned to this message.</param>
     /// <param name="target">The sender of this message, should we decide to respond from the client.</param>
     /// <param name="type">The type of message we are sending.</param>
-    public static void SendGlobalMsg(string message, Color color, string target = "", ChatMessageType type = ChatMessageType.Global)
+    public static void SendGlobalMsg(string message, Color color, string target = "", ChatMessageType type = ChatMessageType.Global, List<ChatItem>? items = null)
     {
-        SendDataToAllPlayers(new ChatMsgPacket(message, type, color, target));
+        SendDataToAllPlayers(new ChatMsgPacket(message, type, color, target, items));
     }
 
     /// <summary>
@@ -829,9 +831,9 @@ public static partial class PacketSender
     /// <param name="color">The color assigned to this message.</param>
     /// <param name="target">The sender of this message, should we decide to respond from the client.</param>
     /// <returns></returns>
-    public static bool SendProximityMsg(string message, ChatMessageType type, Guid mapId, Color color, string target = "")
+    public static bool SendProximityMsg(string message, ChatMessageType type, Guid mapId, Color color, string target = "", List<ChatItem>? items = null)
     {
-        return SendDataAcrossMapInstancesInProximity(mapId, new ChatMsgPacket(message, type, color, target));
+        return SendDataAcrossMapInstancesInProximity(mapId, new ChatMsgPacket(message, type, color, target, items));
     }
 
     /// <summary>
@@ -844,9 +846,9 @@ public static partial class PacketSender
     /// <param name="color">The color assigned to this message.</param>
     /// <param name="target">The sender of this message, should we decide to respond from the client.</param>
     /// <returns></returns>
-    public static bool SendProximityMsgToLayer(string message, ChatMessageType type, Guid mapId, Guid mapInstanceId, Color color, string target = "")
+    public static bool SendProximityMsgToLayer(string message, ChatMessageType type, Guid mapId, Guid mapInstanceId, Color color, string target = "", List<ChatItem>? items = null)
     {
-        return SendDataToProximityOnMapInstance(mapId, mapInstanceId, new ChatMsgPacket(message, type, color, target));
+        return SendDataToProximityOnMapInstance(mapId, mapInstanceId, new ChatMsgPacket(message, type, color, target, items));
     }
 
     /// <summary>
@@ -855,7 +857,7 @@ public static partial class PacketSender
     /// <param name="message">The message to send.</param>
     /// <param name="color">The color assigned to this message.</param>
     /// <param name="target">The sender of this message, should we decide to respond from the client.</param>
-    public static void SendAdminMsg(string message, Color color, string target = "")
+    public static void SendAdminMsg(string message, Color color, string target = "", List<ChatItem>? items = null)
     {
         foreach (var player in Player.OnlinePlayers)
         {
@@ -863,7 +865,7 @@ public static partial class PacketSender
             {
                 if (player.Power != UserRights.None)
                 {
-                    SendChatMsg(player, message, ChatMessageType.Admin, color, target);
+                    SendChatMsg(player, message, ChatMessageType.Admin, color, target, items);
                 }
             }
         }
@@ -876,13 +878,13 @@ public static partial class PacketSender
     /// <param name="message">The message to send.</param>
     /// <param name="color">The color assigned to this message.</param>
     /// <param name="target">The sender of this message, should we decide to respond from the client.</param>
-    public static void SendPartyMsg(Player player, string message, Color color, string target = "")
+    public static void SendPartyMsg(Player player, string message, Color color, string target = "", List<ChatItem>? items = null)
     {
         foreach (var p in player.Party)
         {
             if (p != null)
             {
-                SendChatMsg(p, message, ChatMessageType.Party, color, target);
+                SendChatMsg(p, message, ChatMessageType.Party, color, target, items);
             }
         }
     }
@@ -2280,13 +2282,13 @@ public static partial class PacketSender
     }
 
     //GuildMsgPacket
-    public static void SendGuildMsg(Player player, string message, Color clr, string target = "")
+    public static void SendGuildMsg(Player player, string message, Color clr, string target = "", List<ChatItem>? items = null)
     {
         foreach (var p in player.Guild.FindOnlineMembers())
         {
             if (p != null)
             {
-                SendChatMsg(p, message, ChatMessageType.Guild, clr, target);
+                SendChatMsg(p, message, ChatMessageType.Guild, clr, target, items);
             }
         }
     }


### PR DESCRIPTION
## Summary
- include item link data in chat packets so other players can open item descriptions
- let inventory, bank, and shop "Show" actions send item info to chat
- expose `AppendChatboxItem` for UI code to register linked items
- correctly detect item links even when messages contain multiple bracketed phrases

## Testing
- `dotnet test` *(fails: project file "/workspace/Broken_Reborn/vendor/LiteNetLib/LiteNetLib/LiteNetLib.csproj" was not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e21d3d9c08324b244f64cf70544eb