### PR TITLE
Fix spell forgetting build error

### DIFF
--- a/Intersect.Server.Core/Entities/Player.cs
+++ b/Intersect.Server.Core/Entities/Player.cs
@@ -5672,7 +5672,7 @@ public partial class Player : Entity
 
     public bool TryForgetSpell(Spell spell, bool sendUpdate = true)
     {
-        Spell slot = null;
+        SpellSlot slot = null;
         var slotIndex = -1;
 
         for (var index = 0; index < Spells.Count; ++index)


### PR DESCRIPTION
## Summary
- fix TryForgetSpell to use `SpellSlot` so server builds correctly

## Testing
- `dotnet build Intersect.Server -c Release`


------
https://chatgpt.com/codex/tasks/task_e_68a900e5ef9c8324b5898cc6c1938d99