### PR TITLE
Sync spellbook state and expose spell points

### DIFF
--- a/Framework/Intersect.Framework.Core/Network/Packets/Server/PlayerEntityPacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Server/PlayerEntityPacket.cs
@@ -68,4 +68,7 @@ public partial class PlayerEntityPacket : EntityPacket
 
     [Key(40)]
     public byte GuildBackgroundB { get; set; }
+
+    [Key(41)]
+    public int AvailableSpellPoints { get; set; }
 }

--- a/Intersect.Client.Core/Entities/Player.cs
+++ b/Intersect.Client.Core/Entities/Player.cs
@@ -392,6 +392,7 @@ public partial class Player : Entity, IPlayer
         GuildBackgroundR = playerPacket.GuildBackgroundR;
         GuildBackgroundG = playerPacket.GuildBackgroundG;
         GuildBackgroundB = playerPacket.GuildBackgroundB;
+        Spellbook.AvailableSpellPoints = playerPacket.AvailableSpellPoints;
         GuildSymbolFile = playerPacket.GuildSymbolFile;
         GuildSymbolR = playerPacket.GuildSymbolR;
         GuildSymbolG = playerPacket.GuildSymbolG;

--- a/Intersect.Server.Core/Entities/Player.Database.cs
+++ b/Intersect.Server.Core/Entities/Player.Database.cs
@@ -396,6 +396,7 @@ public partial class Player
                 playerContext = createdPlayerContext = DbInterface.CreatePlayerContext(readOnly: false);
             }
 
+            EnsureSpellbookEntries();
             playerContext.Update(this);
             playerContext.ChangeTracker.DetectChanges();
             playerContext.SaveChanges();

--- a/Intersect.Server.Core/Entities/Player.cs
+++ b/Intersect.Server.Core/Entities/Player.cs
@@ -464,6 +464,8 @@ public partial class Player : Entity
             }
         }
 
+        EnsureSpellbookEntries();
+
         OnlinePlayersById[Id] = this;
         _onlinePlayers.Add(this);
 
@@ -1135,6 +1137,8 @@ public partial class Player : Entity
             pkt.GuildSymbolB = Guild.SymbolB;
 
         }
+
+        pkt.AvailableSpellPoints = Spellbook.AvailableSpellPoints;
         return pkt;
     }
 
@@ -1342,6 +1346,8 @@ public partial class Player : Entity
             PacketSender.SendEntityDataToProximity(this);
             PacketSender.SendExperience(this);
         }
+
+        Save();
     }
 
     /// <summary>
@@ -5617,6 +5623,17 @@ public partial class Player : Entity
         }
 
         return properties;
+    }
+
+    public void EnsureSpellbookEntries()
+    {
+        foreach (var slot in Spells)
+        {
+            if (slot.SpellId != Guid.Empty && !Spellbook.Spells.ContainsKey(slot.SpellId))
+            {
+                Spellbook.Spells[slot.SpellId] = new SpellProperties { Level = 1 };
+            }
+        }
     }
 
     public void SwapSpells(int spell1, int spell2)


### PR DESCRIPTION
## Summary
- add available spell points to player entity packet and client load
- ensure spellbook defaults to level 1 for learned spells and save after level up
- sync spellbook entries before persisting player data

## Testing
- `dotnet test` *(fails: project files not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3c387f538832492386821bea02f7d