### PR TITLE
refactor(spells): harden leveling and server upgrades

### DIFF
--- a/Framework/Intersect.Framework.Core/GameObjects/Spells/PlayerSpellbookState.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Spells/PlayerSpellbookState.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using MessagePack;
-using Intersect.GameObjects;
 
 namespace Intersect.Framework.Core.GameObjects.Spells;
 
@@ -11,49 +10,10 @@ public partial class PlayerSpellbookState
     [Key(0)]
     public int AvailableSpellPoints { get; set; }
 
-    [Key(1)]
-    public Dictionary<Guid, SpellProperties> Spells { get; set; } = [];
-
     [Key(2)]
     public Dictionary<Guid, int> SpellLevels { get; set; } = [];
 
-    public int GetLevel(Guid spellId) =>
-        SpellLevels.TryGetValue(spellId, out var level) ? level : 1;
-
-    public SpellProperties GetOrCreateProperties(Guid spellId)
-    {
-        if (!Spells.TryGetValue(spellId, out var properties))
-        {
-            properties = new SpellProperties();
-            Spells[spellId] = properties;
-        }
-
-        if (!SpellLevels.ContainsKey(spellId))
-        {
-            SpellLevels[spellId] = 1;
-        }
-
-        return properties;
-    }
-
-    public bool TryUpgradeSpell(Guid spellId, out int newLevel)
-    {
-        var currentLevel = GetLevel(spellId);
-        newLevel = currentLevel;
-
-        if (!SpellProgressionStore.BySpellId.TryGetValue(spellId, out var progression))
-        {
-            return false;
-        }
-
-        if (currentLevel >= progression.Levels.Count)
-        {
-            return false;
-        }
-
-        newLevel = currentLevel + 1;
-        SpellLevels[spellId] = newLevel;
-        return true;
-    }
+    public int GetLevelOrDefault(Guid spellId, int fallback = 1) =>
+        SpellLevels.TryGetValue(spellId, out var level) ? level : fallback;
 }
 

--- a/Framework/Intersect.Framework.Core/GameObjects/Spells/SpellProgressionStore.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Spells/SpellProgressionStore.cs
@@ -65,7 +65,7 @@ public static class SpellProgressionStore
             .Select(descriptor => new SpellProgression
             {
                 SpellId = descriptor.Id,
-                Levels = new List<SpellProperties> { new SpellProperties() }
+                Levels = Enumerable.Range(0, 5).Select(_ => new SpellProperties()).ToList()
             });
 
         Load(progressions);

--- a/Framework/Intersect.Framework.Core/Network/Packets/Server/SpellUpgradeFailedPacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Server/SpellUpgradeFailedPacket.cs
@@ -7,10 +7,10 @@ public partial class SpellUpgradeFailedPacket : IntersectPacket
 {
     public enum FailureReason
     {
+        NoSuchSpell,
+        MaxLevelReached,
         NotEnoughPoints,
-        AlreadyMaxLevel,
-        SpellNotOwned,
-        ServerError,
+        RequirementsNotMet,
     }
 
     // Parameterless Constructor for MessagePack

--- a/Intersect.Client.Core/Game/Combat/SpellMath.cs
+++ b/Intersect.Client.Core/Game/Combat/SpellMath.cs
@@ -1,0 +1,29 @@
+using System;
+using Intersect.Client.Entities;
+using Intersect.GameObjects;
+using Intersect.Framework.Core.GameObjects.Spells;
+using Intersect.Framework.Core.Services;
+
+namespace Intersect.Client.Game.Combat;
+
+public static class SpellMath
+{
+    public static SpellLevelingService.EffectiveSpellStats GetEffective(
+        Player player,
+        Guid spellId,
+        SpellProgressionStore store,
+        PlayerSpellbookState state)
+    {
+        if (!SpellDescriptor.TryGet(spellId, out var descriptor))
+        {
+            throw new ArgumentException("Unknown spell", nameof(spellId));
+        }
+
+        var level = state.GetLevelOrDefault(spellId);
+        store.BySpellId.TryGetValue(spellId, out var progression);
+        var row = progression?.GetLevel(level) ?? new SpellProperties();
+
+        return SpellLevelingService.BuildAdjusted(descriptor, row);
+    }
+}
+

--- a/Intersect.Client.Core/Interface/Game/DescriptionWindows/SpellDescriptionWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/DescriptionWindows/SpellDescriptionWindow.cs
@@ -13,7 +13,7 @@ namespace Intersect.Client.Interface.Game.DescriptionWindows;
 public partial class SpellDescriptionWindow() : DescriptionWindowBase(Interface.GameUi.GameCanvas, "DescriptionWindow")
 {
     private SpellDescriptor? _spellDescriptor;
-    private SpellLevelingService.AdjustedSpell? _adjusted;
+    private SpellLevelingService.EffectiveSpellStats? _adjusted;
     private int _level;
 
     public void Show(Guid spellId, ItemDescriptionWindow? itemDecriptionContainer = default)
@@ -56,7 +56,7 @@ public partial class SpellDescriptionWindow() : DescriptionWindowBase(Interface.
 
         if (Globals.Me != null)
         {
-            var level = Globals.Me.Spellbook.GetLevel(_spellDescriptor.Id);
+            var level = Globals.Me.Spellbook.GetLevelOrDefault(_spellDescriptor.Id);
             SpellProgressionStore.BySpellId.TryGetValue(_spellDescriptor.Id, out var progression);
             var row = progression?.GetLevel(level) ?? new SpellProperties();
 

--- a/Intersect.Client.Core/Interface/Game/Hotbar/HotbarItem.cs
+++ b/Intersect.Client.Core/Interface/Game/Hotbar/HotbarItem.cs
@@ -415,7 +415,7 @@ public partial class HotbarItem : SlotItem
 
         if (!_levelLabel.IsHidden && _currentSpell != null)
         {
-            var level = Globals.Me.Spellbook.GetLevel(_currentSpell.Id);
+            var level = Globals.Me.Spellbook.GetLevelOrDefault(_currentSpell.Id);
             var levelText = Strings.EntityBox.Level.ToString(level);
             if (_levelLabel.Text != levelText)
             {

--- a/Intersect.Client.Core/Interface/Game/Spells/SpellItem.cs
+++ b/Intersect.Client.Core/Interface/Game/Spells/SpellItem.cs
@@ -10,7 +10,6 @@ using Intersect.Client.Interface.Game;
 using Intersect.Client.General;
 using Intersect.Client.Framework.GenericClasses;
 using Intersect.GameObjects;
-using Intersect.Framework.Core.GameObjects.Spells;
 using Intersect.Utilities;
 using Intersect.Client.Framework.Input;
 
@@ -25,14 +24,11 @@ public partial class SpellItem : SlotItem
     private readonly Label _cooldownLabel;
     private readonly SpellsWindow _window;
 
-    private SpellProperties _properties;
-
-    public SpellItem(SpellsWindow window, Base parent, int index, Guid spellId, SpellProperties properties)
+    public SpellItem(SpellsWindow window, Base parent, int index, Guid spellId)
         : base(parent, $"{nameof(SpellItem)}{index}", index, null)
     {
         _window = window;
         SpellId = spellId;
-        _properties = properties;
 
         TextureFilename = "spellitem.png";
 
@@ -68,7 +64,7 @@ public partial class SpellItem : SlotItem
         _nameLabel.SetPosition(40, 0);
         _levelPips.SetPosition(40, 20);
 
-        Refresh(properties);
+        Refresh();
     }
 
     private void Item_Clicked(Base sender, MouseButtonState args)
@@ -79,10 +75,9 @@ public partial class SpellItem : SlotItem
         }
     }
 
-    public void Refresh(SpellProperties properties)
+    public void Refresh()
     {
-        _properties = properties;
-        var level = Globals.Me?.Spellbook.GetLevel(SpellId) ?? 1;
+        var level = Globals.Me?.Spellbook.GetLevelOrDefault(SpellId) ?? 1;
         _levelPips.Text = BuildPips(level);
 
         if (SpellDescriptor.TryGet(SpellId, out var descriptor))

--- a/Intersect.Client.Core/Interface/Game/Spells/SpellsWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Spells/SpellsWindow.cs
@@ -101,15 +101,15 @@ public partial class SpellsWindow : Window
         _spellList.ClearChildren();
         Items.Clear();
 
-        if (Globals.Me?.Spellbook?.Spells == null)
+        if (Globals.Me?.Spellbook?.SpellLevels == null)
         {
             return;
         }
 
         var index = 0;
-        foreach (var (spellId, properties) in Globals.Me.Spellbook.Spells.OrderBy(p => SpellDescriptor.GetName(p.Key)))
+        foreach (var spellId in Globals.Me.Spellbook.SpellLevels.Keys.OrderBy(SpellDescriptor.GetName))
         {
-            var item = new SpellItem(this, _spellList, index++, spellId, properties);
+            var item = new SpellItem(this, _spellList, index++, spellId);
             Items.Add(item);
         }
 
@@ -138,13 +138,13 @@ public partial class SpellsWindow : Window
 
     private void UpdateDetails()
     {
-        if (_selectedSpellId == Guid.Empty || Globals.Me?.Spellbook?.Spells == null)
+        if (_selectedSpellId == Guid.Empty || Globals.Me?.Spellbook?.SpellLevels == null)
         {
             _detailPanel.IsVisibleInParent = false;
             return;
         }
 
-        if (!Globals.Me.Spellbook.Spells.ContainsKey(_selectedSpellId))
+        if (!Globals.Me.Spellbook.SpellLevels.ContainsKey(_selectedSpellId))
         {
             _detailPanel.IsVisibleInParent = false;
             return;
@@ -158,7 +158,7 @@ public partial class SpellsWindow : Window
 
         _detailPanel.IsVisibleInParent = true;
         _nameLabel.Text = descriptor.Name;
-        var level = Globals.Me.Spellbook.GetLevel(_selectedSpellId);
+        var level = Globals.Me.Spellbook.GetLevelOrDefault(_selectedSpellId);
         _levelLabel.Text = Strings.EntityBox.Level.ToString(level);
 
         SpellProgressionStore.BySpellId.TryGetValue(_selectedSpellId, out var progression);
@@ -180,7 +180,7 @@ public partial class SpellsWindow : Window
         }
     }
 
-    private static string FormatAdjusted(SpellLevelingService.AdjustedSpell adjusted)
+    private static string FormatAdjusted(SpellLevelingService.EffectiveSpellStats adjusted)
     {
         return $"{Strings.SpellDescription.CastTime}: {TimeSpan.FromMilliseconds(adjusted.CastTimeMs).WithSuffix()}\n" +
                $"{Strings.SpellDescription.Cooldown}: {TimeSpan.FromMilliseconds(adjusted.CooldownTimeMs).WithSuffix()}";

--- a/Intersect.Client.Core/Networking/PacketHandler.cs
+++ b/Intersect.Client.Core/Networking/PacketHandler.cs
@@ -1496,13 +1496,6 @@ internal sealed partial class PacketHandler
 
         Globals.Me.Spellbook.AvailableSpellPoints = packet.RemainingSpellPoints;
 
-        if (!Globals.Me.Spellbook.Spells.TryGetValue(packet.SpellId, out var properties))
-        {
-            properties = new SpellProperties();
-            Globals.Me.Spellbook.Spells[packet.SpellId] = properties;
-        }
-
-        // Update the player's known level for this spell
         Globals.Me.Spellbook.SpellLevels[packet.SpellId] = packet.NewLevel;
 
        Interface.Interface.GameUi.GameMenu.SpellsWindow.Refresh();

--- a/Intersect.Server.Core/Entities/Combat/SpellCastResolver.cs
+++ b/Intersect.Server.Core/Entities/Combat/SpellCastResolver.cs
@@ -14,7 +14,7 @@ public static class SpellCastResolver
     /// <summary>
     /// Builds an adjusted spell based on the caster's level for the provided spell descriptor.
     /// </summary>
-    public static SpellLevelingService.AdjustedSpell Resolve(Entity caster, SpellDescriptor baseSpell)
+    public static SpellLevelingService.EffectiveSpellStats Resolve(Entity caster, SpellDescriptor baseSpell)
     {
         if (baseSpell == null)
         {
@@ -26,7 +26,7 @@ public static class SpellCastResolver
 
         if (caster is Player player)
         {
-            level = player.Spellbook.GetLevel(baseSpell.Id);
+            level = player.Spellbook.GetLevelOrDefault(baseSpell.Id);
 
             if (SpellProgressionStore.BySpellId.TryGetValue(baseSpell.Id, out var progression))
             {

--- a/Intersect.Server.Core/Entities/Entity.cs
+++ b/Intersect.Server.Core/Entities/Entity.cs
@@ -1768,7 +1768,7 @@ public abstract partial class Entity : IEntity
         SpellDescriptor spellDescriptor,
         bool onHitTrigger = false,
         bool trapTrigger = false,
-        SpellLevelingService.AdjustedSpell adjusted = null
+        SpellLevelingService.EffectiveSpellStats adjusted = null
     )
     {
         if (target is Resource || target is EventPageInstance)
@@ -2760,7 +2760,7 @@ public abstract partial class Entity : IEntity
         int startX,
         int startY,
         Entity spellTarget,
-        SpellLevelingService.AdjustedSpell adjusted = null
+        SpellLevelingService.EffectiveSpellStats adjusted = null
     )
     {
         var spellBase = SpellDescriptor.Get(spellId);

--- a/Intersect.Server.Core/Entities/Player.cs
+++ b/Intersect.Server.Core/Entities/Player.cs
@@ -1785,7 +1785,7 @@ public partial class Player : Entity
         SpellDescriptor spellDescriptor,
         bool onHitTrigger = false,
         bool trapTrigger = false,
-        SpellLevelingService.AdjustedSpell adjusted = null
+        SpellLevelingService.EffectiveSpellStats adjusted = null
     )
     {
         if (!trapTrigger && !ValidTauntTarget(target)) //Traps ignore taunts.

--- a/Intersect.Server.Core/Game/Spells/SpellUpgradeService.cs
+++ b/Intersect.Server.Core/Game/Spells/SpellUpgradeService.cs
@@ -1,0 +1,60 @@
+using System;
+using Intersect.GameObjects;
+using Intersect.Framework.Core.GameObjects.Spells;
+using Intersect.Server.Core.Database;
+using Intersect.Server.Core.Entities;
+
+namespace Intersect.Server.Core.Game.Spells;
+
+public enum SpellUpgradeResult
+{
+    Ok,
+    NoSuchSpell,
+    MaxLevelReached,
+    NotEnoughPoints,
+    RequirementsNotMet,
+}
+
+public static class SpellUpgradeService
+{
+    public static SpellUpgradeResult CanUpgradeSpell(Player player, Guid spellId, SpellProgressionStore store)
+    {
+        if (player == null)
+        {
+            throw new ArgumentNullException(nameof(player));
+        }
+
+        if (!player.Spellbook.SpellLevels.ContainsKey(spellId))
+        {
+            return SpellUpgradeResult.NoSuchSpell;
+        }
+
+        if (!store.BySpellId.TryGetValue(spellId, out var progression))
+        {
+            return SpellUpgradeResult.NoSuchSpell;
+        }
+
+        var currentLevel = player.Spellbook.GetLevelOrDefault(spellId);
+        if (currentLevel >= progression.Levels.Count)
+        {
+            return SpellUpgradeResult.MaxLevelReached;
+        }
+
+        if (player.Spellbook.AvailableSpellPoints <= 0)
+        {
+            return SpellUpgradeResult.NotEnoughPoints;
+        }
+
+        return SpellUpgradeResult.Ok;
+    }
+
+    public static (int newLevel, int remainingPoints) ApplyUpgrade(Player player, Guid spellId, IDbContext db)
+    {
+        var newLevel = player.Spellbook.GetLevelOrDefault(spellId) + 1;
+        player.Spellbook.SpellLevels[spellId] = newLevel;
+        player.Spellbook.AvailableSpellPoints--;
+        db.SaveChanges();
+        return (newLevel, player.Spellbook.AvailableSpellPoints);
+    }
+}
+

--- a/Intersect.Tests/Services/SpellLevelingServiceTests.cs
+++ b/Intersect.Tests/Services/SpellLevelingServiceTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Intersect.Framework.Core.GameObjects.Spells;
 using Intersect.Framework.Core.Services;
 using Intersect.GameObjects;
@@ -20,6 +21,24 @@ public class SpellLevelingServiceTests
             VitalCost = new long[] { 10, 20 },
             Combat = new SpellCombatDescriptor { HitRadius = 2 }
         };
+    }
+
+    [Test]
+    public void SpellProgression_GetLevel_Boundaries()
+    {
+        var progression = new SpellProgression
+        {
+            SpellId = Guid.NewGuid(),
+            Levels = new List<SpellProperties>
+            {
+                new SpellProperties(),
+                new SpellProperties()
+            }
+        };
+
+        Assert.IsNotNull(progression.GetLevel(1));
+        Assert.IsNull(progression.GetLevel(0));
+        Assert.IsNull(progression.GetLevel(5));
     }
 
     [Test]
@@ -75,5 +94,23 @@ public class SpellLevelingServiceTests
         Assert.AreEqual(1.5f, adjusted.DebuffDurationFactor);
         Assert.IsTrue(adjusted.UnlocksAoE);
         Assert.AreEqual(5, adjusted.AoERadius);
+    }
+
+    [Test]
+    public void BuildAdjusted_ClampsTimesAndHandlesArrayLengths()
+    {
+        var baseDesc = CreateBaseDescriptor();
+        var row = new SpellProperties
+        {
+            CastTimeDeltaMs = -5000,
+            CooldownDeltaMs = -5000,
+            VitalCostDeltas = new long[] { -5 }
+        };
+
+        var adjusted = SpellLevelingService.BuildAdjusted(baseDesc, row);
+
+        Assert.AreEqual(0, adjusted.CastTimeMs);
+        Assert.AreEqual(0, adjusted.CooldownTimeMs);
+        CollectionAssert.AreEqual(new long[] { 5, 20 }, adjusted.VitalCosts);
     }
 }


### PR DESCRIPTION
## Summary
- remove redundant spell state from PlayerSpellbookState in favor of SpellLevels
- add server-side SpellUpgradeService with validation and response handling
- clamp cast/cooldown times and safely sum vital costs; load 5 default progression rows
- centralize effective stat calculation via SpellMath and update UI/tests

## Testing
- `dotnet test Intersect.Tests/Intersect.Tests.csproj` *(fails: command not found: dotnet)*


------
https://chatgpt.com/codex/tasks/task_e_68a53ad4df248324a4173da36625ae70