### PR TITLE
Handle null equipment descriptors in set bonus calculation

### DIFF
--- a/Intersect.Server.Core/CustomChanges/PlayerCustom.cs
+++ b/Intersect.Server.Core/CustomChanges/PlayerCustom.cs
@@ -293,7 +293,11 @@ namespace Intersect.Server.Entities
             {
                 foreach (var slot in kvp.Value)
                 {
-                    if (!TryGetItemAt(slot, out var item) || item?.Descriptor?.SetId == Guid.Empty)
+                    if (
+                        !TryGetItemAt(slot, out var item) ||
+                        item?.Descriptor == null ||
+                        item.Descriptor.SetId == Guid.Empty
+                    )
                     {
                         continue;
                     }


### PR DESCRIPTION
## Summary
- safeguard set bonus calculation against items missing descriptors to avoid null reference exceptions

## Testing
- `dotnet test` *(fails: project file "/workspace/Broken_Reborn/vendor/LiteNetLib/LiteNetLib/LiteNetLib.csproj" was not found)*
- `dotnet build Intersect.Server.Core/Intersect.Server.Core.csproj` *(fails: NetPacketReader and other types not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abb1c7abc4832499d33c1dc2727a1e