### PR TITLE
Preserve item properties when dropping and picking up

### DIFF
--- a/Intersect.Server.Core/Maps/MapInstance.cs
+++ b/Intersect.Server.Core/Maps/MapInstance.cs
@@ -844,10 +844,10 @@ public partial class MapInstance : IMapInstance
                     VisibleToAll = Options.Instance.Loot.ShowUnownedItems || owner == Guid.Empty
                 };
 
-                // If this is a piece of equipment, set up the stat buffs for it.
+                // If this is a piece of equipment, copy its custom properties to the map item.
                 if (itemDescriptor.ItemType == ItemType.Equipment)
                 {
-                    mapItem.SetupStatBuffs(item);
+                    mapItem.SetupProperties(item);
                 }
 
                 if (mapItem.TileIndex > Options.Instance.Map.MapHeight * Options.Instance.Map.MapWidth || mapItem.TileIndex < 0)

--- a/Intersect.Server.Core/Maps/MapItemInstance.cs
+++ b/Intersect.Server.Core/Maps/MapItemInstance.cs
@@ -1,5 +1,6 @@
 using Intersect.Server.Database;
 using Intersect.Server.Database.PlayerData.Players;
+using Intersect.Framework.Core.GameObjects.Items;
 using Newtonsoft.Json;
 
 namespace Intersect.Server.Maps;
@@ -59,18 +60,17 @@ public partial class MapItem : Item
     }
 
     /// <summary>
-    /// Sets up the Stat Buffs on this map item from a supplied item.
+    /// Copies all of the custom properties from the supplied item to this map item.
     /// </summary>
-    /// <param name="item">The item to take the Stat Buffs from and apply them to this MapItem.</param>
-    public void SetupStatBuffs(Item item)
+    /// <param name="item">The item whose properties should be copied.</param>
+    public void SetupProperties(Item item)
     {
-        if (Properties.StatModifiers != null && item.Properties.StatModifiers != null)
+        if (item?.Properties == null)
         {
-            for (var i = 0; i < Properties.StatModifiers.Length; ++i)
-            {
-                Properties.StatModifiers[i] = item.Properties.StatModifiers.Length > i ? item.Properties.StatModifiers[i] : 0;
-            }
+            return;
         }
+
+        Properties = new ItemProperties(item.Properties);
     }
 
 }


### PR DESCRIPTION
## Summary
- copy item properties to map items when dropping equipment
- clone map item properties when picking up to retain enchant levels
- show enchantment level in pickup action message

## Testing
- `dotnet test` *(fails: project file 'vendor/LiteNetLib/LiteNetLib.csproj' not found)*
- `dotnet build Intersect.Server.Core/Intersect.Server.Core.csproj` *(fails: LiteNetLib namespace missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a53b78b4ec83248d63195471aeb23c