### PR TITLE
feat: add spell level upgrade progression

### DIFF
--- a/Intersect.Server.Core/Database/Spell.cs
+++ b/Intersect.Server.Core/Database/Spell.cs
@@ -35,6 +35,18 @@ public partial class Spell
         set => Properties = JsonConvert.DeserializeObject<SpellProperties>(value ?? string.Empty) ?? new();
     }
 
+    [NotMapped]
+    public Dictionary<int, SpellProperties> LevelUpgrades { get; set; } = new();
+
+    [Column(nameof(LevelUpgrades))]
+    [JsonIgnore]
+    public string LevelUpgradesJson
+    {
+        get => JsonConvert.SerializeObject(LevelUpgrades);
+        set => LevelUpgrades =
+            JsonConvert.DeserializeObject<Dictionary<int, SpellProperties>>(value ?? string.Empty) ?? new();
+    }
+
     public static Spell None => new Spell(Guid.Empty);
 
     public Spell Clone()
@@ -42,7 +54,8 @@ public partial class Spell
         return new Spell
         {
             SpellId = this.SpellId,
-            Properties = new SpellProperties(this.Properties)
+            Properties = new SpellProperties(this.Properties),
+            LevelUpgrades = this.LevelUpgrades.ToDictionary(kv => kv.Key, kv => new SpellProperties(kv.Value))
         };
     }
 
@@ -50,5 +63,6 @@ public partial class Spell
     {
         SpellId = spell.SpellId;
         Properties = new SpellProperties(spell.Properties);
+        LevelUpgrades = spell.LevelUpgrades.ToDictionary(kv => kv.Key, kv => new SpellProperties(kv.Value));
     }
 }

--- a/Intersect.Server.Core/Migrations/Sqlite/Game/20260201000000_AddSpellLevelUpgrades.cs
+++ b/Intersect.Server.Core/Migrations/Sqlite/Game/20260201000000_AddSpellLevelUpgrades.cs
@@ -1,0 +1,23 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Intersect.Server.Migrations.Sqlite.Game
+{
+    public partial class AddSpellLevelUpgrades : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "LevelUpgrades",
+                table: "Spells",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "LevelUpgrades",
+                table: "Spells");
+        }
+    }
+}
+

--- a/Intersect.Server.Core/Migrations/Sqlite/Game/SqliteGameContextModelSnapshot.cs
+++ b/Intersect.Server.Core/Migrations/Sqlite/Game/SqliteGameContextModelSnapshot.cs
@@ -1179,6 +1179,10 @@ namespace Intersect.Server.Migrations.Sqlite.Game
                         .HasColumnType("TEXT")
                         .HasColumnName("VitalCost");
 
+                    b.Property<string>("LevelUpgradesJson")
+                        .HasColumnType("TEXT")
+                        .HasColumnName("LevelUpgrades");
+
                     b.HasKey("Id");
 
                     b.ToTable("Spells");

--- a/Intersect.Server/Migrations/MySql/Game/20260201000000_AddSpellLevelUpgrades.cs
+++ b/Intersect.Server/Migrations/MySql/Game/20260201000000_AddSpellLevelUpgrades.cs
@@ -1,0 +1,23 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Intersect.Server.Migrations.MySql.Game
+{
+    public partial class AddSpellLevelUpgrades : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "LevelUpgrades",
+                table: "Spells",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "LevelUpgrades",
+                table: "Spells");
+        }
+    }
+}
+

--- a/Intersect.Server/Migrations/MySql/Game/MySqlGameContextModelSnapshot.cs
+++ b/Intersect.Server/Migrations/MySql/Game/MySqlGameContextModelSnapshot.cs
@@ -1188,6 +1188,10 @@ namespace Intersect.Server.Migrations.MySql.Game
                         .HasColumnType("longtext")
                         .HasColumnName("VitalCost");
 
+                    b.Property<string>("LevelUpgradesJson")
+                        .HasColumnType("longtext")
+                        .HasColumnName("LevelUpgrades");
+
                     b.HasKey("Id");
 
                     b.ToTable("Spells");


### PR DESCRIPTION
## Summary
- track per-level spell upgrades
- store spell level progression in the database via new migrations

## Testing
- `dotnet build Intersect.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9e487a0a483249f689f43ba8364f5