### PR TITLE
Centralize spell level tracking

### DIFF
--- a/Framework/Intersect.Framework.Core/GameObjects/Spells/SpellProperties.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Spells/SpellProperties.cs
@@ -29,8 +29,6 @@ public partial class SpellProperties
         DebuffDurationFactor = other.DebuffDurationFactor;
         UnlocksAoE = other.UnlocksAoE;
         AoERadiusDelta = other.AoERadiusDelta;
-
-        Level = other.Level;
     }
 
     [Key(0)]
@@ -65,8 +63,5 @@ public partial class SpellProperties
 
     [Key(10)]
     public int AoERadiusDelta { get; set; }
-
-    [IgnoreMember]
-    public int Level { get; set; } = 1;
 }
 

--- a/Intersect.Client.Core/Entities/Player.cs
+++ b/Intersect.Client.Core/Entities/Player.cs
@@ -1480,11 +1480,6 @@ public partial class Player : Entity, IPlayer
             Spellbook.Spells[spellId] = properties;
         }
 
-        if (!Spellbook.SpellLevels.ContainsKey(spellId))
-        {
-            Spellbook.SpellLevels[spellId] = 1;
-        }
-
         return properties;
     }
 

--- a/Intersect.Client.Core/Interface/Game/Spells/SpellItem.cs
+++ b/Intersect.Client.Core/Interface/Game/Spells/SpellItem.cs
@@ -82,7 +82,8 @@ public partial class SpellItem : SlotItem
     public void Refresh(SpellProperties properties)
     {
         _properties = properties;
-        _levelPips.Text = BuildPips(_properties.Level);
+        var level = Globals.Me?.Spellbook.GetLevel(SpellId) ?? 1;
+        _levelPips.Text = BuildPips(level);
 
         if (SpellDescriptor.TryGet(SpellId, out var descriptor))
         {

--- a/Intersect.Client.Core/Interface/Game/Spells/SpellsWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Spells/SpellsWindow.cs
@@ -144,7 +144,7 @@ public partial class SpellsWindow : Window
             return;
         }
 
-        if (!Globals.Me.Spellbook.Spells.TryGetValue(_selectedSpellId, out var properties))
+        if (!Globals.Me.Spellbook.Spells.ContainsKey(_selectedSpellId))
         {
             _detailPanel.IsVisibleInParent = false;
             return;
@@ -158,22 +158,20 @@ public partial class SpellsWindow : Window
 
         _detailPanel.IsVisibleInParent = true;
         _nameLabel.Text = descriptor.Name;
-        _levelLabel.Text = Strings.EntityBox.Level.ToString(properties.Level);
+        var level = Globals.Me.Spellbook.GetLevel(_selectedSpellId);
+        _levelLabel.Text = Strings.EntityBox.Level.ToString(level);
 
-        var currentAdjusted = SpellLevelingService.BuildAdjusted(descriptor, properties);
+        SpellProgressionStore.BySpellId.TryGetValue(_selectedSpellId, out var progression);
+        var currentRow = progression?.GetLevel(level) ?? new SpellProperties();
+        var currentAdjusted = SpellLevelingService.BuildAdjusted(descriptor, currentRow);
         _currentLabel.Text = FormatAdjusted(currentAdjusted);
 
-        SpellProperties? nextRow = null;
-        if (SpellProgressionStore.BySpellId.TryGetValue(_selectedSpellId, out var progression))
-        {
-            nextRow = progression.GetLevel(properties.Level + 1);
-        }
-
+        var nextRow = progression?.GetLevel(level + 1);
         if (nextRow != null)
         {
             var nextAdjusted = SpellLevelingService.BuildAdjusted(descriptor, nextRow);
             _nextLabel.Text = FormatAdjusted(nextAdjusted);
-            _levelUpButton.IsDisabled = !(Globals.Me.Spellbook.AvailableSpellPoints > 0 && properties.Level < 5);
+            _levelUpButton.IsDisabled = !(Globals.Me.Spellbook.AvailableSpellPoints > 0 && level < 5);
         }
         else
         {

--- a/Intersect.Client.Core/Networking/PacketHandler.cs
+++ b/Intersect.Client.Core/Networking/PacketHandler.cs
@@ -1503,7 +1503,6 @@ internal sealed partial class PacketHandler
         }
 
         // Update the player's known level for this spell
-        properties.Level = packet.NewLevel;
         Globals.Me.Spellbook.SpellLevels[packet.SpellId] = packet.NewLevel;
 
        Interface.Interface.GameUi.GameMenu.SpellsWindow.Refresh();

--- a/Intersect.Editor/Serialization/SpellProgressionSerializer.cs
+++ b/Intersect.Editor/Serialization/SpellProgressionSerializer.cs
@@ -32,8 +32,7 @@ public static class SpellProgressionSerializer
             throw new InvalidDataException($"Spell {spellId} progression must contain exactly five rows (found {levels.Count}).");
         }
 
-        // Ensure rows are ordered by level before returning.
-        levels = levels.OrderBy(l => l.Level).ToList();
+        // Assume rows are already ordered by level.
         return new SpellProgression
         {
             SpellId = spellId,
@@ -54,12 +53,9 @@ public static class SpellProgressionSerializer
         }
 
         var list = new List<SpellProperties>(5);
-        for (var i = 1; i <= 5; i++)
+        for (var i = 0; i < 5; i++)
         {
-            var copy = new SpellProperties(levelOne)
-            {
-                Level = i,
-            };
+            var copy = new SpellProperties(levelOne);
             list.Add(copy);
         }
 

--- a/Intersect.Server.Core/Entities/Player.cs
+++ b/Intersect.Server.Core/Entities/Player.cs
@@ -5639,11 +5639,6 @@ public partial class Player : Entity
             Spellbook.Spells[spellId] = properties;
         }
 
-        if (!Spellbook.SpellLevels.ContainsKey(spellId))
-        {
-            Spellbook.SpellLevels[spellId] = 1;
-        }
-
         return properties;
     }
 
@@ -5658,10 +5653,6 @@ public partial class Player : Entity
                     Spellbook.Spells[slot.SpellId] = new SpellProperties();
                 }
 
-                if (!Spellbook.SpellLevels.ContainsKey(slot.SpellId))
-                {
-                    Spellbook.SpellLevels[slot.SpellId] = 1;
-                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- remove level field from `SpellProperties`
- derive spell level from `PlayerSpellbookState` in client UI and network
- simplify spell property retrieval on client and server

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3e98148b883249e9d72871bddd7df