### PR TITLE
feat(spells): add level preview tabs

### DIFF
--- a/Intersect.Client.Core/Interface/Game/DescriptionWindows/SpellPreviewWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/DescriptionWindows/SpellPreviewWindow.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using Intersect.Client.Framework.File_Management;
+using Intersect.Client.Framework.Gwen;
+using Intersect.Client.Framework.Gwen.Control;
+using Intersect.Client.General;
+using Intersect.Client.Localization;
+using Intersect.Framework.Core.GameObjects.Spells;
+using Intersect.GameObjects;
+using Intersect.Enums;
+
+namespace Intersect.Client.Interface.Game.DescriptionWindows;
+
+public class SpellPreviewWindow : SpellDescriptionWindow
+{
+    private static readonly FieldInfo? DescField = typeof(SpellDescriptionWindow).GetField("_spellDescriptor", BindingFlags.Instance | BindingFlags.NonPublic);
+    private static readonly FieldInfo? PropsField = typeof(SpellDescriptionWindow).GetField("_spellProperties", BindingFlags.Instance | BindingFlags.NonPublic);
+    private static readonly FieldInfo? EffectiveField = typeof(SpellDescriptionWindow).GetField("_effectiveProps", BindingFlags.Instance | BindingFlags.NonPublic);
+
+    private int _previewLevel;
+    private int _currentLevel;
+
+    public SpellPreviewWindow(Base parent)
+        : base()
+    {
+        Parent = parent;
+        IsVisibleInParent = false;
+    }
+
+    public void ShowPreview(Guid spellId, int level)
+    {
+        _previewLevel = level;
+        _currentLevel = Globals.Me?.Spells.FirstOrDefault(s => s.Id == spellId)?.Properties?.Level ?? 1;
+
+        var desc = SpellDescriptor.Get(spellId);
+        if (desc != null)
+        {
+            var props = desc.BuildEffectiveProperties(level);
+            DescField?.SetValue(this, desc);
+            PropsField?.SetValue(this, props);
+            EffectiveField?.SetValue(this, props);
+        }
+        else
+        {
+            DescField?.SetValue(this, null);
+            PropsField?.SetValue(this, null);
+            EffectiveField?.SetValue(this, null);
+        }
+
+        SetupDescriptionWindow();
+        base.Show();
+    }
+
+    protected override void SetupHeader()
+    {
+        var desc = (SpellDescriptor?)DescField?.GetValue(this);
+        if (desc == null)
+        {
+            return;
+        }
+
+        var header = AddHeader();
+
+        var tex = GameContentManager.Current.GetTexture(Framework.Content.TextureType.Spell, desc.Icon);
+        if (tex != null)
+        {
+            header.SetIcon(tex, Color.White);
+        }
+
+        header.SetTitle(desc.Name, Color.White);
+        Strings.SpellDescription.SpellTypes.TryGetValue((int)desc.SpellType, out var spellType);
+        header.SetSubtitle(spellType, Color.White);
+
+        var text = _previewLevel > _currentLevel
+            ? $"Nivel necesario: {_previewLevel}"
+            : $"Nivel {_previewLevel}";
+        var color = _previewLevel > _currentLevel ? new Color(170, 170, 170, 255) : Color.White;
+        header.SetDescription(text, color);
+
+        header.SizeToChildren(true, false);
+    }
+}
+

--- a/Intersect.Client.Core/Interface/Game/Spells/SpellsWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Spells/SpellsWindow.cs
@@ -9,8 +9,11 @@ using Intersect.Client.Utilities;
 using Intersect.GameObjects;
 using Intersect.Utilities;
 using Intersect.Framework.Core.GameObjects.Spells;
+using System;
 using System.Collections.Generic;
-using System.Text;
+using System.Linq;
+using Intersect.Client.Interface.Game.DescriptionWindows;
+using Intersect.Client.Interface;
 
 namespace Intersect.Client.Interface.Game.Spells;
 
@@ -24,12 +27,10 @@ public partial class SpellsWindow : Window
     private Base _innerSlotPanel;
 
     // Panel de detalle
-    private readonly ImagePanel _detailPanel;
-    private readonly ImagePanel _iconPanel;
-    private readonly Label _nameLabel;
-    private readonly Label _levelLabel;
-    private readonly ScrollControl _descScroll;
-    private readonly Label _descLabel;
+    private ScrollControl _detailsScroll;
+    private Base _levelTabs;
+    private SpellPreviewWindow? _previewWin;
+    private int _previewLevel;
 
     private int _selectedSlot = -1;
     private int _lastSpellCount;
@@ -60,51 +61,23 @@ public partial class SpellsWindow : Window
         _slotContainer.EnableScroll(false, true);
 
         // PANEL DETALLE DERECHA
-        _detailPanel = new ImagePanel(this, "DetailPanel")
+        _levelTabs = new Base(this)
         {
-            Dock = Pos.Fill,
-            Margin = new Margin(4, 6, 6, 30),
             IsVisibleInParent = false,
         };
-        _detailPanel.SetSize(300, 340);
-        _detailPanel.SetPosition(250, 6);
+        _levelTabs.SetPosition(250, 6);
+        _levelTabs.SetSize(300, 20);
 
-        _iconPanel = new ImagePanel(_detailPanel, "SpellIcon");
-        _iconPanel.SetBounds(8, 8, 48, 48);
-
-        _nameLabel = new Label(_detailPanel, "SpellName")
+        _detailsScroll = new ScrollControl(this)
         {
-            FontName = "sourcesansproblack",
-            FontSize = 14,
-            TextColor = Color.White,
+            AutoHideBars = true,
+            IsVisibleInParent = false,
         };
-        _nameLabel.SetSize(200, 20);
-        _nameLabel.SetPosition(64, 8);
+        _detailsScroll.EnableScroll(false, true);
+        _detailsScroll.SetPosition(250, 30);
+        _detailsScroll.SetSize(300, 316);
 
-        _levelLabel = new Label(_detailPanel, "SpellLevel")
-        {
-            FontName = "sourcesansproblack",
-            FontSize = 10,
-            TextColor = Color.Yellow,
-        };
-        _levelLabel.SetSize(200, 16);
-        _levelLabel.SetPosition(64, 30);
-
-        _descScroll = new ScrollControl(_detailPanel, "SpellDescScroll")
-        {
-            OverflowY = OverflowBehavior.Scroll,
-            OverflowX = OverflowBehavior.Hidden,
-        };
-        _descScroll.EnableScroll(false, true);
-        _descScroll.SetBounds(8, 70, 270, 200);
-
-        _descLabel = new Label(_descScroll, "SpellDesc")
-        {
-            FontName = "sourcesansproblack",
-            FontSize = 10,
-            AutoSizeToContents = true,
-        };
-        _descLabel.SetPosition(0, 0);
+        Interface.EnqueueInGame(() => _previewWin = new SpellPreviewWindow(_detailsScroll));
 
         // CONTEXT MENU
         _contextMenu = new ContextMenu(gameCanvas, "SpellContextMenu")
@@ -273,117 +246,91 @@ public partial class SpellsWindow : Window
 
         if (me == null || spells == null || _selectedSlot < 0 || _selectedSlot >= spells.Length)
         {
-            _detailPanel.IsVisibleInParent = false;
+            _detailsScroll.IsVisibleInParent = false;
+            _levelTabs.IsVisibleInParent = false;
             return;
         }
 
         var id = spells[_selectedSlot].Id;
-        var level = spells[_selectedSlot].Level;
-
-        if (id == Guid.Empty || !SpellDescriptor.TryGet(id, out var desc))
+        if (id == Guid.Empty)
         {
-            _detailPanel.IsVisibleInParent = false;
+            _detailsScroll.IsVisibleInParent = false;
+            _levelTabs.IsVisibleInParent = false;
             return;
         }
 
-        _detailPanel.IsVisibleInParent = true;
+        _detailsScroll.IsVisibleInParent = true;
+        _levelTabs.IsVisibleInParent = true;
 
-        // Icono
-        var tex = GameContentManager.Current.GetTexture(TextureType.Spell, desc.Icon);
-        if (tex != null)
-        {
-            _iconPanel.Texture = tex;
-            _iconPanel.IsVisibleInParent = true;
-        }
-        else
-        {
-            _iconPanel.IsVisibleInParent = false;
-        }
+        OnSelectSpell(id);
+    }
 
-        // Nombre y nivel
-        _nameLabel.Text = desc.Name;
-        _levelLabel.Text = Strings.EntityBox.Level.ToString(level);
-
-        // Descripción/estadísticas básicas
-        var sb = new StringBuilder();
-        if (!string.IsNullOrWhiteSpace(desc.Description))
+    private void BuildLevelTabs(SpellDescriptor desc, int currentLevel)
+    {
+        foreach (var c in _levelTabs.Children.ToArray())
         {
-            sb.AppendLine(desc.Description);
+            c.Dispose();
         }
 
-        if (desc.CooldownDuration > 0)
-        {
-            sb.AppendLine($"{Strings.SpellDescription.Cooldown} {TimeSpan.FromMilliseconds(desc.CooldownDuration).WithSuffix()}");
-        }
+        var max = Options.Instance.Player.MaxSpellLevel;
+        var x = 0;
 
-        if (desc.CastDuration > 0)
+        for (int l = 1; l <= max; l++)
         {
-            sb.AppendLine($"{Strings.SpellDescription.CastTime} {TimeSpan.FromMilliseconds(desc.CastDuration).WithSuffix()}");
-        }
+            var btn = new Button(_levelTabs) { Text = l.ToString() };
+            btn.SetPosition(x, 0);
+            btn.SetSize(24, 20);
+            x += 26;
 
-        // Detalles por nivel usando LevelUpgrades y CustomUpgrades
-        var currentProps = desc.GetPropertiesForLevel(level);
-        if (desc.LevelUpgrades.TryGetValue(level, out var levelUpgrades) &&
-            levelUpgrades?.CustomUpgrades?.Count > 0)
-        {
-            if (sb.Length > 0)
+            if (l == currentLevel)
             {
-                sb.AppendLine();
+                btn.TextColor = new Color(30, 200, 90, 255);
+            }
+            if (l > currentLevel)
+            {
+                btn.TextColor = new Color(170, 170, 170, 255);
             }
 
-            sb.AppendLine($"Nivel {level}:");
-            foreach (var kv in levelUpgrades.CustomUpgrades)
+            var level = l;
+            btn.Clicked += (_, __) =>
             {
-                sb.AppendLine($"{kv.Key}: {kv.Value}");
-            }
-        }
-
-        SpellProperties? nextProps = null;
-        if (level < Options.Instance.Player.MaxSpellLevel &&
-            desc.LevelUpgrades.TryGetValue(level + 1, out var nextLevelUpgrades))
-        {
-            nextProps = desc.GetPropertiesForLevel(level + 1);
-
-            if (nextLevelUpgrades.CustomUpgrades.Count > 0)
-            {
-                sb.AppendLine();
-                sb.AppendLine($"Nivel {level + 1}:");
-                foreach (var kv in nextLevelUpgrades.CustomUpgrades)
+                if (_previewWin == null)
                 {
-                    sb.AppendLine($"{kv.Key}: {kv.Value}");
+                    return;
                 }
-            }
 
-            sb.AppendLine();
-            sb.AppendLine($"Costo para subir al nivel {level + 1}: {level} punto(s) de hechizo");
+                _previewLevel = level;
+                _previewWin.ShowPreview(desc.Id, _previewLevel);
+                _detailsScroll.SetInnerSize(_previewWin.Width, _previewWin.Height);
+                _detailsScroll.UpdateScrollBars();
+            };
         }
 
-        _descLabel.Text = sb.ToString().Trim();
-        _descLabel.Width = _descScroll.Width - _descScroll.VerticalScrollBar.Width;
-        _descLabel.SizeToContents();
-        _descScroll.SetInnerSize(_descScroll.Width, _descLabel.Height);
+        _levelTabs.SizeToChildren(true, true);
+        _levelTabs.Invalidate();
+    }
 
-        // Tooltip para próxima progresión basada en diferencias
-        var tooltip = string.Empty;
-        if (nextProps != null)
+    private void OnSelectSpell(Guid spellId)
+    {
+        var desc = SpellDescriptor.Get(spellId);
+        if (desc == null)
         {
-            var tooltipSb = new StringBuilder();
-            tooltipSb.AppendLine($"Nivel {level + 1}:");
-            foreach (var kv in nextProps.CustomUpgrades)
-            {
-                var currentVal = currentProps.CustomUpgrades.TryGetValue(kv.Key, out var val) ? val : 0;
-                var diff = kv.Value - currentVal;
-                if (diff != 0)
-                {
-                    tooltipSb.AppendLine($"{kv.Key}: {(diff >= 0 ? "+" : string.Empty)}{diff}");
-                }
-            }
-
-            tooltipSb.AppendLine($"Costo: {level} punto(s) de hechizo");
-            tooltip = tooltipSb.ToString().Trim();
+            return;
         }
 
-        _levelLabel.SetToolTipText(tooltip);
+        var currentLevel = Globals.Me?.Spells.FirstOrDefault(s => s.Id == spellId)?.Properties?.Level ?? 1;
+
+        BuildLevelTabs(desc, currentLevel);
+
+        if (_previewWin == null)
+        {
+            return;
+        }
+
+        _previewLevel = currentLevel;
+        _previewWin.ShowPreview(spellId, _previewLevel);
+        _detailsScroll.SetInnerSize(_previewWin.Width, _previewWin.Height);
+        _detailsScroll.UpdateScrollBars();
     }
 
     public override void Hide()


### PR DESCRIPTION
## Summary
- replace SpellDescriptionWindow tweaks with SpellPreviewWindow helper
- wire SpellsWindow level tabs to show previews via the helper
- defer preview initialization until the in-game UI is ready

## Testing
- `dotnet build Intersect.Client.Core/Intersect.Client.Core.csproj` *(fails: NetDataWriter and other LiteNetLib types missing)*
- `dotnet test` *(fails: project file "vendor/LiteNetLib/LiteNetLib/LiteNetLib.csproj" was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aac1c33e8c832490695416e59fd887