### PR TITLE
feat: honor ranking endpoints

### DIFF
--- a/Intersect.Server/Web/Controllers/Api/V1/GuildController.cs
+++ b/Intersect.Server/Web/Controllers/Api/V1/GuildController.cs
@@ -13,6 +13,7 @@ using Intersect.Server.Web.Types.Guild;
 using Intersect.Utilities;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using System.Linq;
 
 namespace Intersect.Server.Web.Controllers.Api.V1
 {
@@ -38,6 +39,34 @@ namespace Intersect.Server.Web.Controllers.Api.V1
             limit = Math.Max(Math.Min(limit, pageSize), 1);
 
             var values = Guild.List(search?.Length > 2 ? search : null, sortBy, sortDirection, page * pageSize, pageSize, out int total);
+
+            if (limit != pageSize)
+            {
+                values = values.Take(limit).ToList();
+            }
+
+            return Ok(new DataPage<KeyValuePair<Guild, int>>(
+                Total: total,
+                Page: page,
+                PageSize: pageSize,
+                Count: values.Count,
+                Values: values
+            ));
+        }
+
+        [HttpGet("honor")]
+        [ProducesResponseType(typeof(DataPage<KeyValuePair<Guild, int>>), (int)HttpStatusCode.OK, ContentTypes.Json)]
+        public IActionResult Honor(
+            [FromQuery] int page = 0,
+            [FromQuery] int pageSize = 0,
+            [FromQuery] int limit = PagingInfo.MaxPageSize
+        )
+        {
+            page = Math.Max(page, 0);
+            pageSize = Math.Max(Math.Min(pageSize, PagingInfo.MaxPageSize), PagingInfo.MinPageSize);
+            limit = Math.Max(Math.Min(limit, pageSize), 1);
+
+            var values = Guild.TopByHonor(page * pageSize, pageSize, out int total);
 
             if (limit != pageSize)
             {

--- a/Intersect.Server/Web/Controllers/Api/V1/PlayerController.cs
+++ b/Intersect.Server/Web/Controllers/Api/V1/PlayerController.cs
@@ -18,6 +18,7 @@ using Intersect.Server.Web.Http;
 using Intersect.Server.Web.Types;
 using Intersect.Server.Web.Types.Player;
 using Intersect.Utilities;
+using System.Linq;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -99,6 +100,34 @@ namespace Intersect.Server.Web.Controllers.Api.V1
                     ],
                     Direction = sortDirection,
                 }],
+            });
+        }
+
+        [HttpGet("honor")]
+        [ProducesResponseType(typeof(DataPage<Player>), (int)HttpStatusCode.OK, ContentTypes.Json)]
+        public IActionResult Honor(
+            [FromQuery] int page = 0,
+            [FromQuery] int pageSize = 0,
+            [FromQuery] int limit = PagingInfo.MaxPageSize
+        )
+        {
+            page = Math.Max(page, 0);
+            pageSize = Math.Max(Math.Min(pageSize, PagingInfo.MaxPageSize), PagingInfo.MinPageSize);
+            limit = Math.Max(Math.Min(limit, pageSize), 1);
+
+            var values = Player.RankByHonor(page, pageSize).ToList();
+            if (limit != pageSize)
+            {
+                values = values.Take(limit).ToList();
+            }
+
+            return Ok(new DataPage<Player>
+            {
+                Total = Player.Count(),
+                Page = page,
+                PageSize = pageSize,
+                Count = values.Count,
+                Values = values,
             });
         }
 


### PR DESCRIPTION
## Summary
- add database query for ranking players by honor
- expose honor-based leaderboards for players and guilds

## Testing
- `dotnet build Intersect.Server/Intersect.Server.csproj` *(fails: NetDataWriter not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af5126fa9483249dfb4199bb147d0d