### PR TITLE
Add support for bestiary unlock sync

### DIFF
--- a/Framework/Intersect.Framework.Core/Network/Packets/Server/UnlockedBestiaryEntriesPacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Server/UnlockedBestiaryEntriesPacket.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+using MessagePack;
+using Intersect.Framework.Core.GameObjects.NPCs;
+
+namespace Intersect.Network.Packets.Server;
+
+[MessagePackObject]
+public partial class UnlockedBestiaryEntriesPacket : IntersectPacket
+{
+    // Parameterless constructor for MessagePack
+    public UnlockedBestiaryEntriesPacket()
+    {
+    }
+
+    public UnlockedBestiaryEntriesPacket(Dictionary<Guid, Dictionary<BestiaryUnlock, int>> unlocks)
+    {
+        Unlocks = unlocks;
+    }
+
+    [Key(0)]
+    public Dictionary<Guid, Dictionary<BestiaryUnlock, int>> Unlocks { get; set; }
+}
+

--- a/Intersect.Client.Core/General/BestiaryController.cs
+++ b/Intersect.Client.Core/General/BestiaryController.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections.Generic;
+using Intersect.Framework.Core.GameObjects.NPCs;
+
+namespace Intersect.Client.General;
+
+public static class BestiaryController
+{
+    private static readonly Dictionary<Guid, Dictionary<BestiaryUnlock, int>> _unlocked = new();
+
+    public static IReadOnlyDictionary<Guid, Dictionary<BestiaryUnlock, int>> Unlocked => _unlocked;
+
+    public static void SetUnlocked(Dictionary<Guid, Dictionary<BestiaryUnlock, int>> unlocks)
+    {
+        _unlocked.Clear();
+        foreach (var pair in unlocks)
+        {
+            _unlocked[pair.Key] = pair.Value;
+        }
+    }
+}
+

--- a/Intersect.Client.Core/Networking/PacketHandler.cs
+++ b/Intersect.Client.Core/Networking/PacketHandler.cs
@@ -2298,6 +2298,12 @@ internal sealed partial class PacketHandler
         }
     }
 
+    //UnlockedBestiaryEntriesPacket
+    public void HandlePacket(IPacketSender packetSender, UnlockedBestiaryEntriesPacket packet)
+    {
+        BestiaryController.SetUnlocked(packet.Unlocks);
+    }
+
     //EnteringGamePacket
     public void HandlePacket(IPacketSender packetSender, EnteringGamePacket packet)
     {

--- a/Intersect.Server.Core/Networking/PacketSender.cs
+++ b/Intersect.Server.Core/Networking/PacketSender.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 using Intersect.Core;
 using Intersect.Enums;
 using Intersect.Framework.Core;
@@ -432,6 +433,7 @@ public static partial class PacketSender
             SendQuestsProgress(player);
             SendItemCooldowns(player);
             SendSpellCooldowns(player);
+            SendUnlockedBestiaryEntries(player);
             SendJobSync(player);
         }
 
@@ -2198,6 +2200,19 @@ public static partial class PacketSender
         }
 
         player.SendPacket(new QuestProgressPacket(dict, hiddenQuests.ToArray()));
+    }
+
+    //UnlockedBestiaryEntriesPacket
+    public static void SendUnlockedBestiaryEntries(Player player)
+    {
+        var unlocks = player.BestiaryUnlocks
+            .GroupBy(b => b.NpcId)
+            .ToDictionary(
+                g => g.Key,
+                g => g.ToDictionary(b => b.UnlockType, b => b.Value)
+            );
+
+        player.SendPacket(new UnlockedBestiaryEntriesPacket(unlocks));
     }
 
     //TradePacket


### PR DESCRIPTION
## Summary
- add UnlockedBestiaryEntriesPacket for synchronizing bestiary unlock data
- send bestiary unlock map to clients and expose simple client controller
- handle bestiary unlock packet client-side to update controller

## Testing
- `dotnet build Intersect.sln` *(fails: LiteNetLib.csproj missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a16af38bc48324a9f80c7115fefcd1