### PR TITLE
Refactor spells window to new layout

### DIFF
--- a/Intersect.Client.Core/Interface/Game/Spells/SpellsWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Spells/SpellsWindow.cs
@@ -2,17 +2,19 @@ using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
+using System.Text;
 using Intersect.Client.Core;
+using Intersect.Client.Framework.Content;
 using Intersect.Client.Framework.File_Management;
 using Intersect.Client.Framework.Gwen;
 using Intersect.Client.Framework.Gwen.Control;
 using Intersect.Client.Localization;
-using Intersect.GameObjects;
+using Intersect.Client.General;
+using Intersect.Client.Networking;
 using Intersect.Framework.Core.GameObjects.Spells;
 using Intersect.Framework.Core.Services;
 using Intersect.Framework.Core.Utilities;
-using Intersect.Client.General;
-using Intersect.Client.Networking;
+using Intersect.GameObjects;
 using Intersect.Utilities;
 
 namespace Intersect.Client.Interface.Game.Spells;
@@ -21,6 +23,7 @@ public partial class SpellsWindow : Window
 {
     private readonly ScrollControl _spellList;
     private readonly ImagePanel _detailPanel;
+    private readonly ImagePanel _iconPanel;
     private readonly Label _nameLabel;
     private readonly Label _levelLabel;
     private readonly Label _currentLabel;
@@ -28,22 +31,26 @@ public partial class SpellsWindow : Window
     private readonly Button _levelUpButton;
 
     private Guid _selectedSpellId = Guid.Empty;
+    private bool _levelUpPending;
 
     public List<SpellItem> Items { get; } = new();
 
     public SpellsWindow(Canvas gameCanvas) : base(gameCanvas, Strings.Spells.Title, false, nameof(SpellsWindow))
     {
+        DisableResizing();
+
         Alignment = [Alignments.Bottom, Alignments.Right];
-        MinimumSize = new Point(300, 300);
+        MinimumSize = new Point(560, 340);
         Margin = new Margin(0, 0, 15, 60);
-        IsResizable = false;
         IsVisibleInTree = false;
+        IsResizable = false;
         IsClosable = true;
 
         _spellList = new ScrollControl(this, nameof(_spellList))
         {
             Dock = Pos.Left,
-            Width = 150,
+            Width = 240,
+            OverflowX = OverflowBehavior.Hidden,
             OverflowY = OverflowBehavior.Scroll,
         };
 
@@ -53,46 +60,50 @@ public partial class SpellsWindow : Window
             IsVisibleInParent = false,
         };
 
+        _iconPanel = new ImagePanel(_detailPanel, nameof(_iconPanel));
+        _iconPanel.SetBounds(8, 8, 48, 48);
+
         _nameLabel = new Label(_detailPanel, nameof(_nameLabel))
         {
             FontName = "sourcesansproblack",
-            FontSize = 12,
+            FontSize = 13,
         };
-        _nameLabel.SetPosition(4, 4);
+        _nameLabel.SetPosition(64, 8);
 
         _levelLabel = new Label(_detailPanel, nameof(_levelLabel))
         {
             FontName = "sourcesansproblack",
             FontSize = 10,
         };
-        _levelLabel.SetPosition(4, 24);
+        _levelLabel.SetPosition(64, 30);
 
         _currentLabel = new Label(_detailPanel, nameof(_currentLabel))
         {
             FontName = "sourcesansproblack",
             FontSize = 10,
         };
-        _currentLabel.SetPosition(4, 44);
+        _currentLabel.SetPosition(8, 70);
 
         _nextLabel = new Label(_detailPanel, nameof(_nextLabel))
         {
             FontName = "sourcesansproblack",
             FontSize = 10,
         };
-        _nextLabel.SetPosition(4, 84);
+        _nextLabel.SetPosition(8, 140);
 
         _levelUpButton = new Button(_detailPanel, nameof(_levelUpButton))
         {
-            Text = "Level Up",
+            Text = Strings.Spells.LevelUp,
             FontName = "sourcesansproblack",
             FontSize = 10,
         };
-        _levelUpButton.SetPosition(4, 120);
+        _levelUpButton.SetPosition(8, 210);
         _levelUpButton.Clicked += (_, _) => LevelUp();
     }
 
     protected override void EnsureInitialized()
     {
+        LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
         Refresh();
     }
 
@@ -101,20 +112,43 @@ public partial class SpellsWindow : Window
         _spellList.ClearChildren();
         Items.Clear();
 
-        if (Globals.Me?.Spellbook?.SpellLevels == null)
+        var spellLevels = Globals.Me?.Spellbook?.SpellLevels;
+        if (spellLevels == null || spellLevels.Count == 0)
         {
+            _selectedSpellId = Guid.Empty;
+            UpdateDetails();
             return;
         }
 
         var index = 0;
-        foreach (var spellId in Globals.Me.Spellbook.SpellLevels.Keys.OrderBy(SpellDescriptor.GetName))
+        foreach (var spellId in spellLevels.Keys.Where(SpellDescriptor.Exists).OrderBy(SpellDescriptor.GetName))
         {
             var item = new SpellItem(this, _spellList, index++, spellId);
             Items.Add(item);
         }
 
-        _spellList.SetInnerSize(_spellList.Width, index * 40);
+        var height = Items.FirstOrDefault()?.Height ?? 40;
+        _spellList.SetInnerSize(_spellList.Width, index * (height + 2));
+
+        TrySelectFirstIfNone();
+        _levelUpPending = false;
         UpdateDetails();
+    }
+
+    private void TrySelectFirstIfNone()
+    {
+        if (_selectedSpellId != Guid.Empty)
+        {
+            return;
+        }
+
+        var spellLevels = Globals.Me?.Spellbook?.SpellLevels;
+        if (spellLevels == null || spellLevels.Count == 0)
+        {
+            return;
+        }
+
+        _selectedSpellId = spellLevels.Keys.Where(SpellDescriptor.Exists).OrderBy(SpellDescriptor.GetName).First();
     }
 
     public void SelectSpell(Guid spellId)
@@ -125,7 +159,7 @@ public partial class SpellsWindow : Window
 
     public void Update()
     {
-        if (!IsVisibleInParent)
+        if (!IsVisibleInTree)
         {
             return;
         }
@@ -138,13 +172,14 @@ public partial class SpellsWindow : Window
 
     private void UpdateDetails()
     {
-        if (_selectedSpellId == Guid.Empty || Globals.Me?.Spellbook?.SpellLevels == null)
+        var spellbook = Globals.Me?.Spellbook;
+        if (_selectedSpellId == Guid.Empty || spellbook?.SpellLevels == null)
         {
             _detailPanel.IsVisibleInParent = false;
             return;
         }
 
-        if (!Globals.Me.Spellbook.SpellLevels.ContainsKey(_selectedSpellId))
+        if (!spellbook.SpellLevels.ContainsKey(_selectedSpellId))
         {
             _detailPanel.IsVisibleInParent = false;
             return;
@@ -157,42 +192,73 @@ public partial class SpellsWindow : Window
         }
 
         _detailPanel.IsVisibleInParent = true;
+
+        var tex = GameContentManager.Current.GetTexture(TextureType.Spell, descriptor.Icon);
+        if (tex != null)
+        {
+            _iconPanel.Texture = tex;
+            _iconPanel.IsVisibleInParent = true;
+        }
+        else
+        {
+            _iconPanel.IsVisibleInParent = false;
+        }
+
         _nameLabel.Text = descriptor.Name;
-        var level = Globals.Me.Spellbook.GetLevelOrDefault(_selectedSpellId);
+        var level = spellbook.GetLevelOrDefault(_selectedSpellId);
         _levelLabel.Text = Strings.EntityBox.Level.ToString(level);
 
-        var currentRow = descriptor.GetProgressionLevel(level) ?? new SpellProgressionRow();
-        var currentAdjusted = SpellMath.GetEffective(descriptor, level, currentRow);
-        _currentLabel.Text = FormatAdjusted(currentAdjusted);
+        var current = SpellMath.GetEffective(descriptor, level);
+        _currentLabel.Text = FormatAdjusted(descriptor, current);
 
-        var nextRow = descriptor.GetProgressionLevel(level + 1);
-        if (nextRow != null)
+        var levelsCount = descriptor.Progression?.Count ?? 0;
+        var hasNext = level < levelsCount;
+
+        if (hasNext)
         {
-            var nextAdjusted = SpellMath.GetEffective(descriptor, level + 1, nextRow);
-            _nextLabel.Text = FormatAdjusted(nextAdjusted);
-            var cost = SpellLevelingService.GetUpgradeCost(level + 1);
-            _levelUpButton.IsDisabled = !(Globals.Me.Spellbook.AvailableSpellPoints >= cost && level < 5);
+            var next = SpellMath.GetEffective(descriptor, level + 1);
+            _nextLabel.Text = FormatAdjusted(descriptor, next);
+            _levelUpButton.IsDisabled = _levelUpPending || spellbook.AvailableSpellPoints <= 0;
+            _levelUpButton.Text = Strings.Spells.LevelUp;
         }
         else
         {
             _nextLabel.Text = Strings.EntityBox.MaxLevel;
             _levelUpButton.IsDisabled = true;
+            _levelUpButton.Text = Strings.EntityBox.MaxLevel;
         }
     }
 
-    private static string FormatAdjusted(SpellLevelingService.EffectiveSpellStats adjusted)
+    private static string FormatAdjusted(SpellDescriptor desc, SpellLevelingService.EffectiveSpellStats stats)
     {
-        return $"{Strings.SpellDescription.CastTime}: {TimeSpan.FromMilliseconds(adjusted.CastTimeMs).WithSuffix()}\n" +
-               $"{Strings.SpellDescription.Cooldown}: {TimeSpan.FromMilliseconds(adjusted.CooldownTimeMs).WithSuffix()}";
+        var sb = new StringBuilder();
+        sb.AppendLine($"{Strings.SpellDescription.CastTime} {TimeSpan.FromMilliseconds(stats.CastTimeMs).WithSuffix()}");
+        sb.AppendLine($"{Strings.SpellDescription.Cooldown} {TimeSpan.FromMilliseconds(stats.CooldownTimeMs).WithSuffix()}");
+        if (desc.Combat.CastRange > 0)
+        {
+            sb.AppendLine($"{Strings.SpellDescription.Distance} {desc.Combat.CastRange}");
+        }
+        if (desc.Combat.CritChance > 0)
+        {
+            sb.AppendLine($"{Strings.SpellDescription.CritChance} {desc.Combat.CritChance}%");
+        }
+        if (desc.Combat.CritMultiplier > 0)
+        {
+            sb.AppendLine($"{Strings.SpellDescription.CritMultiplier} x{desc.Combat.CritMultiplier:0.##}");
+        }
+
+        return sb.ToString();
     }
 
     private void LevelUp()
     {
-        if (_selectedSpellId == Guid.Empty)
+        if (_selectedSpellId == Guid.Empty || _levelUpPending)
         {
             return;
         }
 
+        _levelUpPending = true;
+        _levelUpButton.IsDisabled = true;
         PacketSender.SendRequestSpellUpgrade(_selectedSpellId);
     }
 }


### PR DESCRIPTION
## Summary
- overhaul spells window layout to include icon panel and detailed stats
- integrate existing SpellItem list and selection support
- add pending state and improved level-up handling

## Testing
- `dotnet test` *(fails: project file "vendor/LiteNetLib/LiteNetLib/LiteNetLib.csproj" was not found)*
- `timeout 100s dotnet build Intersect.Client.Core/Intersect.Client.Core.csproj` *(fails: error CS0246: The type or namespace name 'NetDataWriter' could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_68a56134ec1883248acdaa3919675729