### PR TITLE
Add Bestiary unlock editing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -217,6 +217,12 @@ packages/
 
 /assets/**
 !/assets/*.*
+!/assets/graphics/**
+!/assets/graphics/
+!/assets/graphics/gui/
+!/assets/graphics/gui/bestiary/
+!/assets/graphics/gui/bestiary/*
+!/assets/graphics/gui/bestiary/*.png
 
 .local/
 

--- a/Intersect.Client.Core/Interface/Game/Bestiary/BestiaryLootComponent.cs
+++ b/Intersect.Client.Core/Interface/Game/Bestiary/BestiaryLootComponent.cs
@@ -1,6 +1,7 @@
 using Intersect.Client.Framework.Gwen.Control;
 using Intersect.Client.Interface;
 using Intersect.Client.Interface.Game.DescriptionWindows;
+using Intersect.Client.Localization;
 using Intersect.Framework.Core.GameObjects.Items;
 
 namespace Intersect.Client.Interface.Game.Bestiary;
@@ -14,20 +15,20 @@ public partial class BestiaryLootComponent : ImagePanel
     {
         _label = new Label(this)
         {
-            Text = "Locked"
+            Text = Strings.Bestiary.Locked
         };
     }
 
     public void Unlock()
     {
         _unlocked = true;
-        _label.Text = "Unlocked";
+        _label.Text = Strings.Bestiary.Unlocked;
     }
 
     public void Lock()
     {
         _unlocked = false;
-        _label.Text = "Locked";
+        _label.Text = Strings.Bestiary.Locked;
     }
 
     public void CorrectWidth()

--- a/Intersect.Client.Core/Interface/Game/Bestiary/BestiaryMagicComponent.cs
+++ b/Intersect.Client.Core/Interface/Game/Bestiary/BestiaryMagicComponent.cs
@@ -1,6 +1,7 @@
 using Intersect.Client.Framework.Gwen.Control;
 using Intersect.Client.Interface;
 using Intersect.Client.Interface.Game.DescriptionWindows;
+using Intersect.Client.Localization;
 using Intersect.Framework.Core.GameObjects.Items;
 
 namespace Intersect.Client.Interface.Game.Bestiary;
@@ -14,20 +15,20 @@ public partial class BestiaryMagicComponent : ImagePanel
     {
         _label = new Label(this)
         {
-            Text = "Locked"
+            Text = Strings.Bestiary.Locked
         };
     }
 
     public void Unlock()
     {
         _unlocked = true;
-        _label.Text = "Unlocked";
+        _label.Text = Strings.Bestiary.Unlocked;
     }
 
     public void Lock()
     {
         _unlocked = false;
-        _label.Text = "Locked";
+        _label.Text = Strings.Bestiary.Locked;
     }
 
     public void CorrectWidth()

--- a/Intersect.Client.Core/Interface/Game/Bestiary/BestiarySpellCombatComponent.cs
+++ b/Intersect.Client.Core/Interface/Game/Bestiary/BestiarySpellCombatComponent.cs
@@ -1,6 +1,7 @@
 using Intersect.Client.Framework.Gwen.Control;
 using Intersect.Client.Interface;
 using Intersect.Client.Interface.Game.DescriptionWindows;
+using Intersect.Client.Localization;
 using System;
 
 namespace Intersect.Client.Interface.Game.Bestiary;
@@ -14,20 +15,20 @@ public partial class BestiarySpellCombatComponent : ImagePanel
     {
         _label = new Label(this)
         {
-            Text = "Locked"
+            Text = Strings.Bestiary.Locked
         };
     }
 
     public void Unlock()
     {
         _unlocked = true;
-        _label.Text = "Unlocked";
+        _label.Text = Strings.Bestiary.Unlocked;
     }
 
     public void Lock()
     {
         _unlocked = false;
-        _label.Text = "Locked";
+        _label.Text = Strings.Bestiary.Locked;
     }
 
     public void CorrectWidth()

--- a/Intersect.Client.Core/Interface/Game/Bestiary/BestiaryStatsComponent.cs
+++ b/Intersect.Client.Core/Interface/Game/Bestiary/BestiaryStatsComponent.cs
@@ -1,4 +1,5 @@
 using Intersect.Client.Framework.Gwen.Control;
+using Intersect.Client.Localization;
 
 namespace Intersect.Client.Interface.Game.Bestiary;
 
@@ -11,20 +12,20 @@ public partial class BestiaryStatsComponent : ImagePanel
     {
         _label = new Label(this)
         {
-            Text = "Locked"
+            Text = Strings.Bestiary.Locked
         };
     }
 
     public void Unlock()
     {
         _unlocked = true;
-        _label.Text = "Unlocked";
+        _label.Text = Strings.Bestiary.Unlocked;
     }
 
     public void Lock()
     {
         _unlocked = false;
-        _label.Text = "Locked";
+        _label.Text = Strings.Bestiary.Locked;
     }
 
     public void CorrectWidth()

--- a/Intersect.Client.Core/Interface/Game/Bestiary/BestiaryWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Bestiary/BestiaryWindow.cs
@@ -3,6 +3,7 @@ using Intersect.Client.Framework.File_Management;
 using Intersect.Client.Framework.Gwen;
 using Intersect.Client.Framework.Gwen.Control;
 using Intersect.Client.Interface.Game.DescriptionWindows;
+using Intersect.Client.Localization;
 
 namespace Intersect.Client.Interface.Game.Bestiary;
 
@@ -13,7 +14,7 @@ public partial class BestiaryWindow : Window
     private BestiaryLootComponent? _loot;
     private BestiarySpellCombatComponent? _spellCombat;
 
-    public BestiaryWindow(Canvas gameCanvas) : base(gameCanvas, "Bestiary", false, nameof(BestiaryWindow))
+    public BestiaryWindow(Canvas gameCanvas) : base(gameCanvas, Strings.Bestiary.Title, false, nameof(BestiaryWindow))
     {
         Alignment = [Alignments.Center];
         MinimumSize = new Point(x: 400, y: 300);

--- a/Intersect.Client.Core/Localization/Strings.cs
+++ b/Intersect.Client.Core/Localization/Strings.cs
@@ -854,6 +854,18 @@ public static partial class Strings
         public static LocalizedString TwoWeeks = @"2 weeks";
     }
 
+    public partial struct Bestiary
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Title = @"Bestiary";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Locked = @"Locked";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Unlocked = @"Unlocked";
+    }
+
     public partial struct Character
     {
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]

--- a/Intersect.Editor/General/NotifiableBestiaryUnlock.cs
+++ b/Intersect.Editor/General/NotifiableBestiaryUnlock.cs
@@ -1,0 +1,52 @@
+using System.ComponentModel;
+using Intersect.Enums;
+
+namespace Intersect.Editor.General;
+
+public class NotifiableBestiaryUnlock : INotifyPropertyChanged
+{
+    private BestiaryUnlock _unlockType;
+    private int _amount;
+
+    public string DisplayName => $"{_unlockType}: {_amount}";
+
+    public BestiaryUnlock UnlockType
+    {
+        get => _unlockType;
+        set
+        {
+            if (_unlockType == value)
+            {
+                return;
+            }
+
+            _unlockType = value;
+            OnPropertyChanged(nameof(UnlockType));
+            OnPropertyChanged(nameof(DisplayName));
+        }
+    }
+
+    public int Amount
+    {
+        get => _amount;
+        set
+        {
+            if (_amount == value)
+            {
+                return;
+            }
+
+            _amount = value;
+            OnPropertyChanged(nameof(Amount));
+            OnPropertyChanged(nameof(DisplayName));
+        }
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    protected virtual void OnPropertyChanged(string propertyName)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}
+


### PR DESCRIPTION
## Summary
- add NotifiableBestiaryUnlock and wire NPC editor to manage bestiary unlock requirements
- add bestiary localization strings and use them in client bestiary UI
- remove placeholder bestiary lock icons

## Testing
- `~/.dotnet/dotnet test` *(fails: project file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a17e5ddaa48324bb4c71d146df0eee