### PR TITLE
feat: improve spell item level handling

### DIFF
--- a/Intersect.Client.Core/Networking/PacketHandler.cs
+++ b/Intersect.Client.Core/Networking/PacketHandler.cs
@@ -1386,7 +1386,11 @@ internal sealed partial class PacketHandler
             HandlePacket(spl);
         }
 
-        Interface.Interface.EnqueueInGame(ui => ui.SpellsWindow?.Refresh());
+        Interface.Interface.EnqueueInGame(ui =>
+        {
+            ui.SpellsWindow?.Refresh();
+            ui.SpellsWindow?.Update();
+        });
     }
 
     //SpellUpdatePacket


### PR DESCRIPTION
## Summary
- show spell level and disable level controls at boundaries
- update spells window after receiving spell data
- add next level tooltip to level-up control

## Testing
- `dotnet build Intersect.Client.Core/Intersect.Client.Core.csproj -c Release` *(fails: INetLogger not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa99be21588324b1767e4d07a9812e