### PR TITLE
Show spell levels and next-level tooltip preview

### DIFF
--- a/Intersect.Client.Core/Interface/Game/DescriptionWindows/SpellDescriptionWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/DescriptionWindows/SpellDescriptionWindow.cs
@@ -3,12 +3,18 @@ using Intersect.GameObjects;
 using Intersect.Client.Localization;
 using Intersect.Utilities;
 using Intersect.Client.Framework.File_Management;
+using Intersect.Client.Framework.Gwen.Input;
+using Intersect.Client.General;
+using Intersect.Framework.Core.GameObjects.Spells;
+using Intersect.Framework.Core.Services;
 
 namespace Intersect.Client.Interface.Game.DescriptionWindows;
 
 public partial class SpellDescriptionWindow() : DescriptionWindowBase(Interface.GameUi.GameCanvas, "DescriptionWindow")
 {
     private SpellDescriptor? _spellDescriptor;
+    private SpellLevelingService.AdjustedSpell? _adjusted;
+    private int _level;
 
     public void Show(Guid spellId, ItemDescriptionWindow? itemDecriptionContainer = default)
     {
@@ -44,6 +50,26 @@ public partial class SpellDescriptionWindow() : DescriptionWindowBase(Interface.
         if (_spellDescriptor == default)
         {
             return;
+        }
+        _level = 1;
+        _adjusted = null;
+
+        if (Globals.Me != null)
+        {
+            var properties = Globals.Me.GetSpellProperties(_spellDescriptor.Id);
+            var row = properties;
+
+            if (InputHandler.IsShiftDown && SpellProgressionStore.BySpellId.TryGetValue(_spellDescriptor.Id, out var progression))
+            {
+                var next = progression.GetLevel(properties.Level + 1);
+                if (next != null)
+                {
+                    row = next;
+                }
+            }
+
+            _level = row.Level;
+            _adjusted = SpellLevelingService.BuildAdjusted(_spellDescriptor, row);
         }
 
         // Set up our header information.
@@ -98,21 +124,23 @@ public partial class SpellDescriptionWindow() : DescriptionWindowBase(Interface.
         // Set up the header as the item name.
         header.SetTitle(_spellDescriptor.Name, Color.White);
 
-        // Set up the spell type description.
+        // Set up the spell type description with level information.
         Strings.SpellDescription.SpellTypes.TryGetValue((int)_spellDescriptor.SpellType, out var spellType);
-        header.SetSubtitle(spellType, Color.White);
+        var levelText = Strings.EntityBox.Level.ToString(_level);
+        header.SetSubtitle($"{spellType} - {levelText}", Color.White);
 
         // Set up the spelldescription based on what kind of spell it is.
         if (_spellDescriptor.SpellType == (int)SpellType.CombatSpell)
         {
+            var hitRadius = _adjusted?.AoERadius ?? _spellDescriptor.Combat.HitRadius;
             if (_spellDescriptor.Combat.TargetType == SpellTargetType.Projectile)
             {
                 var proj = ProjectileDescriptor.Get(_spellDescriptor.Combat.ProjectileId);
-                header.SetDescription(Strings.SpellDescription.TargetTypes[(int)_spellDescriptor.Combat.TargetType].ToString(proj?.Range ?? 0, _spellDescriptor.Combat.HitRadius), Color.White);
+                header.SetDescription(Strings.SpellDescription.TargetTypes[(int)_spellDescriptor.Combat.TargetType].ToString(proj?.Range ?? 0, hitRadius), Color.White);
             }
             else
             {
-                header.SetDescription(Strings.SpellDescription.TargetTypes[(int)_spellDescriptor.Combat.TargetType].ToString(_spellDescriptor.Combat.CastRange, _spellDescriptor.Combat.HitRadius), Color.White);
+                header.SetDescription(Strings.SpellDescription.TargetTypes[(int)_spellDescriptor.Combat.TargetType].ToString(_spellDescriptor.Combat.CastRange, hitRadius), Color.White);
             }
         }
 
@@ -146,26 +174,29 @@ public partial class SpellDescriptionWindow() : DescriptionWindowBase(Interface.
         }
 
         // Add cast time
+        var castTimeMs = _adjusted?.CastTimeMs ?? _spellDescriptor.CastDuration;
         var castTime = Strings.SpellDescription.Instant;
-        if (_spellDescriptor.CastDuration > 0)
+        if (castTimeMs > 0)
         {
-            castTime = TimeSpan.FromMilliseconds(_spellDescriptor.CastDuration).WithSuffix();
+            castTime = TimeSpan.FromMilliseconds(castTimeMs).WithSuffix();
         }
         rows.AddKeyValueRow(Strings.SpellDescription.CastTime, castTime);
 
         // Add Vital Costs
         for (var i = 0; i < Enum.GetValues<Vital>().Length; i++)
         {
-            if (_spellDescriptor.VitalCost[i] != 0)
+            var cost = _adjusted?.VitalCosts[i] ?? _spellDescriptor.VitalCost[i];
+            if (cost != 0)
             {
-                rows.AddKeyValueRow(Strings.SpellDescription.VitalCosts[i], _spellDescriptor.VitalCost[i].ToString());
+                rows.AddKeyValueRow(Strings.SpellDescription.VitalCosts[i], cost.ToString());
             }
         }
 
         // Add Cooldown time
-        if (_spellDescriptor.CooldownDuration > 0)
+        var cooldownMs = _adjusted?.CooldownTimeMs ?? _spellDescriptor.CooldownDuration;
+        if (cooldownMs > 0)
         {
-            rows.AddKeyValueRow(Strings.SpellDescription.Cooldown, TimeSpan.FromMilliseconds(_spellDescriptor.CooldownDuration).WithSuffix());
+            rows.AddKeyValueRow(Strings.SpellDescription.Cooldown, TimeSpan.FromMilliseconds(cooldownMs).WithSuffix());
         }
 
         // Add Cooldown Group
@@ -240,11 +271,12 @@ public partial class SpellDescriptionWindow() : DescriptionWindowBase(Interface.
         Strings.SpellDescription.DamageTypes.TryGetValue(_spellDescriptor.Combat.DamageType, out var damageType);
         rows.AddKeyValueRow(Strings.SpellDescription.DamageType, damageType);
 
-        if (_spellDescriptor.Combat.Scaling > 0)
+        var scaling = _spellDescriptor.Combat.Scaling + (_adjusted?.PowerScalingBonus ?? 0);
+        if (scaling > 0)
         {
             Strings.SpellDescription.Stats.TryGetValue(_spellDescriptor.Combat.ScalingStat, out var stat);
             rows.AddKeyValueRow(Strings.SpellDescription.ScalingStat, stat);
-            rows.AddKeyValueRow(Strings.SpellDescription.ScalingPercentage, Strings.SpellDescription.Percentage.ToString(_spellDescriptor.Combat.Scaling));
+            rows.AddKeyValueRow(Strings.SpellDescription.ScalingPercentage, Strings.SpellDescription.Percentage.ToString(scaling));
         }
 
         // Crit Chance

--- a/Intersect.Client.Core/Interface/Game/Hotbar/HotbarItem.cs
+++ b/Intersect.Client.Core/Interface/Game/Hotbar/HotbarItem.cs
@@ -23,6 +23,7 @@ public partial class HotbarItem : SlotItem
     private readonly Label _cooldownLabel;
     private readonly Label _equipLabel;
     private readonly Label _keyLabel;
+    private readonly Label _levelLabel;
 
     private Guid _currentId = Guid.Empty;
     private ItemDescriptor? _currentItem = null;
@@ -121,6 +122,21 @@ public partial class HotbarItem : SlotItem
             FontSize = 8,
             Padding = Padding.FourH,
             TextColorOverride = Color.White,
+        };
+
+        _levelLabel = new Label(this, $"LevelLabel{hotbarSlotIndex}")
+        {
+            Alignment = [Alignments.Bottom, Alignments.Left],
+            X = 0,
+            Y = 25,
+            Width = 10,
+            Height = 11,
+            BackgroundTemplateName = "hotbar_label.png",
+            Font = font,
+            FontSize = 8,
+            Padding = Padding.FourH,
+            TextColorOverride = Color.White,
+            IsHidden = true,
         };
     }
 
@@ -387,12 +403,24 @@ public partial class HotbarItem : SlotItem
             _equipLabel.IsHidden = true;
             _quantityLabel.IsHidden = true;
             _cooldownLabel.IsHidden = true;
+            _levelLabel.IsHidden = true;
         }
         else
         {
             _equipLabel.IsHidden = !_isEquipped || invalidInventoryIndex;
             _quantityLabel.IsHidden = _currentItem?.Stackable == false || invalidInventoryIndex;
             _cooldownLabel.IsHidden = !_isFaded || invalidInventoryIndex;
+            _levelLabel.IsHidden = _currentSpell == null || _spellBookItem == null;
+        }
+
+        if (!_levelLabel.IsHidden && _currentSpell != null)
+        {
+            var spellProps = Globals.Me.GetSpellProperties(_currentSpell.Id);
+            var levelText = Strings.EntityBox.Level.ToString(spellProps.Level);
+            if (_levelLabel.Text != levelText)
+            {
+                _levelLabel.Text = levelText;
+            }
         }
 
         if (updateDisplay) //Item on cd and fade is incorrect


### PR DESCRIPTION
## Summary
- Display spell levels on hotbar items
- Show current or next-level spell stats in tooltips depending on shift key

## Testing
- `dotnet test` *(fails: project file "/workspace/Broken_Reborn/vendor/LiteNetLib/LiteNetLib/LiteNetLib.csproj" was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3c783dd90832485be42bcfe7d7ca9