### PR TITLE
Add spell progression editor and serializer

### DIFF
--- a/Intersect.Editor/Forms/Editors/frmSpell.Progression.cs
+++ b/Intersect.Editor/Forms/Editors/frmSpell.Progression.cs
@@ -1,0 +1,67 @@
+using System.Drawing;
+using System.Windows.Forms;
+using DarkUI.Controls;
+
+namespace Intersect.Editor.Forms.Editors;
+
+public partial class FrmSpell
+{
+    private DarkGroupBox grpProgression = null!;
+    private DataGridView grdProgression = null!;
+
+    private void InitializeProgressionTab()
+    {
+        // Group box container
+        grpProgression = new DarkGroupBox
+        {
+            Text = "Progresión (5 niveles)",
+            ForeColor = Color.Gainsboro,
+            BackColor = Color.FromArgb(45, 45, 48),
+            BorderColor = Color.FromArgb(90, 90, 90),
+            Location = new Point(603, 6),
+            Size = new Size(542, 210)
+        };
+
+        // Data grid setup
+        grdProgression = new DataGridView
+        {
+            AllowUserToAddRows = false,
+            AllowUserToDeleteRows = false,
+            AllowUserToResizeColumns = false,
+            AllowUserToResizeRows = false,
+            BackgroundColor = Color.FromArgb(45, 45, 48),
+            BorderStyle = BorderStyle.None,
+            ColumnHeadersBorderStyle = DataGridViewHeaderBorderStyle.None,
+            EnableHeadersVisualStyles = false,
+            RowHeadersVisible = false,
+            AutoSizeColumnsMode = DataGridViewAutoSizeColumnsMode.Fill,
+            Location = new Point(7, 18),
+            Size = new Size(528, 185)
+        };
+
+        // Columns for progression properties
+        grdProgression.Columns.Add(new DataGridViewTextBoxColumn { HeaderText = "Nivel", ReadOnly = true });
+        grdProgression.Columns.Add(new DataGridViewTextBoxColumn { HeaderText = "HP Δ" });
+        grdProgression.Columns.Add(new DataGridViewTextBoxColumn { HeaderText = "MP Δ" });
+        grdProgression.Columns.Add(new DataGridViewTextBoxColumn { HeaderText = "Poder+" });
+        grdProgression.Columns.Add(new DataGridViewTextBoxColumn { HeaderText = "Escalado%" });
+        grdProgression.Columns.Add(new DataGridViewTextBoxColumn { HeaderText = "Cast Δ" });
+        grdProgression.Columns.Add(new DataGridViewTextBoxColumn { HeaderText = "CD Δ" });
+        grdProgression.Columns.Add(new DataGridViewTextBoxColumn { HeaderText = "Buff Str%" });
+        grdProgression.Columns.Add(new DataGridViewTextBoxColumn { HeaderText = "Buff Dur%" });
+        grdProgression.Columns.Add(new DataGridViewTextBoxColumn { HeaderText = "Debuff Str%" });
+        grdProgression.Columns.Add(new DataGridViewTextBoxColumn { HeaderText = "Debuff Dur%" });
+        grdProgression.Columns.Add(new DataGridViewCheckBoxColumn { HeaderText = "Unlocks AoE" });
+        grdProgression.Columns.Add(new DataGridViewTextBoxColumn { HeaderText = "AoE Δ" });
+
+        // Pre-populate five rows for levels 1-5
+        for (var i = 1; i <= 5; i++)
+        {
+            grdProgression.Rows.Add(i, 0, 0, 0, 0f, 0, 0, 0f, 0f, 0f, 0f, false, 0);
+        }
+
+        grpProgression.Controls.Add(grdProgression);
+        pnlContainer.Controls.Add(grpProgression);
+    }
+}
+

--- a/Intersect.Editor/Forms/Editors/frmSpell.cs
+++ b/Intersect.Editor/Forms/Editors/frmSpell.cs
@@ -35,6 +35,7 @@ public partial class FrmSpell : EditorForm
     {
         ApplyHooks();
         InitializeComponent();
+        InitializeProgressionTab();
         Icon = Program.Icon;
         _btnSave = btnSave;
         _btnCancel = btnCancel;

--- a/Intersect.Editor/Serialization/SpellProgressionSerializer.cs
+++ b/Intersect.Editor/Serialization/SpellProgressionSerializer.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Intersect.Framework.Core.GameObjects.Spells;
+using Intersect.GameObjects;
+
+namespace Intersect.Editor.Serialization;
+
+/// <summary>
+/// Provides helpers for working with <see cref="SpellProgression"/> data.
+/// </summary>
+public static class SpellProgressionSerializer
+{
+    /// <summary>
+    /// Builds a <see cref="SpellProgression"/> from the provided rows, validating that exactly
+    /// five rows are present.
+    /// </summary>
+    /// <param name="spellId">Identifier of the spell the progression belongs to.</param>
+    /// <param name="rows">The rows describing each level of the progression.</param>
+    /// <exception cref="InvalidDataException">Thrown when the number of rows is not equal to five.</exception>
+    public static SpellProgression FromRows(Guid spellId, IEnumerable<SpellProperties> rows)
+    {
+        if (rows == null)
+        {
+            throw new ArgumentNullException(nameof(rows));
+        }
+
+        var levels = rows.ToList();
+        if (levels.Count != 5)
+        {
+            throw new InvalidDataException($"Spell {spellId} progression must contain exactly five rows (found {levels.Count}).");
+        }
+
+        // Ensure rows are ordered by level before returning.
+        levels = levels.OrderBy(l => l.Level).ToList();
+        return new SpellProgression
+        {
+            SpellId = spellId,
+            Levels = levels,
+        };
+    }
+
+    /// <summary>
+    /// Generates a default five level progression based on the provided level one template.
+    /// </summary>
+    /// <param name="levelOne">The template row representing level one values.</param>
+    /// <returns>A list containing five copies of the template row with incrementing levels.</returns>
+    public static List<SpellProperties> AutoGenerateFromLevelOne(SpellProperties levelOne)
+    {
+        if (levelOne == null)
+        {
+            throw new ArgumentNullException(nameof(levelOne));
+        }
+
+        var list = new List<SpellProperties>(5);
+        for (var i = 1; i <= 5; i++)
+        {
+            var copy = new SpellProperties(levelOne)
+            {
+                Level = i,
+            };
+            list.Add(copy);
+        }
+
+        return list;
+    }
+}
+


### PR DESCRIPTION
## Summary
- add "Progresión (5 niveles)" grid to spell editor
- create SpellProgressionSerializer with 5-row validation and auto-generate helper

## Testing
- `dotnet build Intersect.Editor/Intersect.Editor.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3ca255c488324a8e16e5d1afecc6d