### PR TITLE
Add spellbook state with lookup support

### DIFF
--- a/Framework/Intersect.Framework.Core/GameObjects/Spells/PlayerSpellbookState.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Spells/PlayerSpellbookState.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Collections.Generic;
+using MessagePack;
+
+namespace Intersect.Framework.Core.GameObjects.Spells;
+
+[MessagePackObject]
+public partial class PlayerSpellbookState
+{
+    [Key(0)]
+    public int AvailableSpellPoints { get; set; }
+
+    [Key(1)]
+    public Dictionary<Guid, SpellProperties> Spells { get; set; } = [];
+}
+

--- a/Intersect.Client.Core/Entities/Player.cs
+++ b/Intersect.Client.Core/Entities/Player.cs
@@ -29,6 +29,7 @@ using Intersect.Framework.Core.GameObjects.Items;
 using Intersect.Framework.Core.GameObjects.Maps;
 using Intersect.Framework.Core.GameObjects.Maps.Attributes;
 using Intersect.Framework.Core.GameObjects.PlayerClass;
+using Intersect.Framework.Core.GameObjects.Spells;
 using Intersect.Framework.Reflection;
 using Intersect.GameObjects;
 using Intersect.Network.Packets.Server;
@@ -142,6 +143,8 @@ public partial class Player : Entity, IPlayer
     IReadOnlyDictionary<Guid, long> IPlayer.SpellCooldowns => SpellCooldowns;
 
     public Dictionary<Guid, long> SpellCooldowns { get; set; } = [];
+
+    public PlayerSpellbookState Spellbook { get; set; } = new();
 
     public int StatPoints { get; set; } = 0;
 
@@ -1466,6 +1469,17 @@ public partial class Player : Entity, IPlayer
         }
 
         return 0;
+    }
+
+    public SpellProperties GetSpellProperties(Guid spellId)
+    {
+        if (!Spellbook.Spells.TryGetValue(spellId, out var properties))
+        {
+            properties = new SpellProperties { Level = 1 };
+            Spellbook.Spells[spellId] = properties;
+        }
+
+        return properties;
     }
 
     public void TryUseSpell(Guid spellId)

--- a/Intersect.Server.Core/Entities/Player.cs
+++ b/Intersect.Server.Core/Entities/Player.cs
@@ -19,6 +19,7 @@ using Intersect.Framework.Core.GameObjects.Maps.Attributes;
 using Intersect.Framework.Core.GameObjects.NPCs;
 using Intersect.Framework.Core.GameObjects.PlayerClass;
 using Intersect.Framework.Core.GameObjects.Quests;
+using Intersect.Framework.Core.GameObjects.Spells;
 using Intersect.Framework.Core.GameObjects.Variables;
 using Intersect.GameObjects;
 using Intersect.Network;
@@ -84,6 +85,9 @@ public partial class Player : Entity
     public long Exp { get; set; }
 
     public int StatPoints { get; set; }
+
+    [NotMapped, JsonIgnore]
+    public PlayerSpellbookState Spellbook { get; set; } = new();
 
     [Column("Equipment"), JsonIgnore]
     public string EquipmentJson
@@ -5602,6 +5606,17 @@ public partial class Player : Entity
         }
 
         return -1;
+    }
+
+    public SpellProperties GetSpellProperties(Guid spellId)
+    {
+        if (!Spellbook.Spells.TryGetValue(spellId, out var properties))
+        {
+            properties = new SpellProperties { Level = 1 };
+            Spellbook.Spells[spellId] = properties;
+        }
+
+        return properties;
     }
 
     public void SwapSpells(int spell1, int spell2)


### PR DESCRIPTION
## Summary
- add PlayerSpellbookState for tracking spell points and spell properties
- expose Spellbook on client and server Player with default Level 1 lookup

## Testing
- `dotnet test` *(fails: project file vendor/LiteNetLib/LiteNetLib.csproj not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3ba5ad37c8324ab608f1f9075f810