### PR TITLE
Add HonorService and centralize honor calculations

### DIFF
--- a/Intersect.Server.Core/Entities/Player.cs
+++ b/Intersect.Server.Core/Entities/Player.cs
@@ -26,6 +26,7 @@ using Intersect.GameObjects;
 using Intersect.Network;
 using Intersect.Network.Packets.Server;
 using Intersect.Server.Core.MapInstancing;
+using Intersect.Server.Core.Services;
 using Intersect.Server.Database;
 using Intersect.Server.Database.Logging.Entities;
 using Intersect.Server.Database.PlayerData;
@@ -1745,34 +1746,8 @@ public partial class Player : Entity
             return;
         }
 
-        Honor += amount;
-        if (Honor < 0)
-        {
-            Honor = 0;
-        }
-
-        RecalculateGrade();
-    }
-
-    private void RecalculateGrade()
-    {
-        // Example rank table; thresholds define the minimum honor for each grade
-        int[] thresholds = { 0, 1000, 2000, 4000, 8000 };
-
-        var newGrade = 0;
-        for (var i = 0; i < thresholds.Length; i++)
-        {
-            if (Honor >= thresholds[i])
-            {
-                newGrade = i;
-            }
-            else
-            {
-                break;
-            }
-        }
-
-        Grade = newGrade;
+        Honor = HonorService.Clamp(Honor + amount);
+        Grade = HonorService.CalculateGrade(Honor);
     }
 
     public void UpdateQuestKillTasks(Entity en)

--- a/Intersect.Server.Core/Services/HonorDecayService.cs
+++ b/Intersect.Server.Core/Services/HonorDecayService.cs
@@ -7,6 +7,7 @@ using Intersect.Framework.Core.GameObjects.Variables;
 using Intersect.Server.Database;
 using Intersect.Server.Entities;
 using Microsoft.EntityFrameworkCore;
+using Intersect.Server.Core.Services;
 
 namespace Intersect.Server.Core.Services;
 
@@ -41,7 +42,7 @@ internal static class HonorDecayService
             }
 
             var reduction = (int)Math.Round(player.Honor * fraction);
-            player.Honor -= reduction;
+            player.Honor = HonorService.Clamp(player.Honor - reduction);
         }
 
         await context.SaveChangesAsync().ConfigureAwait(false);
@@ -54,7 +55,7 @@ internal static class HonorDecayService
             }
 
             var reduction = (int)Math.Round(online.Honor * fraction);
-            online.Honor -= reduction;
+            online.Honor = HonorService.Clamp(online.Honor - reduction);
         }
 
         SetLastRun(now);

--- a/Intersect.Server.Core/Services/HonorService.cs
+++ b/Intersect.Server.Core/Services/HonorService.cs
@@ -1,0 +1,76 @@
+using System;
+
+namespace Intersect.Server.Core.Services;
+
+public static class HonorService
+{
+    public const int MinHonor = -5000;
+    public const int MaxHonor = 5000;
+
+    // Bracket table defining honor ranges, decay amounts, and grades.
+    private static readonly (int Min, int Max, int Decay, int Grade)[] Brackets =
+    {
+        (MinHonor, -4000, 500, -5),
+        (-3999, -3000, 400, -4),
+        (-2999, -2000, 300, -3),
+        (-1999, -1000, 200, -2),
+        (-999, -1, 100, -1),
+        (0, 0, 0, 0),
+        (1, 999, 100, 1),
+        (1000, 1999, 200, 2),
+        (2000, 2999, 300, 3),
+        (3000, 3999, 400, 4),
+        (4000, MaxHonor, 500, 5)
+    };
+
+    public static int Clamp(int honor)
+    {
+        return Math.Clamp(honor, MinHonor, MaxHonor);
+    }
+
+    public static int CalculateGrade(int honor)
+    {
+        foreach (var bracket in Brackets)
+        {
+            if (honor >= bracket.Min && honor <= bracket.Max)
+            {
+                return bracket.Grade;
+            }
+        }
+
+        return 0;
+    }
+
+    public static int DecayTowardsZero(int honor)
+    {
+        if (honor == 0)
+        {
+            return 0;
+        }
+
+        var abs = Math.Abs(honor);
+        var decay = 0;
+        foreach (var bracket in Brackets)
+        {
+            var minAbs = Math.Abs(bracket.Min);
+            var maxAbs = Math.Abs(bracket.Max);
+            if (abs >= minAbs && abs <= maxAbs)
+            {
+                decay = bracket.Decay;
+                break;
+            }
+        }
+
+        if (honor > 0)
+        {
+            honor = Math.Max(0, honor - decay);
+        }
+        else
+        {
+            honor = Math.Min(0, honor + decay);
+        }
+
+        return honor;
+    }
+}
+


### PR DESCRIPTION
## Summary
- add HonorService with clamp, grade, and decay helpers
- use HonorService in Player to clamp honor and compute grades
- clamp honor decay using HonorService

## Testing
- `dotnet test Intersect.Tests.Server/Intersect.Tests.Server.csproj` *(fails: DeliveryMethod etc. missing)*

------
https://chatgpt.com/codex/tasks/task_e_68afc1e0676c83248b872f0d37fd5b67