### PR TITLE
refactor: derive set metadata from descriptor

### DIFF
--- a/Framework/Intersect.Framework.Core/GameObjects/Items/ItemDescriptor.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Items/ItemDescriptor.cs
@@ -181,15 +181,6 @@ public partial class ItemDescriptor : DatabaseObject<ItemDescriptor>, IFolderabl
         get => SetDescriptor.Get(SetId);
         set => SetId = value?.Id ?? Guid.Empty;
     }
-
-    [Column("SetName")]
-    [JsonProperty]
-    public string SetName { get; set; } = string.Empty;
-
-    [Column("SetDescription")]
-    [JsonProperty]
-    public string SetDescription { get; set; } = string.Empty;
-
     public string Description { get; set; } = string.Empty;
 
     public string FemalePaperdoll { get; set; } = string.Empty;

--- a/Framework/Intersect.Framework.Core/GameObjects/SetDescriptor.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/SetDescriptor.cs
@@ -28,6 +28,8 @@ public partial class SetDescriptor : DatabaseObject<SetDescriptor>, IFolderable
 
     public string Name { get; set; } = "New Set";
 
+    public string Description { get; set; } = string.Empty;
+
     [NotMapped]
     public List<Guid> ItemIds { get; set; } = new();
 
@@ -164,4 +166,6 @@ public partial class SetDescriptor : DatabaseObject<SetDescriptor>, IFolderable
     public ItemEffect[] EffectsEnabled => Effects.Select(effect => effect.Type).ToArray();
 
     public static string GetName(Guid id) => Get(id)?.Name ?? "???";
+
+    public static string GetDescription(Guid id) => Get(id)?.Description ?? string.Empty;
 }

--- a/Intersect.Client.Core/Interface/Game/DescriptionWindows/ItemDescriptionWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/DescriptionWindows/ItemDescriptionWindow.cs
@@ -227,7 +227,12 @@ public partial class ItemDescriptionWindow() : DescriptionWindowBase(Interface.G
 
         AddDivider();
         var desc = AddDescription();
-        desc.AddText(_itemDescriptor.SetName, CustomColors.ItemDesc.Primary);
+        desc.AddText(set.Name, CustomColors.ItemDesc.Primary);
+        if (!string.IsNullOrWhiteSpace(set.Description))
+        {
+            desc.AddLineBreak();
+            desc.AddText(set.Description, CustomColors.ItemDesc.Muted);
+        }
 
         var container = AddComponent(new ComponentBase(this, "SetItemsContainer"));
         int x = 0;

--- a/Intersect.Server.Core/Migrations/Sqlite/Game/20250824183759_AddedSetSystem.Designer.cs
+++ b/Intersect.Server.Core/Migrations/Sqlite/Game/20250824183759_AddedSetSystem.Designer.cs
@@ -340,17 +340,9 @@ namespace Intersect.Server.Migrations.Sqlite.Game
                     b.Property<int>("ScalingStat")
                         .HasColumnType("INTEGER");
 
-                    b.Property<string>("SetDescription")
-                        .HasColumnType("TEXT")
-                        .HasColumnName("SetDescription");
-
                     b.Property<Guid>("SetId")
                         .HasColumnType("TEXT")
                         .HasColumnName("Set");
-
-                    b.Property<string>("SetName")
-                        .HasColumnType("TEXT")
-                        .HasColumnName("SetName");
 
                     b.Property<bool>("SingleUse")
                         .HasColumnType("INTEGER")
@@ -1092,6 +1084,9 @@ namespace Intersect.Server.Migrations.Sqlite.Game
                         .HasColumnName("ItemIds");
 
                     b.Property<string>("Name")
+                        .HasColumnType("TEXT");
+
+                    b.Property<string>("Description")
                         .HasColumnType("TEXT");
 
                     b.Property<string>("PercentageStatsJson")

--- a/Intersect.Server.Core/Migrations/Sqlite/Game/20250824183759_AddedSetSystem.cs
+++ b/Intersect.Server.Core/Migrations/Sqlite/Game/20250824183759_AddedSetSystem.cs
@@ -18,24 +18,13 @@ namespace Intersect.Server.Migrations.Sqlite.Game
                 nullable: false,
                 defaultValue: new Guid("00000000-0000-0000-0000-000000000000"));
 
-            migrationBuilder.AddColumn<string>(
-                name: "SetDescription",
-                table: "Items",
-                type: "TEXT",
-                nullable: true);
-
-            migrationBuilder.AddColumn<string>(
-                name: "SetName",
-                table: "Items",
-                type: "TEXT",
-                nullable: true);
-
             migrationBuilder.CreateTable(
                 name: "Sets",
                 columns: table => new
                 {
                     Id = table.Column<Guid>(type: "TEXT", nullable: false),
                     Name = table.Column<string>(type: "TEXT", nullable: true),
+                    Description = table.Column<string>(type: "TEXT", nullable: true),
                     ItemIds = table.Column<string>(type: "TEXT", nullable: true),
                     VitalsGiven = table.Column<string>(type: "TEXT", nullable: true),
                     VitalsRegen = table.Column<string>(type: "TEXT", nullable: true),
@@ -60,14 +49,6 @@ namespace Intersect.Server.Migrations.Sqlite.Game
 
             migrationBuilder.DropColumn(
                 name: "Set",
-                table: "Items");
-
-            migrationBuilder.DropColumn(
-                name: "SetDescription",
-                table: "Items");
-
-            migrationBuilder.DropColumn(
-                name: "SetName",
                 table: "Items");
         }
     }

--- a/Intersect.Server.Core/Migrations/Sqlite/Game/SqliteGameContextModelSnapshot.cs
+++ b/Intersect.Server.Core/Migrations/Sqlite/Game/SqliteGameContextModelSnapshot.cs
@@ -337,17 +337,9 @@ namespace Intersect.Server.Migrations.Sqlite.Game
                     b.Property<int>("ScalingStat")
                         .HasColumnType("INTEGER");
 
-                    b.Property<string>("SetDescription")
-                        .HasColumnType("TEXT")
-                        .HasColumnName("SetDescription");
-
                     b.Property<Guid>("SetId")
                         .HasColumnType("TEXT")
                         .HasColumnName("Set");
-
-                    b.Property<string>("SetName")
-                        .HasColumnType("TEXT")
-                        .HasColumnName("SetName");
 
                     b.Property<bool>("SingleUse")
                         .HasColumnType("INTEGER")
@@ -1089,6 +1081,9 @@ namespace Intersect.Server.Migrations.Sqlite.Game
                         .HasColumnName("ItemIds");
 
                     b.Property<string>("Name")
+                        .HasColumnType("TEXT");
+
+                    b.Property<string>("Description")
                         .HasColumnType("TEXT");
 
                     b.Property<string>("PercentageStatsJson")


### PR DESCRIPTION
## Summary
- remove SetName and SetDescription from ItemDescriptor
- show set name and description from SetDescriptor at runtime
- drop SetName and SetDescription columns from Items migration and add Description to Sets

## Testing
- `dotnet test` *(fails: project files not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab6e0cfb3c8324b1764d83ab7e0c43