### PR TITLE
Add spell upgrade keys and validation

### DIFF
--- a/Framework/Intersect.Framework.Core/GameObjects/Spells/SpellProperties.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Spells/SpellProperties.cs
@@ -10,12 +10,46 @@ public class SpellProperties
     public SpellProperties(SpellProperties other)
     {
         Level = other.Level;
-        CustomUpgrades = new Dictionary<string, int>(other.CustomUpgrades);
+        CustomUpgrades = new Dictionary<string, int>(
+            other.CustomUpgrades.Where(kv => SpellUpgradeKeys.IsValid(kv.Key))
+        );
     }
 
     [Key(0)]
     public int Level { get; set; } = 1;
 
+    private Dictionary<string, int> _customUpgrades = new();
+
     [Key(1)]
-    public Dictionary<string, int> CustomUpgrades { get; set; } = new();
+    public Dictionary<string, int> CustomUpgrades
+    {
+        get => _customUpgrades;
+        set
+        {
+            _customUpgrades = new Dictionary<string, int>();
+            if (value == null)
+            {
+                return;
+            }
+
+            foreach (var kv in value)
+            {
+                if (SpellUpgradeKeys.IsValid(kv.Key))
+                {
+                    _customUpgrades[kv.Key] = kv.Value;
+                }
+            }
+        }
+    }
+
+    public bool TrySetCustomUpgrade(string key, int value)
+    {
+        if (!SpellUpgradeKeys.IsValid(key))
+        {
+            return false;
+        }
+
+        _customUpgrades[key] = value;
+        return true;
+    }
 }

--- a/Framework/Intersect.Framework.Core/GameObjects/Spells/SpellUpgradeKeys.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Spells/SpellUpgradeKeys.cs
@@ -1,0 +1,64 @@
+using System.Collections.Generic;
+
+namespace Intersect.Framework.Core.GameObjects.Spells;
+
+public static class SpellUpgradeKeys
+{
+    public const string CastDuration = "CastDuration";
+    public const string CooldownDuration = "CooldownDuration";
+
+    public static class Combat
+    {
+        public const string CritChance = "Combat.CritChance";
+        public const string CritMultiplier = "Combat.CritMultiplier";
+        public const string HitRadius = "Combat.HitRadius";
+        public const string CastRange = "Combat.CastRange";
+
+        public static class StatDiff
+        {
+            public const string Attack = "Combat.StatDiff.Attack";
+            public const string Intelligence = "Combat.StatDiff.Intelligence";
+            public const string Defense = "Combat.StatDiff.Defense";
+            public const string Vitality = "Combat.StatDiff.Vitality";
+            public const string Speed = "Combat.StatDiff.Speed";
+            public const string Agility = "Combat.StatDiff.Agility";
+            public const string Damages = "Combat.StatDiff.Damages";
+            public const string Cures = "Combat.StatDiff.Cures";
+        }
+
+        public static class VitalDiff
+        {
+            public const string Health = "Combat.VitalDiff.Health";
+            public const string Mana = "Combat.VitalDiff.Mana";
+        }
+    }
+
+    public static class Dash
+    {
+        public const string Range = "Dash.Range";
+    }
+
+    public static readonly HashSet<string> All =
+    [
+        CastDuration,
+        CooldownDuration,
+        Combat.CritChance,
+        Combat.CritMultiplier,
+        Combat.HitRadius,
+        Combat.CastRange,
+        Combat.StatDiff.Attack,
+        Combat.StatDiff.Intelligence,
+        Combat.StatDiff.Defense,
+        Combat.StatDiff.Vitality,
+        Combat.StatDiff.Speed,
+        Combat.StatDiff.Agility,
+        Combat.StatDiff.Damages,
+        Combat.StatDiff.Cures,
+        Combat.VitalDiff.Health,
+        Combat.VitalDiff.Mana,
+        Dash.Range,
+    ];
+
+    public static bool IsValid(string key) => All.Contains(key);
+}
+


### PR DESCRIPTION
## Summary
- define SpellUpgradeKeys registry with all allowed upgrade constants
- validate custom upgrade keys in SpellProperties and expose helper

## Testing
- `dotnet build Framework/Intersect.Framework.Core/Intersect.Framework.Core.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a957e291c483248ed3166f51873d92