### PR TITLE
feat(editor): add auto-fill tier distribution

### DIFF
--- a/Intersect.Editor/Forms/Editors/frmSets.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/frmSets.Designer.cs
@@ -80,6 +80,11 @@ partial class frmSets
         lblVit = new Label();
         lblWis = new Label();
         grpItemsSets = new DarkUI.Controls.DarkGroupBox();
+        grpAutoTiers = new DarkUI.Controls.DarkGroupBox();
+        cmbTierPattern = new DarkUI.Controls.DarkComboBox();
+        chkDistributeFlat = new DarkUI.Controls.DarkCheckBox();
+        chkClearExisting = new DarkUI.Controls.DarkCheckBox();
+        btnAutoFillTiers = new DarkUI.Controls.DarkButton();
         cmbItems = new DarkUI.Controls.DarkComboBox();
         btnRemove = new DarkUI.Controls.DarkButton();
         btnAdd = new DarkUI.Controls.DarkButton();
@@ -145,6 +150,7 @@ partial class frmSets
         ((System.ComponentModel.ISupportInitialize)nudVit).BeginInit();
         ((System.ComponentModel.ISupportInitialize)nudAgi).BeginInit();
         grpItemsSets.SuspendLayout();
+        grpAutoTiers.SuspendLayout();
         grpGeneral.SuspendLayout();
         grpVitalBonuses.SuspendLayout();
         ((System.ComponentModel.ISupportInitialize)nudMPPercentage).BeginInit();
@@ -755,6 +761,64 @@ partial class frmSets
         grpItemsSets.TabIndex = 47;
         grpItemsSets.TabStop = false;
         grpItemsSets.Text = "Item";
+
+        // grpAutoTiers
+        grpAutoTiers.BackColor = System.Drawing.Color.FromArgb(45,45,48);
+        grpAutoTiers.BorderColor = System.Drawing.Color.FromArgb(90,90,90);
+        grpAutoTiers.ForeColor = System.Drawing.Color.Gainsboro;
+        grpAutoTiers.Location = new System.Drawing.Point(244, 446);
+        grpAutoTiers.Margin = new Padding(4,3,4,3);
+        grpAutoTiers.Name = "grpAutoTiers";
+        grpAutoTiers.Padding = new Padding(8,6,8,8);
+        grpAutoTiers.Size = new Size(536, 86);
+        grpAutoTiers.TabIndex = 90;
+        grpAutoTiers.TabStop = false;
+        grpAutoTiers.Text = "Auto-fill Tiers";
+
+        // cmbTierPattern
+        cmbTierPattern.BackColor = System.Drawing.Color.FromArgb(69,73,74);
+        cmbTierPattern.BorderColor = System.Drawing.Color.FromArgb(90,90,90);
+        cmbTierPattern.DrawMode = DrawMode.OwnerDrawFixed;
+        cmbTierPattern.DropDownStyle = ComboBoxStyle.DropDownList;
+        cmbTierPattern.FlatStyle = FlatStyle.Flat;
+        cmbTierPattern.ForeColor = System.Drawing.Color.Gainsboro;
+        cmbTierPattern.Location = new System.Drawing.Point(12, 24);
+        cmbTierPattern.Name = "cmbTierPattern";
+        cmbTierPattern.Size = new Size(180, 24);
+        cmbTierPattern.Items.AddRange(new object[] {
+            "Balanceado (40/30/20/10)",
+            "Adelantado (60/25/10/5)",
+            "Atrasado (10/20/30/40)",
+            "Parejo (igual por tier)"
+        });
+        cmbTierPattern.SelectedIndex = 0;
+
+        // chkDistributeFlat
+        chkDistributeFlat.Location = new System.Drawing.Point(210, 24);
+        chkDistributeFlat.Name = "chkDistributeFlat";
+        chkDistributeFlat.Size = new Size(150, 24);
+        chkDistributeFlat.Text = "Incluir valores planos";
+        chkDistributeFlat.Checked = false;
+
+        // chkClearExisting
+        chkClearExisting.Location = new System.Drawing.Point(210, 50);
+        chkClearExisting.Name = "chkClearExisting";
+        chkClearExisting.Size = new Size(180, 24);
+        chkClearExisting.Text = "Limpiar tiers existentes";
+        chkClearExisting.Checked = true;
+
+        // btnAutoFillTiers
+        btnAutoFillTiers.Location = new System.Drawing.Point(400, 26);
+        btnAutoFillTiers.Name = "btnAutoFillTiers";
+        btnAutoFillTiers.Padding = new Padding(6);
+        btnAutoFillTiers.Size = new Size(120, 28);
+        btnAutoFillTiers.Text = "Autorrellenar";
+        btnAutoFillTiers.Click += btnAutoFillTiers_Click;
+
+        grpAutoTiers.Controls.Add(cmbTierPattern);
+        grpAutoTiers.Controls.Add(chkDistributeFlat);
+        grpAutoTiers.Controls.Add(chkClearExisting);
+        grpAutoTiers.Controls.Add(btnAutoFillTiers);
         // 
         // cmbItems
         // 
@@ -1327,6 +1391,7 @@ partial class frmSets
         Controls.Add(grpStats);
         Controls.Add(grpEffects);
         Controls.Add(grpVitalBonuses);
+        Controls.Add(grpAutoTiers);
         Controls.Add(grpItemsSets);
         Controls.Add(lblTierCount);
         Controls.Add(btnCancel);
@@ -1377,6 +1442,8 @@ partial class frmSets
         grpRegen.PerformLayout();
         ((System.ComponentModel.ISupportInitialize)nudMpRegen).EndInit();
         ((System.ComponentModel.ISupportInitialize)nudHPRegen).EndInit();
+        grpAutoTiers.ResumeLayout(false);
+        grpAutoTiers.PerformLayout();
         toolStrip.ResumeLayout(false);
         toolStrip.PerformLayout();
         ResumeLayout(false);
@@ -1388,6 +1455,11 @@ partial class frmSets
     private DarkUI.Controls.DarkTextBox txtSearch;
     private Controls.GameObjectList lstGameObjects;
     private DarkUI.Controls.DarkGroupBox grpItemsSets;
+    private DarkUI.Controls.DarkGroupBox grpAutoTiers;
+    private DarkUI.Controls.DarkComboBox cmbTierPattern;
+    private DarkUI.Controls.DarkCheckBox chkDistributeFlat;
+    private DarkUI.Controls.DarkCheckBox chkClearExisting;
+    private DarkUI.Controls.DarkButton btnAutoFillTiers;
     private DarkUI.Controls.DarkComboBox cmbItems;
     private DarkUI.Controls.DarkButton btnRemove;
     private DarkUI.Controls.DarkButton btnAdd;

--- a/Intersect.Editor/Forms/Editors/frmSets.cs
+++ b/Intersect.Editor/Forms/Editors/frmSets.cs
@@ -250,6 +250,161 @@ public partial class frmSets : EditorForm
         UpdateSaveButton();
     }
 
+    // -------------------- AUTOFILL TIERS --------------------
+    private void btnAutoFillTiers_Click(object? sender, EventArgs e)
+    {
+        if (mEditorSet == null)
+            return;
+
+        var totalItems = mEditorSet.ItemIds?.Count ?? 0;
+        if (totalItems < 2)
+        {
+            DarkMessageBox.ShowWarning("Este set necesita al menos 2 ítems para definir tiers.", "Auto-fill Tiers");
+            return;
+        }
+
+        // Rango de tiers: 2..totalItems
+        var tierKeys = Enumerable.Range(2, Math.Max(0, totalItems - 1)).ToArray();
+        if (tierKeys.Length == 0) return;
+
+        if (chkClearExisting.Checked)
+        {
+            mEditorSet.BonusTiers.Clear();
+        }
+
+        // Construye pesos según patrón
+        var weights = BuildDistribution(tierKeys.Length, cmbTierPattern.SelectedIndex);
+
+        // Lee valores totales desde NUD (objetivo a distribuir)
+        var flatsStats = new int[(int)Intersect.Enums.Stat.Speed + 1];
+        var pctStats   = new int[flatsStats.Length];
+
+        flatsStats[(int)Stat.Attack]      = (int)nudStr.Value;
+        flatsStats[(int)Stat.Agility]     = (int)nudAgi.Value;
+        flatsStats[(int)Stat.Vitality]    = (int)nudVit.Value;
+        flatsStats[(int)Stat.Intelligence]= (int)nudInt.Value;
+        flatsStats[(int)Stat.Damages]     = (int)nudDmg.Value;
+        flatsStats[(int)Stat.Defense]     = (int)nudDef.Value;
+        flatsStats[(int)Stat.Cures]       = (int)nudCur.Value;
+        flatsStats[(int)Stat.Speed]       = (int)nudSpd.Value;
+
+        pctStats[(int)Stat.Attack]        = (int)nudStrPercentage.Value;
+        pctStats[(int)Stat.Agility]       = (int)nudAgiPercentage.Value;
+        pctStats[(int)Stat.Vitality]      = (int)nudVitPercentage.Value;
+        pctStats[(int)Stat.Intelligence]  = (int)nudIntPercentage.Value;
+        pctStats[(int)Stat.Damages]       = (int)nudDmgPercentage.Value;
+        pctStats[(int)Stat.Defense]       = (int)nudDefPercentage.Value;
+        pctStats[(int)Stat.Cures]         = (int)nudCurPercentage.Value;
+        pctStats[(int)Stat.Speed]         = (int)nudSpdPercentage.Value;
+
+        // Vitals (bonus planos + %)
+        var flatsVitals = new long[(int)Vital.Mana + 1];
+        var pctVitals   = new int[flatsVitals.Length];
+        var regenVitals = new long[flatsVitals.Length];
+
+        flatsVitals[(int)Vital.Health] = (long)nudHealthBonus.Value;
+        flatsVitals[(int)Vital.Mana]   = (long)nudManaBonus.Value;
+        pctVitals[(int)Vital.Health]   = (int)nudHPPercentage.Value;
+        pctVitals[(int)Vital.Mana]     = (int)nudMPPercentage.Value;
+        regenVitals[(int)Vital.Health] = (long)nudHPRegen.Value;
+        regenVitals[(int)Vital.Mana]   = (long)nudMpRegen.Value;
+
+        bool includeFlat = chkDistributeFlat.Checked;
+
+        // Distribuir por tier
+        for (int i = 0; i < tierKeys.Length; i++)
+        {
+            int req = tierKeys[i];
+            float w = weights[i];
+
+            var tier = mEditorSet.BonusTiers.ContainsKey(req)
+                ? mEditorSet.BonusTiers[req]
+                : new SetBonusTier();
+
+            // Asegurar tamaños
+            EnsureArrays(ref tier);
+
+            // Porcentajes SIEMPRE se distribuyen
+            for (int s = 0; s < pctStats.Length; s++)
+            {
+                tier.PercentageStats[s] = RoundShare(pctStats[s], w);
+            }
+            for (int v = 0; v < pctVitals.Length; v++)
+            {
+                tier.PercentageVitals[v] = RoundShare(pctVitals[v], w);
+            }
+
+            // Planos: opcional (suelen dejarse en tiers bajos o no repartirlos)
+            if (includeFlat)
+            {
+                for (int s = 0; s < flatsStats.Length; s++)
+                {
+                    tier.Stats[s] = RoundShare(flatsStats[s], w);
+                }
+                for (int v = 0; v < flatsVitals.Length; v++)
+                {
+                    tier.Vitals[v] = RoundShare(flatsVitals[v], w);
+                    tier.VitalsRegen[v] = RoundShare(regenVitals[v], w);
+                }
+            }
+
+            mEditorSet.BonusTiers[req] = tier;
+        }
+
+        UpdateTierCountLabel();
+        UpdateSaveButton();
+        if (!mChanged.Contains(mEditorSet))
+        {
+            mChanged.Add(mEditorSet);
+            mEditorSet.MakeBackup();
+        }
+    }
+
+    private static void EnsureArrays(ref SetBonusTier tier)
+    {
+        int vlen = Enum.GetValues(typeof(Vital)).Length;
+        int slen = Enum.GetValues(typeof(Stat)).Length;
+        tier.Vitals           = (tier.Vitals?.Length == vlen) ? tier.Vitals : new long[vlen];
+        tier.VitalsRegen      = (tier.VitalsRegen?.Length == vlen) ? tier.VitalsRegen : new long[vlen];
+        tier.PercentageVitals = (tier.PercentageVitals?.Length == vlen) ? tier.PercentageVitals : new int[vlen];
+        tier.Stats            = (tier.Stats?.Length == slen) ? tier.Stats : new int[slen];
+        tier.PercentageStats  = (tier.PercentageStats?.Length == slen) ? tier.PercentageStats : new int[slen];
+        tier.Effects ??= new List<EffectData>();
+    }
+
+    private static int RoundShare(int total, float w) =>
+        (int)Math.Round(total * w, MidpointRounding.AwayFromZero);
+    private static long RoundShare(long total, float w) =>
+        (long)Math.Round(total * w, MidpointRounding.AwayFromZero);
+
+    /// <summary>
+    /// Devuelve pesos normalizados (suman 1.0f) para los tiers 2..N.
+    /// idxPattern: 0 Balanceado, 1 Adelantado, 2 Atrasado, 3 Parejo
+    /// </summary>
+    private static float[] BuildDistribution(int length, int idxPattern)
+    {
+        var raw = new float[length];
+        switch (idxPattern)
+        {
+            case 1: // Adelantado: más peso en el primer tier (2 piezas)
+                for (int i = 0; i < length; i++) raw[i] = (float)Math.Pow(0.5, i); // 1, 0.5, 0.25, ...
+                break;
+            case 2: // Atrasado: más peso en el último tier (N piezas)
+                for (int i = 0; i < length; i++) raw[i] = (float)Math.Pow(0.5, (length - 1 - i));
+                break;
+            case 3: // Parejo
+                for (int i = 0; i < length; i++) raw[i] = 1f;
+                break;
+            default: // Balanceado (suave decreciente)
+                for (int i = 0; i < length; i++) raw[i] = (length - i); // e.g. 4,3,2,1
+                break;
+        }
+        var sum = raw.Sum();
+        if (sum <= 0f) { for (int i = 0; i < length; i++) raw[i] = 1f; sum = length; }
+        for (int i = 0; i < length; i++) raw[i] /= sum;
+        return raw;
+    }
+
     private void toolStripItemNew_Click(object sender, EventArgs e)
     {
         PacketSender.SendCreateObject(GameObjectType.Sets);


### PR DESCRIPTION
## Summary
- add Auto-fill Tiers UI section to Sets editor
- implement tier distribution logic to split stats across tiers

## Testing
- `dotnet build Intersect.Editor/Intersect.Editor.csproj` *(fails: Microsoft.WindowsDesktop.App.WindowsForms runtime pack not available for linux-x64)*
- `dotnet test Intersect.Tests.Editor/Intersect.Tests.Editor.csproj` *(fails during build/restore due to Windows-specific target)*

------
https://chatgpt.com/codex/tasks/task_e_68abe15f86908324ab3e058db12cf845