### PR TITLE
Ensure spell progression defaults and math correctness

### DIFF
--- a/Framework/Intersect.Framework.Core/GameObjects/Spells/SpellDescriptor.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Spells/SpellDescriptor.cs
@@ -162,13 +162,27 @@ public partial class SpellDescriptor : DatabaseObject<SpellDescriptor>, IFoldera
     public string ProgressionJson
     {
         get => JsonConvert.SerializeObject(Progression);
-        set => Progression = string.IsNullOrWhiteSpace(value)
-            ? new List<SpellProgressionRow>()
-            : JsonConvert.DeserializeObject<List<SpellProgressionRow>>(value) ?? new List<SpellProgressionRow>();
+        set
+        {
+            var list = string.IsNullOrWhiteSpace(value)
+                ? new List<SpellProgressionRow>()
+                : JsonConvert.DeserializeObject<List<SpellProgressionRow>>(value) ?? new List<SpellProgressionRow>();
+
+            if (list.Count == 0)
+            {
+                list = new List<SpellProgressionRow>(5);
+                for (var i = 0; i < 5; i++)
+                {
+                    list.Add(new SpellProgressionRow());
+                }
+            }
+
+            Progression = list;
+        }
     }
 
-    public SpellProgressionRow? GetProgressionLevel(int level) =>
-        level >= 1 && level <= Progression.Count ? Progression[level - 1] : null;
+    public SpellProgressionRow GetProgressionLevel(int level) =>
+        level >= 1 && level <= Progression.Count ? Progression[level - 1] : new SpellProgressionRow();
 
     /// <inheritdoc />
     public string Folder { get; set; } = string.Empty;

--- a/Intersect.Tests.Client/Utilities/SpellMathTests.cs
+++ b/Intersect.Tests.Client/Utilities/SpellMathTests.cs
@@ -1,0 +1,61 @@
+using System.Collections.Generic;
+using Intersect.Client.Utilities;
+using Intersect.Framework.Core.GameObjects.Spells;
+using Intersect.GameObjects;
+using NUnit.Framework;
+
+namespace Intersect.Tests.Client.Utilities
+{
+    [TestFixture]
+    public class SpellMathTests
+    {
+        [Test]
+        public void GetEffective_SumsBaseAndDeltasAndClamps()
+        {
+            var descriptor = new SpellDescriptor
+            {
+                CastDuration = 1000,
+                CooldownDuration = 2000,
+                VitalCost = new long[] { 10, 20 },
+                Combat = new SpellCombatDescriptor { HitRadius = 2 },
+                Progression = new List<SpellProgressionRow>
+                {
+                    new SpellProgressionRow
+                    {
+                        CastTimeDeltaMs = -1500,
+                        CooldownDeltaMs = -2500,
+                        VitalCostDeltas = new long[] { -5, 5 },
+                        PowerBonusFlat = 10,
+                        PowerScalingBonus = 0.5f,
+                        BuffStrengthFactor = 1.5f,
+                        BuffDurationFactor = 2f,
+                        DebuffStrengthFactor = 0.5f,
+                        DebuffDurationFactor = 1.5f,
+                        UnlocksAoE = true,
+                        AoERadiusDelta = 3
+                    }
+                }
+            };
+
+            SpellDescriptor.Lookup.Add(descriptor);
+            var state = new PlayerSpellbookState();
+            state.SpellLevels[descriptor.Id] = 1;
+
+            var stats = SpellMath.GetEffective(null, descriptor.Id, state);
+
+            Assert.That(stats.CastTimeMs, Is.EqualTo(0));
+            Assert.That(stats.CooldownTimeMs, Is.EqualTo(0));
+            Assert.That(stats.VitalCosts, Is.EquivalentTo(new long[] { 5, 25 }));
+            Assert.That(stats.PowerBonusFlat, Is.EqualTo(10));
+            Assert.That(stats.PowerScalingBonus, Is.EqualTo(0.5f));
+            Assert.That(stats.BuffStrengthFactor, Is.EqualTo(1.5f));
+            Assert.That(stats.BuffDurationFactor, Is.EqualTo(2f));
+            Assert.That(stats.DebuffStrengthFactor, Is.EqualTo(0.5f));
+            Assert.That(stats.DebuffDurationFactor, Is.EqualTo(1.5f));
+            Assert.That(stats.UnlocksAoE, Is.True);
+            Assert.That(stats.AoERadius, Is.EqualTo(5));
+
+            SpellDescriptor.Lookup.Delete(descriptor);
+        }
+    }
+}

--- a/Intersect.Tests/GameObjects/SpellDescriptorTests.cs
+++ b/Intersect.Tests/GameObjects/SpellDescriptorTests.cs
@@ -1,0 +1,56 @@
+using System.Collections.Generic;
+using Intersect.Enums;
+using Intersect.Framework.Core.GameObjects.Spells;
+using Intersect.GameObjects;
+using NUnit.Framework;
+using Assert = Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
+
+namespace Intersect.GameObjects.Tests
+{
+    [TestFixture]
+    public class SpellDescriptorTests
+    {
+        [Test]
+        public void ProgressionJson_EmptyYieldsFiveDefaultRows()
+        {
+            var descriptor = new SpellDescriptor();
+            descriptor.ProgressionJson = string.Empty;
+
+            Assert.AreEqual(5, descriptor.Progression.Count);
+            foreach (var row in descriptor.Progression)
+            {
+                Assert.IsNotNull(row);
+                Assert.AreEqual(Enum.GetValues<Vital>().Length, row.VitalCostDeltas.Length);
+                Assert.AreEqual(0, row.CastTimeDeltaMs);
+                Assert.AreEqual(0, row.CooldownDeltaMs);
+            }
+        }
+
+        [Test]
+        public void GetProgressionLevel_ReturnsRowOrEmpty()
+        {
+            var row1 = new SpellProgressionRow { CastTimeDeltaMs = 1 };
+            var row2 = new SpellProgressionRow { CastTimeDeltaMs = 2 };
+            var descriptor = new SpellDescriptor
+            {
+                Progression = new List<SpellProgressionRow> { row1, row2 }
+            };
+
+            var first = descriptor.GetProgressionLevel(1);
+            Assert.AreSame(row1, first);
+
+            var second = descriptor.GetProgressionLevel(2);
+            Assert.AreSame(row2, second);
+
+            var below = descriptor.GetProgressionLevel(0);
+            Assert.IsNotNull(below);
+            Assert.AreNotSame(row1, below);
+            Assert.AreEqual(0, below.CastTimeDeltaMs);
+
+            var above = descriptor.GetProgressionLevel(3);
+            Assert.IsNotNull(above);
+            Assert.AreNotSame(row2, above);
+            Assert.AreEqual(0, above.CastTimeDeltaMs);
+        }
+    }
+}

--- a/Intersect.Tests/Plugins/Manifests/Types/AuthorsTests.cs
+++ b/Intersect.Tests/Plugins/Manifests/Types/AuthorsTests.cs
@@ -63,7 +63,7 @@ namespace Intersect.Plugins.Manifests.Types
         public void AreEqual_StringArray()
         {
             var authors = new Authors(new Author(AuthorName), new Author(AuthorStringNameEmail));
-            Assert.IsTrue(authors.Equals([AuthorName, AuthorStringNameEmail]));
+            Assert.IsTrue(authors.Equals(new[] { AuthorName, AuthorStringNameEmail }));
         }
 
         [Test]


### PR DESCRIPTION
## Summary
- Default spell progressions to five empty rows when JSON is missing
- Return empty spell progression rows for out-of-range levels
- Cover spell math and progression behaviors with new tests

## Testing
- `dotnet test Intersect.Tests/Intersect.Tests.csproj`
- `dotnet test Intersect.Tests.Client/Intersect.Tests.Client.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a552bb25948324b36825ffa14902ac