### PR TITLE
Guard aggression respects wings and outlaw status

### DIFF
--- a/Intersect.Server.Core/Entities/Npc.cs
+++ b/Intersect.Server.Core/Entities/Npc.cs
@@ -1491,6 +1491,12 @@ public partial class Npc : Entity
 
     public bool ShouldAttackPlayerOnSight(Player en)
     {
+        // Outlaws are always attacked regardless of NPC faction
+        if (en.Honor < 0)
+        {
+            return true;
+        }
+
         if (IsAllyOf(en))
         {
             return false;
@@ -1498,8 +1504,8 @@ public partial class Npc : Entity
 
         if (Descriptor.Faction != Alignment.Neutral)
         {
-            if (en.Honor < 0 ||
-                (en.Faction != Alignment.Neutral && en.Faction != Descriptor.Faction))
+            // Guards only attack opposing faction players when their wings are enabled
+            if (en.Faction != Alignment.Neutral && en.Faction != Descriptor.Faction && en.Wings == WingState.On)
             {
                 return true;
             }


### PR DESCRIPTION
## Summary
- Attack players with negative Honor on sight regardless of NPC faction
- Require opposing faction players to have wings enabled before guards attack

## Testing
- `dotnet test Intersect.Tests.Server/Intersect.Tests.Server.csproj` *(fails: NetPacketReader not found)*

------
https://chatgpt.com/codex/tasks/task_e_68afc7728b4c8324844569ebb13a428c