### PR TITLE
Initialize spell properties to prevent null reference in spells UI

### DIFF
--- a/Intersect.Client.Core/Interface/Game/Spells/SpellItem.cs
+++ b/Intersect.Client.Core/Interface/Game/Spells/SpellItem.cs
@@ -272,11 +272,13 @@ public partial class SpellItem : SlotItem
             Icon.RenderColor.A = 255;
         }
         // Actualiza nombre y nivel si el hechizo está asignado
-        _nameLabel.Text = $"{spell.Name} Lv.{spellSlots[SlotIndex].Properties.Level}";
-        SpellProperties = spellSlots[SlotIndex].Properties;
+        var properties = spellSlots[SlotIndex].Properties ?? new SpellProperties();
+        spellSlots[SlotIndex].Properties = properties;
+        _nameLabel.Text = $"{spell.Name} Lv.{properties.Level}";
+        SpellProperties = properties;
 
-        _levelUpButton.IsDisabled = !(Globals.Me.SpellPoints > 0 && SpellProperties.Level < Options.Instance.Player.MaxSpellLevel);
-        _levelDownButton.IsDisabled = !(SpellProperties.Level > 1);
+        _levelUpButton.IsDisabled = !(Globals.Me.SpellPoints > 0 && properties.Level < Options.Instance.Player.MaxSpellLevel);
+        _levelDownButton.IsDisabled = !(properties.Level > 1);
 
         if (Path.GetFileName(Icon.Texture?.Name) != spell.Icon)
         {

--- a/Intersect.Client.Core/Spells/Spell.cs
+++ b/Intersect.Client.Core/Spells/Spell.cs
@@ -7,8 +7,8 @@ public partial class Spell
 {
 
     public Guid Id { get; set; }
-    public int Level { get;  set; }
-    public SpellProperties Properties { get;  set; }
+    public int Level { get; set; }
+    public SpellProperties Properties { get; set; } = new();
 
     public Spell Clone()
     {
@@ -16,6 +16,7 @@ public partial class Spell
         {
             Id = Id,
             Level = Level,
+            Properties = new SpellProperties(Properties),
         };
 
         return newSpell;
@@ -25,6 +26,7 @@ public partial class Spell
     {
         Id = spellId;
         Level = level;
+        Properties ??= new SpellProperties();
     }
 
 }


### PR DESCRIPTION
## Summary
- Initialize `Spell.Properties` with a default `SpellProperties` and clone/copy it correctly
- Guard spell slot updates with default properties to avoid null reference crashes

## Testing
- `dotnet test Intersect.sln` *(fails: project file not found for vendor dependencies)*
- `dotnet build Intersect.Client.Core/Intersect.Client.Core.csproj` *(fails: restore canceled due to missing vendor project)*

------
https://chatgpt.com/codex/tasks/task_e_68a93a1bcdd883248eefd1e7328d67e4