### PR TITLE
Fix stats array size for AutoFillTiers

### DIFF
--- a/Intersect.Editor/Forms/Editors/frmSets.cs
+++ b/Intersect.Editor/Forms/Editors/frmSets.cs
@@ -276,8 +276,9 @@ public partial class frmSets : EditorForm
         var weights = BuildDistribution(tierKeys.Length, cmbTierPattern.SelectedIndex);
 
         // Lee valores totales desde NUD (objetivo a distribuir)
-        var flatsStats = new int[(int)Intersect.Enums.Stat.Speed + 1];
-        var pctStats   = new int[flatsStats.Length];
+        var statsLength = Enum.GetValues<Stat>().Length;
+        var flatsStats = new int[statsLength];
+        var pctStats = new int[statsLength];
 
         flatsStats[(int)Stat.Attack]      = (int)nudStr.Value;
         flatsStats[(int)Stat.Agility]     = (int)nudAgi.Value;


### PR DESCRIPTION
## Summary
- prevent IndexOutOfRangeException when auto-distributing set stats by allocating arrays to match enum length

## Testing
- `dotnet test` *(fails: project file not found for vendor dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68abe3e013a483248c404f4e88665fbe