### PR TITLE
Add array normalization helper and tests

### DIFF
--- a/Framework/Intersect.Framework.Core/Collections/ArrayExtensions.cs
+++ b/Framework/Intersect.Framework.Core/Collections/ArrayExtensions.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace Intersect.Collections;
+
+public static partial class ArrayExtensions
+{
+    public static T[] EnsureLen<T>(T[]? array, int length)
+    {
+        if (array?.Length == length)
+        {
+            return array;
+        }
+
+        var newArray = new T[length];
+        if (array is { Length: > 0 })
+        {
+            Array.Copy(array, newArray, Math.Min(array.Length, length));
+        }
+
+        return newArray;
+    }
+}
+

--- a/Framework/Intersect.Framework.Core/GameObjects/SetDescriptor.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/SetDescriptor.cs
@@ -3,6 +3,7 @@ using Intersect.Framework.Core.GameObjects.Items;
 using Intersect.GameObjects;
 using Intersect.Models;
 using Intersect.Utilities;
+using Intersect.Collections;
 using Microsoft.EntityFrameworkCore;
 using Newtonsoft.Json;
 using System.ComponentModel.DataAnnotations.Schema;
@@ -116,11 +117,11 @@ public partial class SetDescriptor : DatabaseObject<SetDescriptor>, IFolderable
 
     public void Validate()
     {
-        Stats ??= new int[Enum.GetValues<Stat>().Length];
-        PercentageStats ??= new int[Enum.GetValues<Stat>().Length];
-        Vitals ??= new long[Enum.GetValues<Vital>().Length];
-        VitalsRegen ??= new long[Enum.GetValues<Vital>().Length];
-        PercentageVitals ??= new int[Enum.GetValues<Vital>().Length];
+        Stats = ArrayExtensions.EnsureLen(Stats, Enum.GetValues<Stat>().Length);
+        PercentageStats = ArrayExtensions.EnsureLen(PercentageStats, Enum.GetValues<Stat>().Length);
+        Vitals = ArrayExtensions.EnsureLen(Vitals, Enum.GetValues<Vital>().Length);
+        VitalsRegen = ArrayExtensions.EnsureLen(VitalsRegen, Enum.GetValues<Vital>().Length);
+        PercentageVitals = ArrayExtensions.EnsureLen(PercentageVitals, Enum.GetValues<Vital>().Length);
         Effects ??= new List<EffectData>();
 
         // (Opcional) limpiar ItemIds que ya no coinciden

--- a/Intersect.Tests/GameObjects/SetDescriptorTests.cs
+++ b/Intersect.Tests/GameObjects/SetDescriptorTests.cs
@@ -1,0 +1,65 @@
+using System;
+using Intersect.Enums;
+using Intersect.GameObjects;
+using NUnit.Framework;
+
+namespace Intersect.Tests.GameObjects;
+
+public class SetDescriptorTests
+{
+    [Test]
+    public void ValidateExpandsAndInitializesArrays()
+    {
+        var descriptor = new SetDescriptor(Guid.NewGuid())
+        {
+            Stats = new int[1],
+            PercentageStats = new int[1],
+            Vitals = new long[1],
+            VitalsRegen = new long[1],
+            PercentageVitals = new int[1]
+        };
+
+        descriptor.Validate();
+
+        Assert.That(descriptor.Stats.Length, Is.EqualTo(Enum.GetValues<Stat>().Length));
+        Assert.That(descriptor.PercentageStats.Length, Is.EqualTo(Enum.GetValues<Stat>().Length));
+        Assert.That(descriptor.Vitals.Length, Is.EqualTo(Enum.GetValues<Vital>().Length));
+        Assert.That(descriptor.VitalsRegen.Length, Is.EqualTo(Enum.GetValues<Vital>().Length));
+        Assert.That(descriptor.PercentageVitals.Length, Is.EqualTo(Enum.GetValues<Vital>().Length));
+    }
+
+    [Test]
+    public void ValidateTruncatesArrays()
+    {
+        var statLen = Enum.GetValues<Stat>().Length;
+        var vitalLen = Enum.GetValues<Vital>().Length;
+        var descriptor = new SetDescriptor(Guid.NewGuid())
+        {
+            Stats = new int[statLen + 1],
+            PercentageStats = new int[statLen + 1],
+            Vitals = new long[vitalLen + 1],
+            VitalsRegen = new long[vitalLen + 1],
+            PercentageVitals = new int[vitalLen + 1]
+        };
+
+        descriptor.Stats[^1] = 42;
+        descriptor.PercentageStats[^1] = 42;
+        descriptor.Vitals[^1] = 42;
+        descriptor.VitalsRegen[^1] = 42;
+        descriptor.PercentageVitals[^1] = 42;
+
+        descriptor.Validate();
+
+        Assert.That(descriptor.Stats.Length, Is.EqualTo(statLen));
+        Assert.That(descriptor.PercentageStats.Length, Is.EqualTo(statLen));
+        Assert.That(descriptor.Vitals.Length, Is.EqualTo(vitalLen));
+        Assert.That(descriptor.VitalsRegen.Length, Is.EqualTo(vitalLen));
+        Assert.That(descriptor.PercentageVitals.Length, Is.EqualTo(vitalLen));
+
+        Assert.That(descriptor.Stats, Does.Not.Contain(42));
+        Assert.That(descriptor.PercentageStats, Does.Not.Contain(42));
+        Assert.That(descriptor.Vitals, Does.Not.Contain(42L));
+        Assert.That(descriptor.VitalsRegen, Does.Not.Contain(42L));
+        Assert.That(descriptor.PercentageVitals, Does.Not.Contain(42));
+    }
+}

--- a/Intersect.Tests/Plugins/Manifests/Types/AuthorsTests.cs
+++ b/Intersect.Tests/Plugins/Manifests/Types/AuthorsTests.cs
@@ -63,7 +63,7 @@ namespace Intersect.Plugins.Manifests.Types
         public void AreEqual_StringArray()
         {
             var authors = new Authors(new Author(AuthorName), new Author(AuthorStringNameEmail));
-            Assert.IsTrue(authors.Equals([AuthorName, AuthorStringNameEmail]));
+            Assert.IsTrue(authors.Equals(new[] { AuthorName, AuthorStringNameEmail }));
         }
 
         [Test]


### PR DESCRIPTION
## Summary
- add generic `EnsureLen` helper to normalize array lengths
- validate `SetDescriptor` arrays after load/creation using `EnsureLen`
- add unit tests covering array expansion and truncation scenarios

## Testing
- `dotnet test Intersect.Tests/Intersect.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68ab723580b8832489801455edf59c65