### PR TITLE
Fix bestiary unlock combo mappings

### DIFF
--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/Conditions/ConditionControl_BeastHasUnlock.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/Conditions/ConditionControl_BeastHasUnlock.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using Intersect.Framework.Core.GameObjects.Conditions.ConditionMetadata;
 using Intersect.Framework.Core.GameObjects.NPCs;
 
@@ -14,14 +15,14 @@ public partial class ConditionControl_BeastHasUnlock : UserControl
     public void SetupFormValues(BeastHasUnlockCondition condition)
     {
         cmbNpc.SelectedIndex = NPCDescriptor.ListIndex(condition.NpcId);
-        cmbUnlock.SelectedIndex = (int)condition.Unlock;
+        cmbUnlock.SelectedItem = condition.Unlock;
         nudValue.Value = condition.Value;
     }
 
     public void SaveFormValues(BeastHasUnlockCondition condition)
     {
         condition.NpcId = NPCDescriptor.IdFromList(cmbNpc.SelectedIndex);
-        condition.Unlock = (BestiaryUnlock)cmbUnlock.SelectedIndex;
+        condition.Unlock = (BestiaryUnlock)cmbUnlock.SelectedItem;
         condition.Value = (int)nudValue.Value;
     }
 
@@ -30,7 +31,7 @@ public partial class ConditionControl_BeastHasUnlock : UserControl
         cmbNpc.Items.Clear();
         cmbNpc.Items.AddRange(NPCDescriptor.Names);
         cmbUnlock.Items.Clear();
-        cmbUnlock.Items.AddRange(Enum.GetNames<BestiaryUnlock>());
+        cmbUnlock.Items.AddRange(Enum.GetValues<BestiaryUnlock>().Cast<object>().ToArray());
         if (cmbNpc.Items.Count > 0 && cmbNpc.SelectedIndex < 0)
         {
             cmbNpc.SelectedIndex = 0;

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/Conditions/ConditionControl_BeastsCompleted.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/Conditions/ConditionControl_BeastsCompleted.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using Intersect.Framework.Core.GameObjects.Conditions.ConditionMetadata;
 using Intersect.Framework.Core.GameObjects.NPCs;
 
@@ -13,20 +14,20 @@ public partial class ConditionControl_BeastsCompleted : UserControl
 
     public void SetupFormValues(BeastsCompletedCondition condition)
     {
-        cmbUnlock.SelectedIndex = (int)condition.Unlock;
+        cmbUnlock.SelectedItem = condition.Unlock;
         nudCount.Value = condition.Count;
     }
 
     public void SaveFormValues(BeastsCompletedCondition condition)
     {
-        condition.Unlock = (BestiaryUnlock)cmbUnlock.SelectedIndex;
+        condition.Unlock = (BestiaryUnlock)cmbUnlock.SelectedItem;
         condition.Count = (int)nudCount.Value;
     }
 
     public new void Show()
     {
         cmbUnlock.Items.Clear();
-        cmbUnlock.Items.AddRange(Enum.GetNames<BestiaryUnlock>());
+        cmbUnlock.Items.AddRange(Enum.GetValues<BestiaryUnlock>().Cast<object>().ToArray());
         if (cmbUnlock.Items.Count > 0 && cmbUnlock.SelectedIndex < 0)
         {
             cmbUnlock.SelectedIndex = 0;

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ChangeBestiary.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_ChangeBestiary.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using Intersect.Editor.Localization;
 using Intersect.Framework.Core.GameObjects.Events.Commands;
 using Intersect.Framework.Core.GameObjects.NPCs;
@@ -17,11 +18,11 @@ public partial class EventCommandChangeBestiary : UserControl
         _eventEditor = editor;
 
         cmbNpc.Items.AddRange(NPCDescriptor.Names);
-        cmbUnlock.Items.AddRange(Enum.GetNames<BestiaryUnlock>());
+        cmbUnlock.Items.AddRange(Enum.GetValues<BestiaryUnlock>().Cast<object>().ToArray());
         cmbOperation.Items.AddRange(new object[] { Strings.EventChangeBestiary.add, Strings.EventChangeBestiary.remove });
 
         cmbNpc.SelectedIndex = NPCDescriptor.ListIndex(_command.NpcId);
-        cmbUnlock.SelectedIndex = (int)_command.UnlockType;
+        cmbUnlock.SelectedItem = _command.UnlockType;
         cmbOperation.SelectedIndex = _command.Add ? 0 : 1;
         nudAmount.Value = _command.Amount;
 
@@ -42,7 +43,7 @@ public partial class EventCommandChangeBestiary : UserControl
     private void btnSave_Click(object sender, EventArgs e)
     {
         _command.NpcId = NPCDescriptor.IdFromList(cmbNpc.SelectedIndex);
-        _command.UnlockType = (BestiaryUnlock)cmbUnlock.SelectedIndex;
+        _command.UnlockType = (BestiaryUnlock)cmbUnlock.SelectedItem;
         _command.Add = cmbOperation.SelectedIndex == 0;
         _command.Amount = (int)nudAmount.Value;
         _eventEditor.FinishCommandEdit();

--- a/Intersect.Editor/Forms/Editors/frmNpc.cs
+++ b/Intersect.Editor/Forms/Editors/frmNpc.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using System.Drawing;
 using System.Drawing.Imaging;
+using System.Linq;
 using System.Windows.Forms;
 using DarkUI.Controls;
 using DarkUI.Forms;
@@ -140,8 +141,9 @@ public partial class FrmNpc : EditorForm
 
         lstBestiary.DataSource = _bestiaryUnlocks;
         lstBestiary.DisplayMember = nameof(NotifiableBestiaryUnlock.DisplayName);
-            cmbBestiary.Items.Clear();
-        cmbBestiary.Items.AddRange(Enum.GetNames<BestiaryUnlock>());
+
+        cmbBestiary.Items.Clear();
+        cmbBestiary.Items.AddRange(Enum.GetValues<BestiaryUnlock>().Cast<object>().ToArray());
         if (cmbBestiary.Items.Count > 0)
         {
             cmbBestiary.SelectedIndex = 0;
@@ -903,7 +905,7 @@ public partial class FrmNpc : EditorForm
         }
 
         var entry = _bestiaryUnlocks[lstBestiary.SelectedIndex];
-        cmbBestiary.SelectedIndex = (int)entry.UnlockType;
+        cmbBestiary.SelectedItem = entry.UnlockType;
         nudBestiaryAmount.Value = entry.Amount;
     }
 
@@ -915,7 +917,7 @@ public partial class FrmNpc : EditorForm
         }
 
         var selectedUnlock = _bestiaryUnlocks[lstBestiary.SelectedIndex];
-        var newType = (BestiaryUnlock)cmbBestiary.SelectedIndex;
+        var newType = (BestiaryUnlock)cmbBestiary.SelectedItem;
 
         if (selectedUnlock.UnlockType == newType)
         {
@@ -927,7 +929,7 @@ public partial class FrmNpc : EditorForm
         if (alreadyExists)
         {
             MessageBox.Show("Este tipo de desbloqueo ya está en la lista.", "Aviso", MessageBoxButtons.OK, MessageBoxIcon.Warning);
-            cmbBestiary.SelectedIndex = (int)selectedUnlock.UnlockType; // Revertir selección
+            cmbBestiary.SelectedItem = selectedUnlock.UnlockType; // Revertir selección
             return;
         }
 
@@ -958,7 +960,7 @@ public partial class FrmNpc : EditorForm
 
     private void btnBestiaryAdd_Click(object sender, EventArgs e)
     {
-        var unlockType = (BestiaryUnlock)cmbBestiary.SelectedIndex;
+        var unlockType = (BestiaryUnlock)cmbBestiary.SelectedItem;
         var amount = (int)nudBestiaryAmount.Value;
 
         // Se agrega a la lista visual sin restricciones


### PR DESCRIPTION
## Summary
- populate bestiary-related combo boxes with enum values
- use SelectedItem instead of SelectedIndex for Bestiary unlocks
- adjust event and condition editors accordingly

## Testing
- `dotnet test` *(fails: project files missing)*
- `dotnet build Intersect.Editor/Intersect.Editor.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aab7280ca083248e9b5bf65a1ad1d2