### PR TITLE
Include spell properties in spell update packets

### DIFF
--- a/Framework/Intersect.Framework.Core/Network/Packets/Server/SpellUpdatePacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Server/SpellUpdatePacket.cs
@@ -1,5 +1,7 @@
 ﻿using MessagePack;
 
+using Intersect.Framework.Core.GameObjects.Spells;
+
 namespace Intersect.Network.Packets.Server;
 
 [MessagePackObject]
@@ -10,11 +12,12 @@ public partial class SpellUpdatePacket : IntersectPacket
     {
     }
 
-    public SpellUpdatePacket(int slot, Guid spellId, int level)
+    public SpellUpdatePacket(int slot, Guid spellId, int level, SpellProperties? properties = null)
     {
         Slot = slot;
         SpellId = spellId;
         Level = level;
+        Properties = properties;
     }
 
     [Key(0)]
@@ -25,5 +28,8 @@ public partial class SpellUpdatePacket : IntersectPacket
 
     [Key(2)]
     public int Level { get; set; }
+
+    [Key(3)]
+    public SpellProperties? Properties { get; set; }
 
 }

--- a/Intersect.Client.Core/Entities/Player.cs
+++ b/Intersect.Client.Core/Entities/Player.cs
@@ -422,7 +422,7 @@ public partial class Player : Entity, IPlayer
                     continue;
                 }
 
-                Spells[spell.Slot].Load(spell.SpellId, spell.Level);
+                Spells[spell.Slot].Load(spell.SpellId, spell.Properties);
             }
 
             if (this == Globals.Me)

--- a/Intersect.Client.Core/Networking/PacketHandler.cs
+++ b/Intersect.Client.Core/Networking/PacketHandler.cs
@@ -1394,7 +1394,7 @@ internal sealed partial class PacketHandler
     {
         if (Globals.Me != null)
         {
-            Globals.Me.Spells[packet.Slot].Load(packet.SpellId, packet.Level);
+            Globals.Me.Spells[packet.Slot].Load(packet.SpellId, packet.Properties);
             Interface.Interface.EnqueueInGame(ui => ui.SpellsWindow?.Update());
         }
     }

--- a/Intersect.Client.Core/Spells/Spell.cs
+++ b/Intersect.Client.Core/Spells/Spell.cs
@@ -22,11 +22,11 @@ public partial class Spell
         return newSpell;
     }
 
-    public void Load(Guid spellId, int level)
+    public void Load(Guid spellId, SpellProperties? properties)
     {
         Id = spellId;
-        Level = level;
-        Properties ??= new SpellProperties();
+        Properties = properties ?? new SpellProperties();
+        Level = Properties.Level;
     }
 
 }

--- a/Intersect.Server.Core/Entities/Player.cs
+++ b/Intersect.Server.Core/Entities/Player.cs
@@ -1145,7 +1145,12 @@ public partial class Player : Entity
             for (var i = 0; i < Options.Instance.Player.MaxSpells; i++)
             {
                 var slot = Spells[i];
-                spells[i] = new SpellUpdatePacket(i, slot.SpellId, slot.Level);
+                spells[i] = new SpellUpdatePacket(
+                    i,
+                    slot.SpellId,
+                    slot.Level,
+                    slot.Properties
+                );
             }
 
             pkt.Spells = spells;

--- a/Intersect.Server.Core/Networking/PacketSender.cs
+++ b/Intersect.Server.Core/Networking/PacketSender.cs
@@ -1306,7 +1306,12 @@ public static partial class PacketSender
         var spells = new SpellUpdatePacket[Options.Instance.Player.MaxSpells];
         for (var i = 0; i < Options.Instance.Player.MaxSpells; i++)
         {
-            spells[i] = new SpellUpdatePacket(i, player.Spells[i].SpellId, player.Spells[i].Level);
+            spells[i] = new SpellUpdatePacket(
+                i,
+                player.Spells[i].SpellId,
+                player.Spells[i].Level,
+                player.Spells[i].Properties
+            );
         }
 
         player.SendPacket(new SpellsPacket(spells));
@@ -1320,7 +1325,14 @@ public static partial class PacketSender
             return;
         }
 
-        player.SendPacket(new SpellUpdatePacket(slot, player.Spells[slot].SpellId, player.Spells[slot].Level));
+        player.SendPacket(
+            new SpellUpdatePacket(
+                slot,
+                player.Spells[slot].SpellId,
+                player.Spells[slot].Level,
+                player.Spells[slot].Properties
+            )
+        );
     }
 
     //EquipmentPacket


### PR DESCRIPTION
## Summary
- extend SpellUpdatePacket with SpellProperties
- send spell properties from server and apply on client
- load spells using full SpellProperties object

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9e865d82c832488087e9a281efc3a