### PR TITLE
Ensure Bestiary unlock data is serialized before NPC save

### DIFF
--- a/Framework/Intersect.Framework.Core/GameObjects/NPCs/NPCDescriptor.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/NPCs/NPCDescriptor.cs
@@ -49,6 +49,11 @@ public partial class NPCDescriptor : DatabaseObject<NPCDescriptor>, IFolderable
         set => BestiaryRequirements = JsonConvert.DeserializeObject<Dictionary<BestiaryUnlock, int>>(value ?? "{}") ?? new();
     }
 
+    public void SyncBestiaryJson()
+    {
+        BestiaryUnlocksJson = JsonConvert.SerializeObject(BestiaryRequirements ?? new());
+    }
+
     [NotMapped, JsonIgnore]
     public long[] MaxVitals
     {

--- a/Intersect.Editor/Forms/Editors/frmNpc.cs
+++ b/Intersect.Editor/Forms/Editors/frmNpc.cs
@@ -16,7 +16,6 @@ using Intersect.Framework.Core.GameObjects.Items;
 using Intersect.Framework.Core.GameObjects.NPCs;
 using Intersect.GameObjects;
 using Intersect.Utilities;
-using Newtonsoft.Json;
 using EventDescriptor = Intersect.Framework.Core.GameObjects.Events.EventDescriptor;
 using Graphics = System.Drawing.Graphics;
 
@@ -91,8 +90,8 @@ public partial class FrmNpc : EditorForm
             // Sort immunities to keep change checker consistent
             item.Immunities.Sort();
 
-            // ✅ Serialize BestiaryRequirements to BestiaryUnlocksJson before saving
-            item.BestiaryUnlocksJson = JsonConvert.SerializeObject(item.BestiaryRequirements);
+            // Ensure BestiaryUnlocksJson is in sync before saving
+            item.SyncBestiaryJson();
 
             PacketSender.SendSaveObject(item);
             item.DeleteBackup();

--- a/Intersect.Server.Core/Database/DbInterface.cs
+++ b/Intersect.Server.Core/Database/DbInterface.cs
@@ -1521,7 +1521,11 @@ public static partial class DbInterface
                         break;
                     }
                     case GameObjectType.Npc:
-                        context.Npcs.Update((NPCDescriptor)gameObject);
+                        if (gameObject is NPCDescriptor npcDescriptor)
+                        {
+                            npcDescriptor.SyncBestiaryJson();
+                            context.Npcs.Update(npcDescriptor);
+                        }
 
                         break;
                     case GameObjectType.Projectile:

--- a/Intersect.Server.Core/Entities/Events/CommandProcessing.cs
+++ b/Intersect.Server.Core/Entities/Events/CommandProcessing.cs
@@ -625,8 +625,17 @@ public static partial class CommandProcessing
                 return;
             }
 
+            if (player.BestiaryUnlocks.Any(
+                    b => b.NpcId == command.NpcId && b.UnlockType == command.UnlockType
+                ))
+            {
+                return;
+            }
+
             unlock = new BestiaryUnlockInstance
             {
+                Player = player,
+                PlayerId = player.Id,
                 NpcId = command.NpcId,
                 UnlockType = command.UnlockType,
                 Value = 0,

--- a/Intersect.Server.Core/Entities/Npc.cs
+++ b/Intersect.Server.Core/Entities/Npc.cs
@@ -187,22 +187,30 @@ public partial class Npc : Entity
 
                     if (killUnlock == null)
                     {
-                        killUnlock = new BestiaryUnlockInstance
+                        if (!player.BestiaryUnlocks.Any(
+                                b => b.NpcId == npcId && b.UnlockType == BestiaryUnlock.Kill
+                            ))
                         {
-                            Player = player,
-                            NpcId = npcId,
-                            UnlockType = BestiaryUnlock.Kill,
-                            Value = 1
-                        };
-                        player.BestiaryUnlocks.Add(killUnlock);
-                        changed = true;
+                            killUnlock = new BestiaryUnlockInstance
+                            {
+                                Player = player,
+                                PlayerId = player.Id,
+                                NpcId = npcId,
+                                UnlockType = BestiaryUnlock.Kill,
+                                Value = 1,
+                            };
+                            player.BestiaryUnlocks.Add(killUnlock);
+                            changed = true;
+                        }
                     }
                     else
                     {
                         var previous = killUnlock.Value;
                         killUnlock.Value++;
                         if (killUnlock.Value != previous)
+                        {
                             changed = true;
+                        }
                     }
                 }
 
@@ -225,13 +233,16 @@ public partial class Npc : Entity
 
                         if (!alreadyUnlocked && killCount >= requiredKills)
                         {
-                            player.BestiaryUnlocks.Add(new BestiaryUnlockInstance
-                            {
-                                Player = player,
-                                NpcId = npcId,
-                                UnlockType = unlockType,
-                                Value = 1
-                            });
+                            player.BestiaryUnlocks.Add(
+                                new BestiaryUnlockInstance
+                                {
+                                    Player = player,
+                                    PlayerId = player.Id,
+                                    NpcId = npcId,
+                                    UnlockType = unlockType,
+                                    Value = 1,
+                                }
+                            );
                             changed = true;
                         }
                     }


### PR DESCRIPTION
## Summary
- Add `SyncBestiaryJson` helper to `NPCDescriptor`
- Call helper from NPC editor before saving
- Sync `BestiaryUnlocksJson` on the server before persisting NPCs
- Include `PlayerId` when recording bestiary unlocks and guard against duplicates

## Testing
- `dotnet build Framework/Intersect.Framework.Core/Intersect.Framework.Core.csproj`
- `dotnet build Intersect.Server.Core/Intersect.Server.Core.csproj` *(fails: NetPacketReader/NetPeer types not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a23eb88d008324822cb02f858d7f10