### PR TITLE
Send spell updates on login, respawn, and level-up

### DIFF
--- a/Intersect.Server.Core/Entities/Player.cs
+++ b/Intersect.Server.Core/Entities/Player.cs
@@ -1210,6 +1210,8 @@ public partial class Player : Entity
         PacketSender.SendEntityDie(this);
         Respawn();
         PacketSender.SendInventory(this);
+        PacketSender.SendPlayerSpells(this);
+        PacketSender.SendSpellPoints(this);
     }
 
     public override void ProcessRegen()
@@ -1390,6 +1392,7 @@ public partial class Player : Entity
                 StartCommonEventsWithTrigger(CommonEventTrigger.LevelUp);
                 PacketSender.SendActionMsg(this, Strings.Combat.LevelUp, CustomColors.Combat.LevelUp);
                 SpellPoints++;
+                PacketSender.SendSpellPoints(this);
                 SpellPointsChanged = true;
             }
         }

--- a/Intersect.Server.Core/Networking/PacketSender.cs
+++ b/Intersect.Server.Core/Networking/PacketSender.cs
@@ -115,6 +115,8 @@ public static partial class PacketSender
             player.LoginWarp();
 
             SendEntityDataTo(client.Entity, player);
+            SendPlayerSpells(player);
+            SendSpellPoints(player);
 
             //Search for login activated events and run them
             player.StartCommonEventsWithTrigger(CommonEventTrigger.Login);


### PR DESCRIPTION
## Summary
- send player spells and spell points when a player logs in
- refresh spells and spell points after a respawn
- notify clients of new spell points gained from leveling

## Testing
- `dotnet test` *(fails: project file '/workspace/Broken_Reborn/vendor/LiteNetLib/LiteNetLib/LiteNetLib.csproj' was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7f352b198832496a3825e77ef48e9