### PR TITLE
Send spells and spell points in entity packet

### DIFF
--- a/Framework/Intersect.Framework.Core/Network/Packets/Server/PlayerEntityPacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Server/PlayerEntityPacket.cs
@@ -68,4 +68,10 @@ public partial class PlayerEntityPacket : EntityPacket
 
     [Key(40)]
     public byte GuildBackgroundB { get; set; }
+
+    [Key(41)]
+    public SpellUpdatePacket[] Spells { get; set; }
+
+    [Key(42)]
+    public int SpellPoints { get; set; }
 }

--- a/Intersect.Client.Core/Entities/Player.cs
+++ b/Intersect.Client.Core/Entities/Player.cs
@@ -407,6 +407,30 @@ public partial class Player : Entity, IPlayer
             }
         }
 
+        SpellPoints = playerPacket.SpellPoints;
+        if (playerPacket.Spells != null)
+        {
+            foreach (var spell in playerPacket.Spells)
+            {
+                if (spell == null)
+                {
+                    continue;
+                }
+
+                if (spell.Slot < 0 || spell.Slot >= Spells.Length)
+                {
+                    continue;
+                }
+
+                Spells[spell.Slot].Load(spell.SpellId, spell.Level);
+            }
+
+            if (this == Globals.Me)
+            {
+                Interface.Interface.EnqueueInGame(ui => ui.SpellsWindow?.Refresh());
+            }
+        }
+
         if (this == Globals.Me && TargetBox == null && Interface.Interface.HasInGameUI)
         {
             TargetBox = new EntityBox(Interface.Interface.GameUi.GameCanvas, EntityType.Player, null);

--- a/Intersect.Server.Core/Entities/Player.cs
+++ b/Intersect.Server.Core/Entities/Player.cs
@@ -1137,6 +1137,19 @@ public partial class Player : Entity
             pkt.GuildSymbolB = Guild.SymbolB;
 
         }
+
+        if (forPlayer == this)
+        {
+            pkt.SpellPoints = SpellPoints;
+            var spells = new SpellUpdatePacket[Options.Instance.Player.MaxSpells];
+            for (var i = 0; i < Options.Instance.Player.MaxSpells; i++)
+            {
+                var slot = Spells[i];
+                spells[i] = new SpellUpdatePacket(i, slot.SpellId, slot.Level);
+            }
+
+            pkt.Spells = spells;
+        }
         return pkt;
     }
 

--- a/Intersect.Server.Core/Networking/PacketSender.cs
+++ b/Intersect.Server.Core/Networking/PacketSender.cs
@@ -115,8 +115,6 @@ public static partial class PacketSender
             player.LoginWarp();
 
             SendEntityDataTo(client.Entity, player);
-            SendPlayerSpells(player);
-            SendSpellPoints(player);
 
             //Search for login activated events and run them
             player.StartCommonEventsWithTrigger(CommonEventTrigger.Login);
@@ -429,9 +427,7 @@ public static partial class PacketSender
         {
             SendExperience(player);
             SendInventory(player);
-            SendPlayerSpells(player);
             SendPointsTo(player);
-            SendSpellPoints(player);
             SendHotbarSlots(player);
             SendQuestsProgress(player);
             SendItemCooldowns(player);


### PR DESCRIPTION
## Summary
- embed player spells and spell points within `PlayerEntityPacket`
- populate and consume new fields on server and client so spells UI initializes on login
- stop sending separate spell and spell-point packets during entity sync

## Testing
- `dotnet test` *(fails: project file vendor/LiteNetLib/LiteNetLib.csproj not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a94d558d1083248eb8b61d18b63caf