### PR TITLE
Ensure Bestiary unlock data is serialized before NPC save

### DIFF
--- a/Framework/Intersect.Framework.Core/GameObjects/NPCs/NPCDescriptor.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/NPCs/NPCDescriptor.cs
@@ -49,6 +49,11 @@ public partial class NPCDescriptor : DatabaseObject<NPCDescriptor>, IFolderable
         set => BestiaryRequirements = JsonConvert.DeserializeObject<Dictionary<BestiaryUnlock, int>>(value ?? "{}") ?? new();
     }
 
+    public void SyncBestiaryJson()
+    {
+        BestiaryUnlocksJson = JsonConvert.SerializeObject(BestiaryRequirements ?? new());
+    }
+
     [NotMapped, JsonIgnore]
     public long[] MaxVitals
     {

--- a/Intersect.Editor/Forms/Editors/frmNpc.cs
+++ b/Intersect.Editor/Forms/Editors/frmNpc.cs
@@ -16,7 +16,6 @@ using Intersect.Framework.Core.GameObjects.Items;
 using Intersect.Framework.Core.GameObjects.NPCs;
 using Intersect.GameObjects;
 using Intersect.Utilities;
-using Newtonsoft.Json;
 using EventDescriptor = Intersect.Framework.Core.GameObjects.Events.EventDescriptor;
 using Graphics = System.Drawing.Graphics;
 
@@ -91,8 +90,8 @@ public partial class FrmNpc : EditorForm
             // Sort immunities to keep change checker consistent
             item.Immunities.Sort();
 
-            // ✅ Serialize BestiaryRequirements to BestiaryUnlocksJson before saving
-            item.BestiaryUnlocksJson = JsonConvert.SerializeObject(item.BestiaryRequirements);
+            // Ensure BestiaryUnlocksJson is in sync before saving
+            item.SyncBestiaryJson();
 
             PacketSender.SendSaveObject(item);
             item.DeleteBackup();


### PR DESCRIPTION
## Summary
- Add `SyncBestiaryJson` helper to `NPCDescriptor`
- Call helper from NPC editor before saving

## Testing
- `dotnet build Framework/Intersect.Framework.Core/Intersect.Framework.Core.csproj`
- `dotnet build Intersect.Editor/Intersect.Editor.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a23eb88d008324822cb02f858d7f10