### PR TITLE
feat: sync bestiary unlocks and progress

### DIFF
--- a/Framework/Intersect.Framework.Core/Network/Packets/Server/UnlockedBestiaryEntriesPacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Server/UnlockedBestiaryEntriesPacket.cs
@@ -13,12 +13,16 @@ public partial class UnlockedBestiaryEntriesPacket : IntersectPacket
     {
     }
 
-    public UnlockedBestiaryEntriesPacket(Dictionary<Guid, int[]> unlocked)
+    public UnlockedBestiaryEntriesPacket(Dictionary<Guid, int[]> unlocked, Dictionary<Guid, int> killCounts)
     {
         Unlocked = unlocked;
+        KillCounts = killCounts;
     }
 
     [Key(0)]
     public Dictionary<Guid, int[]> Unlocked { get; set; } = new();
+
+    [Key(1)]
+    public Dictionary<Guid, int> KillCounts { get; set; } = new();
 }
 

--- a/Intersect.Client.Core/Interface/Game/Bestiary/BestiaryWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Bestiary/BestiaryWindow.cs
@@ -172,8 +172,9 @@ public sealed class BestiaryWindow : Window
         if (!unlocked)
         {
             var killsReq = desc.BestiaryRequirements.TryGetValue(unlock, out var req) ? req : 0;
+            var currentKills = BestiaryController.GetKillCount(npcId);
             var lockedText = killsReq > 0
-                ? $"🔒 Derrota {killsReq} veces para desbloquear."
+                ? $"🔒 Derrota {currentKills}/{killsReq} veces para desbloquear."
                 : "🔒 Información bloqueada.";
 
             var label = new Label(_detailsPanel)

--- a/Intersect.Server.Core/CustomChanges/PacketSenderCustom.cs
+++ b/Intersect.Server.Core/CustomChanges/PacketSenderCustom.cs
@@ -208,7 +208,11 @@ public static partial class PacketSender
                 g => g.Select(b => (int)b.UnlockType).Distinct().ToArray()
             );
 
-        player.SendPacket(new UnlockedBestiaryEntriesPacket(unlocks));
+        var killCounts = player.BestiaryUnlocks
+            .Where(b => b.UnlockType == BestiaryUnlock.Kill)
+            .ToDictionary(b => b.NpcId, b => b.Value);
+
+        player.SendPacket(new UnlockedBestiaryEntriesPacket(unlocks, killCounts));
     }
 
 


### PR DESCRIPTION
## Summary
- send kill counts in `UnlockedBestiaryEntriesPacket`
- sync client bestiary unlocks and track kill progress
- show kill progress for locked bestiary sections

## Testing
- `dotnet test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a299bc4e2083249dce126974e87ae3