### PR TITLE
Handle Set game objects in editor packets

### DIFF
--- a/Intersect.Editor/Networking/PacketHandler.cs
+++ b/Intersect.Editor/Networking/PacketHandler.cs
@@ -736,6 +736,20 @@ internal sealed partial class PacketHandler
                 }
 
                 break;
+            case GameObjectType.Sets:
+                if (deleted)
+                {
+                    var set = SetDescriptor.Get(id);
+                    set.Delete();
+                }
+                else
+                {
+                    var set = new SetDescriptor(id);
+                    set.Load(json);
+                    SetDescriptor.Lookup.Set(id, set);
+                }
+
+                break;
             default:
                 throw new ArgumentOutOfRangeException();
         }


### PR DESCRIPTION
## Summary
- handle Set game objects in editor `GameObjectPacket`

## Testing
- `dotnet test` *(fails: project file "/workspace/Broken_Reborn/vendor/LiteNetLib/LiteNetLib/LiteNetLib.csproj" was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab692814f08324a301e6f562604aed