### PR TITLE
Queue spell UI updates until in-game UI ready

### DIFF
--- a/Intersect.Client.Core/Networking/PacketHandler.cs
+++ b/Intersect.Client.Core/Networking/PacketHandler.cs
@@ -1384,7 +1384,7 @@ internal sealed partial class PacketHandler
             HandlePacket(spl);
         }
 
-        Interface.Interface.GameUi.SpellsWindow?.Refresh();
+        Interface.Interface.EnqueueInGame(ui => ui.SpellsWindow?.Refresh());
     }
 
     //SpellUpdatePacket
@@ -1393,7 +1393,7 @@ internal sealed partial class PacketHandler
         if (Globals.Me != null)
         {
             Globals.Me.Spells[packet.Slot].Load(packet.SpellId, packet.Level);
-            Interface.Interface.GameUi.SpellsWindow?.Update();
+            Interface.Interface.EnqueueInGame(ui => ui.SpellsWindow?.Update());
         }
     }
 


### PR DESCRIPTION
## Summary
- Queue spell refresh/update calls so they execute only after the in-game UI has been initialized

## Testing
- `dotnet test` *(fails: project file /vendor/LiteNetLib/LiteNetLib/LiteNetLib.csproj not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a934d8c14c8324abdd1571c0898cfd