### PR TITLE
Persist spell slot level

### DIFF
--- a/Intersect.Server.Core/Database/PlayerData/PlayerContext.cs
+++ b/Intersect.Server.Core/Database/PlayerData/PlayerContext.cs
@@ -92,6 +92,7 @@ public abstract partial class PlayerContext : IntersectDbContext<PlayerContext>,
         modelBuilder.Entity<Friend>().HasOne(b => b.Target).WithMany().OnDelete(DeleteBehavior.Cascade);
 
         modelBuilder.Entity<Player>().HasMany(b => b.Spells).WithOne(p => p.Player);
+        modelBuilder.Entity<SpellSlot>().Property(s => s.Level).HasDefaultValue(1);
 
         modelBuilder.Entity<Player>().HasMany(b => b.Items).WithOne(p => p.Player);
 

--- a/Intersect.Server.Core/Database/PlayerData/Players/SpellSlot.cs
+++ b/Intersect.Server.Core/Database/PlayerData/Players/SpellSlot.cs
@@ -10,9 +10,7 @@ public partial class SpellSlot : ISlot, IPlayerOwned
 {
     public static SpellSlot Create(int slotIndex) => new(slotIndex);
 
-    public SpellSlot()
-    {
-    }
+    public SpellSlot() { }
 
     public SpellSlot(int slot)
     {
@@ -61,7 +59,7 @@ public partial class SpellSlot : ISlot, IPlayerOwned
     [JsonIgnore]
     public bool IsEmpty => SpellId == default;
 
-    public int Level { get; internal set; }
+    public int Level { get; set; } = 1;
 
     public SpellSlot Clone()
     {

--- a/Intersect.Server.Core/Migrations/Sqlite/Player/20250822000000_AddSpellSlotLevel.Designer.cs
+++ b/Intersect.Server.Core/Migrations/Sqlite/Player/20250822000000_AddSpellSlotLevel.Designer.cs
@@ -1,0 +1,17 @@
+using Intersect.Server.Database.PlayerData;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Intersect.Server.Migrations.Sqlite.Player
+{
+    [DbContext(typeof(SqlitePlayerContext))]
+    [Migration("20250822000000_AddSpellSlotLevel")]
+    partial class AddSpellSlotLevel
+    {
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
+        {
+            new SqlitePlayerContextModelSnapshot().BuildModel(modelBuilder);
+        }
+    }
+}

--- a/Intersect.Server.Core/Migrations/Sqlite/Player/20250822000000_AddSpellSlotLevel.cs
+++ b/Intersect.Server.Core/Migrations/Sqlite/Player/20250822000000_AddSpellSlotLevel.cs
@@ -1,0 +1,24 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Intersect.Server.Migrations.Sqlite.Player
+{
+    public partial class AddSpellSlotLevel : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "Level",
+                table: "Player_Spells",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 1);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Level",
+                table: "Player_Spells");
+        }
+    }
+}

--- a/Intersect.Server.Core/Migrations/Sqlite/Player/SqlitePlayerContextModelSnapshot.cs
+++ b/Intersect.Server.Core/Migrations/Sqlite/Player/SqlitePlayerContextModelSnapshot.cs
@@ -532,6 +532,10 @@ namespace Intersect.Server.Migrations.Sqlite.Player
                     b.Property<int>("Slot")
                         .HasColumnType("INTEGER");
 
+                    b.Property<int>("Level")
+                        .HasColumnType("INTEGER")
+                        .HasDefaultValue(1);
+
                     b.Property<Guid>("SpellId")
                         .HasColumnType("TEXT");
 


### PR DESCRIPTION
## Summary
- persist spell level on player spell slots with default level 1
- add EF migration and snapshot updates for spell slot level column

## Testing
- `dotnet ef database update --project Intersect.Server.Core/Intersect.Server.Core.csproj --context SqlitePlayerContext --startup-project Intersect.Server/Intersect.Server.csproj` *(fails: Build failed. Use dotnet build to see the errors.)*
- `dotnet test` *(fails: project files missing for vendor dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68a7eba5cab48324becacdd9be964b71