### PR TITLE
Use effective spell calculations

### DIFF
--- a/Intersect.Client.Core/Entities/Entity.cs
+++ b/Intersect.Client.Core/Entities/Entity.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
+using System.Linq;
 using Intersect.Client.Core;
 using Intersect.Client.Entities.Events;
 using Intersect.Client.Entities.Projectiles;
@@ -18,6 +19,7 @@ using Intersect.Core;
 using Intersect.Enums;
 using Intersect.Framework.Core;
 using Intersect.Framework.Core.GameObjects.Animations;
+using Intersect.Framework.Core.GameObjects.Spells;
 using Intersect.Framework.Core.GameObjects.Items;
 using Intersect.Framework.Core.GameObjects.Maps;
 using Intersect.Framework.Core.GameObjects.Maps.Attributes;
@@ -2031,7 +2033,13 @@ public partial class Entity : IEntity
         var boundingTexture = GameTexture.GetBoundingTexture(BoundsComparison.Height, castBackground, castForeground);
 
         float remainingTime = CastTime - Timing.Global.Milliseconds;
-        var fillRatio = 1 - remainingTime / castingSpell.CastDuration;
+        SpellProperties? props = null;
+        if (this is Player player)
+        {
+            var spell = player.Spells.FirstOrDefault(s => s.Id == SpellCast);
+            props = spell?.Properties;
+        }
+        var fillRatio = 1 - remainingTime / castingSpell.GetEffectiveCastDuration(props);
 
         var x = (int)Math.Ceiling(Origin.X);
         var y = (int)Math.Ceiling(Origin.Y);
@@ -2237,7 +2245,13 @@ public partial class Entity : IEntity
             var spell = SpellDescriptor.Get(SpellCast);
             if (spell != null)
             {
-                var duration = spell.CastDuration;
+                SpellProperties? props = null;
+                if (this is Player player)
+                {
+                    var pspell = player.Spells.FirstOrDefault(s => s.Id == SpellCast);
+                    props = pspell?.Properties;
+                }
+                var duration = spell.GetEffectiveCastDuration(props);
                 var timeInCast = duration - (CastTime - timingMilliseconds);
 
                 if (AnimatedTextures.TryGetValue(SpriteAnimations.Cast, out _))

--- a/Intersect.Client.Core/Entities/Player.cs
+++ b/Intersect.Client.Core/Entities/Player.cs
@@ -1468,7 +1468,7 @@ public partial class Player : Entity, IPlayer
             return;
         }
 
-        if (spellDescriptor.CastDuration > 0)
+        if (spellDescriptor.GetEffectiveCastDuration(spell.Properties) > 0)
         {
             if (Options.Instance.Combat.MovementCancelsCast && Globals.Me?.IsMoving == true)
             {

--- a/Intersect.Client.Core/Networking/PacketHandler.cs
+++ b/Intersect.Client.Core/Networking/PacketHandler.cs
@@ -33,6 +33,8 @@ using Intersect.Framework.Core.GameObjects.Maps.MapList;
 using Intersect.Framework.Core.Security;
 using Intersect.Localization;
 using Microsoft.Extensions.Logging;
+using System.Linq;
+using Intersect.Framework.Core.GameObjects.Spells;
 
 namespace Intersect.Client.Networking;
 
@@ -1475,7 +1477,16 @@ internal sealed partial class PacketHandler
         var spellId = packet.SpellId;
         if (SpellDescriptor.Get(spellId) != null && Globals.Entities.ContainsKey(entityId))
         {
-            Globals.Entities[entityId].CastTime = Timing.Global.Milliseconds + SpellDescriptor.Get(spellId).CastDuration;
+            var descriptor = SpellDescriptor.Get(spellId);
+            SpellProperties? props = null;
+            if (Globals.Entities[entityId] is Player player)
+            {
+                var spell = player.Spells.FirstOrDefault(s => s.Id == spellId);
+                props = spell?.Properties;
+            }
+
+            Globals.Entities[entityId].CastTime =
+                Timing.Global.Milliseconds + descriptor.GetEffectiveCastDuration(props);
             Globals.Entities[entityId].SpellCast = spellId;
         }
     }

--- a/Intersect.Server.Core/Entities/Combat/DamageOverTimeEffect.cs
+++ b/Intersect.Server.Core/Entities/Combat/DamageOverTimeEffect.cs
@@ -88,9 +88,13 @@ public partial class DamageOverTimeEffect
         }
         
 
-        mInterval = Timing.Global.Milliseconds + SpellDescriptor.Combat.HotDotInterval;
+        var properties = (attacker as Player)?.GetSpellProperties(spellDescriptor.Id);
+        var interval = spellDescriptor.Combat.GetEffectiveHotDotInterval(properties);
+        var duration = spellDescriptor.Combat.GetEffectiveDuration(properties);
+
+        mInterval = Timing.Global.Milliseconds + interval;
         // Subtract 1 since the first tick always occurs when the spell is cast.
-        Count = (SpellDescriptor.Combat.Duration + SpellDescriptor.Combat.HotDotInterval - 1) / SpellDescriptor.Combat.HotDotInterval;
+        Count = (duration + interval - 1) / interval;
     }
 
     public Entity Target { get; }
@@ -150,17 +154,21 @@ public partial class DamageOverTimeEffect
 
         var properties = (Attacker as Player)?.GetSpellProperties(SpellDescriptor.Id);
         var level = properties?.Level ?? 0;
-        var damageHealth = SpellMath.Scale(SpellDescriptor.Combat.VitalDiff[(int)Vital.Health], level);
-        var damageMana = SpellMath.Scale(SpellDescriptor.Combat.VitalDiff[(int)Vital.Mana], level);
+        var damageHealth = SpellMath.Scale(SpellDescriptor.Combat.GetEffectiveVitalDiff(Vital.Health, properties), level);
+        var damageMana = SpellMath.Scale(SpellDescriptor.Combat.GetEffectiveVitalDiff(Vital.Mana, properties), level);
 
         Attacker?.Attack(
             Target, damageHealth, damageMana,
             (DamageType)SpellDescriptor.Combat.DamageType, (Enums.Stat)SpellDescriptor.Combat.ScalingStat,
-            SpellDescriptor.Combat.Scaling, SpellDescriptor.Combat.CritChance, SpellDescriptor.Combat.CritMultiplier, deadAnimations,
+            SpellDescriptor.Combat.GetEffectiveScaling(properties),
+            SpellDescriptor.Combat.GetEffectiveCritChance(properties),
+            SpellDescriptor.Combat.GetEffectiveCritMultiplier(properties),
+            deadAnimations,
             aliveAnimations, false, level
         );
 
-        mInterval = Timing.Global.Milliseconds + SpellDescriptor.Combat.HotDotInterval;
+        var interval = SpellDescriptor.Combat.GetEffectiveHotDotInterval(properties);
+        mInterval = Timing.Global.Milliseconds + interval;
         Count--;
     }
 

--- a/Intersect.Server.Core/Entities/Combat/Status.cs
+++ b/Intersect.Server.Core/Entities/Combat/Status.cs
@@ -108,7 +108,7 @@ public partial class Status
             {
                 var properties = (attacker as Player)?.GetSpellProperties(spell.Id);
                 var level = properties?.Level ?? 0;
-                long vitalDiff = Math.Abs(SpellMath.Scale(spell.Combat.VitalDiff[(int)vital], level));
+                long vitalDiff = Math.Abs(SpellMath.Scale(spell.Combat.GetEffectiveVitalDiff(vital, properties), level));
 
                 // If the user did not configure for this vital to have a mana shield, ignore it
                 if (vitalDiff == 0 && vital == Vital.Mana)
@@ -117,7 +117,8 @@ public partial class Status
                 }
 
                 var shieldAmount = Formulas.CalculateDamage(
-                    vitalDiff, (DamageType)spell.Combat.DamageType, (Enums.Stat)spell.Combat.ScalingStat, spell.Combat.Scaling, 1.0, attacker, en, level
+                    vitalDiff, (DamageType)spell.Combat.DamageType, (Enums.Stat)spell.Combat.ScalingStat,
+                    spell.Combat.GetEffectiveScaling(properties), 1.0, attacker, en, level
                 );
 
                 Shield[(int)vital] = Math.Abs(shieldAmount);

--- a/Intersect.Server.Core/Entities/Entity.cs
+++ b/Intersect.Server.Core/Entities/Entity.cs
@@ -418,7 +418,9 @@ public abstract partial class Entity : IEntity
             return;
         }
 
-        SpellCooldowns[Spells[spellSlot].SpellId] = Timing.Global.MillisecondsUtc + spellDescriptor.CooldownDuration;
+        var props = Spells[spellSlot].Properties;
+        SpellCooldowns[Spells[spellSlot].SpellId] =
+            Timing.Global.MillisecondsUtc + spellDescriptor.GetEffectiveCooldownDuration(props);
     }
 
     /// <summary>
@@ -1663,7 +1665,8 @@ public abstract partial class Entity : IEntity
             var s = projectile.Spell;
             if (s != null)
             {
-                HandleAoESpell(projectile.SpellId, s.Combat.HitRadius, target.MapId, target.X, target.Y, null);
+                var props = (this as Player)?.GetSpellProperties(s.Id);
+                HandleAoESpell(projectile.SpellId, s.Combat.GetEffectiveHitRadius(props), target.MapId, target.X, target.Y, null);
             }
 
             //Check that the npc has not been destroyed by the splash spell
@@ -1848,41 +1851,46 @@ public abstract partial class Entity : IEntity
             aliveAnimations.Add(new KeyValuePair<Guid, Direction>(spellDescriptor.HitAnimationId, Direction.Up));
         }
 
+        var duration = spellDescriptor.Combat.GetEffectiveDuration(spellProperties);
         var statBuffTime = -1;
-        var expireTime = Timing.Global.Milliseconds + spellDescriptor.Combat.Duration;
+        var expireTime = Timing.Global.Milliseconds + duration;
         for (var i = 0; i < Enum.GetValues<Stat>().Length; i++)
         {
             target.Stat[i]
                 .AddBuff(
-                    new Buff(spellDescriptor, spellDescriptor.Combat.StatDiff[i], spellDescriptor.Combat.PercentageStatDiff[i], expireTime)
+                    new Buff(spellDescriptor,
+                        spellDescriptor.Combat.GetEffectiveStatDiff((Stat)i, spellProperties),
+                        spellDescriptor.Combat.PercentageStatDiff[i], expireTime)
                 );
 
-            if (spellDescriptor.Combat.StatDiff[i] != 0 || spellDescriptor.Combat.PercentageStatDiff[i] != 0)
+            if (spellDescriptor.Combat.GetEffectiveStatDiff((Stat)i, spellProperties) != 0 ||
+                spellDescriptor.Combat.PercentageStatDiff[i] != 0)
             {
-                statBuffTime = spellDescriptor.Combat.Duration;
+                statBuffTime = duration;
             }
         }
 
         if (statBuffTime == -1)
         {
-            if (spellDescriptor.Combat.HoTDoT && spellDescriptor.Combat.HotDotInterval > 0)
+            if (spellDescriptor.Combat.HoTDoT && spellDescriptor.Combat.GetEffectiveHotDotInterval(spellProperties) > 0)
             {
-                statBuffTime = spellDescriptor.Combat.Duration;
+                statBuffTime = duration;
             }
         }
 
-        var spellProperties = (this as Player)?.GetSpellProperties(spellDescriptor.Id);
         var spellLevel = spellProperties?.Level ?? 0;
-        var damageHealth = SpellMath.Scale(spellDescriptor.Combat.VitalDiff[(int)Vital.Health], spellLevel);
-        var damageMana = SpellMath.Scale(spellDescriptor.Combat.VitalDiff[(int)Vital.Mana], spellLevel);
+        var damageHealth = SpellMath.Scale(spellDescriptor.Combat.GetEffectiveVitalDiff(Vital.Health, spellProperties), spellLevel);
+        var damageMana = SpellMath.Scale(spellDescriptor.Combat.GetEffectiveVitalDiff(Vital.Mana, spellProperties), spellLevel);
 
         if ((spellDescriptor.Combat.Effect != SpellEffect.OnHit || onHitTrigger) &&
             spellDescriptor.Combat.Effect != SpellEffect.Shield)
         {
             Attack(
                 target, damageHealth, damageMana, (DamageType)spellDescriptor.Combat.DamageType,
-                (Stat)spellDescriptor.Combat.ScalingStat, spellDescriptor.Combat.Scaling, spellDescriptor.Combat.CritChance,
-                spellDescriptor.Combat.CritMultiplier, deadAnimations, aliveAnimations, false, spellLevel
+                (Stat)spellDescriptor.Combat.ScalingStat,
+                spellDescriptor.Combat.GetEffectiveScaling(spellProperties),
+                spellDescriptor.Combat.GetEffectiveCritChance(spellProperties),
+                spellDescriptor.Combat.GetEffectiveCritMultiplier(spellProperties), deadAnimations, aliveAnimations, false, spellLevel
             );
         }
 
@@ -1902,7 +1910,7 @@ public abstract partial class Entity : IEntity
                 {
                     // Else, apply the status
                     new Status(
-                        target, this, spellDescriptor, spellDescriptor.Combat.Effect, spellDescriptor.Combat.Duration,
+                        target, this, spellDescriptor, spellDescriptor.Combat.Effect, duration,
                         spellDescriptor.Combat.TransformSprite
                     );
 
@@ -2418,16 +2426,18 @@ public abstract partial class Entity : IEntity
             return false;
         }
 
+        var spellProperties = (this as Player)?.GetSpellProperties(spell.Id);
+
         // Do we meet the vital requirements?
         if (checkVitalReqs)
         {
-            if (spell.VitalCost[(int)Vital.Mana] > GetVital(Vital.Mana))
+            if (spell.GetEffectiveVitalCost(Vital.Mana, spellProperties) > GetVital(Vital.Mana))
             {
                 reason = SpellCastFailureReason.InsufficientMP;
                 return false;
             }
 
-            if (spell.VitalCost[(int)Vital.Health] >= GetVital(Vital.Health))
+            if (spell.GetEffectiveVitalCost(Vital.Health, spellProperties) >= GetVital(Vital.Health))
             {
                 reason = SpellCastFailureReason.InsufficientHP;
                 return false;
@@ -2496,7 +2506,8 @@ public abstract partial class Entity : IEntity
         //Check for range of a single target spell
         if (singleTargetSpell && target != this)
         {
-            if (!InRangeOf(target, spell.Combat.CastRange))
+            var castRange = spell.Combat.GetEffectiveCastRange(spellProperties);
+            if (!InRangeOf(target, castRange))
             {
                 reason = SpellCastFailureReason.OutOfRange;
                 return false;
@@ -2520,22 +2531,25 @@ public abstract partial class Entity : IEntity
             return;
         }
 
-        if (spellBase.VitalCost[(int)Vital.Mana] > 0)
+        var spellProperties = (this as Player)?.GetSpellProperties(spellId);
+        var manaCost = spellBase.GetEffectiveVitalCost(Vital.Mana, spellProperties);
+        if (manaCost > 0)
         {
-            SubVital(Vital.Mana, spellBase.VitalCost[(int)Vital.Mana]);
+            SubVital(Vital.Mana, manaCost);
         }
         else
         {
-            AddVital(Vital.Mana, -spellBase.VitalCost[(int)Vital.Mana]);
+            AddVital(Vital.Mana, -manaCost);
         }
 
-        if (spellBase.VitalCost[(int)Vital.Health] > 0)
+        var healthCost = spellBase.GetEffectiveVitalCost(Vital.Health, spellProperties);
+        if (healthCost > 0)
         {
-            SubVital(Vital.Health, spellBase.VitalCost[(int)Vital.Health]);
+            SubVital(Vital.Health, healthCost);
         }
         else
         {
-            AddVital(Vital.Health, -spellBase.VitalCost[(int)Vital.Health]);
+            AddVital(Vital.Health, -healthCost);
         }
 
         try
@@ -2583,9 +2597,10 @@ public abstract partial class Entity : IEntity
 
                             if (spellBase.Combat.HitRadius > 0) //Single target spells with AoE hit radius'
                             {
+                                var hitRadius = spellBase.Combat.GetEffectiveHitRadius(spellProperties);
                                 HandleAoESpell(
                                     spellId,
-                                    spellBase.Combat.HitRadius,
+                                    hitRadius,
                                     CastTarget.MapId,
                                     CastTarget.X,
                                     CastTarget.Y,
@@ -2599,7 +2614,7 @@ public abstract partial class Entity : IEntity
 
                             break;
                         case SpellTargetType.AoE:
-                            HandleAoESpell(spellId, spellBase.Combat.HitRadius, MapId, X, Y, null);
+                            HandleAoESpell(spellId, spellBase.Combat.GetEffectiveHitRadius(spellProperties), MapId, X, Y, null);
 
                             break;
                         case SpellTargetType.Projectile:
@@ -2632,10 +2647,10 @@ public abstract partial class Entity : IEntity
                                     this,
                                     spellBase,
                                     SpellEffect.OnHit,
-                                    spellBase.Combat.OnHitDuration,
+                                    spellBase.Combat.GetEffectiveOnHitDuration(spellProperties),
                                     spellBase.Combat.TransformSprite
                                 );
-
+                                
                                 PacketSender.SendActionMsg(
                                     this,
                                     Strings.Combat.Status[(int)spellBase.Combat.Effect],
@@ -2671,7 +2686,8 @@ public abstract partial class Entity : IEntity
                 case SpellType.WarpTo:
                     if (CastTarget != null)
                     {
-                        HandleAoESpell(spellId, spellBase.Combat.CastRange, MapId, X, Y, CastTarget);
+                        var castRange = spellBase.Combat.GetEffectiveCastRange(spellProperties);
+                        HandleAoESpell(spellId, castRange, MapId, X, Y, CastTarget);
                     }
 
                     break;
@@ -2679,7 +2695,7 @@ public abstract partial class Entity : IEntity
                     PacketSender.SendActionMsg(this, Strings.Combat.Dash, CustomColors.Combat.Dash);
                     var dash = new Dash(
                         this,
-                        spellBase.Combat.CastRange,
+                        spellBase.Combat.GetEffectiveCastRange(spellProperties),
                         Dir,
                         Convert.ToBoolean(spellBase.Dash.IgnoreMapBlocks),
                         Convert.ToBoolean(spellBase.Dash.IgnoreActiveResources),


### PR DESCRIPTION
## Summary
- use effective cast durations for spellcasting
- compute spell cooldowns and AoE ranges with effective values
- show cast bar using effective durations

## Testing
- `dotnet test` *(fails: The project file "/workspace/Broken_Reborn/vendor/LiteNetLib/LiteNetLib/LiteNetLib.csproj" was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a95cd79d508324a8ec81047c773ac4