### PR TITLE
Add basic spell progression model and store

### DIFF
--- a/Framework/Intersect.Framework.Core/GameObjects/Spells/SpellProgression.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Spells/SpellProgression.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Intersect.GameObjects;
+
+/// <summary>
+/// Represents a single progression row for a spell level.
+/// </summary>
+public class SpellLevelRow
+{
+    /// <summary>
+    /// Gets or sets the level this row applies to.
+    /// </summary>
+    public int Level { get; set; }
+
+    /// <summary>
+    /// Gets or sets a generic power value for this level.
+    /// This can represent damage, healing, or any other stat that scales with level.
+    /// </summary>
+    public int Power { get; set; }
+}
+
+/// <summary>
+/// Describes the complete progression for a spell.
+/// </summary>
+public class SpellProgression
+{
+    /// <summary>
+    /// Gets or sets the id of the spell that this progression belongs to.
+    /// </summary>
+    public Guid SpellId { get; set; }
+
+    /// <summary>
+    /// Gets the ordered list of level rows that make up this progression.
+    /// </summary>
+    public IList<SpellLevelRow> Levels { get; set; } = new List<SpellLevelRow>();
+
+    /// <summary>
+    /// Retrieves the row for the provided level if one exists.
+    /// </summary>
+    /// <param name="level">The level to query.</param>
+    /// <returns>The <see cref="SpellLevelRow"/> for the requested level or <c>null</c> if not found.</returns>
+    public SpellLevelRow? GetLevel(int level) =>
+        Levels.FirstOrDefault(row => row.Level == level);
+}
+

--- a/Framework/Intersect.Framework.Core/GameObjects/Spells/SpellProgressionStore.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Spells/SpellProgressionStore.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Newtonsoft.Json;
+
+namespace Intersect.GameObjects;
+
+/// <summary>
+/// Provides access to spell progression information for both client and server.
+/// </summary>
+public static class SpellProgressionStore
+{
+    private static readonly Dictionary<Guid, SpellProgression> s_bySpellId = new();
+
+    /// <summary>
+    /// Gets the progression for the specified spell identifier.
+    /// </summary>
+    public static IReadOnlyDictionary<Guid, SpellProgression> BySpellId => s_bySpellId;
+
+    /// <summary>
+    /// Loads progressions from a JSON file on disk.
+    /// If the file does not exist, a hardcoded default is loaded instead.
+    /// </summary>
+    public static void Load(string filePath)
+    {
+        if (File.Exists(filePath))
+        {
+            var json = File.ReadAllText(filePath);
+            var progressions = JsonConvert.DeserializeObject<List<SpellProgression>>(json) ?? new();
+            Load(progressions);
+        }
+        else
+        {
+            LoadDefaults();
+        }
+    }
+
+    /// <summary>
+    /// Populates the store with the provided progressions.
+    /// Ensures each progression contains exactly five rows.
+    /// </summary>
+    private static void Load(IEnumerable<SpellProgression> progressions)
+    {
+        s_bySpellId.Clear();
+        foreach (var progression in progressions)
+        {
+            if (progression.Levels.Count != 5)
+            {
+                throw new InvalidDataException($"Spell {progression.SpellId} must define exactly five progression rows.");
+            }
+
+            // Ensure rows are ordered by level.
+            progression.Levels = progression.Levels.OrderBy(l => l.Level).ToList();
+            s_bySpellId[progression.SpellId] = progression;
+        }
+    }
+
+    /// <summary>
+    /// Temporary hardcoded loader that creates five empty rows for every spell in the database.
+    /// </summary>
+    public static void LoadDefaults()
+    {
+        var progressions = SpellDescriptor.Lookup
+            .Select(pair => (SpellDescriptor)pair.Value)
+            .Select(descriptor => new SpellProgression
+            {
+                SpellId = descriptor.Id,
+                Levels = Enumerable.Range(1, 5)
+                    .Select(level => new SpellLevelRow { Level = level, Power = 0 })
+                    .Cast<SpellLevelRow>()
+                    .ToList()
+            });
+
+        Load(progressions);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `SpellLevelRow` and `SpellProgression` to describe spell level data
- implement `SpellProgressionStore` with loader and default hardcoded progressions

## Testing
- `dotnet build Framework/Intersect.Framework.Core/Intersect.Framework.Core.csproj`
- `dotnet test Framework/Intersect.Framework.Core/Intersect.Framework.Core.csproj` (no tests found)


------
https://chatgpt.com/codex/tasks/task_e_68a3bc180684832490b91061f95b4cd3