### PR TITLE
Use texture icons for set item status

### DIFF
--- a/Intersect.Client.Core/Interface/Game/DescriptionWindows/Components/SetItemComponent.cs
+++ b/Intersect.Client.Core/Interface/Game/DescriptionWindows/Components/SetItemComponent.cs
@@ -1,22 +1,54 @@
+using Intersect.Client.Framework.Content;
+using Intersect.Client.Framework.File_Management;
 using Intersect.Client.Framework.Gwen;
 using Intersect.Client.Framework.Gwen.Control;
 using Intersect.Client.Framework.Graphics;
+using Newtonsoft.Json.Linq;
 
 namespace Intersect.Client.Interface.Game.DescriptionWindows.Components;
 
 public partial class SetItemComponent : ComponentBase
 {
     private readonly ImagePanel _icon;
-    private readonly Label _status;
+    private readonly ImagePanel _status;
+
+    private string _ownedIcon = "set_check.png";
+    private string _missingIcon = "set_x.png";
 
     public SetItemComponent(Base parent, string name = "SetItem") : base(parent, name)
     {
         _icon = new ImagePanel(this, "Icon");
-        _status = new Label(this, "Status")
+        _status = new ImagePanel(this, "Status");
+    }
+
+    public override JObject? GetJson(bool isRoot = false, bool onlySerializeIfNotEmpty = false)
+    {
+        var serialized = base.GetJson(isRoot, onlySerializeIfNotEmpty);
+        serialized?.Add(nameof(_ownedIcon), _ownedIcon);
+        serialized?.Add(nameof(_missingIcon), _missingIcon);
+        return serialized;
+    }
+
+    public override void LoadJson(JToken token, bool isRoot = false)
+    {
+        base.LoadJson(token, isRoot);
+
+        if (token is not JObject obj)
         {
-            FontName = "sourcesansproblack",
-            FontSize = 12,
-        };
+            return;
+        }
+
+        if (obj[nameof(_ownedIcon)] is JValue { Type: JTokenType.String } owned)
+        {
+            _ownedIcon = owned.Value<string>() ?? _ownedIcon;
+        }
+
+        if (obj[nameof(_missingIcon)] is JValue { Type: JTokenType.String } missing)
+        {
+            _missingIcon = missing.Value<string>() ?? _missingIcon;
+        }
+
+        _status.Texture = GameContentManager.Current.GetTexture(TextureType.Misc, _missingIcon);
     }
 
     public void SetIcon(IGameTexture texture, Color color)
@@ -29,8 +61,9 @@ public partial class SetItemComponent : ComponentBase
 
     public void SetStatus(bool owned)
     {
-        _status.SetText(owned ? "✔" : "✗");
-        _status.SetTextColor(owned ? Color.Green : Color.Red, ComponentState.Normal);
+        var textureName = owned ? _ownedIcon : _missingIcon;
+        _status.Texture = GameContentManager.Current.GetTexture(TextureType.Misc, textureName);
+        _status.RenderColor = owned ? Color.Green : Color.Red;
         _status.SizeToContents();
         Align.Center(_status);
     }


### PR DESCRIPTION
## Summary
- load owned/missing icons via GameContentManager.TextureType.Misc in SetItemComponent
- serialize and load icon names for SetItemComponent layouts

## Testing
- `dotnet test -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab4a71b6488324bf3e701b5bf11286