### PR TITLE
refactor: use spell properties

### DIFF
--- a/Intersect.Client.Core/CustomChanges/PacketSenderCustom.cs
+++ b/Intersect.Client.Core/CustomChanges/PacketSenderCustom.cs
@@ -86,9 +86,9 @@ public static partial class PacketSender
         Network.SendPacket(new TakeMailPacket(mailID));
     }
 
-    public static void SendSpellLevelChange(int slotIndex, int delta)
+    public static void SendSpellPropertiesChange(int slotIndex, int delta)
     {
-        var packet = new SpellLevelChangePacket
+        var packet = new SpellPropertiesChangePacket
         {
             SpellSlot = slotIndex,
             Delta = delta

--- a/Intersect.Client.Core/CustomChanges/SpellPropertiesChangePacket.cs
+++ b/Intersect.Client.Core/CustomChanges/SpellPropertiesChangePacket.cs
@@ -3,12 +3,12 @@ using MessagePack;
 namespace Intersect.Network.Packets.Client
 {
     [MessagePackObject]
-    public partial class SpellLevelChangePacket : IntersectPacket
+    public partial class SpellPropertiesChangePacket : IntersectPacket
     {
         // Constructor sin parámetros requerido por MessagePack
-        public SpellLevelChangePacket() { }
+        public SpellPropertiesChangePacket() { }
 
-        public SpellLevelChangePacket(int spellSlot, int delta)
+        public SpellPropertiesChangePacket(int spellSlot, int delta)
         {
             SpellSlot = spellSlot;
             Delta = delta;
@@ -21,4 +21,3 @@ namespace Intersect.Network.Packets.Client
         public int Delta { get; set; } // +1 para subir, -1 para bajar
     }
 }
-

--- a/Intersect.Client.Core/Interface/Game/Spells/SpellItem.cs
+++ b/Intersect.Client.Core/Interface/Game/Spells/SpellItem.cs
@@ -13,6 +13,7 @@ using Intersect.Client.Localization;
 using Intersect.Client.Networking;
 using Intersect.Configuration;
 using Intersect.GameObjects;
+using Intersect.Framework.Core.GameObjects.Spells;
 using Intersect.Utilities;
 
 namespace Intersect.Client.Interface.Game.Spells;
@@ -26,7 +27,7 @@ public partial class SpellItem : SlotItem
     private readonly Button _levelUpButton;
     private readonly Button _levelDownButton;
 
-    public int SpellLevel { get; private set; }
+    public SpellProperties SpellProperties { get; private set; } = new();
     // Context Menu Handling
     private readonly MenuItem _useSpellMenuItem;
     private readonly MenuItem _forgetSpellMenuItem;
@@ -106,7 +107,7 @@ public partial class SpellItem : SlotItem
 
     private void RequestLevelChange(int delta)
     {
-        PacketSender.SendSpellLevelChange(SlotIndex, delta);
+        PacketSender.SendSpellPropertiesChange(SlotIndex, delta);
     }
 
 
@@ -271,11 +272,11 @@ public partial class SpellItem : SlotItem
             Icon.RenderColor.A = 255;
         }
         // Actualiza nombre y nivel si el hechizo está asignado
-        _nameLabel.Text = $"{spell.Name} Lv.{spellSlots[SlotIndex].Level}";
-        SpellLevel = spellSlots[SlotIndex].Level;
+        _nameLabel.Text = $"{spell.Name} Lv.{spellSlots[SlotIndex].Properties.Level}";
+        SpellProperties = spellSlots[SlotIndex].Properties;
 
-        _levelUpButton.IsDisabled = !(Globals.Me.SpellPoints > 0 && SpellLevel < Options.Instance.Player.MaxSpellLevel);
-        _levelDownButton.IsDisabled = !(SpellLevel > 1);
+        _levelUpButton.IsDisabled = !(Globals.Me.SpellPoints > 0 && SpellProperties.Level < Options.Instance.Player.MaxSpellLevel);
+        _levelDownButton.IsDisabled = !(SpellProperties.Level > 1);
 
         if (Path.GetFileName(Icon.Texture?.Name) != spell.Icon)
         {

--- a/Intersect.Server.Core/CustomChanges/PacketHandlerCustom.cs
+++ b/Intersect.Server.Core/CustomChanges/PacketHandlerCustom.cs
@@ -467,7 +467,7 @@ internal sealed partial class PacketHandler
         PacketSender.SendOpenMailBox(player);
     }
 
-    public void HandlePacket(Client client, SpellLevelChangePacket packet)
+    public void HandlePacket(Client client, SpellPropertiesChangePacket packet)
     {
         var player = client?.Entity;
         if (player == null)
@@ -481,7 +481,7 @@ internal sealed partial class PacketHandler
             return;
 
         // ¡Olvídate de SpellDescriptor.Levelable y MaxLevel!
-        var currentLevel = spellSlot.Level;
+        var currentLevel = spellSlot.Properties.Level;
         var newLevel = currentLevel + packet.Delta;
 
         var maxLevel = Options.Instance.Player.MaxSpellLevel;
@@ -503,7 +503,7 @@ internal sealed partial class PacketHandler
             }
         }
 
-        spellSlot.Level = newLevel;
+        spellSlot.Properties.Level = newLevel;
         player.ConsumeSpellPoints(packet.Delta);
 
         using (var context = DbInterface.CreatePlayerContext(readOnly: false))

--- a/Intersect.Server.Core/CustomChanges/SpellPropertiesChangePacket.cs
+++ b/Intersect.Server.Core/CustomChanges/SpellPropertiesChangePacket.cs
@@ -3,12 +3,12 @@ using MessagePack;
 namespace Intersect.Network.Packets.Client
 {
     [MessagePackObject]
-    public partial class SpellLevelChangePacket : IntersectPacket
+    public partial class SpellPropertiesChangePacket : IntersectPacket
     {
         // Constructor sin parámetros requerido por MessagePack
-        public SpellLevelChangePacket() { }
+        public SpellPropertiesChangePacket() { }
 
-        public SpellLevelChangePacket(int spellSlot, int delta)
+        public SpellPropertiesChangePacket(int spellSlot, int delta)
         {
             SpellSlot = spellSlot;
             Delta = delta;
@@ -21,3 +21,4 @@ namespace Intersect.Network.Packets.Client
         public int Delta { get; set; } // +1 para subir, -1 para bajar
     }
 }
+

--- a/Intersect.Server.Core/Database/PlayerData/Players/PlayerSpells.cs
+++ b/Intersect.Server.Core/Database/PlayerData/Players/PlayerSpells.cs
@@ -1,5 +1,6 @@
 using System;
 using System.ComponentModel.DataAnnotations.Schema;
+using Intersect.Framework.Core.GameObjects.Spells;
 using Intersect.Server.Entities;
 using Newtonsoft.Json;
 
@@ -12,7 +13,23 @@ public partial class PlayerSpell : IPlayerOwned
 
     public Guid SpellId { get; set; }
 
-    public int Level { get; set; } = 1;
+    [NotMapped]
+    public SpellProperties Properties { get; set; } = new();
+
+    [Column(nameof(Properties))]
+    [JsonIgnore]
+    public string SpellPropertiesJson
+    {
+        get => JsonConvert.SerializeObject(Properties);
+        set => Properties = JsonConvert.DeserializeObject<SpellProperties>(value ?? string.Empty) ?? new();
+    }
+
+    [NotMapped]
+    public int Level
+    {
+        get => Properties.Level;
+        set => Properties.Level = value;
+    }
 
     public int SpellPointsSpent { get; set; } = 0;
 

--- a/Intersect.Server.Core/Entities/Combat/DamageOverTimeEffect.cs
+++ b/Intersect.Server.Core/Entities/Combat/DamageOverTimeEffect.cs
@@ -148,7 +148,8 @@ public partial class DamageOverTimeEffect
             aliveAnimations.Add(animation);
         }
 
-        var level = (Attacker as Player)?.GetSpellLevel(SpellDescriptor.Id);
+        var properties = (Attacker as Player)?.GetSpellProperties(SpellDescriptor.Id);
+        var level = properties?.Level ?? 0;
         var damageHealth = SpellMath.Scale(SpellDescriptor.Combat.VitalDiff[(int)Vital.Health], level);
         var damageMana = SpellMath.Scale(SpellDescriptor.Combat.VitalDiff[(int)Vital.Mana], level);
 

--- a/Intersect.Server.Core/Entities/Combat/Status.cs
+++ b/Intersect.Server.Core/Entities/Combat/Status.cs
@@ -106,7 +106,8 @@ public partial class Status
         {
             foreach (var vital in Enum.GetValues<Vital>())
             {
-                var level = (attacker as Player)?.GetSpellLevel(spell.Id);
+                var properties = (attacker as Player)?.GetSpellProperties(spell.Id);
+                var level = properties?.Level ?? 0;
                 long vitalDiff = Math.Abs(SpellMath.Scale(spell.Combat.VitalDiff[(int)vital], level));
 
                 // If the user did not configure for this vital to have a mana shield, ignore it

--- a/Intersect.Server.Core/Entities/Entity.cs
+++ b/Intersect.Server.Core/Entities/Entity.cs
@@ -1871,7 +1871,8 @@ public abstract partial class Entity : IEntity
             }
         }
 
-        var spellLevel = (this as Player)?.GetSpellLevel(spellDescriptor.Id);
+        var spellProperties = (this as Player)?.GetSpellProperties(spellDescriptor.Id);
+        var spellLevel = spellProperties?.Level ?? 0;
         var damageHealth = SpellMath.Scale(spellDescriptor.Combat.VitalDiff[(int)Vital.Health], spellLevel);
         var damageMana = SpellMath.Scale(spellDescriptor.Combat.VitalDiff[(int)Vital.Mana], spellLevel);
 

--- a/Intersect.Server.Core/Entities/Player.cs
+++ b/Intersect.Server.Core/Entities/Player.cs
@@ -18,6 +18,7 @@ using Intersect.Config;
 using Intersect.Framework.Core.GameObjects.Maps.Attributes;
 using Intersect.Framework.Core.GameObjects.NPCs;
 using Intersect.Framework.Core.GameObjects.PlayerClass;
+using Intersect.Framework.Core.GameObjects.Spells;
 using Intersect.Framework.Core.GameObjects.Quests;
 using Intersect.Framework.Core.GameObjects.Variables;
 using Intersect.GameObjects;
@@ -5555,8 +5556,8 @@ public partial class Player : Entity
     public PlayerSpell? GetPlayerSpell(Guid spellId) =>
         Spells.Select(s => s.PlayerSpell).FirstOrDefault(ps => ps != null && ps.SpellId == spellId);
 
-    public int GetSpellLevel(Guid spellId) =>
-        Spells.FirstOrDefault(s => s.SpellId == spellId)?.Level ?? 0;
+    public SpellProperties? GetSpellProperties(Guid spellId) =>
+        Spells.FirstOrDefault(s => s.SpellId == spellId)?.Properties;
 
     public bool TryLevelUpSpell(Guid spellId)
     {
@@ -5567,10 +5568,10 @@ public partial class Player : Entity
         if (SpellPoints <= 0)
             return false;
 
-        if (pspell.Level >= 5)
+        if (pspell.Properties.Level >= 5)
             return false;
 
-        pspell.Level++;
+        pspell.Properties.Level++;
         SpellPoints--;
         SpellPointsChanged = true;
         return true;
@@ -5869,8 +5870,9 @@ public partial class Player : Entity
         {
             return;
         }
-        var spellLevel = pspell.Level;
-        _ = spellLevel;
+        var spellProperties = pspell.Properties;
+        var spellLevel = spellProperties.Level;
+        _ = spellProperties;
 
         if (!CanCastSpell(spellDescriptor, target, true, softRetargetOnSelfCast, out var spellCastFailureReason))
         {


### PR DESCRIPTION
## Summary
- switch spell level adjustments to use SpellProperties packet
- expose spell properties for player spells and combat calculations
- update UI to show and modify spell properties

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8f66314108324bd2770ce1e541253