### PR TITLE
Refresh bestiary window and make beast tiles clickable

### DIFF
--- a/Intersect.Client.Core/Interface/Game/Bestiary/BeastTile.cs
+++ b/Intersect.Client.Core/Interface/Game/Bestiary/BeastTile.cs
@@ -34,7 +34,8 @@ namespace Intersect.Client.Interface.Game.Bestiary
             _icon = new ImagePanel(this)
             {
                 Width = 64,
-                Height = 64
+                Height = 64,
+                MouseInputEnabled = true,
             };
             _icon.SetPosition(10, 6);
 

--- a/Intersect.Client.Core/Interface/Game/Bestiary/BestiaryWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Bestiary/BestiaryWindow.cs
@@ -21,6 +21,7 @@ public sealed class BestiaryWindow : Window
     private readonly Button _sortButton;
     private bool _sortAsc = true;
     private readonly List<BeastTile> _tiles = new();
+    private Guid? _selectedNpcId;
 
     public BestiaryWindow(Canvas canvas)
         : base(canvas, Strings.Bestiary.Title, false, nameof(BestiaryWindow))
@@ -55,7 +56,14 @@ public sealed class BestiaryWindow : Window
         LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
 
         BestiaryController.InitializeAllBeasts();
-        BestiaryController.OnUnlockGained += (_, _) => RefreshTilesState();
+        BestiaryController.OnUnlockGained += (npcId, _) =>
+        {
+            RefreshTilesState();
+            if (_selectedNpcId == npcId)
+            {
+                ShowNpcDetails(npcId);
+            }
+        };
 
         BuildTiles();
     }
@@ -113,7 +121,11 @@ public sealed class BestiaryWindow : Window
 
     private void RefreshTilesState() => _tiles.ForEach(t => t.RefreshState());
 
-    private void OnSelectNpc(Guid npcId) => ShowNpcDetails(npcId);
+    private void OnSelectNpc(Guid npcId)
+    {
+        _selectedNpcId = npcId;
+        ShowNpcDetails(npcId);
+    }
 
     private void ShowNpcDetails(Guid npcId)
     {


### PR DESCRIPTION
## Summary
- Refresh Bestiary window when unlock packets are received and update selected NPC details
- Make beast icon tiles respond to mouse clicks

## Testing
- `dotnet build` *(fails: project file not found)*
- `dotnet test` *(fails: project file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a293fb5fe8832481e1936b028fde29