### PR TITLE
Add prism placeholders and basic hooks

### DIFF
--- a/Framework/Intersect.Framework.Core/GameObjects/Prisms/PrismDescriptor.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Prisms/PrismDescriptor.cs
@@ -1,0 +1,36 @@
+using System;
+using System.ComponentModel.DataAnnotations.Schema;
+using Intersect.Models;
+using Newtonsoft.Json;
+
+namespace Intersect.Framework.Core.GameObjects.Prisms;
+
+/// <summary>
+/// Basic descriptor for a territory control prism.
+/// </summary>
+public partial class PrismDescriptor : DatabaseObject<PrismDescriptor>
+{
+    /// <summary>
+    /// Identifier of the player or guild that owns the prism.
+    /// </summary>
+    public Guid OwnerId { get; set; }
+
+    /// <summary>
+    /// Current state of the prism.
+    /// </summary>
+    public PrismState State { get; set; } = PrismState.Placed;
+
+    [JsonConstructor]
+    public PrismDescriptor(Guid id) : base(id)
+    {
+        Name = "New Prism";
+    }
+
+    /// <summary>
+    /// Constructor used by Entity Framework.
+    /// </summary>
+    public PrismDescriptor()
+    {
+        Name = "New Prism";
+    }
+}

--- a/Framework/Intersect.Framework.Core/GameObjects/Prisms/PrismState.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Prisms/PrismState.cs
@@ -1,0 +1,29 @@
+using System;
+
+namespace Intersect.Framework.Core.GameObjects.Prisms;
+
+/// <summary>
+/// Represents the possible states of a prism used for territory control.
+/// </summary>
+public enum PrismState
+{
+    /// <summary>
+    /// The prism has been placed and is protected for a short duration.
+    /// </summary>
+    Placed,
+
+    /// <summary>
+    /// The prism can be attacked by opposing factions.
+    /// </summary>
+    Vulnerable,
+
+    /// <summary>
+    /// The prism has been reinforced after surviving attacks.
+    /// </summary>
+    Reinforced,
+
+    /// <summary>
+    /// The prism has been destroyed.
+    /// </summary>
+    Destroyed
+}

--- a/Intersect.Client.Core/Maps/MapInstance.Prisms.cs
+++ b/Intersect.Client.Core/Maps/MapInstance.Prisms.cs
@@ -1,0 +1,20 @@
+using System;
+using Intersect.Framework.Core.GameObjects.Prisms;
+
+namespace Intersect.Client.Maps;
+
+/// <summary>
+/// Client-side prism data for displaying conquered zones.
+/// </summary>
+public partial class MapInstance
+{
+    /// <summary>
+    /// Identifier of the prism owner if the map is conquered.
+    /// </summary>
+    public Guid? PrismOwnerId { get; set; }
+
+    /// <summary>
+    /// State of the controlling prism.
+    /// </summary>
+    public PrismState PrismState { get; set; } = PrismState.Placed;
+}

--- a/Intersect.Server.Core/Entities/Player.Prisms.cs
+++ b/Intersect.Server.Core/Entities/Player.Prisms.cs
@@ -1,0 +1,38 @@
+using System;
+using Intersect.Framework.Core.GameObjects.Prisms;
+
+namespace Intersect.Server.Entities;
+
+/// <summary>
+/// Prism-related actions that a player can perform.
+/// </summary>
+public partial class Player
+{
+    /// <summary>
+    /// Invoked when the player places a prism.
+    /// </summary>
+    public event Action<Player, PrismDescriptor>? PrismPlaced;
+
+    /// <summary>
+    /// Invoked when the player attacks a prism.
+    /// </summary>
+    public event Action<Player, PrismDescriptor>? PrismAttacked;
+
+    /// <summary>
+    /// Places a new prism and notifies listeners.
+    /// </summary>
+    public void PlacePrism()
+    {
+        var prism = new PrismDescriptor { OwnerId = Id, State = PrismState.Placed };
+        PrismPlaced?.Invoke(this, prism);
+    }
+
+    /// <summary>
+    /// Notifies that the player attacked a prism. Additional honor is awarded.
+    /// </summary>
+    public void AttackPrism(PrismDescriptor prism)
+    {
+        PrismAttacked?.Invoke(this, prism);
+        Honor += 5; // bonus honor for participating in prism combat
+    }
+}

--- a/Intersect.Server.Core/Maps/MapInstance.Prisms.cs
+++ b/Intersect.Server.Core/Maps/MapInstance.Prisms.cs
@@ -1,0 +1,38 @@
+using System;
+using Intersect.Framework.Core.GameObjects.Prisms;
+using Intersect.Server.Entities;
+
+namespace Intersect.Server.Maps;
+
+/// <summary>
+/// Prism tracking for map instances. A prism confers a small honor bonus to
+/// players of the owning faction while they remain on the map.
+/// </summary>
+public partial class MapInstance
+{
+    /// <summary>
+    /// Prism currently controlling this map instance, if any.
+    /// </summary>
+    public PrismDescriptor? ControllingPrism { get; private set; }
+
+    /// <summary>
+    /// Places a prism on this map instance.
+    /// </summary>
+    public void PlacePrism(Player player)
+    {
+        ControllingPrism = new PrismDescriptor { OwnerId = player.Id, State = PrismState.Placed };
+        player.Honor += 10; // bonus honor for placing a prism
+    }
+
+    /// <summary>
+    /// Applies area bonus to players standing on the map.
+    /// </summary>
+    public void ApplyPrismBonus(Player player)
+    {
+        if (ControllingPrism != null && ControllingPrism.OwnerId == player.Id)
+        {
+            // simple honor tick to show the bonus mechanism
+            player.Honor += 1;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `PrismState` enum and `PrismDescriptor` for territory control
- hook prism placement and attacks in server `Player` with honor bonuses
- track controlling prism per map and expose prism data to client `MapInstance`

## Testing
- `dotnet build Framework/Intersect.Framework.Core/Intersect.Framework.Core.csproj`
- `dotnet build Intersect.Server.Core/Intersect.Server.Core.csproj` *(fails: NetPacketReader not found)*
- `dotnet test Intersect.Tests.Server/Intersect.Tests.Server.csproj` *(fails: NetDataWriter not found)*


------
https://chatgpt.com/codex/tasks/task_e_68af4e14533c8324a01a52f6818ae386