### PR TITLE
Add packets and handlers for spell upgrades

### DIFF
--- a/Framework/Intersect.Framework.Core/Network/Packets/Client/RequestSpellUpgradePacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Client/RequestSpellUpgradePacket.cs
@@ -1,0 +1,21 @@
+using MessagePack;
+
+namespace Intersect.Network.Packets.Client;
+
+[MessagePackObject]
+public partial class RequestSpellUpgradePacket : IntersectPacket
+{
+    // Parameterless Constructor for MessagePack
+    public RequestSpellUpgradePacket()
+    {
+    }
+
+    public RequestSpellUpgradePacket(Guid spellId)
+    {
+        SpellId = spellId;
+    }
+
+    [Key(0)]
+    public Guid SpellId { get; set; }
+}
+

--- a/Framework/Intersect.Framework.Core/Network/Packets/Server/SpellUpgradeFailedPacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Server/SpellUpgradeFailedPacket.cs
@@ -1,0 +1,33 @@
+using MessagePack;
+
+namespace Intersect.Network.Packets.Server;
+
+[MessagePackObject]
+public partial class SpellUpgradeFailedPacket : IntersectPacket
+{
+    public enum Reason
+    {
+        NotEnoughPoints,
+        AlreadyMaxLevel,
+        SpellNotOwned,
+        ServerError,
+    }
+
+    // Parameterless Constructor for MessagePack
+    public SpellUpgradeFailedPacket()
+    {
+    }
+
+    public SpellUpgradeFailedPacket(Guid spellId, Reason reason)
+    {
+        SpellId = spellId;
+        Reason = reason;
+    }
+
+    [Key(0)]
+    public Guid SpellId { get; set; }
+
+    [Key(1)]
+    public Reason Reason { get; set; }
+}
+

--- a/Framework/Intersect.Framework.Core/Network/Packets/Server/SpellUpgradedPacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Server/SpellUpgradedPacket.cs
@@ -1,0 +1,29 @@
+using MessagePack;
+
+namespace Intersect.Network.Packets.Server;
+
+[MessagePackObject]
+public partial class SpellUpgradedPacket : IntersectPacket
+{
+    // Parameterless Constructor for MessagePack
+    public SpellUpgradedPacket()
+    {
+    }
+
+    public SpellUpgradedPacket(Guid spellId, int newLevel, int remainingSpellPoints)
+    {
+        SpellId = spellId;
+        NewLevel = newLevel;
+        RemainingSpellPoints = remainingSpellPoints;
+    }
+
+    [Key(0)]
+    public Guid SpellId { get; set; }
+
+    [Key(1)]
+    public int NewLevel { get; set; }
+
+    [Key(2)]
+    public int RemainingSpellPoints { get; set; }
+}
+

--- a/Intersect.Client.Core/Networking/PacketHandler.cs
+++ b/Intersect.Client.Core/Networking/PacketHandler.cs
@@ -30,6 +30,7 @@ using Intersect.Framework.Core.GameObjects.Mapping.Tilesets;
 using Intersect.Framework.Core.GameObjects.Maps;
 using Intersect.Framework.Core.GameObjects.Maps.Attributes;
 using Intersect.Framework.Core.GameObjects.Maps.MapList;
+using Intersect.Framework.Core.GameObjects.Spells;
 using Intersect.Framework.Core.Security;
 using Intersect.Localization;
 using Microsoft.Extensions.Logging;
@@ -1482,6 +1483,28 @@ internal sealed partial class PacketHandler
                 Globals.Me.SpellCooldowns[cd.Key] = time;
             }
         }
+    }
+
+    //SpellUpgradedPacket
+    public void HandlePacket(IPacketSender packetSender, SpellUpgradedPacket packet)
+    {
+        if (Globals.Me != null)
+        {
+            Globals.Me.Spellbook.AvailableSpellPoints = packet.RemainingSpellPoints;
+            if (!Globals.Me.Spellbook.Spells.TryGetValue(packet.SpellId, out var properties))
+            {
+                properties = new SpellProperties();
+                Globals.Me.Spellbook.Spells[packet.SpellId] = properties;
+            }
+
+            properties.Level = packet.NewLevel;
+        }
+    }
+
+    //SpellUpgradeFailedPacket
+    public void HandlePacket(IPacketSender packetSender, SpellUpgradeFailedPacket packet)
+    {
+        // Failure handling can be implemented as needed
     }
 
     //ItemCooldownPacket

--- a/Intersect.Client.Core/Networking/PacketSender.cs
+++ b/Intersect.Client.Core/Networking/PacketSender.cs
@@ -226,6 +226,11 @@ public static partial class PacketSender
         Network.SendPacket(new UseSpellPacket(slot, targetId, Globals.ShouldSoftRetargetOnSelfCast));
     }
 
+    public static void SendRequestSpellUpgrade(Guid spellId)
+    {
+        Network.SendPacket(new RequestSpellUpgradePacket(spellId));
+    }
+
     public static void SendUnequipItem(int slot)
     {
         Network.SendPacket(new UnequipItemPacket(slot));

--- a/Intersect.Server.Core/Networking/PacketHandler.cs
+++ b/Intersect.Server.Core/Networking/PacketHandler.cs
@@ -1863,6 +1863,18 @@ internal sealed partial class PacketHandler
         }
     }
 
+    //RequestSpellUpgradePacket
+    public void HandlePacket(Client client, RequestSpellUpgradePacket packet)
+    {
+        var player = client?.Entity;
+        if (player == null)
+        {
+            return;
+        }
+
+        // Spell upgrade request handling to be implemented
+    }
+
     //UnequipItemPacket
     public void HandlePacket(Client client, UnequipItemPacket packet)
     {


### PR DESCRIPTION
## Summary
- add RequestSpellUpgradePacket for clients
- add SpellUpgradedPacket and SpellUpgradeFailedPacket responses
- register new spell upgrade packets in client/server handlers

## Testing
- `dotnet test` *(fails: project file vendor/LiteNetLib/LiteNetLib.csproj was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3be2f51948324bdc50d5a9c8dbb88