### PR TITLE
Include spell level in network packets

### DIFF
--- a/Framework/Intersect.Framework.Core/Network/Packets/Server/SpellUpdatePacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Server/SpellUpdatePacket.cs
@@ -10,10 +10,11 @@ public partial class SpellUpdatePacket : IntersectPacket
     {
     }
 
-    public SpellUpdatePacket(int slot, Guid spellId)
+    public SpellUpdatePacket(int slot, Guid spellId, int level)
     {
         Slot = slot;
         SpellId = spellId;
+        Level = level;
     }
 
     [Key(0)]
@@ -21,5 +22,8 @@ public partial class SpellUpdatePacket : IntersectPacket
 
     [Key(1)]
     public Guid SpellId { get; set; }
+
+    [Key(2)]
+    public int Level { get; set; }
 
 }

--- a/Intersect.Client.Core/Networking/PacketHandler.cs
+++ b/Intersect.Client.Core/Networking/PacketHandler.cs
@@ -1390,7 +1390,7 @@ internal sealed partial class PacketHandler
     {
         if (Globals.Me != null)
         {
-            Globals.Me.Spells[packet.Slot].Load(packet.SpellId);
+            Globals.Me.Spells[packet.Slot].Load(packet.SpellId, packet.Level);
         }
     }
 

--- a/Intersect.Client.Core/Spells/Spell.cs
+++ b/Intersect.Client.Core/Spells/Spell.cs
@@ -9,16 +9,19 @@ public partial class Spell
 
     public Spell Clone()
     {
-        var newSpell = new Spell() {
-            Id = Id
+        var newSpell = new Spell()
+        {
+            Id = Id,
+            Level = Level,
         };
 
         return newSpell;
     }
 
-    public void Load(Guid spellId)
+    public void Load(Guid spellId, int level)
     {
         Id = spellId;
+        Level = level;
     }
 
 }

--- a/Intersect.Server.Core/Networking/PacketSender.cs
+++ b/Intersect.Server.Core/Networking/PacketSender.cs
@@ -1308,7 +1308,7 @@ public static partial class PacketSender
         var spells = new SpellUpdatePacket[Options.Instance.Player.MaxSpells];
         for (var i = 0; i < Options.Instance.Player.MaxSpells; i++)
         {
-            spells[i] = new SpellUpdatePacket(i, player.Spells[i].SpellId);
+            spells[i] = new SpellUpdatePacket(i, player.Spells[i].SpellId, player.Spells[i].Level);
         }
 
         player.SendPacket(new SpellsPacket(spells));
@@ -1322,7 +1322,7 @@ public static partial class PacketSender
             return;
         }
 
-        player.SendPacket(new SpellUpdatePacket(slot, player.Spells[slot].SpellId));
+        player.SendPacket(new SpellUpdatePacket(slot, player.Spells[slot].SpellId, player.Spells[slot].Level));
     }
 
     //EquipmentPacket


### PR DESCRIPTION
## Summary
- add `Level` to `SpellUpdatePacket`
- send spell level from server
- load spell levels on the client

## Testing
- `dotnet build Intersect.Client.Core/Intersect.Client.Core.csproj`
- `dotnet test -p:EnableWindowsTargeting=true` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7f19904d88324b366c9bdf820a482