### PR TITLE
Add effect stacking and passive filtering for item effects

### DIFF
--- a/Documentation/effect-stacking.md
+++ b/Documentation/effect-stacking.md
@@ -1,0 +1,13 @@
+# Effect Stacking Rules
+
+`EffectData` now defines how item effects behave when multiple instances of the same effect are applied.
+
+## Properties
+
+- `IsPassive`: only effects marked as passive are applied during stat construction.
+- `Stacking`:
+  - `Stack` – duplicate effects add their percentages together.
+  - `Renew` – a duplicate replaces the existing effect, renewing its duration.
+  - `Ignore` – duplicates are discarded.
+
+Active effects (`IsPassive` set to `false`) are ignored when building equipment stats and must be handled by runtime systems.

--- a/Framework/Intersect.Framework.Core/GameObjects/Items/EffectData.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Items/EffectData.cs
@@ -9,15 +9,28 @@ public partial class EffectData
     {
         Type = default;
         Percentage = default;
+        IsPassive = true;
+        Stacking = EffectStacking.Stack;
     }
 
-    public EffectData(ItemEffect type, int percentage)
+    public EffectData(
+        ItemEffect type,
+        int percentage,
+        bool isPassive = true,
+        EffectStacking stacking = EffectStacking.Stack
+    )
     {
         Type = type;
         Percentage = percentage;
+        IsPassive = isPassive;
+        Stacking = stacking;
     }
 
     public ItemEffect Type { get; set; }
 
     public int Percentage { get; set; }
+
+    public bool IsPassive { get; set; }
+
+    public EffectStacking Stacking { get; set; }
 }

--- a/Framework/Intersect.Framework.Core/GameObjects/Items/EffectExtensions.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Items/EffectExtensions.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+
+namespace Intersect.Framework.Core.GameObjects.Items;
+
+public static class EffectExtensions
+{
+    public static void ApplyEffect(this IDictionary<ItemEffect, int> dest, EffectData effect)
+    {
+        if (!effect.IsPassive)
+        {
+            return;
+        }
+
+        switch (effect.Stacking)
+        {
+            case EffectStacking.Ignore:
+                if (!dest.ContainsKey(effect.Type))
+                {
+                    dest[effect.Type] = effect.Percentage;
+                }
+                break;
+            case EffectStacking.Renew:
+                dest[effect.Type] = effect.Percentage;
+                break;
+            default:
+                if (dest.ContainsKey(effect.Type))
+                {
+                    dest[effect.Type] += effect.Percentage;
+                }
+                else
+                {
+                    dest[effect.Type] = effect.Percentage;
+                }
+                break;
+        }
+    }
+}

--- a/Framework/Intersect.Framework.Core/GameObjects/Items/EffectStacking.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Items/EffectStacking.cs
@@ -1,0 +1,8 @@
+namespace Intersect.Framework.Core.GameObjects.Items;
+
+public enum EffectStacking
+{
+    Stack,
+    Renew,
+    Ignore
+}

--- a/Framework/Intersect.Framework.Core/GameObjects/SetBonusTier.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/SetBonusTier.cs
@@ -48,7 +48,9 @@ public class SetBonusTier
             Vitals.ToArray(),
             VitalsRegen.ToArray(),
             PercentageVitals.ToArray(),
-            Effects.Select(e => new EffectData(e.Type, e.Percentage)).ToList()
+            Effects
+                .Select(e => new EffectData(e.Type, e.Percentage, e.IsPassive, e.Stacking))
+                .ToList()
         );
     }
 

--- a/Intersect.Server.Core/CustomChanges/PlayerCustom.cs
+++ b/Intersect.Server.Core/CustomChanges/PlayerCustom.cs
@@ -391,14 +391,7 @@ namespace Intersect.Server.Entities
 
             foreach (var effect in setBonuses.effects)
             {
-                if (p.mEquipmentBonusEffects.ContainsKey(effect.Type))
-                {
-                    p.mEquipmentBonusEffects[effect.Type] += effect.Percentage;
-                }
-                else
-                {
-                    p.mEquipmentBonusEffects.Add(effect.Type, effect.Percentage);
-                }
+                p.mEquipmentBonusEffects.ApplyEffect(effect);
             }
 
             for (var vitalIndex = 0; vitalIndex < Enum.GetValues<Vital>().Length; vitalIndex++)

--- a/Intersect.Tests/GameObjects/EffectStackingTests.cs
+++ b/Intersect.Tests/GameObjects/EffectStackingTests.cs
@@ -1,0 +1,51 @@
+using System.Collections.Generic;
+using Intersect.Enums;
+using Intersect.Framework.Core.GameObjects.Items;
+using NUnit.Framework;
+
+namespace Intersect.Tests.GameObjects;
+
+public class EffectStackingTests
+{
+    [Test]
+    public void ApplyEffect_StacksDuplicates()
+    {
+        var bonuses = new Dictionary<ItemEffect, int>();
+        var effect1 = new EffectData(ItemEffect.Luck, 10, true, EffectStacking.Stack);
+        var effect2 = new EffectData(ItemEffect.Luck, 5, true, EffectStacking.Stack);
+        bonuses.ApplyEffect(effect1);
+        bonuses.ApplyEffect(effect2);
+        Assert.That(bonuses[ItemEffect.Luck], Is.EqualTo(15));
+    }
+
+    [Test]
+    public void ApplyEffect_IgnoresDuplicates()
+    {
+        var bonuses = new Dictionary<ItemEffect, int>();
+        var effect1 = new EffectData(ItemEffect.Luck, 10, true, EffectStacking.Ignore);
+        var effect2 = new EffectData(ItemEffect.Luck, 5, true, EffectStacking.Ignore);
+        bonuses.ApplyEffect(effect1);
+        bonuses.ApplyEffect(effect2);
+        Assert.That(bonuses[ItemEffect.Luck], Is.EqualTo(10));
+    }
+
+    [Test]
+    public void ApplyEffect_RenewsDuplicates()
+    {
+        var bonuses = new Dictionary<ItemEffect, int>();
+        var effect1 = new EffectData(ItemEffect.Luck, 10, true, EffectStacking.Renew);
+        var effect2 = new EffectData(ItemEffect.Luck, 5, true, EffectStacking.Renew);
+        bonuses.ApplyEffect(effect1);
+        bonuses.ApplyEffect(effect2);
+        Assert.That(bonuses[ItemEffect.Luck], Is.EqualTo(5));
+    }
+
+    [Test]
+    public void ApplyEffect_SkipsNonPassive()
+    {
+        var bonuses = new Dictionary<ItemEffect, int>();
+        var effect = new EffectData(ItemEffect.Luck, 10, false, EffectStacking.Stack);
+        bonuses.ApplyEffect(effect);
+        Assert.That(bonuses.ContainsKey(ItemEffect.Luck), Is.False);
+    }
+}


### PR DESCRIPTION
## Summary
- extend `EffectData` with passive flag and stacking options
- apply only passive effects when building stats and handle duplicates via stacking rules
- document effect stacking and cover combinations with new tests

## Testing
- `dotnet test Intersect.Tests/Intersect.Tests.csproj` *(fails: LiteNetLib project missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7a7a85d88324971dd6d139805488