### PR TITLE
Refresh spell UI on spell packets

### DIFF
--- a/Intersect.Client.Core/Interface/Game/Spells/SpellItem.cs
+++ b/Intersect.Client.Core/Interface/Game/Spells/SpellItem.cs
@@ -274,6 +274,9 @@ public partial class SpellItem : SlotItem
         _nameLabel.Text = $"{spell.Name} Lv.{spellSlots[SlotIndex].Level}";
         SpellLevel = spellSlots[SlotIndex].Level;
 
+        _levelUpButton.IsDisabled = !(Globals.Me.SpellPoints > 0 && SpellLevel < Options.Instance.Player.MaxSpellLevel);
+        _levelDownButton.IsDisabled = !(SpellLevel > 1);
+
         if (Path.GetFileName(Icon.Texture?.Name) != spell.Icon)
         {
             var spellIconTexture = GameContentManager.Current.GetTexture(TextureType.Spell, spell.Icon);

--- a/Intersect.Client.Core/Networking/PacketHandler.cs
+++ b/Intersect.Client.Core/Networking/PacketHandler.cs
@@ -1383,6 +1383,8 @@ internal sealed partial class PacketHandler
         {
             HandlePacket(spl);
         }
+
+        Interface.Interface.GameUi.SpellsWindow?.Update();
     }
 
     //SpellUpdatePacket
@@ -1391,6 +1393,7 @@ internal sealed partial class PacketHandler
         if (Globals.Me != null)
         {
             Globals.Me.Spells[packet.Slot].Load(packet.SpellId, packet.Level);
+            Interface.Interface.GameUi.SpellsWindow?.Update();
         }
     }
 
@@ -1430,6 +1433,7 @@ internal sealed partial class PacketHandler
         if (Globals.Me != null)
         {
             Globals.Me.SpellPoints = packet.SpellPoints;
+            Interface.Interface.GameUi.SpellsWindow?.Update();
         }
     }
 


### PR DESCRIPTION
## Summary
- Refresh spells window when spells, spell points, or spell packets update
- Disable spell level up/down controls based on available spell points and level bounds

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7f4f593ac8324909f5590a036c606