### PR TITLE
feat: add bestiary unlock chat notice

### DIFF
--- a/Intersect.Client.Core/Controllers/BestiaryController.cs
+++ b/Intersect.Client.Core/Controllers/BestiaryController.cs
@@ -3,6 +3,10 @@ using System.Collections.Generic;
 using System.Linq;
 using Intersect.Framework.Core.GameObjects.NPCs;
 using Intersect.Network.Packets.Server;
+using Intersect.Client.Interface.Game.Chat;
+using Intersect.Client.Localization;
+using Intersect.Enums;
+using Intersect;
 
 namespace Intersect.Client.Controllers;
 
@@ -69,6 +73,17 @@ public static class BestiaryController
                 if (set.Add(unlock))
                 {
                     OnUnlockGained?.Invoke(npcId, unlock); // ✅ esto debe disparar Refresh en BeastTile
+
+                    if (NPCDescriptor.TryGet(npcId, out var desc))
+                    {
+                        ChatboxMsg.AddMessage(
+                            new ChatboxMsg(
+                                Strings.Bestiary.UnlockNotice.ToString(desc.Name, unlock),
+                                CustomColors.Alerts.Success,
+                                ChatMessageType.Notice
+                            )
+                        );
+                    }
                 }
             }
         }

--- a/Intersect.Client.Core/Localization/Strings.cs
+++ b/Intersect.Client.Core/Localization/Strings.cs
@@ -864,6 +864,9 @@ public static partial class Strings
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public static LocalizedString Unlocked = @"Unlocked";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString UnlockNotice = @"Unlocked {1} for {0}";
     }
 
     public partial struct Character


### PR DESCRIPTION
## Summary
- announce new bestiary unlocks in chat
- add localized string for unlock notice

## Testing
- `dotnet test` *(fails: project file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a382239d0c8324b85d532f4e36deb1