### PR TITLE
Actualizar ventana de hechizos

### DIFF
--- a/Intersect.Client.Core/Interface/Game/Spells/SpellsWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Spells/SpellsWindow.cs
@@ -79,14 +79,22 @@ public partial class SpellsWindow : Window
         if (!IsVisibleInTree)
             return;
 
+        _lblSpellPoints.Text = $"Puntos de hechizo: {Globals.Me.SpellPoints}";
+
         var slotCount = Math.Min(Items.Count, Options.Instance.Player.MaxSpells);
         for (var i = 0; i < slotCount; i++)
         {
             Items[i].Update();
         }
+    }
 
-        // Aquí puedes actualizar los puntos si tienes acceso
-        // _lblSpellPoints.Text = $"Puntos de hechizo: {PlayerInfo.SpellPoints}";
+    public void Refresh()
+    {
+        var slotCount = Math.Min(Items.Count, Options.Instance.Player.MaxSpells);
+        for (var i = 0; i < slotCount; i++)
+        {
+            Items[i].Update();
+        }
     }
 
     public override void Hide()

--- a/Intersect.Client.Core/Networking/PacketHandler.cs
+++ b/Intersect.Client.Core/Networking/PacketHandler.cs
@@ -1384,7 +1384,7 @@ internal sealed partial class PacketHandler
             HandlePacket(spl);
         }
 
-        Interface.Interface.GameUi.SpellsWindow?.Update();
+        Interface.Interface.GameUi.SpellsWindow?.Refresh();
     }
 
     //SpellUpdatePacket
@@ -1433,7 +1433,7 @@ internal sealed partial class PacketHandler
         if (Globals.Me != null)
         {
             Globals.Me.SpellPoints = packet.SpellPoints;
-            Interface.Interface.GameUi.SpellsWindow?.Update();
+            Interface.Interface.GameUi.SpellsWindow?.Refresh();
         }
     }
 


### PR DESCRIPTION
## Resumen
- Mostrar puntos de hechizo actuales en la ventana de hechizos
- Añadir método `Refresh` para actualizar todos los slots
- Invocar `Refresh` desde `PacketHandler` al recibir paquetes de hechizos y puntos

## Testing
- `dotnet test` *(falla: project file not found)*
- `dotnet build Intersect.Client.Core/Intersect.Client.Core.csproj` *(falla: NetPacketReader not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7f6db23c083248f3e1ee404611710