### PR TITLE
feat: add spell point system

### DIFF
--- a/Framework/Intersect.Framework.Core/Network/Packets/Server/UpdateSpellPointsPacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Server/UpdateSpellPointsPacket.cs
@@ -1,0 +1,19 @@
+using MessagePack;
+
+namespace Intersect.Network.Packets.Server;
+
+[MessagePackObject]
+public partial class UpdateSpellPointsPacket : IntersectPacket
+{
+    public UpdateSpellPointsPacket()
+    {
+    }
+
+    public UpdateSpellPointsPacket(int spellPoints)
+    {
+        SpellPoints = spellPoints;
+    }
+
+    [Key(0)]
+    public int SpellPoints { get; set; }
+}

--- a/Intersect.Client.Core/Entities/Player.cs
+++ b/Intersect.Client.Core/Entities/Player.cs
@@ -145,6 +145,8 @@ public partial class Player : Entity, IPlayer
 
     public int StatPoints { get; set; } = 0;
 
+    public int SpellPoints { get; set; } = 0;
+
     public EntityBox? TargetBox { get; set; }
 
     public PlayerStatusWindow? StatusWindow { get; set; }

--- a/Intersect.Client.Core/Networking/PacketHandler.cs
+++ b/Intersect.Client.Core/Networking/PacketHandler.cs
@@ -1424,6 +1424,15 @@ internal sealed partial class PacketHandler
         }
     }
 
+    //UpdateSpellPointsPacket
+    public void HandlePacket(IPacketSender packetSender, UpdateSpellPointsPacket packet)
+    {
+        if (Globals.Me != null)
+        {
+            Globals.Me.SpellPoints = packet.SpellPoints;
+        }
+    }
+
     //HotbarPacket
     public void HandlePacket(IPacketSender packetSender, HotbarPacket packet)
     {

--- a/Intersect.Client.Framework/Entities/IPlayer.cs
+++ b/Intersect.Client.Framework/Entities/IPlayer.cs
@@ -10,6 +10,7 @@ public interface IPlayer : IEntity
     long Experience { get; }
     long ExperienceToNextLevel { get; }
     int StatPoints { get; }
+    int SpellPoints { get; }
     bool IsInParty { get; }
     IReadOnlyList<IPartyMember> PartyMembers { get; }
     long CombatTimer { get; }

--- a/Intersect.Server.Core/Networking/PacketSender.cs
+++ b/Intersect.Server.Core/Networking/PacketSender.cs
@@ -429,6 +429,7 @@ public static partial class PacketSender
             SendInventory(player);
             SendPlayerSpells(player);
             SendPointsTo(player);
+            SendSpellPoints(player);
             SendHotbarSlots(player);
             SendQuestsProgress(player);
             SendItemCooldowns(player);
@@ -1382,6 +1383,18 @@ public static partial class PacketSender
     public static void SendPointsTo(Player player)
     {
         player.SendPacket(new StatPointsPacket(player.StatPoints), TransmissionMode.Any);
+    }
+
+    //SpellPointsPacket
+    public static void SendSpellPoints(Player player)
+    {
+        if (!player.SpellPointsChanged)
+        {
+            return;
+        }
+
+        player.SpellPointsChanged = false;
+        player.SendPacket(new UpdateSpellPointsPacket(player.SpellPoints), TransmissionMode.Any);
     }
 
     //HotbarPacket


### PR DESCRIPTION
## Summary
- add SpellPoints tracking for players and award points on level up
- add UpdateSpellPointsPacket and server/client handling
- expose spell point data through networking and player interfaces

## Testing
- `~/.dotnet/dotnet build -p:EnableWindowsTargeting=true` *(fails: 'SpellSlot' does not contain a definition for 'SpellId')*

------
https://chatgpt.com/codex/tasks/task_e_68a682a80ed48324bae2867fa7a3f97f