### PR TITLE
Add bestiary window and components

### DIFF
--- a/Intersect.Client.Core/Interface/Game/Bestiary/BestiaryLootComponent.cs
+++ b/Intersect.Client.Core/Interface/Game/Bestiary/BestiaryLootComponent.cs
@@ -1,0 +1,47 @@
+using Intersect.Client.Framework.Gwen.Control;
+using Intersect.Client.Interface;
+using Intersect.Client.Interface.Game.DescriptionWindows;
+using Intersect.Framework.Core.GameObjects.Items;
+
+namespace Intersect.Client.Interface.Game.Bestiary;
+
+public partial class BestiaryLootComponent : ImagePanel
+{
+    private readonly Label _label;
+    private bool _unlocked;
+
+    public BestiaryLootComponent(Base parent, string name = "BestiaryLoot") : base(parent, name)
+    {
+        _label = new Label(this)
+        {
+            Text = "Locked"
+        };
+    }
+
+    public void Unlock()
+    {
+        _unlocked = true;
+        _label.Text = "Unlocked";
+    }
+
+    public void Lock()
+    {
+        _unlocked = false;
+        _label.Text = "Locked";
+    }
+
+    public void CorrectWidth()
+    {
+        if (Parent == null)
+        {
+            return;
+        }
+
+        SetSize(Parent.InnerWidth - 20, Height);
+    }
+
+    public void ShowItemTooltip(ItemDescriptor item)
+    {
+        Interface.GameUi.ItemDescriptionWindow.Show(item, 1);
+    }
+}

--- a/Intersect.Client.Core/Interface/Game/Bestiary/BestiaryMagicComponent.cs
+++ b/Intersect.Client.Core/Interface/Game/Bestiary/BestiaryMagicComponent.cs
@@ -1,0 +1,47 @@
+using Intersect.Client.Framework.Gwen.Control;
+using Intersect.Client.Interface;
+using Intersect.Client.Interface.Game.DescriptionWindows;
+using Intersect.Framework.Core.GameObjects.Items;
+
+namespace Intersect.Client.Interface.Game.Bestiary;
+
+public partial class BestiaryMagicComponent : ImagePanel
+{
+    private readonly Label _label;
+    private bool _unlocked;
+
+    public BestiaryMagicComponent(Base parent, string name = "BestiaryMagic") : base(parent, name)
+    {
+        _label = new Label(this)
+        {
+            Text = "Locked"
+        };
+    }
+
+    public void Unlock()
+    {
+        _unlocked = true;
+        _label.Text = "Unlocked";
+    }
+
+    public void Lock()
+    {
+        _unlocked = false;
+        _label.Text = "Locked";
+    }
+
+    public void CorrectWidth()
+    {
+        if (Parent == null)
+        {
+            return;
+        }
+
+        SetSize(Parent.InnerWidth - 20, Height);
+    }
+
+    public void ShowItemTooltip(ItemDescriptor item)
+    {
+        Interface.GameUi.ItemDescriptionWindow.Show(item, 1);
+    }
+}

--- a/Intersect.Client.Core/Interface/Game/Bestiary/BestiarySpellCombatComponent.cs
+++ b/Intersect.Client.Core/Interface/Game/Bestiary/BestiarySpellCombatComponent.cs
@@ -1,0 +1,47 @@
+using Intersect.Client.Framework.Gwen.Control;
+using Intersect.Client.Interface;
+using Intersect.Client.Interface.Game.DescriptionWindows;
+using System;
+
+namespace Intersect.Client.Interface.Game.Bestiary;
+
+public partial class BestiarySpellCombatComponent : ImagePanel
+{
+    private readonly Label _label;
+    private bool _unlocked;
+
+    public BestiarySpellCombatComponent(Base parent, string name = "BestiarySpellCombat") : base(parent, name)
+    {
+        _label = new Label(this)
+        {
+            Text = "Locked"
+        };
+    }
+
+    public void Unlock()
+    {
+        _unlocked = true;
+        _label.Text = "Unlocked";
+    }
+
+    public void Lock()
+    {
+        _unlocked = false;
+        _label.Text = "Locked";
+    }
+
+    public void CorrectWidth()
+    {
+        if (Parent == null)
+        {
+            return;
+        }
+
+        SetSize(Parent.InnerWidth - 20, Height);
+    }
+
+    public void ShowSpellTooltip(Guid spellId)
+    {
+        Interface.GameUi.SpellDescriptionWindow.Show(spellId);
+    }
+}

--- a/Intersect.Client.Core/Interface/Game/Bestiary/BestiaryStatsComponent.cs
+++ b/Intersect.Client.Core/Interface/Game/Bestiary/BestiaryStatsComponent.cs
@@ -1,0 +1,39 @@
+using Intersect.Client.Framework.Gwen.Control;
+
+namespace Intersect.Client.Interface.Game.Bestiary;
+
+public partial class BestiaryStatsComponent : ImagePanel
+{
+    private readonly Label _label;
+    private bool _unlocked;
+
+    public BestiaryStatsComponent(Base parent, string name = "BestiaryStats") : base(parent, name)
+    {
+        _label = new Label(this)
+        {
+            Text = "Locked"
+        };
+    }
+
+    public void Unlock()
+    {
+        _unlocked = true;
+        _label.Text = "Unlocked";
+    }
+
+    public void Lock()
+    {
+        _unlocked = false;
+        _label.Text = "Locked";
+    }
+
+    public void CorrectWidth()
+    {
+        if (Parent == null)
+        {
+            return;
+        }
+
+        SetSize(Parent.InnerWidth - 20, Height);
+    }
+}

--- a/Intersect.Client.Core/Interface/Game/Bestiary/BestiaryWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Bestiary/BestiaryWindow.cs
@@ -1,0 +1,70 @@
+using Intersect.Client.Core;
+using Intersect.Client.Framework.File_Management;
+using Intersect.Client.Framework.Gwen;
+using Intersect.Client.Framework.Gwen.Control;
+using Intersect.Client.Interface.Game.DescriptionWindows;
+
+namespace Intersect.Client.Interface.Game.Bestiary;
+
+public partial class BestiaryWindow : Window
+{
+    private BestiaryStatsComponent? _stats;
+    private BestiaryMagicComponent? _magic;
+    private BestiaryLootComponent? _loot;
+    private BestiarySpellCombatComponent? _spellCombat;
+
+    public BestiaryWindow(Canvas gameCanvas) : base(gameCanvas, "Bestiary", false, nameof(BestiaryWindow))
+    {
+        Alignment = [Alignments.Center];
+        MinimumSize = new Point(x: 400, y: 300);
+        IsResizable = true;
+        IsClosable = true;
+    }
+
+    protected override void EnsureInitialized()
+    {
+        LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
+
+        _stats = new BestiaryStatsComponent(this, "StatsComponent");
+        _stats.SetPosition(10, 30);
+
+        _magic = new BestiaryMagicComponent(this, "MagicComponent");
+        _magic.SetPosition(10, 80);
+
+        _loot = new BestiaryLootComponent(this, "LootComponent");
+        _loot.SetPosition(10, 130);
+
+        _spellCombat = new BestiarySpellCombatComponent(this, "SpellCombatComponent");
+        _spellCombat.SetPosition(10, 180);
+
+        Resized += (_, _) =>
+        {
+            _stats?.CorrectWidth();
+            _magic?.CorrectWidth();
+            _loot?.CorrectWidth();
+            _spellCombat?.CorrectWidth();
+        };
+
+        Reset();
+    }
+
+    public override void Show()
+    {
+        Reset();
+        base.Show();
+    }
+
+    public override void Hide()
+    {
+        base.Hide();
+        Reset();
+    }
+
+    private void Reset()
+    {
+        _stats?.Lock();
+        _magic?.Lock();
+        _loot?.Lock();
+        _spellCombat?.Lock();
+    }
+}


### PR DESCRIPTION
## Summary
- add BestiaryWindow under game interface
- create BestiaryStatsComponent, BestiaryMagicComponent, BestiaryLootComponent, and BestiarySpellCombatComponent with lock/unlock and tooltip hooks

## Testing
- `dotnet build Intersect.Client.Core/Intersect.Client.Core.csproj` *(fails: LiteNetLib missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a1766934f48324a7b40c43c7f00e6a