### PR TITLE
Add item set bonuses to player stats

### DIFF
--- a/Intersect.Server.Core/CustomChanges/PlayerCustom.cs
+++ b/Intersect.Server.Core/CustomChanges/PlayerCustom.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using Intersect.Enums;
+using Intersect.Framework.Core.GameObjects;
 using Intersect.Framework.Core.GameObjects.Items;
 using Intersect.Server.Database;
 using Intersect.Server.Database.PlayerData.Players;
@@ -271,6 +272,50 @@ namespace Intersect.Server.Entities
         {
             InMailBox = true;
             PacketSender.SendOpenSendMail(this);
+        }
+
+        public (int[] stats, int[] percentStats, long[] vitals, int[] percentVitals, List<EffectData> effects) GetSetBonuses()
+        {
+            var stats = new int[Enum.GetValues<Stat>().Length];
+            var percentStats = new int[Enum.GetValues<Stat>().Length];
+            var vitals = new long[Enum.GetValues<Vital>().Length];
+            var percentVitals = new int[Enum.GetValues<Vital>().Length];
+            var effects = new List<EffectData>();
+
+            var sets = EquippedItems
+                .Where(i => i.Descriptor?.SetId != Guid.Empty)
+                .GroupBy(i => i.Descriptor.SetId);
+
+            foreach (var grp in sets)
+            {
+                var set = SetBase.Get(grp.Key);
+                if (set == null || !set.HasBonuses())
+                {
+                    continue;
+                }
+
+                var ratio = (float)grp.Count() / Math.Max(1, set.ItemIds.Count);
+                var (s, ps, v, pv, eff) = set.GetBonuses();
+
+                for (var i = 0; i < stats.Length; i++)
+                {
+                    stats[i] += (int)(s[i] * ratio);
+                    percentStats[i] += (int)(ps[i] * ratio);
+                }
+
+                for (var i = 0; i < vitals.Length; i++)
+                {
+                    vitals[i] += (long)(v[i] * ratio);
+                    percentVitals[i] += (int)(pv[i] * ratio);
+                }
+
+                foreach (var e in eff)
+                {
+                    effects.Add(new EffectData(e.Type, (int)(e.Percentage * ratio)));
+                }
+            }
+
+            return (stats, percentStats, vitals, percentVitals, effects);
         }
 
         public bool HasEnoughSpellPoints(int delta)

--- a/Intersect.Server.Core/Entities/Player.cs
+++ b/Intersect.Server.Core/Entities/Player.cs
@@ -1310,6 +1310,9 @@ public partial class Player : Entity
             }
         }
 
+        var setBonuses = GetSetBonuses();
+        classVital += setBonuses.vitals[vital] + setBonuses.percentVitals[vital] * baseVital / 100;
+
         //Must have at least 1 hp and no less than 0 mp
         if (vital == (int)Vital.Health)
         {
@@ -2071,6 +2074,10 @@ public partial class Player : Entity
                 percentageStats += descriptor.PercentageStatsGiven[(int)statType];
             }
         }
+
+        var setBonuses = GetSetBonuses();
+        flatStats += setBonuses.stats[(int)statType];
+        percentageStats += setBonuses.percentStats[(int)statType];
 
         return new Tuple<int, int>(flatStats, percentageStats);
     }
@@ -4076,6 +4083,9 @@ public partial class Player : Entity
             }
             value += item.Descriptor.GetEffectPercentage(effect);
         }
+
+        var setBonuses = GetSetBonuses();
+        value += setBonuses.effects.Where(e => e.Type == effect).Sum(e => e.Percentage);
 
         return value;
     }


### PR DESCRIPTION
## Summary
- compute proportional set bonuses for equipped item sets
- include set bonuses in stat, vital, and effect calculations

## Testing
- `dotnet test` *(fails: project files missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ab43d64cec8324b8eb432b44984c82