### PR TITLE
Ensure PlayerSpell records exist for learned spells

### DIFF
--- a/Intersect.Server.Core/Database/PlayerData/Players/SpellSlot.cs
+++ b/Intersect.Server.Core/Database/PlayerData/Players/SpellSlot.cs
@@ -91,7 +91,31 @@ public partial class SpellSlot : ISlot, IPlayerOwned
 
     public void Set(Spell spell)
     {
-        SpellId = spell.SpellId;
+        if (spell == null || spell.SpellId == Guid.Empty)
+        {
+            PlayerSpell = null;
+            PlayerSpellId = Guid.Empty;
+            _spellId = Guid.Empty;
+            Properties = new SpellProperties();
+            return;
+        }
+
+        if (PlayerSpell == null)
+        {
+            PlayerSpell = new PlayerSpell
+            {
+                SpellId = spell.SpellId,
+                Properties = new SpellProperties(spell.Properties),
+                PlayerId = PlayerId
+            };
+            PlayerSpellId = PlayerSpell.Id;
+        }
+        else
+        {
+            PlayerSpell.SpellId = spell.SpellId;
+            PlayerSpell.Properties = new SpellProperties(spell.Properties);
+        }
+
         Properties = new SpellProperties(spell.Properties);
     }
 

--- a/Intersect.Server.Core/Entities/Player.cs
+++ b/Intersect.Server.Core/Entities/Player.cs
@@ -5612,6 +5612,10 @@ public partial class Player : Entity
             if (Spells[i].SpellId == Guid.Empty)
             {
                 Spells[i].Set(spell);
+                if (Spells[i].PlayerSpell != null)
+                {
+                    Spells[i].PlayerSpell.PlayerId = Id;
+                }
                 if (sendUpdate)
                 {
                     PacketSender.SendPlayerSpellUpdate(this, i);


### PR DESCRIPTION
## Summary
- create PlayerSpell data when assigning spells to slots
- associate PlayerSpell with player when learning spells

## Testing
- `dotnet build Intersect.Server.Core/Intersect.Server.Core.csproj` *(fails: NetLogLevel not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9be4bfb7083249df7df50bfc6a44a