### PR TITLE
Refactor SpellSlot to use serialized SpellProperties

### DIFF
--- a/Intersect.Server.Core/Database/PlayerData/PlayerContext.cs
+++ b/Intersect.Server.Core/Database/PlayerData/PlayerContext.cs
@@ -92,7 +92,6 @@ public abstract partial class PlayerContext : IntersectDbContext<PlayerContext>,
         modelBuilder.Entity<Friend>().HasOne(b => b.Target).WithMany().OnDelete(DeleteBehavior.Cascade);
 
         modelBuilder.Entity<Player>().HasMany(b => b.Spells).WithOne(p => p.Player);
-        modelBuilder.Entity<SpellSlot>().Property(s => s.Level).HasDefaultValue(1);
 
         modelBuilder.Entity<Player>().HasMany(b => b.Items).WithOne(p => p.Player);
 

--- a/Intersect.Server.Core/Database/PlayerData/Players/SpellSlot.cs
+++ b/Intersect.Server.Core/Database/PlayerData/Players/SpellSlot.cs
@@ -1,6 +1,7 @@
 using System;
 using System.ComponentModel.DataAnnotations.Schema;
 using Intersect.Collections.Slotting;
+using Intersect.Framework.Core.GameObjects.Spells;
 using Intersect.Server.Entities;
 using Newtonsoft.Json;
 
@@ -59,7 +60,23 @@ public partial class SpellSlot : ISlot, IPlayerOwned
     [JsonIgnore]
     public bool IsEmpty => SpellId == default;
 
-    public int Level { get; set; } = 1;
+    [NotMapped]
+    public SpellProperties Properties { get; set; } = new();
+
+    [Column(nameof(Properties))]
+    [JsonIgnore]
+    public string SpellPropertiesJson
+    {
+        get => JsonConvert.SerializeObject(Properties);
+        set => Properties = JsonConvert.DeserializeObject<SpellProperties>(value ?? string.Empty) ?? new();
+    }
+
+    [NotMapped]
+    public int Level
+    {
+        get => Properties.Level;
+        set => Properties.Level = value;
+    }
 
     public SpellSlot Clone()
     {
@@ -68,14 +85,14 @@ public partial class SpellSlot : ISlot, IPlayerOwned
             PlayerSpellId = PlayerSpellId,
             PlayerSpell = PlayerSpell,
             _spellId = _spellId,
-            Level = Level
+            Properties = new SpellProperties(Properties)
         };
     }
 
     public void Set(Spell spell)
     {
         SpellId = spell.SpellId;
-        Level = spell.Properties?.Level ?? 1;
+        Properties = new SpellProperties(spell.Properties);
     }
 
     public void Set(SpellSlot slot)
@@ -83,6 +100,6 @@ public partial class SpellSlot : ISlot, IPlayerOwned
         PlayerSpellId = slot.PlayerSpellId;
         PlayerSpell = slot.PlayerSpell;
         _spellId = slot._spellId;
-        Level = slot.Level;
+        Properties = new SpellProperties(slot.Properties);
     }
 }

--- a/Intersect.Server.Core/Entities/Player.cs
+++ b/Intersect.Server.Core/Entities/Player.cs
@@ -5556,7 +5556,7 @@ public partial class Player : Entity
         Spells.Select(s => s.PlayerSpell).FirstOrDefault(ps => ps != null && ps.SpellId == spellId);
 
     public int GetSpellLevel(Guid spellId) =>
-        GetPlayerSpell(spellId)?.Level ?? 0;
+        Spells.FirstOrDefault(s => s.SpellId == spellId)?.Level ?? 0;
 
     public bool TryLevelUpSpell(Guid spellId)
     {

--- a/Intersect.Server.Core/Migrations/Sqlite/Player/SqlitePlayerContextModelSnapshot.cs
+++ b/Intersect.Server.Core/Migrations/Sqlite/Player/SqlitePlayerContextModelSnapshot.cs
@@ -535,6 +535,10 @@ namespace Intersect.Server.Migrations.Sqlite.Player
                     b.Property<Guid>("SpellId")
                         .HasColumnType("TEXT");
 
+                    b.Property<string>("SpellPropertiesJson")
+                        .HasColumnType("TEXT")
+                        .HasColumnName("Properties");
+
                     b.HasKey("Id");
 
                     b.HasIndex("PlayerId");

--- a/Intersect.Server/Migrations/MySql/Player/MySqlPlayerContextModelSnapshot.cs
+++ b/Intersect.Server/Migrations/MySql/Player/MySqlPlayerContextModelSnapshot.cs
@@ -487,6 +487,10 @@ namespace Intersect.Server.Migrations.MySql.Player
                         .HasColumnType("char(36)")
                         .UseCollation("ascii_general_ci");
 
+                    b.Property<string>("SpellPropertiesJson")
+                        .HasColumnType("longtext")
+                        .HasColumnName("Properties");
+
                     b.HasKey("Id");
 
                     b.HasIndex("PlayerId");


### PR DESCRIPTION
## Summary
- store spell data in new `SpellProperties` JSON column
- expose `Level` via `SpellProperties` and update spell level lookups
- adjust EF model snapshots for new `Properties` column

## Testing
- `dotnet test Intersect.Tests/Intersect.Tests.csproj` *(fails: AuthorsTests.cs(66,35): error CS0121: The call is ambiguous between the following methods or properties: 'Authors.Equals(IEnumerable<Author>)' and 'Authors.Equals(IEnumerable<string>)')*

------
https://chatgpt.com/codex/tasks/task_e_68a800d819d0832484af9fa29ab772db