### PR TITLE
Handle spell upgrade packets

### DIFF
--- a/Framework/Intersect.Framework.Core/GameObjects/Spells/SpellProperties.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Spells/SpellProperties.cs
@@ -37,6 +37,8 @@ public partial class SpellProperties
         {
             CustomRolls[kvp.Key] = (int[])kvp.Value.Clone();
         }
+
+        Level = other.Level;
     }
 
     [Key(0)]
@@ -77,5 +79,8 @@ public partial class SpellProperties
 
     [Key(12)]
     public Dictionary<int, int[]> CustomRolls { get; set; } = new Dictionary<int, int[]>();
+
+    [IgnoreMember]
+    public int Level { get; set; } = 1;
 }
 

--- a/Intersect.Client.Core/Networking/PacketHandler.cs
+++ b/Intersect.Client.Core/Networking/PacketHandler.cs
@@ -1489,18 +1489,30 @@ internal sealed partial class PacketHandler
     //SpellUpgradedPacket
     public void HandlePacket(IPacketSender packetSender, SpellUpgradedPacket packet)
     {
-        if (Globals.Me != null)
+        if (Globals.Me == null)
         {
-            Globals.Me.Spellbook.AvailableSpellPoints = packet.RemainingSpellPoints;
-            if (!Globals.Me.Spellbook.Spells.TryGetValue(packet.SpellId, out var properties))
-            {
-                properties = new SpellProperties();
-                Globals.Me.Spellbook.Spells[packet.SpellId] = properties;
-            }
+            return;
+        }
 
-            Globals.Me.Spellbook.SpellLevels[packet.SpellId] = packet.NewLevel;
-           Interface.GameUi.GameMenu.SpellsWindow.Refresh();
+        Globals.Me.Spellbook.AvailableSpellPoints = packet.RemainingSpellPoints;
 
+        if (!Globals.Me.Spellbook.Spells.TryGetValue(packet.SpellId, out var properties))
+        {
+            properties = new SpellProperties();
+            Globals.Me.Spellbook.Spells[packet.SpellId] = properties;
+        }
+
+        // Update the player's known level for this spell
+        properties.Level = packet.NewLevel;
+        Globals.Me.Spellbook.SpellLevels[packet.SpellId] = packet.NewLevel;
+
+        Interface.GameUi.GameMenu.SpellsWindow.Refresh();
+
+        // Refresh any open spell tooltip (e.g. from the hotbar)
+        var tooltip = Interface.GameUi.SpellDescriptionWindow;
+        if (tooltip?.IsVisibleInTree == true)
+        {
+            tooltip.Show(packet.SpellId);
         }
     }
 


### PR DESCRIPTION
## Summary
- update SpellUpgradedPacket handling to apply new spell level and available points and refresh related UI
- add Level property to SpellProperties for client-side tracking

## Testing
- `dotnet test` *(fails: project file missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a3d6c0ff408324bc9b119a177c3071