### PR TITLE
refactor: centralize spell properties

### DIFF
--- a/Framework/Intersect.Framework.Core/GameObjects/Spells/PlayerSpellbookState.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Spells/PlayerSpellbookState.cs
@@ -20,6 +20,22 @@ public partial class PlayerSpellbookState
     public int GetLevel(Guid spellId) =>
         SpellLevels.TryGetValue(spellId, out var level) ? level : 1;
 
+    public SpellProperties GetOrCreateProperties(Guid spellId)
+    {
+        if (!Spells.TryGetValue(spellId, out var properties))
+        {
+            properties = new SpellProperties();
+            Spells[spellId] = properties;
+        }
+
+        if (!SpellLevels.ContainsKey(spellId))
+        {
+            SpellLevels[spellId] = 1;
+        }
+
+        return properties;
+    }
+
     public bool TryUpgradeSpell(Guid spellId, out int newLevel)
     {
         var currentLevel = GetLevel(spellId);

--- a/Intersect.Client.Core/Entities/Player.cs
+++ b/Intersect.Client.Core/Entities/Player.cs
@@ -1472,22 +1472,6 @@ public partial class Player : Entity, IPlayer
         return 0;
     }
 
-    public SpellProperties GetSpellProperties(Guid spellId)
-    {
-        if (!Spellbook.Spells.TryGetValue(spellId, out var properties))
-        {
-            properties = new SpellProperties();
-            Spellbook.Spells[spellId] = properties;
-        }
-
-        if (!Spellbook.SpellLevels.ContainsKey(spellId))
-        {
-            Spellbook.SpellLevels[spellId] = 1;
-        }
-
-        return properties;
-    }
-
     public void TryUseSpell(Guid spellId)
     {
         if (spellId == Guid.Empty)

--- a/Intersect.Server.Core/Entities/Player.Database.cs
+++ b/Intersect.Server.Core/Entities/Player.Database.cs
@@ -396,7 +396,6 @@ public partial class Player
                 playerContext = createdPlayerContext = DbInterface.CreatePlayerContext(readOnly: false);
             }
 
-            EnsureSpellbookEntries();
             playerContext.Update(this);
             playerContext.ChangeTracker.DetectChanges();
             playerContext.SaveChanges();

--- a/Intersect.Server.Core/Entities/Player.cs
+++ b/Intersect.Server.Core/Entities/Player.cs
@@ -469,8 +469,6 @@ public partial class Player : Entity
             }
         }
 
-        EnsureSpellbookEntries();
-
         OnlinePlayersById[Id] = this;
         _onlinePlayers.Add(this);
 
@@ -5629,41 +5627,6 @@ public partial class Player : Entity
         }
 
         return -1;
-    }
-
-    public SpellProperties GetSpellProperties(Guid spellId)
-    {
-        if (!Spellbook.Spells.TryGetValue(spellId, out var properties))
-        {
-            properties = new SpellProperties();
-            Spellbook.Spells[spellId] = properties;
-        }
-
-        if (!Spellbook.SpellLevels.ContainsKey(spellId))
-        {
-            Spellbook.SpellLevels[spellId] = 1;
-        }
-
-        return properties;
-    }
-
-    public void EnsureSpellbookEntries()
-    {
-        foreach (var slot in Spells)
-        {
-            if (slot.SpellId != Guid.Empty)
-            {
-                if (!Spellbook.Spells.ContainsKey(slot.SpellId))
-                {
-                    Spellbook.Spells[slot.SpellId] = new SpellProperties();
-                }
-
-                if (!Spellbook.SpellLevels.ContainsKey(slot.SpellId))
-                {
-                    Spellbook.SpellLevels[slot.SpellId] = 1;
-                }
-            }
-        }
     }
 
     public void SwapSpells(int spell1, int spell2)


### PR DESCRIPTION
## Summary
- centralize spell property lookup on PlayerSpellbookState
- drop old GetSpellProperties helpers from player entities
- remove obsolete EnsureSpellbookEntries usage

## Testing
- `dotnet build` *(fails: project file "vendor/LiteNetLib/LiteNetLib.csproj" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3e992d4688324ab2d83567aeb3ac9