### PR TITLE
Decouple spell levels from assets and centralize upgrades

### DIFF
--- a/Framework/Intersect.Framework.Core/GameObjects/Spells/PlayerSpellbookState.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Spells/PlayerSpellbookState.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using MessagePack;
+using Intersect.GameObjects;
 
 namespace Intersect.Framework.Core.GameObjects.Spells;
 
@@ -12,5 +13,31 @@ public partial class PlayerSpellbookState
 
     [Key(1)]
     public Dictionary<Guid, SpellProperties> Spells { get; set; } = [];
+
+    [Key(2)]
+    public Dictionary<Guid, int> SpellLevels { get; set; } = [];
+
+    public int GetLevel(Guid spellId) =>
+        SpellLevels.TryGetValue(spellId, out var level) ? level : 1;
+
+    public bool TryUpgradeSpell(Guid spellId, out int newLevel)
+    {
+        var currentLevel = GetLevel(spellId);
+        newLevel = currentLevel;
+
+        if (!SpellProgressionStore.BySpellId.TryGetValue(spellId, out var progression))
+        {
+            return false;
+        }
+
+        if (currentLevel >= progression.Levels.Count)
+        {
+            return false;
+        }
+
+        newLevel = currentLevel + 1;
+        SpellLevels[spellId] = newLevel;
+        return true;
+    }
 }
 

--- a/Framework/Intersect.Framework.Core/GameObjects/Spells/SpellProgression.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Spells/SpellProgression.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Intersect.Framework.Core.GameObjects.Spells;
 
 namespace Intersect.GameObjects;
@@ -28,5 +27,5 @@ public class SpellProgression
     /// <param name="level">The level to query.</param>
     /// <returns>The <see cref="SpellProperties"/> for the requested level or <c>null</c> if not found.</returns>
     public SpellProperties? GetLevel(int level) =>
-        Levels.FirstOrDefault(row => row.Level == level);
+        level >= 1 && level <= Levels.Count ? Levels[level - 1] : null;
 }

--- a/Framework/Intersect.Framework.Core/GameObjects/Spells/SpellProgressionStore.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Spells/SpellProgressionStore.cs
@@ -39,20 +39,18 @@ public static class SpellProgressionStore
 
     /// <summary>
     /// Populates the store with the provided progressions.
-    /// Ensures each progression contains exactly five rows.
+    /// Ensures each progression contains at least one row.
     /// </summary>
     private static void Load(IEnumerable<SpellProgression> progressions)
     {
         s_bySpellId.Clear();
         foreach (var progression in progressions)
         {
-            if (progression.Levels.Count != 5)
+            if (progression.Levels.Count == 0)
             {
-                throw new InvalidDataException($"Spell {progression.SpellId} must define exactly five progression rows.");
+                throw new InvalidDataException($"Spell {progression.SpellId} must define at least one progression row.");
             }
 
-            // Ensure rows are ordered by level.
-            progression.Levels = progression.Levels.OrderBy(l => l.Level).ToList();
             s_bySpellId[progression.SpellId] = progression;
         }
     }
@@ -67,9 +65,7 @@ public static class SpellProgressionStore
             .Select(descriptor => new SpellProgression
             {
                 SpellId = descriptor.Id,
-                Levels = Enumerable.Range(1, 5)
-                    .Select(level => new SpellProperties { Level = level })
-                    .ToList()
+                Levels = new List<SpellProperties> { new SpellProperties() }
             });
 
         Load(progressions);

--- a/Framework/Intersect.Framework.Core/GameObjects/Spells/SpellProperties.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Spells/SpellProperties.cs
@@ -19,7 +19,6 @@ public partial class SpellProperties
             throw new ArgumentNullException(nameof(other));
         }
 
-        Level = other.Level;
         LastUsedAtMs = other.LastUsedAtMs;
         Array.Copy(other.VitalCostDeltas, VitalCostDeltas, Enum.GetValues<Vital>().Length);
         PowerBonusFlat = other.PowerBonusFlat;
@@ -41,45 +40,42 @@ public partial class SpellProperties
     }
 
     [Key(0)]
-    public int Level { get; set; }
-
-    [Key(1)]
     public long LastUsedAtMs { get; set; }
 
-    [Key(2)]
+    [Key(1)]
     public long[] VitalCostDeltas { get; set; } = new long[Enum.GetValues<Vital>().Length];
 
-    [Key(3)]
+    [Key(2)]
     public int PowerBonusFlat { get; set; }
 
-    [Key(4)]
+    [Key(3)]
     public float PowerScalingBonus { get; set; }
 
-    [Key(5)]
+    [Key(4)]
     public int CastTimeDeltaMs { get; set; }
 
-    [Key(6)]
+    [Key(5)]
     public int CooldownDeltaMs { get; set; }
 
-    [Key(7)]
+    [Key(6)]
     public float BuffStrengthFactor { get; set; }
 
-    [Key(8)]
+    [Key(7)]
     public float BuffDurationFactor { get; set; }
 
-    [Key(9)]
+    [Key(8)]
     public float DebuffStrengthFactor { get; set; }
 
-    [Key(10)]
+    [Key(9)]
     public float DebuffDurationFactor { get; set; }
 
-    [Key(11)]
+    [Key(10)]
     public bool UnlocksAoE { get; set; }
 
-    [Key(12)]
+    [Key(11)]
     public int AoERadiusDelta { get; set; }
 
-    [Key(13)]
+    [Key(12)]
     public Dictionary<int, int[]> CustomRolls { get; set; } = new Dictionary<int, int[]>();
 }
 

--- a/Framework/Intersect.Framework.Core/Network/Packets/Server/SpellUpgradeFailedPacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Server/SpellUpgradeFailedPacket.cs
@@ -5,7 +5,7 @@ namespace Intersect.Network.Packets.Server;
 [MessagePackObject]
 public partial class SpellUpgradeFailedPacket : IntersectPacket
 {
-    public enum Reason
+    public enum FailureReason
     {
         NotEnoughPoints,
         AlreadyMaxLevel,
@@ -18,7 +18,7 @@ public partial class SpellUpgradeFailedPacket : IntersectPacket
     {
     }
 
-    public SpellUpgradeFailedPacket(Guid spellId, Reason reason)
+    public SpellUpgradeFailedPacket(Guid spellId, FailureReason reason)
     {
         SpellId = spellId;
         Reason = reason;
@@ -28,6 +28,6 @@ public partial class SpellUpgradeFailedPacket : IntersectPacket
     public Guid SpellId { get; set; }
 
     [Key(1)]
-    public Reason Reason { get; set; }
+    public FailureReason Reason { get; set; }
 }
 

--- a/Intersect.Client.Core/Entities/Player.cs
+++ b/Intersect.Client.Core/Entities/Player.cs
@@ -1476,8 +1476,13 @@ public partial class Player : Entity, IPlayer
     {
         if (!Spellbook.Spells.TryGetValue(spellId, out var properties))
         {
-            properties = new SpellProperties { Level = 1 };
+            properties = new SpellProperties();
             Spellbook.Spells[spellId] = properties;
+        }
+
+        if (!Spellbook.SpellLevels.ContainsKey(spellId))
+        {
+            Spellbook.SpellLevels[spellId] = 1;
         }
 
         return properties;

--- a/Intersect.Client.Core/Interface/Game/DescriptionWindows/SpellDescriptionWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/DescriptionWindows/SpellDescriptionWindow.cs
@@ -56,19 +56,21 @@ public partial class SpellDescriptionWindow() : DescriptionWindowBase(Interface.
 
         if (Globals.Me != null)
         {
-            var properties = Globals.Me.GetSpellProperties(_spellDescriptor.Id);
-            var row = properties;
+            var level = Globals.Me.Spellbook.GetLevel(_spellDescriptor.Id);
+            SpellProgressionStore.BySpellId.TryGetValue(_spellDescriptor.Id, out var progression);
+            var row = progression?.GetLevel(level) ?? new SpellProperties();
 
-            if (InputHandler.IsShiftDown && SpellProgressionStore.BySpellId.TryGetValue(_spellDescriptor.Id, out var progression))
+            if (InputHandler.IsShiftDown && progression != null)
             {
-                var next = progression.GetLevel(properties.Level + 1);
+                var next = progression.GetLevel(level + 1);
                 if (next != null)
                 {
                     row = next;
+                    level += 1;
                 }
             }
 
-            _level = row.Level;
+            _level = level;
             _adjusted = SpellLevelingService.BuildAdjusted(_spellDescriptor, row);
         }
 

--- a/Intersect.Client.Core/Interface/Game/Hotbar/HotbarItem.cs
+++ b/Intersect.Client.Core/Interface/Game/Hotbar/HotbarItem.cs
@@ -415,8 +415,8 @@ public partial class HotbarItem : SlotItem
 
         if (!_levelLabel.IsHidden && _currentSpell != null)
         {
-            var spellProps = Globals.Me.GetSpellProperties(_currentSpell.Id);
-            var levelText = Strings.EntityBox.Level.ToString(spellProps.Level);
+            var level = Globals.Me.Spellbook.GetLevel(_currentSpell.Id);
+            var levelText = Strings.EntityBox.Level.ToString(level);
             if (_levelLabel.Text != levelText)
             {
                 _levelLabel.Text = levelText;

--- a/Intersect.Client.Core/Networking/PacketHandler.cs
+++ b/Intersect.Client.Core/Networking/PacketHandler.cs
@@ -1497,7 +1497,7 @@ internal sealed partial class PacketHandler
                 Globals.Me.Spellbook.Spells[packet.SpellId] = properties;
             }
 
-            properties.Level = packet.NewLevel;
+            Globals.Me.Spellbook.SpellLevels[packet.SpellId] = packet.NewLevel;
         }
     }
 

--- a/Intersect.Server.Core/CustomChanges/PacketSenderCustom.cs
+++ b/Intersect.Server.Core/CustomChanges/PacketSenderCustom.cs
@@ -226,7 +226,7 @@ public static partial class PacketSender
         player.SendPacket(new SpellUpgradedPacket(spellId, newLevel, player.Spellbook.AvailableSpellPoints));
     }
 
-    public static void SendSpellUpgradeFailed(Player player, Guid spellId, SpellUpgradeFailedPacket.Reason reason)
+    public static void SendSpellUpgradeFailed(Player player, Guid spellId, SpellUpgradeFailedPacket.FailureReason reason)
     {
         if (player == null)
         {

--- a/Intersect.Server.Core/Entities/Combat/SpellCastResolver.cs
+++ b/Intersect.Server.Core/Entities/Combat/SpellCastResolver.cs
@@ -22,20 +22,15 @@ public static class SpellCastResolver
         }
 
         var level = 1;
-        var row = new SpellProperties { Level = level };
+        var row = new SpellProperties();
 
         if (caster is Player player)
         {
-            var props = player.GetSpellProperties(baseSpell.Id);
-            level = props?.Level ?? 1;
+            level = player.Spellbook.GetLevel(baseSpell.Id);
 
             if (SpellProgressionStore.BySpellId.TryGetValue(baseSpell.Id, out var progression))
             {
-                row = progression.GetLevel(level) ?? new SpellProperties { Level = level };
-            }
-            else
-            {
-                row.Level = level;
+                row = progression.GetLevel(level) ?? new SpellProperties();
             }
         }
 

--- a/Intersect.Server.Core/Entities/Player.cs
+++ b/Intersect.Server.Core/Entities/Player.cs
@@ -5633,8 +5633,13 @@ public partial class Player : Entity
     {
         if (!Spellbook.Spells.TryGetValue(spellId, out var properties))
         {
-            properties = new SpellProperties { Level = 1 };
+            properties = new SpellProperties();
             Spellbook.Spells[spellId] = properties;
+        }
+
+        if (!Spellbook.SpellLevels.ContainsKey(spellId))
+        {
+            Spellbook.SpellLevels[spellId] = 1;
         }
 
         return properties;
@@ -5644,9 +5649,17 @@ public partial class Player : Entity
     {
         foreach (var slot in Spells)
         {
-            if (slot.SpellId != Guid.Empty && !Spellbook.Spells.ContainsKey(slot.SpellId))
+            if (slot.SpellId != Guid.Empty)
             {
-                Spellbook.Spells[slot.SpellId] = new SpellProperties { Level = 1 };
+                if (!Spellbook.Spells.ContainsKey(slot.SpellId))
+                {
+                    Spellbook.Spells[slot.SpellId] = new SpellProperties();
+                }
+
+                if (!Spellbook.SpellLevels.ContainsKey(slot.SpellId))
+                {
+                    Spellbook.SpellLevels[slot.SpellId] = 1;
+                }
             }
         }
     }

--- a/Intersect.Tests/Services/SpellLevelingServiceTests.cs
+++ b/Intersect.Tests/Services/SpellLevelingServiceTests.cs
@@ -26,7 +26,7 @@ public class SpellLevelingServiceTests
     public void BuildAdjusted_Level1_NoChanges()
     {
         var baseDesc = CreateBaseDescriptor();
-        var row = new SpellProperties { Level = 1 };
+        var row = new SpellProperties();
 
         var adjusted = SpellLevelingService.BuildAdjusted(baseDesc, row);
 
@@ -49,7 +49,6 @@ public class SpellLevelingServiceTests
         var baseDesc = CreateBaseDescriptor();
         var row = new SpellProperties
         {
-            Level = 5,
             CastTimeDeltaMs = -100,
             CooldownDeltaMs = -200,
             VitalCostDeltas = new long[] { -5, 5 },


### PR DESCRIPTION
## Summary
- remove level metadata from spell properties and progression store
- track and upgrade spell levels within PlayerSpellbookState
- update server/client handlers to use centralized spell level logic

## Testing
- `dotnet test Intersect.Tests/Intersect.Tests.csproj -v minimal` *(fails: warns about analyzer issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a3ca2d63d883248361303bc94f1666