### PR TITLE
Support Set game object packets

### DIFF
--- a/Intersect.Client.Core/Networking/PacketHandler.cs
+++ b/Intersect.Client.Core/Networking/PacketHandler.cs
@@ -1884,6 +1884,8 @@ internal sealed partial class PacketHandler
             case GameObjectType.Event:
                 //Clients don't store event data, im an idiot.
                 break;
+            case GameObjectType.Set:
+                goto default;
             default:
                 var lookup = type.GetLookup();
 

--- a/Intersect.Server.Core/Networking/PacketSender.cs
+++ b/Intersect.Server.Core/Networking/PacketSender.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Intersect.Core;
 using Intersect.Enums;
 using Intersect.Framework.Core;
+using Intersect.Framework.Core.GameObjects;
 using Intersect.Framework.Core.GameObjects.Animations;
 using Intersect.Framework.Core.GameObjects.Crafting;
 using Intersect.Framework.Core.GameObjects.Events;
@@ -1958,6 +1959,13 @@ public static partial class PacketSender
                 break;
             case GameObjectType.UserVariable:
                 foreach (var obj in UserVariableDescriptor.Lookup)
+                {
+                    SendGameObject(client, obj.Value, false, false, packetList);
+                }
+
+                break;
+            case GameObjectType.Set:
+                foreach (var obj in SetBase.Lookup)
                 {
                     SendGameObject(client, obj.Value, false, false, packetList);
                 }

--- a/Intersect.Server/Networking/NetworkedPacketHandler.cs
+++ b/Intersect.Server/Networking/NetworkedPacketHandler.cs
@@ -1,6 +1,7 @@
 using Intersect.Core;
 using Intersect.Enums;
 using Intersect.Framework.Core;
+using Intersect.Framework.Core.GameObjects;
 using Intersect.Framework.Core.GameObjects.Animations;
 using Intersect.Framework.Core.GameObjects.Crafting;
 using Intersect.Framework.Core.GameObjects.Events;
@@ -975,6 +976,10 @@ internal sealed partial class NetworkedPacketHandler
                     obj = UserVariableDescriptor.Get(id);
 
                     break;
+                case GameObjectType.Set:
+                    obj = SetBase.Get(id);
+
+                    break;
 
                 default:
                     throw new ArgumentOutOfRangeException();
@@ -1107,7 +1112,10 @@ internal sealed partial class NetworkedPacketHandler
                     obj = UserVariableDescriptor.Get(id);
 
                     break;
+                case GameObjectType.Set:
+                    obj = SetBase.Get(id);
 
+                    break;
                 default:
                     throw new ArgumentOutOfRangeException();
             }


### PR DESCRIPTION
## Summary
- send Set game objects to clients
- handle Set objects in SaveGameObject and DeleteGameObject packets
- process Set objects on the client

## Testing
- `dotnet test` *(fails: project file vendor/LiteNetLib/LiteNetLib.csproj not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab40dd3d7483249db29ba644f4841e