### PR TITLE
Fix spell override signature and editor color issues

### DIFF
--- a/Intersect.Client.Core/Interface/Game/Spells/SpellsWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Spells/SpellsWindow.cs
@@ -123,6 +123,19 @@ public partial class SpellsWindow : Window
         UpdateDetails();
     }
 
+    public void Update()
+    {
+        if (!IsVisibleInParent)
+        {
+            return;
+        }
+
+        foreach (var item in Items)
+        {
+            item.Update();
+        }
+    }
+
     private void UpdateDetails()
     {
         if (_selectedSpellId == Guid.Empty || Globals.Me?.Spellbook?.Spells == null)

--- a/Intersect.Editor/Forms/Editors/frmSpell.Progression.cs
+++ b/Intersect.Editor/Forms/Editors/frmSpell.Progression.cs
@@ -15,7 +15,7 @@ public partial class FrmSpell
         grpProgression = new DarkGroupBox
         {
             Text = "Progresión (5 niveles)",
-            ForeColor = Color.Gainsboro,
+            ForeColor = Color.FromArgb(220, 220, 220),
             BackColor = Color.FromArgb(45, 45, 48),
             BorderColor = Color.FromArgb(90, 90, 90),
             Location = new Point(603, 6),

--- a/Intersect.Server.Core/Entities/Player.cs
+++ b/Intersect.Server.Core/Entities/Player.cs
@@ -21,6 +21,7 @@ using Intersect.Framework.Core.GameObjects.PlayerClass;
 using Intersect.Framework.Core.GameObjects.Quests;
 using Intersect.Framework.Core.GameObjects.Spells;
 using Intersect.Framework.Core.GameObjects.Variables;
+using Intersect.Framework.Core.Services;
 using Intersect.GameObjects;
 using Intersect.Network;
 using Intersect.Network.Packets.Server;
@@ -1785,7 +1786,8 @@ public partial class Player : Entity
         Entity target,
         SpellDescriptor spellDescriptor,
         bool onHitTrigger = false,
-        bool trapTrigger = false
+        bool trapTrigger = false,
+        SpellLevelingService.AdjustedSpell adjusted = null
     )
     {
         if (!trapTrigger && !ValidTauntTarget(target)) //Traps ignore taunts.
@@ -1793,7 +1795,7 @@ public partial class Player : Entity
             return;
         }
 
-        base.TryAttack(target, spellDescriptor, onHitTrigger, trapTrigger);
+        base.TryAttack(target, spellDescriptor, onHitTrigger, trapTrigger, adjusted);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- align Player.TryAttack override with base signature and pass adjusted data
- expose Update for SpellsWindow to refresh item cooldowns
- replace unsupported Gainsboro color in spell editor

## Testing
- `dotnet build Intersect.sln` *(fails: missing vendor csproj)*
- `dotnet build Framework/Intersect.Framework.Core/Intersect.Framework.Core.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a3b502b02c832486c67700aa794da4