### PR TITLE
Sort Bestiary mobs by level

### DIFF
--- a/Intersect.Client.Core/Interface/Game/Bestiary/BestiaryWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Bestiary/BestiaryWindow.cs
@@ -11,6 +11,7 @@ using Intersect.Framework.Core.GameObjects.Items;
 using System.Drawing;
 using Intersect;
 using Intersect.Enums;
+using System.Linq;
 namespace Intersect.Client.Interface.Game.Bestiary;
 public sealed class BestiaryWindow : Window
 {
@@ -82,7 +83,10 @@ public sealed class BestiaryWindow : Window
         }
 
         var list = filtered
-            .OrderBy(id => NPCDescriptor.TryGet(id, out var d) ? d.Name : string.Empty)
+            .Select(id => (id, desc: NPCDescriptor.TryGet(id, out var d) ? d : null))
+            .OrderBy(t => t.desc?.Level > 0 ? t.desc.Level : int.MaxValue)
+            .ThenBy(t => t.desc?.Name ?? string.Empty)
+            .Select(t => t.id)
             .ToList();
         const int tileW = 84, tileH = 104, pad = 6;
         var cols = Math.Max(1, (_tilesScroll.Width - _tilesScroll.VerticalScrollBar.Width) / (tileW + pad));


### PR DESCRIPTION
## Summary
- sort bestiary mob tiles by NPC level and fallback to name
- add missing System.Linq import

## Testing
- `dotnet test` *(fails: project file vendor/LiteNetLib/LiteNetLib.csproj not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a37a9776fc832499a701f6075e6d34