### PR TITLE
feat: add death animations for entities

### DIFF
--- a/Framework/Intersect.Framework.Core/Config/CombatOptions.cs
+++ b/Framework/Intersect.Framework.Core/Config/CombatOptions.cs
@@ -17,6 +17,8 @@ public partial class CombatOptions
 
     public int MinAttackRate { get; set; } = 500; //2 attacks per second
 
+    public string PlayerDeathAnimationId { get; set; } = "95f735e1-0c32-46a8-9a9a-b472a7a3fedd";
+
     //Combat
     public int RegenTime { get; set; } = 3000; //3 seconds
 

--- a/Framework/Intersect.Framework.Core/Config/Options.cs
+++ b/Framework/Intersect.Framework.Core/Config/Options.cs
@@ -228,6 +228,8 @@ public partial record Options
 
     #endregion Configuration Properties
 
+    public static string PlayerDeathAnimationId => Instance.Combat.PlayerDeathAnimationId;
+
     #region Player Stat Scaling Helpers
 
     public static int VitalityHealthmultiplier => Instance.Player.VitalityHealthmultiplier;

--- a/Framework/Intersect.Framework.Core/GameObjects/NPCs/NPCDescriptor.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/NPCs/NPCDescriptor.cs
@@ -175,6 +175,17 @@ public partial class NPCDescriptor : DatabaseObject<NPCDescriptor>, IFolderable
         set => AttackAnimationId = value?.Id ?? Guid.Empty;
     }
 
+    [Column("DeathAnimation")]
+    public Guid DeathAnimationId { get; set; }
+
+    [NotMapped]
+    [JsonIgnore]
+    public AnimationDescriptor DeathAnimation
+    {
+        get => AnimationDescriptor.Get(DeathAnimationId);
+        set => DeathAnimationId = value?.Id ?? Guid.Empty;
+    }
+
     //Behavior
     public bool Aggressive { get; set; }
 

--- a/Intersect.Editor/Forms/Editors/frmNpc.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/frmNpc.Designer.cs
@@ -113,6 +113,8 @@ namespace Intersect.Editor.Forms.Editors
             lblCritChance = new Label();
             cmbAttackAnimation = new DarkComboBox();
             lblAttackAnimation = new Label();
+            cmbDeathAnimation = new DarkComboBox();
+            lblDeathAnimation = new Label();
             lblDamage = new Label();
             grpCommonEvents = new DarkGroupBox();
             cmbOnDeathEventParty = new DarkComboBox();
@@ -1066,6 +1068,8 @@ namespace Intersect.Editor.Forms.Editors
             grpCombat.Controls.Add(lblCritChance);
             grpCombat.Controls.Add(cmbAttackAnimation);
             grpCombat.Controls.Add(lblAttackAnimation);
+            grpCombat.Controls.Add(cmbDeathAnimation);
+            grpCombat.Controls.Add(lblDeathAnimation);
             grpCombat.Controls.Add(lblDamage);
             grpCombat.ForeColor = System.Drawing.Color.Gainsboro;
             grpCombat.Location = new System.Drawing.Point(536, 6);
@@ -1298,9 +1302,41 @@ namespace Intersect.Editor.Forms.Editors
             lblCritChance.Size = new Size(93, 15);
             lblCritChance.TabIndex = 52;
             lblCritChance.Text = "Crit Chance (%):";
-            // 
+            //
+            // cmbDeathAnimation
+            //
+            cmbDeathAnimation.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            cmbDeathAnimation.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            cmbDeathAnimation.BorderStyle = ButtonBorderStyle.Solid;
+            cmbDeathAnimation.ButtonColor = System.Drawing.Color.FromArgb(43, 43, 43);
+            cmbDeathAnimation.DrawDropdownHoverOutline = false;
+            cmbDeathAnimation.DrawFocusRectangle = false;
+            cmbDeathAnimation.DrawMode = DrawMode.OwnerDrawFixed;
+            cmbDeathAnimation.DropDownStyle = ComboBoxStyle.DropDownList;
+            cmbDeathAnimation.FlatStyle = FlatStyle.Flat;
+            cmbDeathAnimation.ForeColor = System.Drawing.Color.Gainsboro;
+            cmbDeathAnimation.FormattingEnabled = true;
+            cmbDeathAnimation.Location = new System.Drawing.Point(14, 306);
+            cmbDeathAnimation.Margin = new Padding(4, 3, 4, 3);
+            cmbDeathAnimation.Name = "cmbDeathAnimation";
+            cmbDeathAnimation.Size = new Size(276, 24);
+            cmbDeathAnimation.TabIndex = 49;
+            cmbDeathAnimation.Text = null;
+            cmbDeathAnimation.TextPadding = new Padding(2);
+            cmbDeathAnimation.SelectedIndexChanged += cmbDeathAnimation_SelectedIndexChanged;
+            //
+            // lblDeathAnimation
+            //
+            lblDeathAnimation.AutoSize = true;
+            lblDeathAnimation.Location = new System.Drawing.Point(10, 289);
+            lblDeathAnimation.Margin = new Padding(4, 0, 4, 0);
+            lblDeathAnimation.Name = "lblDeathAnimation";
+            lblDeathAnimation.Size = new Size(99, 15);
+            lblDeathAnimation.TabIndex = 48;
+            lblDeathAnimation.Text = "Death Animation:";
+            //
             // cmbAttackAnimation
-            // 
+            //
             cmbAttackAnimation.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
             cmbAttackAnimation.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
             cmbAttackAnimation.BorderStyle = ButtonBorderStyle.Solid;
@@ -2477,6 +2513,8 @@ namespace Intersect.Editor.Forms.Editors
         private System.Windows.Forms.Label lblCritChance;
         private DarkComboBox cmbAttackAnimation;
         private System.Windows.Forms.Label lblAttackAnimation;
+        private DarkComboBox cmbDeathAnimation;
+        private System.Windows.Forms.Label lblDeathAnimation;
         private System.Windows.Forms.Label lblDamage;
         private DarkComboBox cmbHostileNPC;
         private DarkComboBox cmbSpell;

--- a/Intersect.Editor/Forms/Editors/frmNpc.cs
+++ b/Intersect.Editor/Forms/Editors/frmNpc.cs
@@ -124,6 +124,9 @@ public partial class FrmNpc : EditorForm
         cmbAttackAnimation.Items.Clear();
         cmbAttackAnimation.Items.Add(Strings.General.None);
         cmbAttackAnimation.Items.AddRange(AnimationDescriptor.Names);
+        cmbDeathAnimation.Items.Clear();
+        cmbDeathAnimation.Items.Add(Strings.General.None);
+        cmbDeathAnimation.Items.AddRange(AnimationDescriptor.Names);
         cmbOnDeathEventKiller.Items.Clear();
         cmbOnDeathEventKiller.Items.Add(Strings.General.None);
         cmbOnDeathEventKiller.Items.AddRange(EventDescriptor.Names);
@@ -269,6 +272,7 @@ public partial class FrmNpc : EditorForm
         lblScalingStat.Text = Strings.NpcEditor.scalingstat;
         lblScaling.Text = Strings.NpcEditor.scalingamount;
         lblAttackAnimation.Text = Strings.NpcEditor.attackanimation;
+        lblDeathAnimation.Text = Strings.NpcEditor.deathanimation;
 
         //Searching/Sorting
         btnAlphabetical.ToolTipText = Strings.NpcEditor.sortalphabetically;
@@ -351,6 +355,7 @@ public partial class FrmNpc : EditorForm
             cmbDamageType.SelectedIndex = mEditorItem.DamageType;
             cmbScalingStat.SelectedIndex = mEditorItem.ScalingStat;
             cmbAttackAnimation.SelectedIndex = AnimationDescriptor.ListIndex(mEditorItem.AttackAnimationId) + 1;
+            cmbDeathAnimation.SelectedIndex = AnimationDescriptor.ListIndex(mEditorItem.DeathAnimationId) + 1;
             cmbAttackSpeedModifier.SelectedIndex = mEditorItem.AttackSpeedModifier;
             nudAttackSpeedValue.Value = mEditorItem.AttackSpeedValue;
 
@@ -701,6 +706,12 @@ public partial class FrmNpc : EditorForm
     {
         mEditorItem.AttackAnimation =
             AnimationDescriptor.Get(AnimationDescriptor.IdFromList(cmbAttackAnimation.SelectedIndex - 1));
+    }
+
+    private void cmbDeathAnimation_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mEditorItem.DeathAnimation =
+            AnimationDescriptor.Get(AnimationDescriptor.IdFromList(cmbDeathAnimation.SelectedIndex - 1));
     }
 
     private void cmbDamageType_SelectedIndexChanged(object sender, EventArgs e)

--- a/Intersect.Editor/Localization/Strings.cs
+++ b/Intersect.Editor/Localization/Strings.cs
@@ -4588,6 +4588,8 @@ Tick timer saved in server config.json.";
 
         public static LocalizedString attackanimation = @"Attack Animation:";
 
+        public static LocalizedString deathanimation = @"Death Animation:";
+
         public static LocalizedString attackonsightconditions = @"Attack Player on Sight";
 
         public static LocalizedString attackspeed = @"Attack Speed";

--- a/Intersect.Server.Core/Entities/Npc.cs
+++ b/Intersect.Server.Core/Entities/Npc.cs
@@ -153,6 +153,11 @@ public partial class Npc : Entity
 
         Range = (byte)npcDescriptor.SightRange;
         mPathFinder = new Pathfinder(this);
+
+        if (npcDescriptor.DeathAnimationId != Guid.Empty)
+        {
+            DeathAnimation = npcDescriptor.DeathAnimationId;
+        }
     }
 
     public NPCDescriptor Descriptor { get; private set; }

--- a/Intersect.Server.Core/Entities/Player.cs
+++ b/Intersect.Server.Core/Entities/Player.cs
@@ -1189,6 +1189,7 @@ public partial class Player : Entity
         CastTarget = null;
 
         //Flag death to the client
+        PlayDeathAnimation();
         PacketSender.SendPlayerDeath(this);
 
         //Event trigger


### PR DESCRIPTION
## Summary
- allow configuring a default player death animation
- add death animation support to NPC descriptors and entities
- expose death animation controls in the NPC editor

## Testing
- `dotnet build Intersect.sln` *(fails: project file vendor/LiteNetLib/LiteNetLib.csproj not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aac2fd988c832490e76d492fd9cc57