### PR TITLE
feat(editor): validate sets before saving

### DIFF
--- a/Framework/Intersect.Framework.Core/GameObjects/SetBonusTier.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/SetBonusTier.cs
@@ -4,6 +4,7 @@ using Intersect.Collections;
 using Newtonsoft.Json;
 using System;
 using System.Linq;
+using System.Runtime.Serialization;
 
 namespace Intersect.GameObjects;
 
@@ -20,6 +21,9 @@ public class SetBonusTier
     public int[] PercentageVitals { get; set; } = new int[Enum.GetValues<Vital>().Length];
 
     public List<EffectData> Effects { get; set; } = new();
+
+    [OnDeserialized]
+    internal void OnDeserializedMethod(StreamingContext context) => Validate();
 
     public void Validate()
     {

--- a/Framework/Intersect.Framework.Core/GameObjects/SetDescriptor.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/SetDescriptor.cs
@@ -9,6 +9,7 @@ using Newtonsoft.Json;
 using System.ComponentModel.DataAnnotations.Schema;
 using System;
 using System.Linq;
+using System.Runtime.Serialization;
 
 namespace Intersect.GameObjects;
 
@@ -26,6 +27,9 @@ public partial class SetDescriptor : DatabaseObject<SetDescriptor>, IFolderable
     {
         Validate();
     }
+
+    [OnDeserialized]
+    internal void OnDeserializedMethod(StreamingContext context) => Validate();
 
 
 

--- a/Intersect.Editor/Forms/Editors/frmSets.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/frmSets.Designer.cs
@@ -84,6 +84,7 @@ partial class frmSets
         btnRemove = new DarkUI.Controls.DarkButton();
         btnAdd = new DarkUI.Controls.DarkButton();
         lblItemSet = new Label();
+        lblTierCount = new Label();
         lstItems = new ListBox();
         grpGeneral = new DarkUI.Controls.DarkGroupBox();
         btnAddFolder = new DarkUI.Controls.DarkButton();
@@ -800,7 +801,7 @@ partial class frmSets
         btnAdd.Click += btnAdd_Click;
         // 
         // lblItemSet
-        // 
+        //
         lblItemSet.AutoSize = true;
         lblItemSet.Location = new System.Drawing.Point(9, 222);
         lblItemSet.Margin = new Padding(4, 0, 4, 0);
@@ -808,6 +809,9 @@ partial class frmSets
         lblItemSet.Size = new Size(34, 15);
         lblItemSet.TabIndex = 31;
         lblItemSet.Text = "Item:";
+        //
+        // lblTierCount
+        //
         // 
         // lstItems
         // 
@@ -1087,6 +1091,16 @@ partial class frmSets
         grpEffects.TabIndex = 60;
         grpEffects.TabStop = false;
         grpEffects.Text = "Bonus Effects";
+        //
+        // lblTierCount
+        //
+        lblTierCount.AutoSize = true;
+        lblTierCount.Location = new System.Drawing.Point(243, 446);
+        lblTierCount.Margin = new Padding(4, 0, 4, 0);
+        lblTierCount.Name = "lblTierCount";
+        lblTierCount.Size = new Size(130, 15);
+        lblTierCount.TabIndex = 50;
+        lblTierCount.Text = "Defined/Equipped: 0/0";
         // 
         // lstBonusEffects
         // 
@@ -1314,6 +1328,7 @@ partial class frmSets
         Controls.Add(grpEffects);
         Controls.Add(grpVitalBonuses);
         Controls.Add(grpItemsSets);
+        Controls.Add(lblTierCount);
         Controls.Add(btnCancel);
         Controls.Add(grpGeneral);
         Controls.Add(grpRegen);
@@ -1377,6 +1392,7 @@ partial class frmSets
     private DarkUI.Controls.DarkButton btnRemove;
     private DarkUI.Controls.DarkButton btnAdd;
     private Label lblItemSet;
+    private Label lblTierCount;
     private ListBox lstItems;
     private DarkUI.Controls.DarkGroupBox grpGeneral;
     private DarkUI.Controls.DarkButton btnAddFolder;

--- a/Intersect.Editor/Forms/Editors/frmSets.cs
+++ b/Intersect.Editor/Forms/Editors/frmSets.cs
@@ -11,6 +11,7 @@ using Intersect.Editor.General;
 using Intersect.Framework.Core.Config;
 using Intersect.Models;
 using Intersect.Framework.Core.GameObjects.Items;
+using System.Linq;
 
 namespace Intersect.Editor.Forms.Editors;
 
@@ -130,9 +131,8 @@ public partial class frmSets : EditorForm
                 mEditorSet.MakeBackup();
             }
         }
-
-
-
+        UpdateTierCountLabel();
+        UpdateSaveButton();
         UpdateToolStripItems();
     }
     private void form_KeyDown(object sender, KeyEventArgs e)
@@ -156,6 +156,31 @@ public partial class frmSets : EditorForm
             lstBonusEffects.Items.Add(GetBonusEffectRow((ItemEffect)idx));
             idx++;
         }
+    }
+
+    private void UpdateSaveButton()
+    {
+        if (mEditorSet == null)
+        {
+            btnSave.Enabled = false;
+            return;
+        }
+
+        var ids = mEditorSet.ItemIds;
+        var hasItems = ids.Count > 0;
+        var hasDuplicates = ids.Count != ids.Distinct().Count;
+        btnSave.Enabled = hasItems && !hasDuplicates;
+    }
+
+    private void UpdateTierCountLabel()
+    {
+        if (mEditorSet == null)
+        {
+            lblTierCount.Text = "Defined/Equipped: 0/0";
+            return;
+        }
+
+        lblTierCount.Text = $"Defined/Equipped: {mEditorSet.BonusTiers.Count}/{mEditorSet.ItemIds.Count}";
     }
     private void btnSave_Click(object sender, EventArgs e)
     {
@@ -201,6 +226,9 @@ public partial class frmSets : EditorForm
 
             cmbItems.SelectedIndex = 0;
         }
+
+        UpdateTierCountLabel();
+        UpdateSaveButton();
     }
 
     private void btnRemove_Click(object sender, EventArgs e)
@@ -217,6 +245,9 @@ public partial class frmSets : EditorForm
             lstItems.Items.Remove(selectedItem);
             mEditorSet.ItemIds.Remove(selectedItem.Id);
         }
+
+        UpdateTierCountLabel();
+        UpdateSaveButton();
     }
 
     private void toolStripItemNew_Click(object sender, EventArgs e)


### PR DESCRIPTION
## Summary
- disable Set save when items are missing or duplicated
- ensure set bonus arrays are validated on deserialization
- show defined vs equipped item counts while editing a set

## Testing
- `dotnet test Intersect.Tests/Intersect.Tests.csproj` *(fails: The name 'ClassDescriptor' does not exist)*
- `dotnet build Intersect.Editor/Intersect.Editor.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7e0a678883249578bf87623186b0