### PR TITLE
Add wing toggle and faction grade support

### DIFF
--- a/Framework/Intersect.Framework.Core/Entities/FactionGrade.cs
+++ b/Framework/Intersect.Framework.Core/Entities/FactionGrade.cs
@@ -1,0 +1,10 @@
+namespace Intersect.Enums;
+
+public enum FactionGrade
+{
+    Recruit = 0,
+    Soldier = 1,
+    Officer = 2,
+    Commander = 3,
+    Legend = 4,
+}

--- a/Intersect.Client.Core/Entities/Player.cs
+++ b/Intersect.Client.Core/Entities/Player.cs
@@ -2782,21 +2782,19 @@ public partial class Player : Entity, IPlayer
             DrawEquipment($"aura_{Grade}.png", Color.White);
         }
 
-        if (Wings == WingState.On)
+        if (Wings is WingState.On)
         {
             DrawEquipment(GetWingTexture(), Color.White);
         }
     }
 
-    private string GetWingTexture()
-    {
-        return Faction switch
+    private string GetWingTexture() =>
+        Faction switch
         {
             Alignment.Serolf => "wings_serolf.png",
             Alignment.Nidraj => "wings_nidraj.png",
             _ => "wings.png",
         };
-    }
 
     public override void DrawEquipment(string filename, Color renderColor)
     {
@@ -2877,15 +2875,12 @@ public partial class Player : Entity, IPlayer
             }
         }
 
-        switch (Faction)
+        textColor = Faction switch
         {
-            case Alignment.Serolf:
-                textColor = Color.Blue;
-                break;
-            case Alignment.Nidraj:
-                textColor = Color.Red;
-                break;
-        }
+            Alignment.Serolf => Color.Blue,
+            Alignment.Nidraj => Color.Red,
+            _ => textColor,
+        };
 
         if (borderColor is not { A: > 0 })
         {

--- a/Intersect.Client.Core/Interface/Game/FactionWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/FactionWindow.cs
@@ -5,6 +5,8 @@ using Intersect.Client.Framework.File_Management;
 using Intersect.Client.Framework.Gwen;
 using Intersect.Client.Framework.Gwen.Control;
 using Intersect.Client.General;
+using Intersect.Client.Networking;
+using Intersect.Enums;
 
 namespace Intersect.Client.Interface.Game;
 
@@ -15,7 +17,7 @@ public partial class FactionWindow : Window
 {
     private readonly Label _honorLabel;
     private readonly Label _gradeLabel;
-    private readonly Label _rankingLabel;
+    private readonly Button _wingsButton;
 
     public FactionWindow(Canvas gameCanvas) : base(gameCanvas, nameof(FactionWindow), false, nameof(FactionWindow))
     {
@@ -28,8 +30,21 @@ public partial class FactionWindow : Window
         _gradeLabel = new Label(this, "GradeLabel");
         _gradeLabel.SetPosition(10, 40);
 
-        _rankingLabel = new Label(this, "RankingLabel");
-        _rankingLabel.SetPosition(10, 70);
+        _wingsButton = new Button(this, "WingsButton");
+        _wingsButton.SetPosition(10, 70);
+        _wingsButton.SetText("Toggle Wings");
+        _wingsButton.Clicked += (s, e) =>
+        {
+            var me = Globals.Me;
+            if (me == null)
+            {
+                return;
+            }
+
+            var newState = me.Wings == WingState.On ? WingState.Off : WingState.On;
+            me.Wings = newState;
+            PacketSender.SendToggleWings(newState);
+        };
     }
 
     /// <summary>
@@ -44,12 +59,8 @@ public partial class FactionWindow : Window
         }
 
         _honorLabel.Text = $"Honor: {me.Honor}";
-        _gradeLabel.Text = $"Grade: {me.Grade}";
-
-        // Ranking name derived from grade; this is a simple placeholder mapping.
-        string[] rankNames = { "Recruit", "Soldier", "Officer", "Commander", "Legend" };
-        var rankIndex = Math.Clamp(me.Grade, 0, rankNames.Length - 1);
-        _rankingLabel.Text = $"Ranking: {rankNames[rankIndex]}";
+        var grade = (FactionGrade)Math.Clamp(me.Grade, 0, (int)FactionGrade.Legend);
+        _gradeLabel.Text = $"Grade: {grade}";
     }
 }
 


### PR DESCRIPTION
## Summary
- add faction grade enum and display
- toggle wings from faction window
- simplify wing texture and color logic

## Testing
- `dotnet build Intersect.Client.Core/Intersect.Client.Core.csproj -nologo` *(fails: LiteNetLib namespace missing)*

------
https://chatgpt.com/codex/tasks/task_e_68afc7b8d96c83249f71641b114efa2c