### PR TITLE
Track spell point investments in spell updates

### DIFF
--- a/Framework/Intersect.Framework.Core/Network/Packets/Server/PlayerEntityPacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Server/PlayerEntityPacket.cs
@@ -70,7 +70,7 @@ public partial class PlayerEntityPacket : EntityPacket
     public byte GuildBackgroundB { get; set; }
 
     [Key(41)]
-    public SpellUpdatePacket[] Spells { get; set; }
+    public SpellUpdatePacket[] Spells { get; set; } = [];
 
     [Key(42)]
     public int SpellPoints { get; set; }

--- a/Framework/Intersect.Framework.Core/Network/Packets/Server/SpellUpdatePacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Server/SpellUpdatePacket.cs
@@ -12,12 +12,19 @@ public partial class SpellUpdatePacket : IntersectPacket
     {
     }
 
-    public SpellUpdatePacket(int slot, Guid spellId, int level, SpellProperties? properties = null)
+    public SpellUpdatePacket(
+        int slot,
+        Guid spellId,
+        int level,
+        SpellProperties? properties = null,
+        int spellPointsSpent = 0
+    )
     {
         Slot = slot;
         SpellId = spellId;
         Level = level;
         Properties = properties;
+        SpellPointsSpent = spellPointsSpent;
     }
 
     [Key(0)]
@@ -31,5 +38,8 @@ public partial class SpellUpdatePacket : IntersectPacket
 
     [Key(3)]
     public SpellProperties? Properties { get; set; }
+
+    [Key(4)]
+    public int SpellPointsSpent { get; set; }
 
 }

--- a/Intersect.Client.Core/Entities/Player.cs
+++ b/Intersect.Client.Core/Entities/Player.cs
@@ -432,7 +432,7 @@ public partial class Player : Entity, IPlayer
                     continue;
                 }
 
-                Spells[spell.Slot].Load(spell.SpellId, spell.Properties);
+                Spells[spell.Slot].Load(spell.SpellId, spell.Properties, spell.SpellPointsSpent);
             }
 
             if (this == Globals.Me)

--- a/Intersect.Client.Core/Networking/PacketHandler.cs
+++ b/Intersect.Client.Core/Networking/PacketHandler.cs
@@ -1398,7 +1398,7 @@ internal sealed partial class PacketHandler
     {
         if (Globals.Me != null)
         {
-            Globals.Me.Spells[packet.Slot].Load(packet.SpellId, packet.Properties);
+            Globals.Me.Spells[packet.Slot].Load(packet.SpellId, packet.Properties, packet.SpellPointsSpent);
             Interface.Interface.EnqueueInGame(ui => ui.SpellsWindow?.Update());
         }
     }

--- a/Intersect.Client.Core/Spells/Spell.cs
+++ b/Intersect.Client.Core/Spells/Spell.cs
@@ -9,6 +9,7 @@ public partial class Spell
     public Guid Id { get; set; }
     public int Level { get; set; }
     public SpellProperties Properties { get; set; } = new();
+    public int SpellPointsSpent { get; set; }
 
     public Spell Clone()
     {
@@ -17,16 +18,18 @@ public partial class Spell
             Id = Id,
             Level = Level,
             Properties = new SpellProperties(Properties),
+            SpellPointsSpent = SpellPointsSpent,
         };
 
         return newSpell;
     }
 
-    public void Load(Guid spellId, SpellProperties? properties)
+    public void Load(Guid spellId, SpellProperties? properties, int spellPointsSpent = 0)
     {
         Id = spellId;
         Properties = properties ?? new SpellProperties();
         Level = Properties.Level;
+        SpellPointsSpent = spellPointsSpent;
     }
 
 }

--- a/Intersect.Server.Core/Entities/Player.cs
+++ b/Intersect.Server.Core/Entities/Player.cs
@@ -1199,7 +1199,8 @@ public partial class Player : Entity
                     i,
                     slot.SpellId,
                     slot.Level,
-                    slot.Properties
+                    slot.Properties,
+                    slot.SpellPointsSpent
                 );
             }
 

--- a/Intersect.Server.Core/Networking/PacketSender.cs
+++ b/Intersect.Server.Core/Networking/PacketSender.cs
@@ -1311,7 +1311,8 @@ public static partial class PacketSender
                 i,
                 player.Spells[i].SpellId,
                 player.Spells[i].Level,
-                player.Spells[i].Properties
+                player.Spells[i].Properties,
+                player.Spells[i].SpellPointsSpent
             );
         }
 
@@ -1331,7 +1332,8 @@ public static partial class PacketSender
                 slot,
                 player.Spells[slot].SpellId,
                 player.Spells[slot].Level,
-                player.Spells[slot].Properties
+                player.Spells[slot].Properties,
+                player.Spells[slot].SpellPointsSpent
             )
         );
     }


### PR DESCRIPTION
## Summary
- carry spell point expenditure through `SpellUpdatePacket`
- load and propagate spell point data on client and server entities
- refresh player spell point data when spells update

## Testing
- `dotnet build` *(fails: project files missing)*

------
https://chatgpt.com/codex/tasks/task_e_68af1a5fa0d48324ab36946ee4cf6e90