### PR TITLE
Fix set bonus calculation and integrate set editor into main form

### DIFF
--- a/Intersect.Editor/Forms/frmMain.Designer.cs
+++ b/Intersect.Editor/Forms/frmMain.Designer.cs
@@ -116,6 +116,7 @@ namespace Intersect.Editor.Forms
             this.spellEditorToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.variableEditorToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.timeEditorToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.setEditorToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.helpToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.postQuestionToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.reportBugToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -817,7 +818,8 @@ namespace Intersect.Editor.Forms
             this.shopEditorToolStripMenuItem,
             this.spellEditorToolStripMenuItem,
             this.variableEditorToolStripMenuItem,
-            this.timeEditorToolStripMenuItem});
+            this.timeEditorToolStripMenuItem,
+            this.setEditorToolStripMenuItem});
             this.contentEditorsToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
             this.contentEditorsToolStripMenuItem.Name = "contentEditorsToolStripMenuItem";
             this.contentEditorsToolStripMenuItem.Size = new System.Drawing.Size(101, 20);
@@ -934,7 +936,15 @@ namespace Intersect.Editor.Forms
             this.timeEditorToolStripMenuItem.Size = new System.Drawing.Size(191, 22);
             this.timeEditorToolStripMenuItem.Text = "Time Editor";
             this.timeEditorToolStripMenuItem.Click += new System.EventHandler(this.timeEditorToolStripMenuItem_Click);
-            // 
+            //
+            // setEditorToolStripMenuItem
+            //
+            this.setEditorToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
+            this.setEditorToolStripMenuItem.Name = "setEditorToolStripMenuItem";
+            this.setEditorToolStripMenuItem.Size = new System.Drawing.Size(191, 22);
+            this.setEditorToolStripMenuItem.Text = "Set Editor";
+            this.setEditorToolStripMenuItem.Click += new System.EventHandler(this.setEditorToolStripMenuItem_Click);
+            //
             // helpToolStripMenuItem
             // 
             this.helpToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
@@ -1107,12 +1117,13 @@ namespace Intersect.Editor.Forms
 		private ToolStripMenuItem questEditorToolStripMenuItem;
 		private ToolStripMenuItem resourceEditorToolStripMenuItem;
 		private ToolStripMenuItem shopEditorToolStripMenuItem;
-		private ToolStripMenuItem spellEditorToolStripMenuItem;
-		private ToolStripMenuItem variableEditorToolStripMenuItem;
-		private ToolStripMenuItem timeEditorToolStripMenuItem;
-		private ToolStripMenuItem helpToolStripMenuItem;
-		private ToolStripMenuItem postQuestionToolStripMenuItem;
-		private ToolStripMenuItem reportBugToolStripMenuItem;
+                private ToolStripMenuItem spellEditorToolStripMenuItem;
+                private ToolStripMenuItem variableEditorToolStripMenuItem;
+                private ToolStripMenuItem timeEditorToolStripMenuItem;
+                private ToolStripMenuItem setEditorToolStripMenuItem;
+                private ToolStripMenuItem helpToolStripMenuItem;
+                private ToolStripMenuItem postQuestionToolStripMenuItem;
+                private ToolStripMenuItem reportBugToolStripMenuItem;
 		private ToolStripMenuItem aboutToolStripMenuItem;
 		private DarkMenuStrip menuStrip;
 		private ToolStripMenuItem toolsToolStripMenuItem;

--- a/Intersect.Editor/Forms/frmMain.cs
+++ b/Intersect.Editor/Forms/frmMain.cs
@@ -70,6 +70,7 @@ public partial class FrmMain : Form
     private FrmSwitchVariable mSwitchVariableEditor;
 
     private FrmTime mTimeEditor;
+    private frmSets mSetEditor;
 
     //General Editting Variables
     bool mTMouseDown;
@@ -1302,6 +1303,11 @@ public partial class FrmMain : Form
         PacketSender.SendOpenEditor(GameObjectType.Time);
     }
 
+    private void setEditorToolStripMenuItem_Click(object sender, EventArgs e)
+    {
+        PacketSender.SendOpenEditor(GameObjectType.Sets);
+    }
+
     private void layersToolStripMenuItem_DropDownOpened(object sender, EventArgs e)
     {
         foreach (var itm in ((ToolStripMenuItem)sender).DropDownItems)
@@ -1726,6 +1732,15 @@ public partial class FrmMain : Form
                         mTimeEditor = new FrmTime();
                         mTimeEditor.InitEditor(DaylightCycleDescriptor.Instance);
                         mTimeEditor.Show();
+                    }
+
+                    break;
+                case GameObjectType.Sets:
+                    if (mSetEditor == null || !mSetEditor.Visible)
+                    {
+                        mSetEditor = new frmSets();
+                        mSetEditor.InitEditor();
+                        mSetEditor.Show();
                     }
 
                     break;

--- a/Intersect.Server.Core/CustomChanges/PlayerCustom.cs
+++ b/Intersect.Server.Core/CustomChanges/PlayerCustom.cs
@@ -290,30 +290,27 @@ namespace Intersect.Server.Entities
             foreach (var grp in sets)
             {
                 var set = SetDescriptor.Get(grp.Key);
-                if (set == null || !set.HasBonuses())
+                if (set == null || !set.HasBonuses)
                 {
                     continue;
                 }
 
                 var ratio = (float)grp.Count() / Math.Max(1, set.ItemIds.Count);
-                var (s, ps, v, pv, eff) = set.GetBonuses();
+                var (s, ps, v, pv, eff) = set.GetBonuses(ratio);
 
                 for (var i = 0; i < stats.Length; i++)
                 {
-                    stats[i] += (int)(s[i] * ratio);
-                    percentStats[i] += (int)(ps[i] * ratio);
+                    stats[i] += s[i];
+                    percentStats[i] += ps[i];
                 }
 
                 for (var i = 0; i < vitals.Length; i++)
                 {
-                    vitals[i] += (long)(v[i] * ratio);
-                    percentVitals[i] += (int)(pv[i] * ratio);
+                    vitals[i] += v[i];
+                    percentVitals[i] += pv[i];
                 }
 
-                foreach (var e in eff)
-                {
-                    effects.Add(new EffectData(e.Type, (int)(e.Percentage * ratio)));
-                }
+                effects.AddRange(eff);
             }
 
             return (stats, percentStats, vitals, percentVitals, effects);


### PR DESCRIPTION
## Summary
- use `SetDescriptor.HasBonuses` property instead of invoking
- pass ratio to `GetBonuses` and remove double scaling for set bonuses
- add Set Editor menu item in MainForm and open `frmSets`

## Testing
- `dotnet build Intersect.Editor/Intersect.Editor.csproj` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68ab37bd7de083249ede91180d14539b