### PR TITLE
Initialize spell properties from descriptor defaults

### DIFF
--- a/Intersect.Server.Core/Database/PlayerData/Players/PlayerSpell.cs
+++ b/Intersect.Server.Core/Database/PlayerData/Players/PlayerSpell.cs
@@ -2,6 +2,7 @@ using System;
 using System.ComponentModel.DataAnnotations.Schema;
 using Intersect.Collections.Slotting;
 using Intersect.Framework.Core.GameObjects.Spells;
+using Intersect.GameObjects;
 using Intersect.Server.Entities;
 using Newtonsoft.Json;
 
@@ -76,7 +77,16 @@ public partial class PlayerSpell : ISlot, IPlayerOwned
         }
 
         SpellId = spell.SpellId;
-        Properties = new SpellProperties(spell.Properties);
+        var descriptor = SpellDescriptor.Get(spell.SpellId);
+        var sourceProperties = spell.Properties;
+
+        if ((sourceProperties == null || sourceProperties.CustomUpgrades.Count == 0) &&
+            descriptor?.Properties != null)
+        {
+            sourceProperties = descriptor.Properties;
+        }
+
+        Properties = new SpellProperties(sourceProperties);
     }
 
     public void Set(PlayerSpell slot)

--- a/Intersect.Server.Core/Database/Spell.cs
+++ b/Intersect.Server.Core/Database/Spell.cs
@@ -10,10 +10,23 @@ public partial class Spell
         Properties = new SpellProperties();
     }
 
-    public Spell(Guid spellId)
+    public Spell(Guid spellId, SpellProperties properties = null)
     {
         SpellId = spellId;
-        Properties = new SpellProperties();
+
+        var descriptor = SpellDescriptor.Get(spellId);
+        if (properties != null)
+        {
+            Properties = new SpellProperties(properties);
+        }
+        else if (descriptor?.Properties != null)
+        {
+            Properties = new SpellProperties(descriptor.Properties);
+        }
+        else
+        {
+            Properties = new SpellProperties();
+        }
     }
 
     public Guid SpellId { get; set; }

--- a/Intersect.Server.Core/Entities/Player.cs
+++ b/Intersect.Server.Core/Entities/Player.cs
@@ -5602,9 +5602,18 @@ public partial class Player : Entity
             return false;
         }
 
-        if (SpellDescriptor.Get(spell.SpellId) == null)
+        var descriptor = SpellDescriptor.Get(spell.SpellId);
+        if (descriptor == null)
         {
             return false;
+        }
+
+        if (spell.Properties == null || spell.Properties.CustomUpgrades.Count == 0)
+        {
+            if (descriptor.Properties != null)
+            {
+                spell.Properties = new SpellProperties(descriptor.Properties);
+            }
         }
 
         for (var i = 0; i < Options.Instance.Player.MaxSpells; i++)


### PR DESCRIPTION
## Summary
- Initialize `Spell.Properties` from the associated descriptor when constructing a spell
- Ensure `TryTeachSpell` and `PlayerSpell.Set` populate spell properties from descriptor defaults when first creating a spell

## Testing
- `dotnet build Intersect.Server.Core`
- `dotnet test Intersect.Tests.Server` *(fails: Could not find path 'Intersect.Network/bin/Release/keys/network.handshake.bkey.pub')*

------
https://chatgpt.com/codex/tasks/task_e_68a9e3ffba208324bd084f593bf2eacc