### PR TITLE
feat: implement honor adjustments for player PvP kills

### DIFF
--- a/Intersect.Server.Core/Entities/Entity.cs
+++ b/Intersect.Server.Core/Entities/Entity.cs
@@ -3156,6 +3156,12 @@ public abstract partial class Entity : IEntity
         // Run events and other things.
         killer?.KilledEntity(this);
 
+        // Honor and faction handling for PvP kills
+        if (killer is Player attacker && this is Player victim)
+        {
+            attacker.HandlePlayerKill(victim);
+        }
+
         if (dropItems)
         {
             var lootGenerated = new List<Player>();


### PR DESCRIPTION
## Summary
- track honor when players kill each other
- penalize neutral kills and apply diminishing returns on repeat victims
- recalculate grade after honor changes

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af1ce85a60832482cd08288908971d