### PR TITLE
feat: implement alignment-based PvP honor service

### DIFF
--- a/Intersect.Server.Core/Entities/Entity.cs
+++ b/Intersect.Server.Core/Entities/Entity.cs
@@ -27,6 +27,7 @@ using Intersect.Utilities;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Stat = Intersect.Enums.Stat;
+using Intersect.Server.Services;
 
 namespace Intersect.Server.Entities;
 
@@ -3156,16 +3157,9 @@ public abstract partial class Entity : IEntity
         // Run events and other things.
         killer?.KilledEntity(this);
 
-        // Honor and faction handling for PvP kills
         if (killer is Player attacker && this is Player victim)
         {
-            attacker.HandlePlayerKill(victim);
-
-            // Penalize attacking much lower level players
-            if (Math.Abs(attacker.Level - victim.Level) > victim.Level * 0.3f)
-            {
-                attacker.AdjustHonor(-5);
-            }
+            AlignmentPvPService.HandleKill(attacker, victim);
         }
 
         if (dropItems)

--- a/Intersect.Server.Core/Services/AlignmentPvPService.cs
+++ b/Intersect.Server.Core/Services/AlignmentPvPService.cs
@@ -1,0 +1,81 @@
+using System;
+using Intersect.Enums;
+using Intersect.Server.Entities;
+using Intersect.Server.Database;
+using Intersect.Server.Database.PlayerData.Players;
+
+namespace Intersect.Server.Services;
+
+internal static class AlignmentPvPService
+{
+    private const int HonorReward = 10;
+    private const int FactionPenalty = 5;
+    private const int NeutralPenalty = 10;
+    private const int UnfairLevelPenalty = 5;
+    private static readonly TimeSpan RewardCooldown = TimeSpan.FromMinutes(5);
+
+    public static void HandleKill(Player killer, Player victim)
+    {
+        if (killer == null || victim == null || killer == victim)
+        {
+            return;
+        }
+
+        var now = DateTime.UtcNow;
+
+        foreach (var entry in killer.RecentPlayerVictims.ToArray())
+        {
+            if (now - entry.Value > RewardCooldown)
+            {
+                killer.RecentPlayerVictims.TryRemove(entry.Key, out _);
+            }
+        }
+
+        if (victim.Faction == Alignment.Neutral)
+        {
+            HonorService.AdjustHonor(killer, -NeutralPenalty);
+            return;
+        }
+
+        if (killer.Faction == victim.Faction)
+        {
+            HonorService.AdjustHonor(killer, -FactionPenalty);
+            return;
+        }
+
+        var levelDiff = Math.Abs(killer.Level - victim.Level);
+        var maxLevel = Math.Max(killer.Level, victim.Level);
+        if (levelDiff > maxLevel * 0.3f)
+        {
+            if (killer.Level > victim.Level)
+            {
+                HonorService.AdjustHonor(killer, -UnfairLevelPenalty);
+            }
+
+            return;
+        }
+
+        var honorDelta = HonorReward;
+        if (killer.RecentPlayerVictims.TryGetValue(victim.Id, out var lastKill) &&
+            now - lastKill < RewardCooldown)
+        {
+            honorDelta /= 2;
+        }
+
+        HonorService.AdjustHonor(killer, honorDelta);
+        HonorService.AdjustHonor(victim, -honorDelta);
+
+        killer.RecentPlayerVictims[victim.Id] = now;
+
+        try
+        {
+            using var context = DbInterface.CreatePlayerContext(readOnly: false);
+            context.Player_KillLogs.Add(new KillLog(killer, victim));
+            context.SaveChanges();
+        }
+        catch
+        {
+            // ignore logging failures
+        }
+    }
+}

--- a/Intersect.Server.Core/Services/HonorService.cs
+++ b/Intersect.Server.Core/Services/HonorService.cs
@@ -1,0 +1,43 @@
+using System;
+using Intersect.Server.Entities;
+
+namespace Intersect.Server.Services;
+
+internal static class HonorService
+{
+    private static readonly int[] GradeThresholds = { 0, 1000, 2000, 4000, 8000 };
+
+    public static void AdjustHonor(Player player, int amount)
+    {
+        if (player == null || amount == 0)
+        {
+            return;
+        }
+
+        player.Honor += amount;
+        if (player.Honor < 0)
+        {
+            player.Honor = 0;
+        }
+
+        RecalculateGrade(player);
+    }
+
+    public static void RecalculateGrade(Player player)
+    {
+        var newGrade = 0;
+        for (var i = 0; i < GradeThresholds.Length; i++)
+        {
+            if (player.Honor >= GradeThresholds[i])
+            {
+                newGrade = i;
+            }
+            else
+            {
+                break;
+            }
+        }
+
+        player.Grade = newGrade;
+    }
+}


### PR DESCRIPTION
## Summary
- add HonorService for clamping honor and grade recalculation
- introduce AlignmentPvPService to handle fair PvP honor with faction and level penalties
- delegate player kill handling and honor updates to the new services

## Testing
- `dotnet test` *(fails: project file "vendor/LiteNetLib/LiteNetLib/LiteNetLib.csproj" was not found)*
- `dotnet build Intersect.Server.Core/Intersect.Server.Core.csproj` *(fails: NetPacketReader not found)*

------
https://chatgpt.com/codex/tasks/task_e_68afc1e7863483248288488e07bb791f