### PR TITLE
Add set-based vital regeneration bonuses

### DIFF
--- a/Framework/Intersect.Framework.Core/GameObjects/SetDescriptor.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/SetDescriptor.cs
@@ -125,15 +125,16 @@ public partial class SetDescriptor : DatabaseObject<SetDescriptor>, IFolderable
         ItemIds = ItemIds.Where(id => ItemDescriptor.Get(id)?.SetId == Id).ToList();
     }
 
-    public (int[] stats, int[] percentStats, long[] vitals, int[] percentVitals, List<EffectData> effects) GetBonuses(float ratio)
+    public (int[] stats, int[] percentStats, long[] vitals, long[] vitalsRegen, int[] percentVitals, List<EffectData> effects) GetBonuses(float ratio)
     {
         var scaledStats = Stats.Select(v => (int)(v * ratio)).ToArray();
         var scaledPercentStats = PercentageStats.Select(v => (int)(v * ratio)).ToArray();
         var scaledVitals = Vitals.Select(v => (long)(v * ratio)).ToArray();
+        var scaledVitalsRegen = VitalsRegen.Select(v => (long)(v * ratio)).ToArray();
         var scaledPercentVitals = PercentageVitals.Select(v => (int)(v * ratio)).ToArray();
         var scaledEffects = Effects.Select(e => new EffectData(e.Type, (int)(e.Percentage * ratio))).ToList();
 
-        return (scaledStats, scaledPercentStats, scaledVitals, scaledPercentVitals, scaledEffects);
+        return (scaledStats, scaledPercentStats, scaledVitals, scaledVitalsRegen, scaledPercentVitals, scaledEffects);
     }
 
     [NotMapped, JsonIgnore]

--- a/Intersect.Server.Core/CustomChanges/PlayerCustom.cs
+++ b/Intersect.Server.Core/CustomChanges/PlayerCustom.cs
@@ -275,11 +275,12 @@ namespace Intersect.Server.Entities
             PacketSender.SendOpenSendMail(this);
         }
 
-        public (int[] stats, int[] percentStats, long[] vitals, int[] percentVitals, List<EffectData> effects) GetSetBonuses()
+        public (int[] stats, int[] percentStats, long[] vitals, long[] vitalsRegen, int[] percentVitals, List<EffectData> effects) GetSetBonuses()
         {
             var stats = new int[Enum.GetValues<Stat>().Length];
             var percentStats = new int[Enum.GetValues<Stat>().Length];
             var vitals = new long[Enum.GetValues<Vital>().Length];
+            var vitalsRegen = new long[Enum.GetValues<Vital>().Length];
             var percentVitals = new int[Enum.GetValues<Vital>().Length];
             var effects = new List<EffectData>();
 
@@ -296,7 +297,7 @@ namespace Intersect.Server.Entities
                 }
 
                 var ratio = (float)grp.Count() / Math.Max(1, set.ItemIds.Count);
-                var (s, ps, v, pv, eff) = set.GetBonuses(ratio);
+                var (s, ps, v, vr, pv, eff) = set.GetBonuses(ratio);
 
                 for (var i = 0; i < stats.Length; i++)
                 {
@@ -307,13 +308,14 @@ namespace Intersect.Server.Entities
                 for (var i = 0; i < vitals.Length; i++)
                 {
                     vitals[i] += v[i];
+                    vitalsRegen[i] += vr[i];
                     percentVitals[i] += pv[i];
                 }
 
                 effects.AddRange(eff);
             }
 
-            return (stats, percentStats, vitals, percentVitals, effects);
+            return (stats, percentStats, vitals, vitalsRegen, percentVitals, effects);
         }
 
         public bool HasEnoughSpellPoints(int delta)

--- a/Intersect.Server.Core/Entities/Player.cs
+++ b/Intersect.Server.Core/Entities/Player.cs
@@ -4098,6 +4098,8 @@ public partial class Player : Entity
         {
             regen += item.Descriptor.VitalsRegen[(int)vital];
         }
+        var setBonuses = GetSetBonuses();
+        regen += setBonuses.vitalsRegen[(int)vital];
 
         return regen;
     }


### PR DESCRIPTION
## Summary
- scale and return vital regeneration in SetDescriptor.GetBonuses
- include set vital regen in PlayerCustom.GetSetBonuses
- factor set regen into Player.GetEquipmentVitalRegen

## Testing
- `dotnet build Intersect.sln` *(fails: project file /workspace/Broken_Reborn/vendor/LiteNetLib/LiteNetLib/LiteNetLib.csproj was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab692d07dc8324842cb5c00c34be13