### PR TITLE
Ensure guild faction alignment for invitations

### DIFF
--- a/Intersect.Server.Core/CustomChanges/Player.Guild.cs
+++ b/Intersect.Server.Core/CustomChanges/Player.Guild.cs
@@ -48,7 +48,13 @@ namespace Intersect.Server.Entities
             }
             Guild?.UpdateMemberList();
         }
-       
+
+        public void SetFaction(Alignment faction)
+        {
+            Faction = faction;
+            LastFactionSwapAt = DateTime.UtcNow;
+        }
+
     }
 
 }

--- a/Intersect.Server.Core/Localization/Strings.cs
+++ b/Intersect.Server.Core/Localization/Strings.cs
@@ -764,6 +764,9 @@ public static partial class Strings
         public readonly LocalizedString InviteAlreadyInGuild = @"The player you're trying to invite is already in a guild or has a pending invite.";
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString InviteDifferentFaction = @"You cannot invite players from a different faction.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public readonly LocalizedString InviteDeclined = @"You have declined the request to join {00}.";
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
@@ -807,6 +810,9 @@ public static partial class Strings
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public readonly LocalizedString NotReceivedInvite = @"You've not received any guild invites yet.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString DifferentFaction = @"Your faction does not match the guild's faction.";
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public readonly LocalizedString Promoted = @"{00} has been promoted to {01}!";

--- a/Intersect.Server.Core/Networking/PacketHandler.cs
+++ b/Intersect.Server.Core/Networking/PacketHandler.cs
@@ -2834,6 +2834,12 @@ internal sealed partial class PacketHandler
                     // Are we already in a guild? or have a pending invite?
                     if (target.Guild == null && target.PendingGuildInvite == default)
                     {
+                        if (target.Faction != Alignment.Neutral && target.Faction != player.Faction)
+                        {
+                            PacketSender.SendChatMsg(player, Strings.Guilds.InviteDifferentFaction, ChatMessageType.Guild, CustomColors.Alerts.Error);
+                            return;
+                        }
+
                         // Thank god, we can FINALLY get started!
                         // Set our invite and send our players the relevant messages.
                         target.PendingGuildInvite = new GuildInvite
@@ -3036,6 +3042,20 @@ internal sealed partial class PacketHandler
 
                 return;
             }
+        }
+
+        var guildFaction = inviter?.Faction ?? guild.GetFaction();
+        if (player.Faction != Alignment.Neutral && player.Faction != guildFaction)
+        {
+            PacketSender.SendChatMsg(player, Strings.Guilds.DifferentFaction, ChatMessageType.Guild, CustomColors.Alerts.Error);
+            player.PendingGuildInvite = default;
+            player.Save();
+            return;
+        }
+
+        if (player.Faction == Alignment.Neutral)
+        {
+            player.SetFaction(guildFaction);
         }
 
         // Accept our invite!


### PR DESCRIPTION
## Summary
- verify guild faction matches player faction when inviting members
- allow neutral players to adopt guild faction and record swap time
- add localization for faction mismatches

## Testing
- `dotnet test` *(fails: project files not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af4d63f9f8832484a7910ad42a9cdb