### PR TITLE
Add spell leveling service and tests

### DIFF
--- a/Framework/Intersect.Framework.Core/Services/SpellLevelingService.cs
+++ b/Framework/Intersect.Framework.Core/Services/SpellLevelingService.cs
@@ -1,0 +1,69 @@
+using System;
+using Intersect.GameObjects;
+using Intersect.Framework.Core.GameObjects.Spells;
+
+namespace Intersect.Framework.Core.Services;
+
+public static class SpellLevelingService
+{
+    public sealed class AdjustedSpell
+    {
+        public int CastTimeMs { get; init; }
+        public int CooldownTimeMs { get; init; }
+        public long[] VitalCosts { get; init; } = Array.Empty<long>();
+        public int PowerBonusFlat { get; init; }
+        public float PowerScalingBonus { get; init; }
+        public float BuffStrengthFactor { get; init; }
+        public float BuffDurationFactor { get; init; }
+        public float DebuffStrengthFactor { get; init; }
+        public float DebuffDurationFactor { get; init; }
+        public bool UnlocksAoE { get; init; }
+        public int AoERadius { get; init; }
+    }
+
+    public static AdjustedSpell BuildAdjusted(SpellDescriptor baseDesc, SpellProperties row)
+    {
+        if (baseDesc == null)
+        {
+            throw new ArgumentNullException(nameof(baseDesc));
+        }
+
+        if (row == null)
+        {
+            throw new ArgumentNullException(nameof(row));
+        }
+
+        var castTime = baseDesc.CastDuration + row.CastTimeDeltaMs;
+        var cooldown = baseDesc.CooldownDuration + row.CooldownDeltaMs;
+
+        var vitalCosts = new long[baseDesc.VitalCost.Length];
+        for (var i = 0; i < vitalCosts.Length; ++i)
+        {
+            var delta = 0L;
+            if (row.VitalCostDeltas != null && i < row.VitalCostDeltas.Length)
+            {
+                delta = row.VitalCostDeltas[i];
+            }
+
+            vitalCosts[i] = baseDesc.VitalCost[i] + delta;
+        }
+
+        var aoeRadius = baseDesc.Combat?.HitRadius ?? 0;
+        aoeRadius += row.AoERadiusDelta;
+
+        return new AdjustedSpell
+        {
+            CastTimeMs = castTime,
+            CooldownTimeMs = cooldown,
+            VitalCosts = vitalCosts,
+            PowerBonusFlat = row.PowerBonusFlat,
+            PowerScalingBonus = row.PowerScalingBonus,
+            BuffStrengthFactor = row.BuffStrengthFactor,
+            BuffDurationFactor = row.BuffDurationFactor,
+            DebuffStrengthFactor = row.DebuffStrengthFactor,
+            DebuffDurationFactor = row.DebuffDurationFactor,
+            UnlocksAoE = row.UnlocksAoE,
+            AoERadius = aoeRadius,
+        };
+    }
+}

--- a/Intersect.Tests/Services/SpellLevelingServiceTests.cs
+++ b/Intersect.Tests/Services/SpellLevelingServiceTests.cs
@@ -1,0 +1,80 @@
+using System;
+using Intersect.Framework.Core.GameObjects.Spells;
+using Intersect.Framework.Core.Services;
+using Intersect.GameObjects;
+using NUnit.Framework;
+using Assert = Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
+using CollectionAssert = Microsoft.VisualStudio.TestTools.UnitTesting.CollectionAssert;
+
+namespace Intersect.Services;
+
+[TestFixture]
+public class SpellLevelingServiceTests
+{
+    private static SpellDescriptor CreateBaseDescriptor()
+    {
+        return new SpellDescriptor
+        {
+            CastDuration = 1000,
+            CooldownDuration = 2000,
+            VitalCost = new long[] { 10, 20 },
+            Combat = new SpellCombatDescriptor { HitRadius = 2 }
+        };
+    }
+
+    [Test]
+    public void BuildAdjusted_Level1_NoChanges()
+    {
+        var baseDesc = CreateBaseDescriptor();
+        var row = new SpellProperties { Level = 1 };
+
+        var adjusted = SpellLevelingService.BuildAdjusted(baseDesc, row);
+
+        Assert.AreEqual(1000, adjusted.CastTimeMs);
+        Assert.AreEqual(2000, adjusted.CooldownTimeMs);
+        CollectionAssert.AreEqual(new long[] { 10, 20 }, adjusted.VitalCosts);
+        Assert.AreEqual(0, adjusted.PowerBonusFlat);
+        Assert.AreEqual(0f, adjusted.PowerScalingBonus);
+        Assert.AreEqual(0f, adjusted.BuffStrengthFactor);
+        Assert.AreEqual(0f, adjusted.BuffDurationFactor);
+        Assert.AreEqual(0f, adjusted.DebuffStrengthFactor);
+        Assert.AreEqual(0f, adjusted.DebuffDurationFactor);
+        Assert.IsFalse(adjusted.UnlocksAoE);
+        Assert.AreEqual(2, adjusted.AoERadius);
+    }
+
+    [Test]
+    public void BuildAdjusted_Level5_AdjustsValues()
+    {
+        var baseDesc = CreateBaseDescriptor();
+        var row = new SpellProperties
+        {
+            Level = 5,
+            CastTimeDeltaMs = -100,
+            CooldownDeltaMs = -200,
+            VitalCostDeltas = new long[] { -5, 5 },
+            PowerBonusFlat = 10,
+            PowerScalingBonus = 0.5f,
+            BuffStrengthFactor = 1.5f,
+            BuffDurationFactor = 2f,
+            DebuffStrengthFactor = 0.5f,
+            DebuffDurationFactor = 1.5f,
+            UnlocksAoE = true,
+            AoERadiusDelta = 3
+        };
+
+        var adjusted = SpellLevelingService.BuildAdjusted(baseDesc, row);
+
+        Assert.AreEqual(900, adjusted.CastTimeMs);
+        Assert.AreEqual(1800, adjusted.CooldownTimeMs);
+        CollectionAssert.AreEqual(new long[] { 5, 25 }, adjusted.VitalCosts);
+        Assert.AreEqual(10, adjusted.PowerBonusFlat);
+        Assert.AreEqual(0.5f, adjusted.PowerScalingBonus);
+        Assert.AreEqual(1.5f, adjusted.BuffStrengthFactor);
+        Assert.AreEqual(2f, adjusted.BuffDurationFactor);
+        Assert.AreEqual(0.5f, adjusted.DebuffStrengthFactor);
+        Assert.AreEqual(1.5f, adjusted.DebuffDurationFactor);
+        Assert.IsTrue(adjusted.UnlocksAoE);
+        Assert.AreEqual(5, adjusted.AoERadius);
+    }
+}


### PR DESCRIPTION
## Summary
- add `SpellLevelingService` to compute adjusted spell stats from leveling properties
- cover basic level 1 and level 5 behavior in `SpellLevelingServiceTests`

## Testing
- `dotnet test Intersect.Tests/Intersect.Tests.csproj -v minimal` *(fails: AuthorsTests.cs(66,35) error CS0121 ambiguous call)*

------
https://chatgpt.com/codex/tasks/task_e_68a3bc45bef88324b29cb33501d4d94e