### PR TITLE
Add set index and deletion behavior for items

### DIFF
--- a/Framework/Intersect.Framework.Core/GameObjects/Items/ItemDescriptor.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Items/ItemDescriptor.cs
@@ -170,6 +170,11 @@ public partial class ItemDescriptor : DatabaseObject<ItemDescriptor>, IFolderabl
         set => EventId = value?.Id ?? Guid.Empty;
     }
 
+    /// <summary>
+    /// Identifier of the set this item belongs to.
+    /// The database relationship uses <c>ON DELETE SET DEFAULT</c>,
+    /// so removing a set automatically resets this value to <see cref="Guid.Empty"/>.
+    /// </summary>
     [Column("Set")]
     [JsonProperty]
     public Guid SetId { get; set; }

--- a/Intersect.Server.Core/Migrations/Sqlite/Game/20250824183759_AddedSetSystem.Designer.cs
+++ b/Intersect.Server.Core/Migrations/Sqlite/Game/20250824183759_AddedSetSystem.Designer.cs
@@ -404,7 +404,17 @@ namespace Intersect.Server.Migrations.Sqlite.Game
 
                     b.HasKey("Id");
 
+                    b.HasIndex("SetId");
+
                     b.ToTable("Items");
+                });
+
+            modelBuilder.Entity("Intersect.Framework.Core.GameObjects.Items.ItemDescriptor", b =>
+                {
+                    b.HasOne("Intersect.GameObjects.SetDescriptor", "Set")
+                        .WithMany()
+                        .HasForeignKey("SetId")
+                        .OnDelete(DeleteBehavior.SetDefault);
                 });
 
             modelBuilder.Entity("Intersect.Framework.Core.GameObjects.Mapping.Tilesets.TilesetDescriptor", b =>

--- a/Intersect.Server.Core/Migrations/Sqlite/Game/20250824183759_AddedSetSystem.cs
+++ b/Intersect.Server.Core/Migrations/Sqlite/Game/20250824183759_AddedSetSystem.cs
@@ -50,11 +50,34 @@ namespace Intersect.Server.Migrations.Sqlite.Game
                 {
                     table.PrimaryKey("PK_Sets", x => x.Id);
                 });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Items_Set",
+                table: "Items",
+                column: "Set");
+
+            // When a set is deleted, items referencing it should become unset.
+            // Use SET DEFAULT so the Set column reverts to Guid.Empty instead of restricting the delete.
+            migrationBuilder.AddForeignKey(
+                name: "FK_Items_Sets_Set",
+                table: "Items",
+                column: "Set",
+                principalTable: "Sets",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetDefault);
         }
 
         /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Items_Sets_Set",
+                table: "Items");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Items_Set",
+                table: "Items");
+
             migrationBuilder.DropTable(
                 name: "Sets");
 

--- a/Intersect.Server.Core/Migrations/Sqlite/Game/SqliteGameContextModelSnapshot.cs
+++ b/Intersect.Server.Core/Migrations/Sqlite/Game/SqliteGameContextModelSnapshot.cs
@@ -401,7 +401,17 @@ namespace Intersect.Server.Migrations.Sqlite.Game
 
                     b.HasKey("Id");
 
+                    b.HasIndex("SetId");
+
                     b.ToTable("Items");
+                });
+
+            modelBuilder.Entity("Intersect.Framework.Core.GameObjects.Items.ItemDescriptor", b =>
+                {
+                    b.HasOne("Intersect.GameObjects.SetDescriptor", "Set")
+                        .WithMany()
+                        .HasForeignKey("SetId")
+                        .OnDelete(DeleteBehavior.SetDefault);
                 });
 
             modelBuilder.Entity("Intersect.Framework.Core.GameObjects.Mapping.Tilesets.TilesetDescriptor", b =>


### PR DESCRIPTION
## Summary
- index Items.Set with `IX_Items_Set`
- set foreign key from Items to Sets with `ON DELETE SET DEFAULT`
- document deletion behavior on item SetId

## Testing
- `dotnet test` *(fails: project file vendor/LiteNetLib/LiteNetLib.csproj not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab6e1263cc8324b10ace414053737b