### PR TITLE
Guard index removal in set migrations

### DIFF
--- a/Intersect.Server.Core/Migrations/Sqlite/Game/20250824183759_AddedSetSystem.cs
+++ b/Intersect.Server.Core/Migrations/Sqlite/Game/20250824183759_AddedSetSystem.cs
@@ -63,9 +63,8 @@ namespace Intersect.Server.Migrations.Sqlite.Game
                 name: "FK_Items_Sets_Set",
                 table: "Items");
 
-            migrationBuilder.DropIndex(
-                name: "IX_Items_Set",
-                table: "Items");
+            // This index may not exist if a newer migration has already removed it.
+            migrationBuilder.Sql("DROP INDEX IF EXISTS \"IX_Items_Set\";");
 
             migrationBuilder.DropTable(
                 name: "Sets");

--- a/Intersect.Server.Core/Migrations/Sqlite/Game/20250824235256_AddedSetTiersSystem.cs
+++ b/Intersect.Server.Core/Migrations/Sqlite/Game/20250824235256_AddedSetTiersSystem.cs
@@ -14,9 +14,8 @@ namespace Intersect.Server.Migrations.Sqlite.Game
                 name: "FK_Items_Sets_Set",
                 table: "Items");
 
-            migrationBuilder.DropIndex(
-                name: "IX_Items_Set",
-                table: "Items");
+            // Older databases may already have the index removed, so guard the drop.
+            migrationBuilder.Sql("DROP INDEX IF EXISTS \"IX_Items_Set\";");
 
             migrationBuilder.AlterColumn<string>(
                 name: "VitalsRegen",


### PR DESCRIPTION
## Summary
- Guard `IX_Items_Set` index drops so migrations succeed even when the index is absent

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*
- `dotnet test Intersect.Tests.Server/Intersect.Tests.Server.csproj` *(fails: Could not find path 'Intersect.Network/bin/Release/keys/network.handshake.bkey.pub')*

------
https://chatgpt.com/codex/tasks/task_e_68ababb2be748324ac2e8eca04d6ad2a