### PR TITLE
Integrate spell leveling adjustments

### DIFF
--- a/Framework/Intersect.Framework.Core/GameObjects/Spells/SpellProgression.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Spells/SpellProgression.cs
@@ -1,28 +1,14 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Intersect.Framework.Core.GameObjects.Spells;
 
 namespace Intersect.GameObjects;
 
 /// <summary>
-/// Represents a single progression row for a spell level.
-/// </summary>
-public class SpellLevelRow
-{
-    /// <summary>
-    /// Gets or sets the level this row applies to.
-    /// </summary>
-    public int Level { get; set; }
-
-    /// <summary>
-    /// Gets or sets a generic power value for this level.
-    /// This can represent damage, healing, or any other stat that scales with level.
-    /// </summary>
-    public int Power { get; set; }
-}
-
-/// <summary>
 /// Describes the complete progression for a spell.
+/// Each level row is represented by <see cref="SpellProperties"/> allowing
+/// for adjustments to many aspects of a spell as it levels up.
 /// </summary>
 public class SpellProgression
 {
@@ -34,14 +20,13 @@ public class SpellProgression
     /// <summary>
     /// Gets the ordered list of level rows that make up this progression.
     /// </summary>
-    public IList<SpellLevelRow> Levels { get; set; } = new List<SpellLevelRow>();
+    public IList<SpellProperties> Levels { get; set; } = new List<SpellProperties>();
 
     /// <summary>
     /// Retrieves the row for the provided level if one exists.
     /// </summary>
     /// <param name="level">The level to query.</param>
-    /// <returns>The <see cref="SpellLevelRow"/> for the requested level or <c>null</c> if not found.</returns>
-    public SpellLevelRow? GetLevel(int level) =>
+    /// <returns>The <see cref="SpellProperties"/> for the requested level or <c>null</c> if not found.</returns>
+    public SpellProperties? GetLevel(int level) =>
         Levels.FirstOrDefault(row => row.Level == level);
 }
-

--- a/Framework/Intersect.Framework.Core/GameObjects/Spells/SpellProgressionStore.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Spells/SpellProgressionStore.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Newtonsoft.Json;
+using Intersect.Framework.Core.GameObjects.Spells;
 
 namespace Intersect.GameObjects;
 
@@ -67,8 +68,7 @@ public static class SpellProgressionStore
             {
                 SpellId = descriptor.Id,
                 Levels = Enumerable.Range(1, 5)
-                    .Select(level => new SpellLevelRow { Level = level, Power = 0 })
-                    .Cast<SpellLevelRow>()
+                    .Select(level => new SpellProperties { Level = level })
                     .ToList()
             });
 

--- a/Intersect.Server.Core/Entities/Combat/SpellCastResolver.cs
+++ b/Intersect.Server.Core/Entities/Combat/SpellCastResolver.cs
@@ -1,0 +1,44 @@
+using System;
+using Intersect.Framework.Core.GameObjects.Spells;
+using Intersect.Framework.Core.Services;
+using Intersect.GameObjects;
+using Intersect.Server.Entities;
+
+namespace Intersect.Server.Entities.Combat;
+
+/// <summary>
+/// Helper methods for resolving a spell cast at a given level.
+/// </summary>
+public static class SpellCastResolver
+{
+    /// <summary>
+    /// Builds an adjusted spell based on the caster's level for the provided spell descriptor.
+    /// </summary>
+    public static SpellLevelingService.AdjustedSpell Resolve(Entity caster, SpellDescriptor baseSpell)
+    {
+        if (baseSpell == null)
+        {
+            throw new ArgumentNullException(nameof(baseSpell));
+        }
+
+        var level = 1;
+        var row = new SpellProperties { Level = level };
+
+        if (caster is Player player)
+        {
+            var props = player.GetSpellProperties(baseSpell.Id);
+            level = props?.Level ?? 1;
+
+            if (SpellProgressionStore.BySpellId.TryGetValue(baseSpell.Id, out var progression))
+            {
+                row = progression.GetLevel(level) ?? new SpellProperties { Level = level };
+            }
+            else
+            {
+                row.Level = level;
+            }
+        }
+
+        return SpellLevelingService.BuildAdjusted(baseSpell, row);
+    }
+}


### PR DESCRIPTION
## Summary
- incorporate spell progression rows using SpellProperties
- add resolver to compute adjusted spell data by level
- apply adjusted costs, cooldowns, cast time, and AoE during spell casting and attacks

## Testing
- ❌ `dotnet test -c Release` (command not found)

------
https://chatgpt.com/codex/tasks/task_e_68a3c3eb19548324a25114dcbf3be53a