### PR TITLE
Use per-spell level for spell effects

### DIFF
--- a/Intersect.Server.Core/Entities/Combat/DamageOverTimeEffect.cs
+++ b/Intersect.Server.Core/Entities/Combat/DamageOverTimeEffect.cs
@@ -4,6 +4,7 @@ using Intersect.Enums;
 using Intersect.Framework.Core;
 using Intersect.GameObjects;
 using Intersect.Utilities;
+using Intersect.Server.General;
 using Microsoft.Extensions.Logging;
 
 namespace Intersect.Server.Entities.Combat;
@@ -147,14 +148,15 @@ public partial class DamageOverTimeEffect
             aliveAnimations.Add(animation);
         }
 
-        var damageHealth = SpellDescriptor.Combat.VitalDiff[(int)Vital.Health];
-        var damageMana = SpellDescriptor.Combat.VitalDiff[(int)Vital.Mana];
+        var level = (Attacker as Player)?.GetSpellLevel(SpellDescriptor.Id);
+        var damageHealth = SpellMath.Scale(SpellDescriptor.Combat.VitalDiff[(int)Vital.Health], level);
+        var damageMana = SpellMath.Scale(SpellDescriptor.Combat.VitalDiff[(int)Vital.Mana], level);
 
         Attacker?.Attack(
             Target, damageHealth, damageMana,
             (DamageType)SpellDescriptor.Combat.DamageType, (Enums.Stat)SpellDescriptor.Combat.ScalingStat,
             SpellDescriptor.Combat.Scaling, SpellDescriptor.Combat.CritChance, SpellDescriptor.Combat.CritMultiplier, deadAnimations,
-            aliveAnimations, false
+            aliveAnimations, false, level
         );
 
         mInterval = Timing.Global.Milliseconds + SpellDescriptor.Combat.HotDotInterval;

--- a/Intersect.Server.Core/Entities/Combat/Status.cs
+++ b/Intersect.Server.Core/Entities/Combat/Status.cs
@@ -106,7 +106,8 @@ public partial class Status
         {
             foreach (var vital in Enum.GetValues<Vital>())
             {
-                long vitalDiff = Math.Abs(spell.Combat.VitalDiff[(int)vital]);
+                var level = (attacker as Player)?.GetSpellLevel(spell.Id);
+                long vitalDiff = Math.Abs(SpellMath.Scale(spell.Combat.VitalDiff[(int)vital], level));
 
                 // If the user did not configure for this vital to have a mana shield, ignore it
                 if (vitalDiff == 0 && vital == Vital.Mana)
@@ -115,7 +116,7 @@ public partial class Status
                 }
 
                 var shieldAmount = Formulas.CalculateDamage(
-                    vitalDiff, (DamageType)spell.Combat.DamageType, (Enums.Stat)spell.Combat.ScalingStat, spell.Combat.Scaling, 1.0, attacker, en
+                    vitalDiff, (DamageType)spell.Combat.DamageType, (Enums.Stat)spell.Combat.ScalingStat, spell.Combat.Scaling, 1.0, attacker, en, level
                 );
 
                 Shield[(int)vital] = Math.Abs(shieldAmount);

--- a/Intersect.Server.Core/Entities/Entity.cs
+++ b/Intersect.Server.Core/Entities/Entity.cs
@@ -1871,8 +1871,9 @@ public abstract partial class Entity : IEntity
             }
         }
 
-        var damageHealth = spellDescriptor.Combat.VitalDiff[(int)Vital.Health];
-        var damageMana = spellDescriptor.Combat.VitalDiff[(int)Vital.Mana];
+        var spellLevel = (this as Player)?.GetSpellLevel(spellDescriptor.Id);
+        var damageHealth = SpellMath.Scale(spellDescriptor.Combat.VitalDiff[(int)Vital.Health], spellLevel);
+        var damageMana = SpellMath.Scale(spellDescriptor.Combat.VitalDiff[(int)Vital.Mana], spellLevel);
 
         if ((spellDescriptor.Combat.Effect != SpellEffect.OnHit || onHitTrigger) &&
             spellDescriptor.Combat.Effect != SpellEffect.Shield)
@@ -1880,7 +1881,7 @@ public abstract partial class Entity : IEntity
             Attack(
                 target, damageHealth, damageMana, (DamageType)spellDescriptor.Combat.DamageType,
                 (Stat)spellDescriptor.Combat.ScalingStat, spellDescriptor.Combat.Scaling, spellDescriptor.Combat.CritChance,
-                spellDescriptor.Combat.CritMultiplier, deadAnimations, aliveAnimations, false
+                spellDescriptor.Combat.CritMultiplier, deadAnimations, aliveAnimations, false, spellLevel
             );
         }
 
@@ -2066,7 +2067,8 @@ public abstract partial class Entity : IEntity
         double critMultiplier,
         List<KeyValuePair<Guid, Direction>> deadAnimations = null,
         List<KeyValuePair<Guid, Direction>> aliveAnimations = null,
-        bool isAutoAttack = false
+        bool isAutoAttack = false,
+        int? spellLevel = null
     )
     {
         var damagingAttack = baseDamage > 0;
@@ -2096,7 +2098,7 @@ public abstract partial class Entity : IEntity
         if (!(enemy is Resource))
         {
             baseDamage = Formulas.CalculateDamage(
-            baseDamage, damageType, scalingStat, scaling, critMultiplier, this, enemy
+            baseDamage, damageType, scalingStat, scaling, critMultiplier, this, enemy, spellLevel
         );
         }
 
@@ -2221,7 +2223,7 @@ public abstract partial class Entity : IEntity
         if (secondaryDamage != 0)
         {
             secondaryDamage = Formulas.CalculateDamage(
-                secondaryDamage, damageType, scalingStat, scaling, critMultiplier, this, enemy
+                secondaryDamage, damageType, scalingStat, scaling, critMultiplier, this, enemy, spellLevel
             );
 
             if (secondaryDamage < 0 && secondaryDamagingAttack)

--- a/Intersect.Server.Core/General/Formulas.cs
+++ b/Intersect.Server.Core/General/Formulas.cs
@@ -52,7 +52,8 @@ public partial class Formulas
         int scaling,
         double critMultiplier,
         Entity attacker,
-        Entity victim
+        Entity victim,
+        int? attackerLevel = null
     )
     {
         if (_formulas == null)
@@ -110,7 +111,7 @@ public partial class Formulas
             expression.Parameters["A_Speed"] = attacker.Stat[(int)Stat.Agility].Value();
             expression.Parameters["A_AbilityPwr"] = attacker.Stat[(int)Stat.Intelligence].Value();
             expression.Parameters["A_MagicResist"] = attacker.Stat[(int)Stat.Vitality].Value();
-            expression.Parameters["A_Level"] = attacker.Level;
+            expression.Parameters["A_Level"] = attackerLevel ?? attacker.Level;
             expression.Parameters["V_Attack"] = victim.Stat[(int)Stat.Attack].Value();
             expression.Parameters["V_Defense"] = victim.Stat[(int)Stat.Defense].Value();
             // Use agility in place of speed for combat calculations

--- a/Intersect.Server.Core/General/SpellMath.cs
+++ b/Intersect.Server.Core/General/SpellMath.cs
@@ -1,0 +1,15 @@
+using Intersect.Server.Entities;
+
+namespace Intersect.Server.General;
+
+public static class SpellMath
+{
+    public static long Scale(long value, int? level = null)
+    {
+        if (level.HasValue && level.Value > 1)
+        {
+            return value * level.Value;
+        }
+        return value;
+    }
+}


### PR DESCRIPTION
## Summary
- add `SpellMath` to scale values by spell level
- compute spell level when applying spell effects
- allow damage formulas to override attacker level

## Testing
- `dotnet build Intersect.Server.Core/Intersect.Server.Core.csproj` *(fails: DeliveryMethod not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7f6ee38e08324b83d2ef28950b86c