### PR TITLE
Expand bestiary loot with nested table helper

### DIFF
--- a/Framework/Intersect.Framework.Core/GameObjects/Items/LootTableHelpers.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Items/LootTableHelpers.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+
+namespace Intersect.Framework.Core.GameObjects.Items;
+
+/// <summary>
+///     Helper methods for working with loot tables. Provides a utility to expand
+///     nested tables into a flat collection of item chances.
+/// </summary>
+public static class LootTableHelpers
+{
+    /// <summary>
+    ///     Expands a collection of drops, resolving any nested tables using the
+    ///     supplied resolver and returning a dictionary mapping the final item id
+    ///     to its accumulated drop chance.
+    /// </summary>
+    /// <param name="drops">Initial drops to expand.</param>
+    /// <param name="tableResolver">
+    ///     Delegate used to resolve the drops belonging to a nested loot table.
+    ///     The delegate should return <c>null</c> when the supplied id does not
+    ///     reference a loot table.
+    /// </param>
+    /// <returns>Dictionary of item ids to their aggregated chance values.</returns>
+    public static IReadOnlyDictionary<Guid, double> Expand(IEnumerable<Drop> drops,
+        Func<Guid, IEnumerable<Drop>?>? tableResolver = null)
+    {
+        var result = new Dictionary<Guid, double>();
+        ExpandInternal(drops, 1d, tableResolver ?? (_ => null), result, new HashSet<Guid>());
+        return result;
+    }
+
+    private static void ExpandInternal(IEnumerable<Drop> drops, double parentChance,
+        Func<Guid, IEnumerable<Drop>?> resolver, IDictionary<Guid, double> result,
+        ISet<Guid> visited)
+    {
+        foreach (var drop in drops)
+        {
+            var nested = resolver(drop.ItemId);
+            if (nested != null && visited.Add(drop.ItemId))
+            {
+                ExpandInternal(nested, parentChance * drop.Chance, resolver, result, visited);
+                visited.Remove(drop.ItemId);
+            }
+            else
+            {
+                var chance = parentChance * drop.Chance;
+                if (result.TryGetValue(drop.ItemId, out var existing))
+                {
+                    result[drop.ItemId] = existing + chance;
+                }
+                else
+                {
+                    result[drop.ItemId] = chance;
+                }
+            }
+        }
+    }
+}
+

--- a/Intersect.Client.Core/Interface/Game/Bestiary/BestiaryLootComponent.cs
+++ b/Intersect.Client.Core/Interface/Game/Bestiary/BestiaryLootComponent.cs
@@ -1,7 +1,12 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 using Intersect.Client.Framework.Gwen.Control;
 using Intersect.Client.Interface;
 using Intersect.Client.Interface.Game.DescriptionWindows;
 using Intersect.Framework.Core.GameObjects.Items;
+using Intersect.Framework.Core.GameObjects.NPCs;
 
 namespace Intersect.Client.Interface.Game.Bestiary;
 
@@ -43,5 +48,42 @@ public partial class BestiaryLootComponent : ImagePanel
     public void ShowItemTooltip(ItemDescriptor item)
     {
         Interface.GameUi.ItemDescriptionWindow.Show(item, 1);
+    }
+
+    /// <summary>
+    ///     Populates the component with the loot drops from the provided NPC
+    ///     descriptor. Nested loot tables are expanded using
+    ///     <see cref="LootTableHelpers"/> and the resulting aggregated chances are
+    ///     displayed as text.
+    /// </summary>
+    /// <param name="npc">NPC whose loot should be displayed.</param>
+    /// <param name="tableResolver">
+    ///     Optional delegate used to resolve nested loot tables. When <c>null</c>
+    ///     only the NPC's direct drops are considered.
+    /// </param>
+    public void SetLoot(NPCDescriptor npc, Func<Guid, IEnumerable<Drop>?>? tableResolver = null)
+    {
+        _unlocked = true;
+
+        var expanded = LootTableHelpers.Expand(npc.Drops, tableResolver);
+        var builder = new StringBuilder();
+
+        foreach (var (itemId, chance) in expanded.OrderBy(kvp => kvp.Key))
+        {
+            var item = ItemDescriptor.Get(itemId);
+            if (item == null)
+            {
+                continue;
+            }
+
+            if (builder.Length > 0)
+            {
+                builder.Append('\n');
+            }
+
+            builder.Append($"{item.Name}: {chance:P2}");
+        }
+
+        _label.Text = builder.Length > 0 ? builder.ToString() : "Unlocked";
     }
 }


### PR DESCRIPTION
## Summary
- add LootTableHelpers to recursively expand nested loot tables
- show aggregated loot chances in bestiary component using new helper

## Testing
- `dotnet build Intersect.sln` *(fails: project file "/workspace/Broken_Reborn/vendor/LiteNetLib/LiteNetLib/LiteNetLib.csproj" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a17c27f7088324b4f79d9169b6baa6