### PR TITLE
refactor: robust bestiary stats panel handling

### DIFF
--- a/Intersect.Client.Core/Interface/Game/Bestiary/BestiaryStatsPanel.cs
+++ b/Intersect.Client.Core/Interface/Game/Bestiary/BestiaryStatsPanel.cs
@@ -8,6 +8,7 @@ using Intersect.GameObjects;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.Linq;
 
 namespace Intersect.Client.Interface.Game.Bestiary;
 
@@ -50,8 +51,14 @@ public class BestiaryStatsPanel : Base
     
     }
 
-    public void UpdateData(NPCDescriptor desc)
+    public void UpdateData(NPCDescriptor? desc)
     {
+        if (desc == null)
+        {
+            Hide();
+            return;
+        }
+
         int yOffset = 0;
 
         // Aseguramos que todas las etiquetas comiencen ocultas para evitar
@@ -78,13 +85,18 @@ public class BestiaryStatsPanel : Base
         }
 
         _levelLabel.Text = $"Nivel: {desc.Level}";
-        _levelLabel.SetPosition(0, yOffset); yOffset += _levelLabel.Height + 4;
+        _levelLabel.SetPosition(0, yOffset);
+        yOffset += _levelLabel.Height + 4;
 
-        _healthLabel.Text = $"Vida: {desc.MaxVitalsLookup[Vital.Health]}";
-        _healthLabel.SetPosition(0, yOffset); yOffset += _healthLabel.Height + 4;
+        var health = desc.MaxVitalsLookup.TryGetValue(Vital.Health, out var h) ? h : 0;
+        _healthLabel.Text = $"Vida: {health}";
+        _healthLabel.SetPosition(0, yOffset);
+        yOffset += _healthLabel.Height + 4;
 
-        _manaLabel.Text = $"Mana: {desc.MaxVitalsLookup[Vital.Mana]}";
-        _manaLabel.SetPosition(0, yOffset); yOffset += _manaLabel.Height + 4;
+        var mana = desc.MaxVitalsLookup.TryGetValue(Vital.Mana, out var m) ? m : 0;
+        _manaLabel.Text = $"Mana: {mana}";
+        _manaLabel.SetPosition(0, yOffset);
+        yOffset += _manaLabel.Height + 4;
 
         var scalingValue = desc.Stats.Length > desc.ScalingStat ? desc.Stats[desc.ScalingStat] : 0;
         var baseDamage = desc.Damage + scalingValue * (desc.Scaling / 100f);
@@ -92,10 +104,12 @@ public class BestiaryStatsPanel : Base
         var maxAttack = (int)Math.Round(baseDamage * 1.025f);
 
         _minDamageLabel.Text = $"Daño Mínimo: {minAttack}";
-        _minDamageLabel.SetPosition(0, yOffset); yOffset += _minDamageLabel.Height + 4;
+        _minDamageLabel.SetPosition(0, yOffset);
+        yOffset += _minDamageLabel.Height + 4;
 
         _maxDamageLabel.Text = $"Daño Máximo: {maxAttack}";
-        _maxDamageLabel.SetPosition(0, yOffset); yOffset += _maxDamageLabel.Height + 4;
+        _maxDamageLabel.SetPosition(0, yOffset);
+        yOffset += _maxDamageLabel.Height + 4;
 
         SetSize(300, yOffset);
     }

--- a/Intersect.Client.Core/Interface/Game/Bestiary/BestiaryWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Bestiary/BestiaryWindow.cs
@@ -131,8 +131,12 @@ public sealed class BestiaryWindow : Window
     private void ShowNpcDetails(Guid npcId)
     {
         _detailsScroll.DeleteAllChildren();
+        _statsPanel = null;
 
-        if (!NPCDescriptor.TryGet(npcId, out var desc)) return;
+        if (!NPCDescriptor.TryGet(npcId, out var desc))
+        {
+            return;
+        }
 
         int yOffset = 0;
 
@@ -177,7 +181,7 @@ public sealed class BestiaryWindow : Window
             // el panel de estadísticas para evitar mostrar datos stale.
             if (unlock == BestiaryUnlock.Stats && _statsPanel != null)
             {
-                _statsPanel.IsHidden = true;
+                _statsPanel.Hide();
             }
 
             var killsReq = desc.BestiaryRequirements.TryGetValue(unlock, out var req) ? req : 0;
@@ -206,13 +210,11 @@ public sealed class BestiaryWindow : Window
                 if (_statsPanel == null)
                 {
                     _statsPanel = new BestiaryStatsPanel(_detailsScroll);
-                    _statsPanel.SetPosition(20, yOffset);
                 }
-                _statsPanel.IsHidden = false;
 
+                _statsPanel.SetPosition(20, yOffset);
+                _statsPanel.Show();
                 _statsPanel.UpdateData(desc);
-           
-
                 yOffset += _statsPanel.Height + 8;
                 break;
 


### PR DESCRIPTION
## Summary
- reset bestiary stats panel when rebuilding details
- replace IsHidden toggling with explicit Show/Hide calls
- validate NPC vitals and descriptor when updating stats panel

## Testing
- `dotnet test Intersect.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*
- `dotnet build Intersect.Client.Core/Intersect.Client.Core.csproj` *(fails: Could not find handshake key resource)*

------
https://chatgpt.com/codex/tasks/task_e_68a36f4c01248324b77175e3284d14db