### PR TITLE
Persist and test spell progression data

### DIFF
--- a/Intersect.Server.Core/Database/PlayerData/Players/PlayerSpell.cs
+++ b/Intersect.Server.Core/Database/PlayerData/Players/PlayerSpell.cs
@@ -40,7 +40,7 @@ public partial class PlayerSpell : ISlot, IPlayerOwned
     [JsonIgnore]
     public string SpellPropertiesJson
     {
-        get => JsonConvert.SerializeObject(Properties);
+        get => JsonConvert.SerializeObject(Properties ??= new());
         set => Properties = JsonConvert.DeserializeObject<SpellProperties>(value ?? string.Empty) ?? new();
     }
 

--- a/Intersect.Server.Core/Database/Spell.cs
+++ b/Intersect.Server.Core/Database/Spell.cs
@@ -44,7 +44,7 @@ public partial class Spell
     [JsonIgnore]
     public string SpellPropertiesJson
     {
-        get => JsonConvert.SerializeObject(Properties);
+        get => JsonConvert.SerializeObject(Properties ??= new());
         set => Properties = JsonConvert.DeserializeObject<SpellProperties>(value ?? string.Empty) ?? new();
     }
 
@@ -55,7 +55,7 @@ public partial class Spell
     [JsonIgnore]
     public string LevelUpgradesJson
     {
-        get => JsonConvert.SerializeObject(LevelUpgrades);
+        get => JsonConvert.SerializeObject(LevelUpgrades ??= new());
         set => LevelUpgrades =
             JsonConvert.DeserializeObject<Dictionary<int, SpellProperties>>(value ?? string.Empty) ?? new();
     }

--- a/Intersect.Server.Core/Migrations/Sqlite/Player/20250823020530_AddSpellsLevels.Designer.cs
+++ b/Intersect.Server.Core/Migrations/Sqlite/Player/20250823020530_AddSpellsLevels.Designer.cs
@@ -466,31 +466,6 @@ namespace Intersect.Server.Migrations.Sqlite.Player
                     b.ToTable("Player_MailBox");
                 });
 
-            modelBuilder.Entity("Intersect.Server.Database.PlayerData.Players.PlayerSpell", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("TEXT");
-
-                    b.Property<Guid>("PlayerId")
-                        .HasColumnType("TEXT");
-
-                    b.Property<Guid>("SpellId")
-                        .HasColumnType("TEXT");
-
-                    b.Property<int>("SpellPointsSpent")
-                        .HasColumnType("INTEGER");
-
-                    b.Property<string>("SpellPropertiesJson")
-                        .HasColumnType("TEXT")
-                        .HasColumnName("Properties");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("PlayerId");
-
-                    b.ToTable("PlayerSpell");
-                });
 
             modelBuilder.Entity("Intersect.Server.Database.PlayerData.Players.PlayerVariable", b =>
                 {
@@ -549,7 +524,7 @@ namespace Intersect.Server.Migrations.Sqlite.Player
                     b.ToTable("Player_Quests");
                 });
 
-            modelBuilder.Entity("Intersect.Server.Database.PlayerData.Players.SpellSlot", b =>
+            modelBuilder.Entity("Intersect.Server.Database.PlayerData.Players.PlayerSpell", b =>
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
@@ -558,11 +533,11 @@ namespace Intersect.Server.Migrations.Sqlite.Player
                     b.Property<Guid>("PlayerId")
                         .HasColumnType("TEXT");
 
-                    b.Property<Guid>("PlayerSpellId")
-                        .HasColumnType("TEXT");
-
                     b.Property<int>("Slot")
                         .HasColumnType("INTEGER");
+
+                    b.Property<Guid>("SpellId")
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("SpellPropertiesJson")
                         .HasColumnType("TEXT")
@@ -571,8 +546,6 @@ namespace Intersect.Server.Migrations.Sqlite.Player
                     b.HasKey("Id");
 
                     b.HasIndex("PlayerId");
-
-                    b.HasIndex("PlayerSpellId");
 
                     b.ToTable("Player_Spells");
                 });
@@ -991,16 +964,6 @@ namespace Intersect.Server.Migrations.Sqlite.Player
                     b.Navigation("SenderPlayer");
                 });
 
-            modelBuilder.Entity("Intersect.Server.Database.PlayerData.Players.PlayerSpell", b =>
-                {
-                    b.HasOne("Intersect.Server.Entities.Player", "Player")
-                        .WithMany()
-                        .HasForeignKey("PlayerId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.Navigation("Player");
-                });
 
             modelBuilder.Entity("Intersect.Server.Database.PlayerData.Players.PlayerVariable", b =>
                 {
@@ -1024,7 +987,7 @@ namespace Intersect.Server.Migrations.Sqlite.Player
                     b.Navigation("Player");
                 });
 
-            modelBuilder.Entity("Intersect.Server.Database.PlayerData.Players.SpellSlot", b =>
+            modelBuilder.Entity("Intersect.Server.Database.PlayerData.Players.PlayerSpell", b =>
                 {
                     b.HasOne("Intersect.Server.Entities.Player", "Player")
                         .WithMany("Spells")
@@ -1032,15 +995,7 @@ namespace Intersect.Server.Migrations.Sqlite.Player
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
 
-                    b.HasOne("Intersect.Server.Database.PlayerData.Players.PlayerSpell", "PlayerSpell")
-                        .WithMany()
-                        .HasForeignKey("PlayerSpellId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
                     b.Navigation("Player");
-
-                    b.Navigation("PlayerSpell");
                 });
 
             modelBuilder.Entity("Intersect.Server.Database.PlayerData.Players.UserVariable", b =>

--- a/Intersect.Server.Core/Migrations/Sqlite/Player/20250823020530_AddSpellsLevels.cs
+++ b/Intersect.Server.Core/Migrations/Sqlite/Player/20250823020530_AddSpellsLevels.cs
@@ -11,11 +11,6 @@ namespace Intersect.Server.Migrations.Sqlite.Player
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.RenameColumn(
-                name: "SpellId",
-                table: "Player_Spells",
-                newName: "PlayerSpellId");
-
             migrationBuilder.AddColumn<int>(
                 name: "SpellPoints",
                 table: "Players",
@@ -28,72 +23,11 @@ namespace Intersect.Server.Migrations.Sqlite.Player
                 table: "Player_Spells",
                 type: "TEXT",
                 nullable: true);
-
-            migrationBuilder.CreateTable(
-                name: "PlayerSpell",
-                columns: table => new
-                {
-                    Id = table.Column<Guid>(type: "TEXT", nullable: false),
-                    SpellId = table.Column<Guid>(type: "TEXT", nullable: false),
-                    Properties = table.Column<string>(type: "TEXT", nullable: true),
-                    SpellPointsSpent = table.Column<int>(type: "INTEGER", nullable: false),
-                    PlayerId = table.Column<Guid>(type: "TEXT", nullable: false)
-                },
-                constraints: table =>
-                {
-                    table.PrimaryKey("PK_PlayerSpell", x => x.Id);
-                    table.ForeignKey(
-                        name: "FK_PlayerSpell_Players_PlayerId",
-                        column: x => x.PlayerId,
-                        principalTable: "Players",
-                        principalColumn: "Id",
-                        onDelete: ReferentialAction.Cascade);
-                });
-
-            migrationBuilder.Sql(
-                @"INSERT INTO PlayerSpell (Id, SpellId, Properties, SpellPointsSpent, PlayerId)
-                  SELECT Id, PlayerSpellId, Properties, 0, PlayerId FROM Player_Spells;
-                  UPDATE Player_Spells SET PlayerSpellId = Id;");
-
-            migrationBuilder.CreateIndex(
-                name: "IX_Player_Spells_PlayerSpellId",
-                table: "Player_Spells",
-                column: "PlayerSpellId");
-
-            migrationBuilder.CreateIndex(
-                name: "IX_PlayerSpell_PlayerId",
-                table: "PlayerSpell",
-                column: "PlayerId");
-
-            migrationBuilder.AddForeignKey(
-                name: "FK_Player_Spells_PlayerSpell_PlayerSpellId",
-                table: "Player_Spells",
-                column: "PlayerSpellId",
-                principalTable: "PlayerSpell",
-                principalColumn: "Id",
-                onDelete: ReferentialAction.Cascade);
         }
 
         /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.DropForeignKey(
-                name: "FK_Player_Spells_PlayerSpell_PlayerSpellId",
-                table: "Player_Spells");
-
-            migrationBuilder.Sql(
-                @"UPDATE Player_Spells
-                   SET PlayerSpellId = (
-                       SELECT SpellId FROM PlayerSpell WHERE PlayerSpell.Id = Player_Spells.PlayerSpellId
-                   );");
-
-            migrationBuilder.DropTable(
-                name: "PlayerSpell");
-
-            migrationBuilder.DropIndex(
-                name: "IX_Player_Spells_PlayerSpellId",
-                table: "Player_Spells");
-
             migrationBuilder.DropColumn(
                 name: "SpellPoints",
                 table: "Players");
@@ -101,11 +35,6 @@ namespace Intersect.Server.Migrations.Sqlite.Player
             migrationBuilder.DropColumn(
                 name: "Properties",
                 table: "Player_Spells");
-
-            migrationBuilder.RenameColumn(
-                name: "PlayerSpellId",
-                table: "Player_Spells",
-                newName: "SpellId");
         }
     }
 }

--- a/Intersect.Server.Core/Migrations/Sqlite/Player/20250823143937_AddSpellsLevelse.cs
+++ b/Intersect.Server.Core/Migrations/Sqlite/Player/20250823143937_AddSpellsLevelse.cs
@@ -11,19 +11,6 @@ namespace Intersect.Server.Migrations.Sqlite.Player
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.DropForeignKey(
-                name: "FK_Player_Spells_PlayerSpell_PlayerSpellId",
-                table: "Player_Spells");
-
-            migrationBuilder.DropIndex(
-                name: "IX_Player_Spells_PlayerSpellId",
-                table: "Player_Spells");
-
-            migrationBuilder.RenameColumn(
-                name: "PlayerSpellId",
-                table: "Player_Spells",
-                newName: "SpellId");
-
             migrationBuilder.AddColumn<int>(
                 name: "SpellPointsSpent",
                 table: "Player_Spells",
@@ -38,50 +25,6 @@ namespace Intersect.Server.Migrations.Sqlite.Player
             migrationBuilder.DropColumn(
                 name: "SpellPointsSpent",
                 table: "Player_Spells");
-
-            migrationBuilder.RenameColumn(
-                name: "SpellId",
-                table: "Player_Spells",
-                newName: "PlayerSpellId");
-
-            migrationBuilder.CreateTable(
-                name: "PlayerSpell",
-                columns: table => new
-                {
-                    Id = table.Column<Guid>(type: "BLOB", nullable: false),
-                    PlayerId = table.Column<Guid>(type: "BLOB", nullable: false),
-                    SpellId = table.Column<Guid>(type: "BLOB", nullable: false),
-                    SpellPointsSpent = table.Column<int>(type: "INTEGER", nullable: false),
-                    Properties = table.Column<string>(type: "TEXT", nullable: true)
-                },
-                constraints: table =>
-                {
-                    table.PrimaryKey("PK_PlayerSpell", x => x.Id);
-                    table.ForeignKey(
-                        name: "FK_PlayerSpell_Players_PlayerId",
-                        column: x => x.PlayerId,
-                        principalTable: "Players",
-                        principalColumn: "Id",
-                        onDelete: ReferentialAction.Cascade);
-                });
-
-            migrationBuilder.CreateIndex(
-                name: "IX_Player_Spells_PlayerSpellId",
-                table: "Player_Spells",
-                column: "PlayerSpellId");
-
-            migrationBuilder.CreateIndex(
-                name: "IX_PlayerSpell_PlayerId",
-                table: "PlayerSpell",
-                column: "PlayerId");
-
-            migrationBuilder.AddForeignKey(
-                name: "FK_Player_Spells_PlayerSpell_PlayerSpellId",
-                table: "Player_Spells",
-                column: "PlayerSpellId",
-                principalTable: "PlayerSpell",
-                principalColumn: "Id",
-                onDelete: ReferentialAction.Cascade);
         }
     }
 }

--- a/Intersect.Tests.Server/Database/PlayerSpellSerializationTests.cs
+++ b/Intersect.Tests.Server/Database/PlayerSpellSerializationTests.cs
@@ -1,0 +1,28 @@
+using System;
+using Intersect.Framework.Core.GameObjects.Spells;
+using Intersect.Server.Database.PlayerData.Players;
+using Newtonsoft.Json;
+using NUnit.Framework;
+
+namespace Intersect.Tests.Server.Database;
+
+public class PlayerSpellSerializationTests
+{
+    [Test]
+    public void PlayerSpellLevelRoundTrip()
+    {
+        var spell = new PlayerSpell(0)
+        {
+            SpellId = Guid.NewGuid(),
+            SpellPointsSpent = 3
+        };
+        spell.Level = 5;
+
+        var json = JsonConvert.SerializeObject(spell);
+        var result = JsonConvert.DeserializeObject<PlayerSpell>(json);
+
+        Assert.NotNull(result);
+        Assert.That(result.Level, Is.EqualTo(5));
+        Assert.That(result.SpellPointsSpent, Is.EqualTo(3));
+    }
+}

--- a/Intersect.Tests/GameObjects/SpellSerializationTests.cs
+++ b/Intersect.Tests/GameObjects/SpellSerializationTests.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using Intersect.GameObjects;
+using Intersect.Framework.Core.GameObjects.Spells;
+using Newtonsoft.Json;
+using NUnit.Framework;
+
+namespace Intersect.Tests.GameObjects;
+
+public class SpellSerializationTests
+{
+    [Test]
+    public void SpellDescriptorLevelUpgradesRoundTrip()
+    {
+        var descriptor = new SpellDescriptor(Guid.NewGuid())
+        {
+            LevelUpgrades = new Dictionary<int, SpellProperties>
+            {
+                [2] = new SpellProperties { Level = 2 }
+            }
+        };
+
+        var json = JsonConvert.SerializeObject(descriptor);
+        var result = JsonConvert.DeserializeObject<SpellDescriptor>(json);
+
+        Assert.NotNull(result);
+        Assert.NotNull(result.LevelUpgrades);
+        Assert.That(result.LevelUpgrades.ContainsKey(2));
+        Assert.That(result.LevelUpgrades[2].Level, Is.EqualTo(2));
+    }
+}


### PR DESCRIPTION
## Summary
- ensure spell properties and level upgrades are initialized before persistence
- simplify and correct migrations adding spell progression columns
- cover spell descriptor and player spell serialization with tests

## Testing
- `dotnet test Intersect.Tests/Intersect.Tests.csproj` *(fails: AuthorsTests.cs ambiguous call)*
- `dotnet test Intersect.Tests.Server/Intersect.Tests.Server.csproj` *(fails: missing LiteNetLib types)*

------
https://chatgpt.com/codex/tasks/task_e_68aa959e1bb0832491b877d868bdcd00