### PR TITLE
Grant spell points on level up and enforce spell upgrade cost

### DIFF
--- a/Framework/Intersect.Framework.Core/Services/SpellLevelingService.cs
+++ b/Framework/Intersect.Framework.Core/Services/SpellLevelingService.cs
@@ -36,4 +36,12 @@ public static class SpellLevelingService
 
         return SpellMath.GetEffective(baseDesc, 0, row);
     }
+
+    /// <summary>
+    ///     Calculates the spell point cost required to upgrade a spell to the
+    ///     specified <paramref name="level"/>.
+    /// </summary>
+    /// <param name="level">The level the spell is being upgraded to.</param>
+    /// <returns>The number of spell points required for the upgrade.</returns>
+    public static int GetUpgradeCost(int level) => level;
 }

--- a/Intersect.Client.Core/Interface/Game/Spells/SpellsWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Spells/SpellsWindow.cs
@@ -170,7 +170,8 @@ public partial class SpellsWindow : Window
         {
             var nextAdjusted = SpellMath.GetEffective(descriptor, level + 1, nextRow);
             _nextLabel.Text = FormatAdjusted(nextAdjusted);
-            _levelUpButton.IsDisabled = !(Globals.Me.Spellbook.AvailableSpellPoints > 0 && level < 5);
+            var cost = SpellLevelingService.GetUpgradeCost(level + 1);
+            _levelUpButton.IsDisabled = !(Globals.Me.Spellbook.AvailableSpellPoints >= cost && level < 5);
         }
         else
         {

--- a/Intersect.Server.Core/Entities/Player.cs
+++ b/Intersect.Server.Core/Entities/Player.cs
@@ -1387,6 +1387,7 @@ public partial class Player : Entity
             while (Level < targetLevel)
             {
                 SetLevel(Level + 1, resetExperience, sendPackets: false);
+                Spellbook.AvailableSpellPoints++;
                 messageList.Add((Strings.Player.LevelUp.ToString(Level), CustomColors.Combat.LevelUp));
 
                 if ((classDescriptor?.Id == ClassId || ClassDescriptor.TryGet(ClassId, out classDescriptor)) && classDescriptor?.Spells != default)
@@ -1445,6 +1446,8 @@ public partial class Player : Entity
 
         PacketSender.SendPointsTo(this);
         PacketSender.SendPlayerSpells(this);
+
+        Save();
 
         if (StatPoints > 0)
         {

--- a/Intersect.Server.Core/Entities/SpellUpgradeService.cs
+++ b/Intersect.Server.Core/Entities/SpellUpgradeService.cs
@@ -3,6 +3,7 @@ using Intersect.GameObjects;
 using Intersect.Server.Database;
 using Intersect.Framework.Core.Utilities;
 using Intersect.Framework.Core.GameObjects.Spells;
+using Intersect.Framework.Core.Services;
 
 
 namespace Intersect.Server.Entities;
@@ -42,7 +43,8 @@ public static class SpellUpgradeService
             return SpellUpgradeResult.MaxLevelReached;
         }
 
-        if (player.Spellbook.AvailableSpellPoints <= 0)
+        var cost = SpellLevelingService.GetUpgradeCost(currentLevel + 1);
+        if (player.Spellbook.AvailableSpellPoints < cost)
         {
             return SpellUpgradeResult.NotEnoughPoints;
         }
@@ -53,8 +55,9 @@ public static class SpellUpgradeService
     public static (int newLevel, int remainingPoints) ApplyUpgrade(Player player, Guid spellId, IDbContext db)
     {
         var newLevel = player.Spellbook.GetLevelOrDefault(spellId) + 1;
+        var cost = SpellLevelingService.GetUpgradeCost(newLevel);
         player.Spellbook.SpellLevels[spellId] = newLevel;
-        player.Spellbook.AvailableSpellPoints--;
+        player.Spellbook.AvailableSpellPoints -= cost;
         db.SaveChanges();
 
         var descriptor = SpellDescriptor.Get(spellId);

--- a/Intersect.Tests/Services/SpellLevelingServiceTests.cs
+++ b/Intersect.Tests/Services/SpellLevelingServiceTests.cs
@@ -113,4 +113,11 @@ public class SpellLevelingServiceTests
         Assert.AreEqual(0, adjusted.CooldownTimeMs);
         CollectionAssert.AreEqual(new long[] { 5, 20 }, adjusted.VitalCosts);
     }
+
+    [Test]
+    public void GetUpgradeCost_ReturnsTargetLevel()
+    {
+        Assert.AreEqual(1, SpellLevelingService.GetUpgradeCost(1));
+        Assert.AreEqual(3, SpellLevelingService.GetUpgradeCost(3));
+    }
 }


### PR DESCRIPTION
## Summary
- award players a spell point whenever they level up and persist it
- add shared helper to compute spell upgrade point cost
- enforce upgrade cost on server and client
- cover cost helper with tests

## Testing
- `dotnet test Intersect.Tests/Intersect.Tests.csproj` *(fails: The call is ambiguous between the following methods or properties: 'Authors.Equals(IEnumerable<Author>)' and 'Authors.Equals(IEnumerable<string>)')*
- `dotnet build Intersect.Server.Core/Intersect.Server.Core.csproj` *(fails: missing LiteNetLib types such as DeliveryMethod and NetPeer)*


------
https://chatgpt.com/codex/tasks/task_e_68a55be2fa708324a061cd18566c387c