### PR TITLE
feat: add summon npc spell

### DIFF
--- a/Framework/Intersect.Framework.Core/GameObjects/Spells/SpellDescriptor.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Spells/SpellDescriptor.cs
@@ -175,4 +175,6 @@ public partial class SpellDescriptor : DatabaseObject<SpellDescriptor>, IFoldera
             .Select(i => (SpellDescriptor)i.Value)
             .ToArray();
     }
+
+    public Guid SummonNpcId { get; set; } = Guid.Empty;
 }

--- a/Framework/Intersect.Framework.Core/GameObjects/Spells/SpellType.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Spells/SpellType.cs
@@ -11,4 +11,6 @@ public enum SpellType
     Dash = 3,
 
     Event = 4,
+
+    SummonNpc = 5,
 }

--- a/Intersect.Client.Core/Localization/Strings.cs
+++ b/Intersect.Client.Core/Localization/Strings.cs
@@ -2924,6 +2924,7 @@ If you are sure you want to hand over your guild enter '\c{{#ff8080}}{02}\c{{}}'
             {2, @"Warp to Target"},
             {3, @"Dash"},
             {4, @"Special"},
+            {5, @"Summon NPC"},
         };
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]

--- a/Intersect.Editor/Forms/Editors/frmSpell.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/frmSpell.Designer.cs
@@ -159,6 +159,9 @@ namespace Intersect.Editor.Forms.Editors
             lblManaDamage = new Label();
             grpEvent = new DarkGroupBox();
             cmbEvent = new DarkComboBox();
+            grpSummon = new DarkGroupBox();
+            lblNpc = new Label();
+            cmbNpc = new DarkComboBox();
             grpDash = new DarkGroupBox();
             grpDashCollisions = new DarkGroupBox();
             chkIgnoreInactiveResources = new DarkCheckBox();
@@ -238,6 +241,7 @@ namespace Intersect.Editor.Forms.Editors
             ((System.ComponentModel.ISupportInitialize)nudMPDamage).BeginInit();
             ((System.ComponentModel.ISupportInitialize)nudHPDamage).BeginInit();
             grpEvent.SuspendLayout();
+            grpSummon.SuspendLayout();
             grpDash.SuspendLayout();
             grpDashCollisions.SuspendLayout();
             grpWarp.SuspendLayout();
@@ -256,6 +260,7 @@ namespace Intersect.Editor.Forms.Editors
             pnlContainer.Controls.Add(grpTargetInfo);
             pnlContainer.Controls.Add(grpCombat);
             pnlContainer.Controls.Add(grpEvent);
+            pnlContainer.Controls.Add(grpSummon);
             pnlContainer.Controls.Add(grpDash);
             pnlContainer.Controls.Add(grpWarp);
             pnlContainer.Location = new System.Drawing.Point(244, 39);
@@ -2013,9 +2018,58 @@ namespace Intersect.Editor.Forms.Editors
             cmbEvent.Text = null;
             cmbEvent.TextPadding = new Padding(2);
             cmbEvent.SelectedIndexChanged += cmbEvent_SelectedIndexChanged;
-            // 
+            //
+            // grpSummon
+            //
+            grpSummon.BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
+            grpSummon.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            grpSummon.Controls.Add(cmbNpc);
+            grpSummon.Controls.Add(lblNpc);
+            grpSummon.ForeColor = System.Drawing.Color.Gainsboro;
+            grpSummon.Location = new System.Drawing.Point(603, 6);
+            grpSummon.Margin = new Padding(4, 3, 4, 3);
+            grpSummon.Name = "grpSummon";
+            grpSummon.Padding = new Padding(4, 3, 4, 3);
+            grpSummon.Size = new Size(288, 55);
+            grpSummon.TabIndex = 41;
+            grpSummon.TabStop = false;
+            grpSummon.Text = "Summon NPC";
+            grpSummon.Visible = false;
+            //
+            // lblNpc
+            //
+            lblNpc.AutoSize = true;
+            lblNpc.Location = new System.Drawing.Point(7, 25);
+            lblNpc.Margin = new Padding(4, 0, 4, 0);
+            lblNpc.Name = "lblNpc";
+            lblNpc.Size = new Size(35, 15);
+            lblNpc.TabIndex = 0;
+            lblNpc.Text = "NPC:";
+            //
+            // cmbNpc
+            //
+            cmbNpc.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            cmbNpc.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            cmbNpc.BorderStyle = ButtonBorderStyle.Solid;
+            cmbNpc.ButtonColor = System.Drawing.Color.FromArgb(43, 43, 43);
+            cmbNpc.DrawDropdownHoverOutline = false;
+            cmbNpc.DrawFocusRectangle = false;
+            cmbNpc.DrawMode = DrawMode.OwnerDrawFixed;
+            cmbNpc.DropDownStyle = ComboBoxStyle.DropDownList;
+            cmbNpc.FlatStyle = FlatStyle.Flat;
+            cmbNpc.ForeColor = System.Drawing.Color.Gainsboro;
+            cmbNpc.FormattingEnabled = true;
+            cmbNpc.Location = new System.Drawing.Point(49, 22);
+            cmbNpc.Margin = new Padding(4, 3, 4, 3);
+            cmbNpc.Name = "cmbNpc";
+            cmbNpc.Size = new Size(222, 24);
+            cmbNpc.TabIndex = 1;
+            cmbNpc.Text = null;
+            cmbNpc.TextPadding = new Padding(2);
+            cmbNpc.SelectedIndexChanged += cmbNpc_SelectedIndexChanged;
+            //
             // grpDash
-            // 
+            //
             grpDash.BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
             grpDash.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
             grpDash.Controls.Add(grpDashCollisions);
@@ -2529,6 +2583,8 @@ namespace Intersect.Editor.Forms.Editors
             ((System.ComponentModel.ISupportInitialize)nudMPDamage).EndInit();
             ((System.ComponentModel.ISupportInitialize)nudHPDamage).EndInit();
             grpEvent.ResumeLayout(false);
+            grpSummon.ResumeLayout(false);
+            grpSummon.PerformLayout();
             grpDash.ResumeLayout(false);
             grpDash.PerformLayout();
             grpDashCollisions.ResumeLayout(false);
@@ -2582,6 +2638,9 @@ namespace Intersect.Editor.Forms.Editors
         private DarkCheckBox chkIgnoreMapBlocks;
         private DarkCheckBox chkIgnoreActiveResources;
         private DarkGroupBox grpEvent;
+        private DarkGroupBox grpSummon;
+        private System.Windows.Forms.Label lblNpc;
+        private DarkComboBox cmbNpc;
         private System.Windows.Forms.Panel pnlContainer;
         private DarkButton btnSave;
         private DarkButton btnCancel;

--- a/Intersect.Editor/Forms/Editors/frmSpell.cs
+++ b/Intersect.Editor/Forms/Editors/frmSpell.cs
@@ -10,6 +10,7 @@ using Intersect.Framework.Core.GameObjects.Animations;
 using Intersect.Framework.Core.GameObjects.Events;
 using Intersect.Framework.Core.GameObjects.Items;
 using Intersect.Framework.Core.GameObjects.Maps.MapList;
+using Intersect.Framework.Core.GameObjects.NPCs;
 using Intersect.GameObjects;
 using Intersect.Utilities;
 using Graphics = System.Drawing.Graphics;
@@ -105,6 +106,8 @@ public partial class FrmSpell : EditorForm
         cmbEvent.Items.Clear();
         cmbEvent.Items.Add(Strings.General.None);
         cmbEvent.Items.AddRange(EventDescriptor.Names);
+        cmbNpc.Items.Clear();
+        cmbNpc.Items.AddRange(NPCDescriptor.Names);
         cmbTickAnimation.Items.Clear();
         cmbTickAnimation.Items.Add(Strings.General.None);
         cmbTickAnimation.Items.AddRange(AnimationDescriptor.Names);
@@ -268,6 +271,8 @@ public partial class FrmSpell : EditorForm
         btnVisualMapSelector.Text = Strings.Warping.visual;
 
         grpEvent.Text = Strings.SpellEditor.Event;
+        grpSummon.Text = Strings.SpellEditor.summonnpc;
+        lblNpc.Text = Strings.SpellEditor.npc;
 
         //Searching/Sorting
         btnAlphabetical.ToolTipText = Strings.SpellEditor.sortalphabetically;
@@ -341,6 +346,7 @@ public partial class FrmSpell : EditorForm
         grpWarp.Hide();
         grpDash.Hide();
         grpEvent.Hide();
+        grpSummon.Hide();
         cmbTargetType.Enabled = true;
 
         // Reset our combat data location, since event type spells can move it.
@@ -417,6 +423,11 @@ public partial class FrmSpell : EditorForm
             chkIgnoreActiveResources.Checked = mEditorItem.Dash.IgnoreActiveResources;
             chkIgnoreInactiveResources.Checked = mEditorItem.Dash.IgnoreInactiveResources;
             chkIgnoreZDimensionBlocks.Checked = mEditorItem.Dash.IgnoreZDimensionAttributes;
+        }
+        else if (cmbType.SelectedIndex == (int)SpellType.SummonNpc)
+        {
+            grpSummon.Show();
+            cmbNpc.SelectedIndex = NPCDescriptor.ListIndex(mEditorItem.SummonNpcId);
         }
 
         if (cmbType.SelectedIndex == (int)SpellType.Event)
@@ -762,6 +773,11 @@ public partial class FrmSpell : EditorForm
     private void cmbEvent_SelectedIndexChanged(object sender, EventArgs e)
     {
         mEditorItem.EventId = EventDescriptor.IdFromList(cmbEvent.SelectedIndex - 1);
+    }
+
+    private void cmbNpc_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mEditorItem.SummonNpcId = NPCDescriptor.IdFromList(cmbNpc.SelectedIndex);
     }
 
     private void btnVisualMapSelector_Click(object sender, EventArgs e)

--- a/Intersect.Editor/Localization/Strings.cs
+++ b/Intersect.Editor/Localization/Strings.cs
@@ -5352,6 +5352,10 @@ Tick timer saved in server config.json.";
 
         public static LocalizedString dashrange = @"Dash Range (tiles): {00}";
 
+        public static LocalizedString summonnpc = @"Summon NPC";
+
+        public static LocalizedString npc = @"NPC:";
+
         public static LocalizedString defense = @"Defense:";
 
         public static LocalizedString delete = @"Delete Spell";
@@ -5495,6 +5499,7 @@ Tick timer saved in server config.json.";
             {2, @"Warp to Target"},
             {3, @"Dash"},
             {4, @"Event"},
+            {5, @"Summon NPC"},
         };
 
         public static LocalizedString undo = @"Undo Changes";

--- a/Intersect.Server.Core/Entities/Entity.cs
+++ b/Intersect.Server.Core/Entities/Entity.cs
@@ -2685,6 +2685,31 @@ public abstract partial class Entity : IEntity
                     );
 
                     break;
+                case SpellType.SummonNpc:
+                    if (spellBase.SummonNpcId != Guid.Empty)
+                    {
+                        if (MapController.TryGetInstanceFromMap(MapId, MapInstanceId, out var mapInstance))
+                        {
+                            var summonX = X + 1;
+                            var summonY = Y;
+                            var direction = Dir;
+
+                            var summonedNpc = mapInstance.SpawnNpc((byte)summonX, (byte)summonY, direction, spellBase.SummonNpcId, true);
+                            if (summonedNpc != null)
+                            {
+                                if (this is Player player)
+                                {
+                                    player.SpawnedNpcs.Add(summonedNpc);
+                                }
+                                else if (this is Npc npcCaster)
+                                {
+                                    // Optional: track NPC summons here.
+                                }
+                            }
+                        }
+                    }
+
+                    break;
                 default:
                     break;
             }

--- a/Intersect.Server.Core/Entities/Events/CommandProcessing.cs
+++ b/Intersect.Server.Core/Entities/Events/CommandProcessing.cs
@@ -856,10 +856,10 @@ public static partial class CommandProcessing
         }
     }
 
-    //Spawn Npc Command
+    //Spawn Npc Command (accepts any entity as caller)
     private static void ProcessCommand(
         SpawnNpcCommand command,
-        Player player,
+        Entity caller,
         Event eventInstance,
         CommandInstance stackInfo,
         Stack<CommandInstance> callStack
@@ -870,7 +870,7 @@ public static partial class CommandProcessing
         var tileX = 0;
         var tileY = 0;
         Direction direction = (byte)Direction.Up;
-        var targetEntity = (Entity)player;
+        var targetEntity = caller;
         if (mapId != Guid.Empty)
         {
             tileX = command.X;
@@ -879,7 +879,7 @@ public static partial class CommandProcessing
         }
         else
         {
-            if (command.EntityId != Guid.Empty)
+            if (command.EntityId != Guid.Empty && caller is Player player)
             {
                 foreach (var evt in player.EventLookup)
                 {
@@ -939,10 +939,14 @@ public static partial class CommandProcessing
         }
 
         var tile = new TileHelper(mapId, tileX, tileY);
-        if (tile.TryFix() && MapController.TryGetInstanceFromMap(mapId, player.MapInstanceId, out var instance))
+        if (tile.TryFix() && MapController.TryGetInstanceFromMap(mapId, caller.MapInstanceId, out var instance))
         {
             var npc = instance.SpawnNpc((byte)tileX, (byte)tileY, direction, npcId, true);
-            player.SpawnedNpcs.Add(npc);
+            if (caller is Player playerCaller)
+            {
+                playerCaller.SpawnedNpcs.Add(npc);
+            }
+            // NPC callers currently do not track spawned NPCs.
         }
     }
 


### PR DESCRIPTION
## Summary
- add `SummonNpc` spell type and store summon target NPC
- show new spell type in client/editor strings
- implement server-side summoning and event command support
- expose NPC selection in spell editor

## Testing
- `dotnet build` *(fails: project file vendor/LiteNetLib/LiteNetLib.csproj was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a09438785883249c3944de8b910402