### PR TITLE
Add tiered set bonuses based on equipped pieces

### DIFF
--- a/Framework/Intersect.Framework.Core/GameObjects/SetBonusTier.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/SetBonusTier.cs
@@ -1,0 +1,72 @@
+using Intersect.Enums;
+using Intersect.Framework.Core.GameObjects.Items;
+using Intersect.Collections;
+using Newtonsoft.Json;
+using System;
+using System.Linq;
+
+namespace Intersect.GameObjects;
+
+public class SetBonusTier
+{
+    public int[] Stats { get; set; } = new int[Enum.GetValues<Stat>().Length];
+
+    public int[] PercentageStats { get; set; } = new int[Enum.GetValues<Stat>().Length];
+
+    public long[] Vitals { get; set; } = new long[Enum.GetValues<Vital>().Length];
+
+    public long[] VitalsRegen { get; set; } = new long[Enum.GetValues<Vital>().Length];
+
+    public int[] PercentageVitals { get; set; } = new int[Enum.GetValues<Vital>().Length];
+
+    public List<EffectData> Effects { get; set; } = new();
+
+    public void Validate()
+    {
+        Stats = ArrayExtensions.EnsureLen(Stats, Enum.GetValues<Stat>().Length);
+        PercentageStats = ArrayExtensions.EnsureLen(PercentageStats, Enum.GetValues<Stat>().Length);
+        Vitals = ArrayExtensions.EnsureLen(Vitals, Enum.GetValues<Vital>().Length);
+        VitalsRegen = ArrayExtensions.EnsureLen(VitalsRegen, Enum.GetValues<Vital>().Length);
+        PercentageVitals = ArrayExtensions.EnsureLen(PercentageVitals, Enum.GetValues<Vital>().Length);
+        Effects ??= new List<EffectData>();
+    }
+
+    [JsonIgnore]
+    public bool HasBonuses =>
+        Stats.Any(s => s != 0) ||
+        PercentageStats.Any(s => s != 0) ||
+        Vitals.Any(v => v != 0) ||
+        PercentageVitals.Any(v => v != 0) ||
+        VitalsRegen.Any(v => v != 0) ||
+        Effects.Any();
+
+    public (int[] stats, int[] percentStats, long[] vitals, long[] vitalsRegen, int[] percentVitals, List<EffectData> effects) GetBonuses()
+    {
+        return (
+            Stats.ToArray(),
+            PercentageStats.ToArray(),
+            Vitals.ToArray(),
+            VitalsRegen.ToArray(),
+            PercentageVitals.ToArray(),
+            Effects.Select(e => new EffectData(e.Type, e.Percentage)).ToList()
+        );
+    }
+
+    public int GetEffectPercentage(ItemEffect type)
+    {
+        return Effects.Find(effect => effect.Type == type)?.Percentage ?? 0;
+    }
+
+    public void SetEffectOfType(ItemEffect type, int value)
+    {
+        var effectToEdit = Effects.Find(effect => effect.Type == type);
+        if (effectToEdit != null)
+        {
+            effectToEdit.Percentage = value;
+        }
+    }
+
+    [JsonIgnore]
+    public ItemEffect[] EffectsEnabled => Effects.Select(effect => effect.Type).ToArray();
+}
+

--- a/Intersect.Server.Core/CustomChanges/PlayerCustom.cs
+++ b/Intersect.Server.Core/CustomChanges/PlayerCustom.cs
@@ -296,8 +296,7 @@ namespace Intersect.Server.Entities
                     continue;
                 }
 
-                var ratio = (float)grp.Count() / Math.Max(1, set.ItemIds.Count);
-                var (s, ps, v, vr, pv, eff) = set.GetBonuses(ratio);
+                var (s, ps, v, vr, pv, eff) = set.GetBonuses(grp.Count());
 
                 for (var i = 0; i < stats.Length; i++)
                 {

--- a/Intersect.Tests/GameObjects/SetDescriptorTests.cs
+++ b/Intersect.Tests/GameObjects/SetDescriptorTests.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using Intersect.Enums;
+using Intersect.Framework.Core.GameObjects.Items;
 using Intersect.GameObjects;
 using NUnit.Framework;
 
@@ -12,20 +14,27 @@ public class SetDescriptorTests
     {
         var descriptor = new SetDescriptor(Guid.NewGuid())
         {
-            Stats = new int[1],
-            PercentageStats = new int[1],
-            Vitals = new long[1],
-            VitalsRegen = new long[1],
-            PercentageVitals = new int[1]
+            BonusTiers = new Dictionary<int, SetBonusTier>
+            {
+                [1] = new SetBonusTier
+                {
+                    Stats = new int[1],
+                    PercentageStats = new int[1],
+                    Vitals = new long[1],
+                    VitalsRegen = new long[1],
+                    PercentageVitals = new int[1]
+                }
+            }
         };
 
         descriptor.Validate();
 
-        Assert.That(descriptor.Stats.Length, Is.EqualTo(Enum.GetValues<Stat>().Length));
-        Assert.That(descriptor.PercentageStats.Length, Is.EqualTo(Enum.GetValues<Stat>().Length));
-        Assert.That(descriptor.Vitals.Length, Is.EqualTo(Enum.GetValues<Vital>().Length));
-        Assert.That(descriptor.VitalsRegen.Length, Is.EqualTo(Enum.GetValues<Vital>().Length));
-        Assert.That(descriptor.PercentageVitals.Length, Is.EqualTo(Enum.GetValues<Vital>().Length));
+        var tier = descriptor.BonusTiers[1];
+        Assert.That(tier.Stats.Length, Is.EqualTo(Enum.GetValues<Stat>().Length));
+        Assert.That(tier.PercentageStats.Length, Is.EqualTo(Enum.GetValues<Stat>().Length));
+        Assert.That(tier.Vitals.Length, Is.EqualTo(Enum.GetValues<Vital>().Length));
+        Assert.That(tier.VitalsRegen.Length, Is.EqualTo(Enum.GetValues<Vital>().Length));
+        Assert.That(tier.PercentageVitals.Length, Is.EqualTo(Enum.GetValues<Vital>().Length));
     }
 
     [Test]
@@ -35,31 +44,65 @@ public class SetDescriptorTests
         var vitalLen = Enum.GetValues<Vital>().Length;
         var descriptor = new SetDescriptor(Guid.NewGuid())
         {
-            Stats = new int[statLen + 1],
-            PercentageStats = new int[statLen + 1],
-            Vitals = new long[vitalLen + 1],
-            VitalsRegen = new long[vitalLen + 1],
-            PercentageVitals = new int[vitalLen + 1]
+            BonusTiers = new Dictionary<int, SetBonusTier>
+            {
+                [1] = new SetBonusTier
+                {
+                    Stats = new int[statLen + 1],
+                    PercentageStats = new int[statLen + 1],
+                    Vitals = new long[vitalLen + 1],
+                    VitalsRegen = new long[vitalLen + 1],
+                    PercentageVitals = new int[vitalLen + 1]
+                }
+            }
         };
 
-        descriptor.Stats[^1] = 42;
-        descriptor.PercentageStats[^1] = 42;
-        descriptor.Vitals[^1] = 42;
-        descriptor.VitalsRegen[^1] = 42;
-        descriptor.PercentageVitals[^1] = 42;
+        var tier = descriptor.BonusTiers[1];
+        tier.Stats[^1] = 42;
+        tier.PercentageStats[^1] = 42;
+        tier.Vitals[^1] = 42;
+        tier.VitalsRegen[^1] = 42;
+        tier.PercentageVitals[^1] = 42;
 
         descriptor.Validate();
 
-        Assert.That(descriptor.Stats.Length, Is.EqualTo(statLen));
-        Assert.That(descriptor.PercentageStats.Length, Is.EqualTo(statLen));
-        Assert.That(descriptor.Vitals.Length, Is.EqualTo(vitalLen));
-        Assert.That(descriptor.VitalsRegen.Length, Is.EqualTo(vitalLen));
-        Assert.That(descriptor.PercentageVitals.Length, Is.EqualTo(vitalLen));
+        var validatedTier = descriptor.BonusTiers[1];
+        Assert.That(validatedTier.Stats.Length, Is.EqualTo(statLen));
+        Assert.That(validatedTier.PercentageStats.Length, Is.EqualTo(statLen));
+        Assert.That(validatedTier.Vitals.Length, Is.EqualTo(vitalLen));
+        Assert.That(validatedTier.VitalsRegen.Length, Is.EqualTo(vitalLen));
+        Assert.That(validatedTier.PercentageVitals.Length, Is.EqualTo(vitalLen));
 
-        Assert.That(descriptor.Stats, Does.Not.Contain(42));
-        Assert.That(descriptor.PercentageStats, Does.Not.Contain(42));
-        Assert.That(descriptor.Vitals, Does.Not.Contain(42L));
-        Assert.That(descriptor.VitalsRegen, Does.Not.Contain(42L));
-        Assert.That(descriptor.PercentageVitals, Does.Not.Contain(42));
+        Assert.That(validatedTier.Stats, Does.Not.Contain(42));
+        Assert.That(validatedTier.PercentageStats, Does.Not.Contain(42));
+        Assert.That(validatedTier.Vitals, Does.Not.Contain(42L));
+        Assert.That(validatedTier.VitalsRegen, Does.Not.Contain(42L));
+        Assert.That(validatedTier.PercentageVitals, Does.Not.Contain(42));
+    }
+
+    [Test]
+    public void ValidateMigratesLegacyBonuses()
+    {
+        var descriptor = new SetDescriptor(Guid.NewGuid())
+        {
+            Stats = new[] { 1 },
+            PercentageStats = new[] { 2 },
+            Vitals = new long[] { 3 },
+            VitalsRegen = new long[] { 4 },
+            PercentageVitals = new[] { 5 },
+            Effects = new List<EffectData> { new(ItemEffect.Luck, 10) },
+            ItemIds = new List<Guid> { Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid() }
+        };
+
+        descriptor.Validate();
+
+        Assert.That(descriptor.BonusTiers.ContainsKey(3), Is.True);
+        var tier = descriptor.BonusTiers[3];
+        Assert.That(tier.Stats[0], Is.EqualTo(1));
+        Assert.That(tier.PercentageStats[0], Is.EqualTo(2));
+        Assert.That(tier.Vitals[0], Is.EqualTo(3));
+        Assert.That(tier.VitalsRegen[0], Is.EqualTo(4));
+        Assert.That(tier.PercentageVitals[0], Is.EqualTo(5));
+        Assert.That(tier.Effects[0].Percentage, Is.EqualTo(10));
     }
 }


### PR DESCRIPTION
## Summary
- introduce `SetBonusTier` and tier dictionary in `SetDescriptor`
- migrate legacy single-tier data to default tier for full set
- adjust set bonus calculations to use tier based on piece count
- update tests for tiered bonuses

## Testing
- `~/.dotnet/dotnet test Intersect.Tests/Intersect.Tests.csproj --filter "SetDescriptorTests"`

------
https://chatgpt.com/codex/tasks/task_e_68ab77efc26c8324837b005cd537553e