### PR TITLE
Fix missing SpellSlot members

### DIFF
--- a/Intersect.Server.Core/Database/PlayerData/Players/SpellSlot.cs
+++ b/Intersect.Server.Core/Database/PlayerData/Players/SpellSlot.cs
@@ -38,8 +38,53 @@ public partial class SpellSlot : ISlot, IPlayerOwned
     [ForeignKey(nameof(PlayerId))]
     public virtual Player Player { get; private set; }
 
+    // Backing field for NPC or non-player spell identifiers.
+    private Guid _spellId;
+
+    [NotMapped]
+    public Guid SpellId
+    {
+        get => PlayerSpell?.SpellId ?? _spellId;
+        set
+        {
+            if (PlayerSpell != null)
+            {
+                PlayerSpell.SpellId = value;
+            }
+            else
+            {
+                _spellId = value;
+            }
+        }
+    }
+
     [JsonIgnore]
-    public bool IsEmpty => PlayerSpellId == default;
+    public bool IsEmpty => SpellId == default;
 
     public int Level { get; internal set; }
+
+    public SpellSlot Clone()
+    {
+        return new SpellSlot(Slot)
+        {
+            PlayerSpellId = PlayerSpellId,
+            PlayerSpell = PlayerSpell,
+            _spellId = _spellId,
+            Level = Level
+        };
+    }
+
+    public void Set(Spell spell)
+    {
+        SpellId = spell.SpellId;
+        Level = spell.Properties?.Level ?? 1;
+    }
+
+    public void Set(SpellSlot slot)
+    {
+        PlayerSpellId = slot.PlayerSpellId;
+        PlayerSpell = slot.PlayerSpell;
+        _spellId = slot._spellId;
+        Level = slot.Level;
+    }
 }


### PR DESCRIPTION
## Summary
- restore SpellSlot interface with SpellId property
- add Set and Clone helpers for spells

## Testing
- `dotnet build Intersect.Server.Core/Intersect.Server.Core.csproj` *(fails: NetManager not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7e66f3e208324aa7c03a91182f36e