### PR TITLE
Populate player spell records before adding foreign key

### DIFF
--- a/Intersect.Server.Core/Migrations/Sqlite/Player/20250823020530_AddSpellsLevels.cs
+++ b/Intersect.Server.Core/Migrations/Sqlite/Player/20250823020530_AddSpellsLevels.cs
@@ -50,6 +50,11 @@ namespace Intersect.Server.Migrations.Sqlite.Player
                         onDelete: ReferentialAction.Cascade);
                 });
 
+            migrationBuilder.Sql(
+                @"INSERT INTO PlayerSpell (Id, SpellId, Properties, SpellPointsSpent, PlayerId)
+                  SELECT Id, PlayerSpellId, Properties, 0, PlayerId FROM Player_Spells;
+                  UPDATE Player_Spells SET PlayerSpellId = Id;");
+
             migrationBuilder.CreateIndex(
                 name: "IX_Player_Spells_PlayerSpellId",
                 table: "Player_Spells",
@@ -75,6 +80,12 @@ namespace Intersect.Server.Migrations.Sqlite.Player
             migrationBuilder.DropForeignKey(
                 name: "FK_Player_Spells_PlayerSpell_PlayerSpellId",
                 table: "Player_Spells");
+
+            migrationBuilder.Sql(
+                @"UPDATE Player_Spells
+                   SET PlayerSpellId = (
+                       SELECT SpellId FROM PlayerSpell WHERE PlayerSpell.Id = Player_Spells.PlayerSpellId
+                   );");
 
             migrationBuilder.DropTable(
                 name: "PlayerSpell");


### PR DESCRIPTION
## Summary
- Populate PlayerSpell table and update Player_Spells references before adding foreign key
- Restore spell IDs when rolling back migration

## Testing
- `dotnet build Intersect.Server.Core/Intersect.Server.Core.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a92a710d5c8324a2fd946d6777ec75