### PR TITLE
feat: apply spell scaling based on properties

### DIFF
--- a/Intersect.Server.Core/Entities/Combat/DamageOverTimeEffect.cs
+++ b/Intersect.Server.Core/Entities/Combat/DamageOverTimeEffect.cs
@@ -88,7 +88,7 @@ public partial class DamageOverTimeEffect
         }
         
 
-        var properties = (attacker as Player)?.GetSpellProperties(spellDescriptor.Id);
+        var properties = SpellMath.Scale(spellDescriptor, (attacker as Player)?.GetSpellProperties(spellDescriptor.Id));
         var interval = spellDescriptor.Combat.GetEffectiveHotDotInterval(properties);
         var duration = spellDescriptor.Combat.GetEffectiveDuration(properties);
 
@@ -152,10 +152,10 @@ public partial class DamageOverTimeEffect
             aliveAnimations.Add(animation);
         }
 
-        var properties = (Attacker as Player)?.GetSpellProperties(SpellDescriptor.Id);
-        var level = properties?.Level ?? 0;
-        var damageHealth = SpellMath.Scale(SpellDescriptor.Combat.GetEffectiveVitalDiff(Vital.Health, properties), level);
-        var damageMana = SpellMath.Scale(SpellDescriptor.Combat.GetEffectiveVitalDiff(Vital.Mana, properties), level);
+        var properties = SpellMath.Scale(SpellDescriptor, (Attacker as Player)?.GetSpellProperties(SpellDescriptor.Id));
+        var level = properties.Level;
+        var damageHealth = SpellDescriptor.Combat.GetEffectiveVitalDiff(Vital.Health, properties);
+        var damageMana = SpellDescriptor.Combat.GetEffectiveVitalDiff(Vital.Mana, properties);
 
         Attacker?.Attack(
             Target, damageHealth, damageMana,

--- a/Intersect.Server.Core/Entities/Combat/Status.cs
+++ b/Intersect.Server.Core/Entities/Combat/Status.cs
@@ -104,11 +104,11 @@ public partial class Status
         // If we're adding a shield, actually add that according to the settings.
         if (type == SpellEffect.Shield)
         {
+            var properties = SpellMath.Scale(spell, (attacker as Player)?.GetSpellProperties(spell.Id));
+            var level = properties.Level;
             foreach (var vital in Enum.GetValues<Vital>())
             {
-                var properties = (attacker as Player)?.GetSpellProperties(spell.Id);
-                var level = properties?.Level ?? 0;
-                long vitalDiff = Math.Abs(SpellMath.Scale(spell.Combat.GetEffectiveVitalDiff(vital, properties), level));
+                long vitalDiff = Math.Abs(spell.Combat.GetEffectiveVitalDiff(vital, properties));
 
                 // If the user did not configure for this vital to have a mana shield, ignore it
                 if (vitalDiff == 0 && vital == Vital.Mana)

--- a/Intersect.Server.Core/Entities/Player.cs
+++ b/Intersect.Server.Core/Entities/Player.cs
@@ -1788,6 +1788,7 @@ public partial class Player : Entity
     public override void TryAttack(
         Entity target,
         SpellDescriptor spellDescriptor,
+        SpellProperties? spellProperties = null,
         bool onHitTrigger = false,
         bool trapTrigger = false
     )
@@ -1797,7 +1798,7 @@ public partial class Player : Entity
             return;
         }
 
-        base.TryAttack(target, spellDescriptor, onHitTrigger, trapTrigger);
+        base.TryAttack(target, spellDescriptor, spellProperties, onHitTrigger, trapTrigger);
     }
 
     /// <summary>
@@ -5899,8 +5900,7 @@ public partial class Player : Entity
             return;
         }
         var spellProperties = pspell.Properties;
-        var spellLevel = spellProperties.Level;
-        _ = spellProperties;
+        CastSpellProperties = spellProperties;
 
         if (!CanCastSpell(spellDescriptor, target, true, softRetargetOnSelfCast, out var spellCastFailureReason))
         {

--- a/Intersect.Server.Core/General/SpellMath.cs
+++ b/Intersect.Server.Core/General/SpellMath.cs
@@ -1,15 +1,28 @@
-using Intersect.Server.Entities;
+using Intersect.Framework.Core.GameObjects.Spells;
 
 namespace Intersect.Server.General;
 
 public static class SpellMath
 {
-    public static long Scale(long value, int? level = null)
+    public static SpellProperties Scale(SpellDescriptor descriptor, SpellProperties? properties = null)
     {
-        if (level.HasValue && level.Value > 1)
+        var scaled = descriptor.GetPropertiesForLevel(properties?.Level ?? 1);
+
+        if (properties?.CustomUpgrades?.Count > 0)
         {
-            return value * level.Value;
+            foreach (var kv in properties.CustomUpgrades)
+            {
+                if (scaled.CustomUpgrades.ContainsKey(kv.Key))
+                {
+                    scaled.CustomUpgrades[kv.Key] += kv.Value;
+                }
+                else
+                {
+                    scaled.CustomUpgrades[kv.Key] = kv.Value;
+                }
+            }
         }
-        return value;
+
+        return scaled;
     }
 }

--- a/Intersect.Server.Core/Maps/MapTrapInstance.cs
+++ b/Intersect.Server.Core/Maps/MapTrapInstance.cs
@@ -65,7 +65,7 @@ public partial class MapTrapInstance
                     return;
                 }
 
-                Owner.TryAttack(entity, ParentSpell, false, true);
+                Owner.TryAttack(entity, ParentSpell, null, false, true);
                 Triggered = true;
             }
         }


### PR DESCRIPTION
## Summary
- pass SpellProperties through TryAttack to honor spell levels
- compute combat values using scaled spell properties
- update status and damage-over-time effects for new scaling

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: package not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa92b2bfa483249225e33767b784cd