### PR TITLE
Avoid crash when bestiary updates after window disposal

### DIFF
--- a/Intersect.Client.Core/Interface/Game/Bestiary/BestiaryWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Bestiary/BestiaryWindow.cs
@@ -55,16 +55,18 @@ public sealed class BestiaryWindow : Window
         LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
 
         BestiaryController.InitializeAllBeasts();
-        BestiaryController.OnUnlockGained += (npcId, _) =>
-        {
-            RefreshTilesState();
-            if (_selectedNpcId == npcId)
-            {
-                ShowNpcDetails(npcId);
-            }
-        };
+        BestiaryController.OnUnlockGained += OnUnlockGained;
 
         BuildTiles();
+    }
+
+    private void OnUnlockGained(Guid npcId, BestiaryUnlock _)
+    {
+        RefreshTilesState();
+        if (_selectedNpcId == npcId)
+        {
+            ShowNpcDetails(npcId);
+        }
     }
 
     private void BuildTiles()
@@ -326,6 +328,12 @@ public sealed class BestiaryWindow : Window
         lbl.SizeToContents();
         yOffset += lbl.Height + 4;
       
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        BestiaryController.OnUnlockGained -= OnUnlockGained;
+        base.Dispose(disposing);
     }
 
     internal void Update()


### PR DESCRIPTION
## Summary
- Unsubscribe `BestiaryWindow` from `BestiaryController.OnUnlockGained`
- Add dispose override to prevent refresh on destroyed controls

## Testing
- `dotnet build Intersect.Client.Core/Intersect.Client.Core.csproj` *(fails: Could not find a part of the path 'Intersect.Client.network.handshake.bkey.pub')*
- `dotnet build Intersect.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab3759e4e88324b3e6e301cb157715