### PR TITLE
Use HonorService for honor decay and update grades

### DIFF
--- a/Intersect.Server.Core/Services/HonorDecayService.cs
+++ b/Intersect.Server.Core/Services/HonorDecayService.cs
@@ -33,7 +33,6 @@ internal static class HonorDecayService
 
         using var context = DbInterface.CreatePlayerContext(readOnly: false);
         var players = await context.Players.ToListAsync().ConfigureAwait(false);
-        var fraction = decayPercent / 100.0;
         foreach (var player in players)
         {
             if (player.Honor == 0)
@@ -41,8 +40,8 @@ internal static class HonorDecayService
                 continue;
             }
 
-            var reduction = (int)Math.Round(player.Honor * fraction);
-            player.Honor = HonorService.Clamp(player.Honor - reduction);
+            player.Honor = HonorService.DecayTowardsZero(player.Honor, decayPercent);
+            player.Grade = HonorService.CalculateGrade(player.Honor);
         }
 
         await context.SaveChangesAsync().ConfigureAwait(false);
@@ -54,8 +53,8 @@ internal static class HonorDecayService
                 continue;
             }
 
-            var reduction = (int)Math.Round(online.Honor * fraction);
-            online.Honor = HonorService.Clamp(online.Honor - reduction);
+            online.Honor = HonorService.DecayTowardsZero(online.Honor, decayPercent);
+            online.Grade = HonorService.CalculateGrade(online.Honor);
         }
 
         SetLastRun(now);

--- a/Intersect.Server.Core/Services/HonorService.cs
+++ b/Intersect.Server.Core/Services/HonorService.cs
@@ -41,6 +41,45 @@ public static class HonorService
         return 0;
     }
 
+    public static int DecayTowardsZero(int honor, double percent)
+    {
+        if (honor == 0 || percent <= 0)
+        {
+            return honor;
+        }
+
+        if (percent >= 100)
+        {
+            return DecayTowardsZero(honor);
+        }
+
+        var abs = Math.Abs(honor);
+        var decay = 0;
+        foreach (var bracket in Brackets)
+        {
+            var minAbs = Math.Abs(bracket.Min);
+            var maxAbs = Math.Abs(bracket.Max);
+            if (abs >= minAbs && abs <= maxAbs)
+            {
+                decay = bracket.Decay;
+                break;
+            }
+        }
+
+        decay = (int)Math.Round(decay * (percent / 100.0));
+
+        if (honor > 0)
+        {
+            honor = Math.Max(0, honor - decay);
+        }
+        else
+        {
+            honor = Math.Min(0, honor + decay);
+        }
+
+        return honor;
+    }
+
     public static int DecayTowardsZero(int honor)
     {
         if (honor == 0)


### PR DESCRIPTION
## Summary
- add percent-based overload to `HonorService.DecayTowardsZero`
- apply `HonorService.DecayTowardsZero` during weekly honor decay and recalc grades

## Testing
- `dotnet build Intersect.Server.Core/Intersect.Server.Core.csproj` *(fails: Metadata file 'Intersect.Network.dll' could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_68afc75459e48324b75083f08d1aa478