### PR TITLE
feat: decay player honor weekly

### DIFF
--- a/Framework/Intersect.Framework.Core/Config/PlayerOptions.cs
+++ b/Framework/Intersect.Framework.Core/Config/PlayerOptions.cs
@@ -48,6 +48,11 @@ public partial class PlayerOptions
     public int ExpLossOnDeathPercent { get; set; } = 0;
 
     /// <summary>
+    /// Percentage between 0 and 100 applied weekly to move player honor toward zero.
+    /// </summary>
+    public int HonorDecayPercent { get; set; } = 0;
+
+    /// <summary>
     /// Number of hotbar slots a player has.
     /// </summary>
     public int HotbarSlotCount { get; set; } = DefaultHotbarSlotCount;

--- a/Intersect.Server.Core/Services/HonorDecayService.cs
+++ b/Intersect.Server.Core/Services/HonorDecayService.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Intersect.Config;
+using Intersect.Enums;
+using Intersect.Framework.Core.GameObjects.Variables;
+using Intersect.Server.Database;
+using Intersect.Server.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace Intersect.Server.Core.Services;
+
+internal static class HonorDecayService
+{
+    private const string LastDecayVariableName = "HonorDecayLastRun";
+
+    public static async Task TryRunAsync()
+    {
+        var now = DateTime.UtcNow;
+        var lastRun = GetLastRun();
+        if ((now - lastRun).TotalDays < 7)
+        {
+            return;
+        }
+
+        var decayPercent = Options.Instance.Player.HonorDecayPercent;
+        if (decayPercent <= 0)
+        {
+            SetLastRun(now);
+            return;
+        }
+
+        using var context = DbInterface.CreatePlayerContext(readOnly: false);
+        var players = await context.Players.ToListAsync().ConfigureAwait(false);
+        var fraction = decayPercent / 100.0;
+        foreach (var player in players)
+        {
+            if (player.Honor == 0)
+            {
+                continue;
+            }
+
+            var reduction = (int)Math.Round(player.Honor * fraction);
+            player.Honor -= reduction;
+        }
+
+        await context.SaveChangesAsync().ConfigureAwait(false);
+
+        foreach (var online in Player.OnlinePlayers)
+        {
+            if (online == null || online.Honor == 0)
+            {
+                continue;
+            }
+
+            var reduction = (int)Math.Round(online.Honor * fraction);
+            online.Honor -= reduction;
+        }
+
+        SetLastRun(now);
+    }
+
+    private static DateTime GetLastRun()
+    {
+        var variable = ServerVariableDescriptor.Lookup.Values
+            .OfType<ServerVariableDescriptor>()
+            .FirstOrDefault(v => v.Name == LastDecayVariableName);
+
+        if (variable == null)
+        {
+            variable = new ServerVariableDescriptor(Guid.NewGuid())
+            {
+                Name = LastDecayVariableName,
+                DataType = VariableDataType.String,
+                ValueData = DateTime.MinValue.ToString("o")
+            };
+            ServerVariableDescriptor.Lookup.Set(variable.Id, variable);
+            DbInterface.UpdatedServerVariables.TryAdd(variable.Id, variable);
+            return DateTime.MinValue;
+        }
+
+        return DateTime.TryParse(variable.Value.String, out var parsed)
+            ? parsed
+            : DateTime.MinValue;
+    }
+
+    private static void SetLastRun(DateTime time)
+    {
+        var variable = ServerVariableDescriptor.Lookup.Values
+            .OfType<ServerVariableDescriptor>()
+            .FirstOrDefault(v => v.Name == LastDecayVariableName);
+        if (variable == null)
+        {
+            return;
+        }
+
+        variable.Value.String = time.ToString("o");
+        DbInterface.UpdatedServerVariables.AddOrUpdate(variable.Id, variable, (id, old) => variable);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add HonorDecayPercent option to players
- schedule weekly honor decay across all players
- track last honor decay to avoid double application

## Testing
- `dotnet test` *(fails: project file vendor/LiteNetLib/LiteNetLib/LiteNetLib.csproj was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af1cf3487c8324bf14fc1ef5dc5d4d