### PR TITLE
Add SetBase entity and database support for item sets

### DIFF
--- a/Framework/Intersect.Framework.Core/Descriptors/GameObjectType.cs
+++ b/Framework/Intersect.Framework.Core/Descriptors/GameObjectType.cs
@@ -3,6 +3,7 @@ using Intersect.Framework.Core.GameObjects.Animations;
 using Intersect.Framework.Core.GameObjects.Crafting;
 using Intersect.Framework.Core.GameObjects.Events;
 using Intersect.Framework.Core.GameObjects.Items;
+using Intersect.Framework.Core.GameObjects;
 using Intersect.Framework.Core.GameObjects.Mapping.Tilesets;
 using Intersect.Framework.Core.GameObjects.Maps;
 using Intersect.Framework.Core.GameObjects.NPCs;
@@ -71,4 +72,7 @@ public enum GameObjectType
 
     [GameObjectInfo(typeof(UserVariableDescriptor), "user_variables")]
     UserVariable,
+
+    [GameObjectInfo(typeof(SetBase), "sets")]
+    Set,
 }

--- a/Framework/Intersect.Framework.Core/GameObjects/SetBase.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/SetBase.cs
@@ -1,0 +1,80 @@
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Linq;
+using Intersect.Enums;
+using Intersect.Framework.Core.GameObjects.Items;
+using Intersect.Models;
+using Newtonsoft.Json;
+
+namespace Intersect.Framework.Core.GameObjects;
+
+public partial class SetBase : DatabaseObject<SetBase>, IFolderable
+{
+    public SetBase()
+    {
+        Initialize();
+    }
+
+    [JsonConstructor]
+    public SetBase(Guid id) : base(id)
+    {
+        Initialize();
+    }
+
+    private void Initialize()
+    {
+        Name = "New Set";
+        ItemIds = [];
+        StatsGiven = new int[Enum.GetValues<Stat>().Length];
+        PercentageStatsGiven = new int[Enum.GetValues<Stat>().Length];
+        VitalsGiven = new long[Enum.GetValues<Vital>().Length];
+        PercentageVitalsGiven = new int[Enum.GetValues<Vital>().Length];
+        Effects = [];
+    }
+
+    [NotMapped]
+    public List<Guid> ItemIds { get; set; }
+
+    [Column("ItemIds"), JsonIgnore]
+    public string ItemIdsJson
+    {
+        get => JsonConvert.SerializeObject(ItemIds);
+        set => ItemIds = JsonConvert.DeserializeObject<List<Guid>>(value ?? string.Empty) ?? [];
+    }
+
+    [Column("StatsGiven")]
+    public int[] StatsGiven { get; set; }
+
+    [Column("PercentageStatsGiven")]
+    public int[] PercentageStatsGiven { get; set; }
+
+    [Column("VitalsGiven")]
+    public long[] VitalsGiven { get; set; }
+
+    [Column("PercentageVitalsGiven")]
+    public int[] PercentageVitalsGiven { get; set; }
+
+    [NotMapped]
+    public List<EffectData> Effects { get; set; }
+
+    [Column("Effects"), JsonIgnore]
+    public string EffectsJson
+    {
+        get => JsonConvert.SerializeObject(Effects);
+        set => Effects = JsonConvert.DeserializeObject<List<EffectData>>(value ?? string.Empty) ?? [];
+    }
+
+    public string Folder { get; set; } = string.Empty;
+
+    public bool HasBonuses()
+    {
+        return (StatsGiven?.Any(v => v != 0) ?? false)
+               || (PercentageStatsGiven?.Any(v => v != 0) ?? false)
+               || (VitalsGiven?.Any(v => v != 0) ?? false)
+               || (PercentageVitalsGiven?.Any(v => v != 0) ?? false)
+               || (Effects?.Count > 0);
+    }
+
+    public (int[] stats, int[] percentageStats, long[] vitals, int[] percentageVitals, List<EffectData> effects) GetBonuses()
+        => (StatsGiven, PercentageStatsGiven, VitalsGiven, PercentageVitalsGiven, Effects);
+}
+

--- a/Intersect.Server.Core/Core/Bootstrapper.cs
+++ b/Intersect.Server.Core/Core/Bootstrapper.cs
@@ -8,6 +8,7 @@ using Intersect.Core;
 using Intersect.Factories;
 using Intersect.Framework.Core.GameObjects.Events;
 using Intersect.Framework.Core.GameObjects.Items;
+using Intersect.Framework.Core.GameObjects;
 using Intersect.Framework.Core.GameObjects.Maps;
 using Intersect.Framework.Core.GameObjects.NPCs;
 using Intersect.Framework.Logging;
@@ -303,6 +304,7 @@ internal static class Bootstrapper
         Console.WriteLine(Strings.Commandoutput.MapCount.ToString(MapDescriptor.Lookup.Count));
         Console.WriteLine(Strings.Commandoutput.EventCount.ToString(EventDescriptor.Lookup.Count));
         Console.WriteLine(Strings.Commandoutput.ItemCount.ToString(ItemDescriptor.Lookup.Count));
+        Console.WriteLine(Strings.Commandoutput.SetCount.ToString(SetBase.Lookup.Count));
         Console.WriteLine();
         Console.WriteLine(Strings.Commandoutput.GameTime.ToString(Time.GetTime().ToString("F")));
         Console.WriteLine();

--- a/Intersect.Server.Core/Database/DbInterface.cs
+++ b/Intersect.Server.Core/Database/DbInterface.cs
@@ -21,6 +21,7 @@ using Intersect.Framework.Core.GameObjects.NPCs;
 using Intersect.Framework.Core.GameObjects.PlayerClass;
 using Intersect.Framework.Core.GameObjects.Resources;
 using Intersect.Framework.Core.GameObjects.Variables;
+using Intersect.Framework.Core.GameObjects;
 using Intersect.Framework.Reflection;
 using Intersect.GameObjects;
 using Intersect.Models;
@@ -720,6 +721,10 @@ public static partial class DbInterface
                 ItemDescriptor.Lookup.Clear();
 
                 break;
+            case GameObjectType.Set:
+                SetBase.Lookup.Clear();
+
+                break;
             case GameObjectType.Npc:
                 NPCDescriptor.Lookup.Clear();
 
@@ -818,6 +823,13 @@ public static partial class DbInterface
                         foreach (var itm in loadedItems)
                         {
                             ItemDescriptor.Lookup.Set(itm.Id, itm);
+                        }
+
+                        break;
+                    case GameObjectType.Set:
+                        foreach (var set in context.Sets)
+                        {
+                            SetBase.Lookup.Set(set.Id, set);
                         }
 
                         break;

--- a/Intersect.Server.Core/Database/GameData/GameContext.cs
+++ b/Intersect.Server.Core/Database/GameData/GameContext.cs
@@ -3,6 +3,7 @@ using Intersect.Framework.Core.GameObjects.Animations;
 using Intersect.Framework.Core.GameObjects.Crafting;
 using Intersect.Framework.Core.GameObjects.Events;
 using Intersect.Framework.Core.GameObjects.Items;
+using Intersect.Framework.Core.GameObjects;
 using Intersect.Framework.Core.GameObjects.Mapping.Tilesets;
 using Intersect.Framework.Core.GameObjects.Maps.MapList;
 using Intersect.Framework.Core.GameObjects.NPCs;
@@ -40,6 +41,8 @@ public abstract partial class GameContext : IntersectDbContext<GameContext>, IGa
 
     //Items
     public DbSet<ItemDescriptor> Items { get; set; }
+
+    public DbSet<SetBase> Sets { get; set; }
 
     //Equipment Properties of Items
     public DbSet<EquipmentProperties> Items_EquipmentProperties { get; set; }

--- a/Intersect.Server.Core/Database/GameData/IGameContext.cs
+++ b/Intersect.Server.Core/Database/GameData/IGameContext.cs
@@ -2,6 +2,7 @@ using Intersect.Framework.Core.GameObjects.Animations;
 using Intersect.Framework.Core.GameObjects.Crafting;
 using Intersect.Framework.Core.GameObjects.Events;
 using Intersect.Framework.Core.GameObjects.Items;
+using Intersect.Framework.Core.GameObjects;
 using Intersect.Framework.Core.GameObjects.Mapping.Tilesets;
 using Intersect.Framework.Core.GameObjects.Maps.MapList;
 using Intersect.Framework.Core.GameObjects.NPCs;
@@ -27,6 +28,8 @@ public interface IGameContext : IDbContext
     DbSet<EventDescriptor> Events { get; set; }
 
     DbSet<ItemDescriptor> Items { get; set; }
+
+    DbSet<SetBase> Sets { get; set; }
 
     DbSet<EquipmentProperties> Items_EquipmentProperties { get; set; }
 

--- a/Intersect.Server.Core/Localization/Strings.cs
+++ b/Intersect.Server.Core/Localization/Strings.cs
@@ -436,6 +436,9 @@ public static partial class Strings
         public readonly LocalizedString ItemCount = @" - {00} Items.";
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString SetCount = @" - {00} Sets.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public readonly LocalizedString KillSuccess = @"{00} has been killed!";
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]

--- a/Intersect.Server.Core/Migrations/Sqlite/Game/20250830000000_AddSets.cs
+++ b/Intersect.Server.Core/Migrations/Sqlite/Game/20250830000000_AddSets.cs
@@ -1,0 +1,36 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Intersect.Server.Migrations.Sqlite.Game
+{
+    public partial class AddSets : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Sets",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(nullable: false),
+                    TimeCreated = table.Column<long>(nullable: false),
+                    Name = table.Column<string>(nullable: true),
+                    Folder = table.Column<string>(nullable: true),
+                    ItemIds = table.Column<string>(nullable: true),
+                    StatsGiven = table.Column<string>(nullable: true),
+                    PercentageStatsGiven = table.Column<string>(nullable: true),
+                    VitalsGiven = table.Column<string>(nullable: true),
+                    PercentageVitalsGiven = table.Column<string>(nullable: true),
+                    Effects = table.Column<string>(nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Sets", x => x.Id);
+                });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(name: "Sets");
+        }
+    }
+}

--- a/Intersect.Server/Migrations/MySql/Game/20250830000000_AddSets.cs
+++ b/Intersect.Server/Migrations/MySql/Game/20250830000000_AddSets.cs
@@ -1,0 +1,36 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Intersect.Server.Migrations.MySql.Game
+{
+    public partial class AddSets : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Sets",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(nullable: false),
+                    TimeCreated = table.Column<long>(nullable: false),
+                    Name = table.Column<string>(nullable: true),
+                    Folder = table.Column<string>(nullable: true),
+                    ItemIds = table.Column<string>(nullable: true),
+                    StatsGiven = table.Column<string>(nullable: true),
+                    PercentageStatsGiven = table.Column<string>(nullable: true),
+                    VitalsGiven = table.Column<string>(nullable: true),
+                    PercentageVitalsGiven = table.Column<string>(nullable: true),
+                    Effects = table.Column<string>(nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Sets", x => x.Id);
+                });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(name: "Sets");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add new SetBase game object with item references, stat/vital bonuses, and effects
- register sets in data contexts, loaders, and bootstrapper
- create SQLite and MySQL migrations for Sets table

## Testing
- `dotnet test` *(fails: project file vendor/LiteNetLib/LiteNetLib.csproj not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab3a50875c8324ac25e57803bf6d37