### PR TITLE
Cache set bonus calculations

### DIFF
--- a/Intersect.Server.Core/Entities/Player.cs
+++ b/Intersect.Server.Core/Entities/Player.cs
@@ -176,6 +176,27 @@ public partial class Player : Entity
     [NotMapped, JsonIgnore]
     private readonly Dictionary<ItemEffect, int> mEquipmentBonusEffects = new();
 
+    [NotMapped, JsonIgnore]
+    private readonly int[] mSetBonusStats = new int[Enum.GetValues<Stat>().Length];
+
+    [NotMapped, JsonIgnore]
+    private readonly int[] mSetBonusPercentStats = new int[Enum.GetValues<Stat>().Length];
+
+    [NotMapped, JsonIgnore]
+    private readonly long[] mSetBonusVitals = new long[Enum.GetValues<Vital>().Length];
+
+    [NotMapped, JsonIgnore]
+    private readonly long[] mSetBonusVitalsRegen = new long[Enum.GetValues<Vital>().Length];
+
+    [NotMapped, JsonIgnore]
+    private readonly int[] mSetBonusPercentVitals = new int[Enum.GetValues<Vital>().Length];
+
+    [NotMapped, JsonIgnore]
+    private List<EffectData> mSetBonusEffects = new();
+
+    [NotMapped, JsonIgnore]
+    private int mSetBonusHash;
+
 
     public DateTime? LastOnline { get; set; }
 


### PR DESCRIPTION
## Summary
- cache set bonus stats and effects on the player
- recompute set bonuses only when equipment hash changes
- snapshot equipment state before recalculating for thread safety

## Testing
- `dotnet test Intersect.Tests/Intersect.Tests.csproj` *(fails: NetPacketReader, DeliveryMethod, NetLogLevel, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7a7c42708324aa7a75eeb087c1cd