### PR TITLE
Prevent TryBlock crash when no shield is equipped

### DIFF
--- a/Intersect.Client.Core/Entities/Player.cs
+++ b/Intersect.Client.Core/Entities/Player.cs
@@ -2034,7 +2034,7 @@ public partial class Player : Entity, IPlayer
     public bool TryBlock()
     {
         var shieldIndex = Options.Instance.Equipment.ShieldSlot;
-        var myShieldIndex = MyEquipment.GetValueOrDefault(shieldIndex).FirstOrDefault(-1);
+        var myShieldIndex = MyEquipment?.GetValueOrDefault(shieldIndex)?.FirstOrDefault(-1) ?? -1;
 
         // Return false if character is attacking, or blocking or if they don't have a shield equipped.
         if (IsAttacking || IsBlocking || shieldIndex < 0 || myShieldIndex < 0)


### PR DESCRIPTION
## Summary
- Guard against missing shield in `TryBlock` to avoid ArgumentNullException

## Testing
- `dotnet test Intersect.Tests.Client/Intersect.Tests.Client.csproj` *(fails: Could not find a part of the path 'Intersect.Network/bin/Release/keys/network.handshake.bkey.pub')*


------
https://chatgpt.com/codex/tasks/task_e_68a384e78a4883249274d206ff6d3cc7