### PR TITLE
fix: persist bestiary kills across relog

### DIFF
--- a/Intersect.Server.Core/Database/PlayerData/PlayerContext.cs
+++ b/Intersect.Server.Core/Database/PlayerData/PlayerContext.cs
@@ -208,6 +208,9 @@ public abstract partial class PlayerContext : IntersectDbContext<PlayerContext>,
 
         foreach (var itm in player.Bank)
             Entry(itm).State = EntityState.Detached;
+
+        foreach (var itm in player.BestiaryUnlocks)
+            Entry(itm).State = EntityState.Detached;
     }
 
 }

--- a/Intersect.Server.Core/Entities/Player.Database.cs
+++ b/Intersect.Server.Core/Entities/Player.Database.cs
@@ -199,6 +199,7 @@ public partial class Player
         entityEntry.Collection(p => p.Quests).Load();
         entityEntry.Collection(p => p.Spells).Load();
         entityEntry.Collection(p => p.Variables).Load();
+        entityEntry.Collection(p => p.BestiaryUnlocks).Load();
 
         if (loadBags)
         {


### PR DESCRIPTION
## Summary
- load bestiary kill records when loading a player
- detach bestiary unlock entries when disposing player context

## Testing
- `/usr/share/dotnet/dotnet test` *(fails: project file vendor/LiteNetLib/LiteNetLib/LiteNetLib.csproj not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2a2a67cbc8324a121031714cf05c3