### PR TITLE
Add prism combat states and handling

### DIFF
--- a/Framework/Intersect.Framework.Core/GameObjects/Prisms/PrismState.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Prisms/PrismState.cs
@@ -18,9 +18,14 @@ public enum PrismState
     Vulnerable,
 
     /// <summary>
-    /// The prism has been reinforced after surviving attacks.
+    /// The prism is currently under attack.
     /// </summary>
-    Reinforced,
+    UnderAttack,
+
+    /// <summary>
+    /// The prism has been dominated after surviving attacks.
+    /// </summary>
+    Dominated,
 
     /// <summary>
     /// The prism has been destroyed.

--- a/Intersect.Client.Core/Maps/MapInstance.Prisms.cs
+++ b/Intersect.Client.Core/Maps/MapInstance.Prisms.cs
@@ -17,4 +17,14 @@ public partial class MapInstance
     /// State of the controlling prism.
     /// </summary>
     public PrismState PrismState { get; set; } = PrismState.Placed;
+
+    /// <summary>
+    /// True if the prism is currently under attack.
+    /// </summary>
+    public bool PrismUnderAttack => PrismState == PrismState.UnderAttack;
+
+    /// <summary>
+    /// True if the prism has been dominated.
+    /// </summary>
+    public bool PrismDominated => PrismState == PrismState.Dominated;
 }

--- a/Intersect.Server.Core/Entities/Player.Prisms.cs
+++ b/Intersect.Server.Core/Entities/Player.Prisms.cs
@@ -32,7 +32,17 @@ public partial class Player
     /// </summary>
     public void AttackPrism(PrismDescriptor prism)
     {
+        prism.State = PrismState.UnderAttack;
         PrismAttacked?.Invoke(this, prism);
         Honor += 5; // bonus honor for participating in prism combat
+    }
+
+    /// <summary>
+    /// Marks a prism as dominated after a successful defense.
+    /// </summary>
+    public void DominatePrism(PrismDescriptor prism)
+    {
+        prism.State = PrismState.Dominated;
+        Honor += 10; // extra honor for dominating a prism
     }
 }

--- a/Intersect.Server.Core/Maps/MapInstance.Prisms.cs
+++ b/Intersect.Server.Core/Maps/MapInstance.Prisms.cs
@@ -16,6 +16,16 @@ public partial class MapInstance
     public PrismDescriptor? ControllingPrism { get; private set; }
 
     /// <summary>
+    /// True if the controlling prism is under attack.
+    /// </summary>
+    public bool PrismUnderAttack => ControllingPrism?.State == PrismState.UnderAttack;
+
+    /// <summary>
+    /// True if the controlling prism is dominated.
+    /// </summary>
+    public bool PrismDominated => ControllingPrism?.State == PrismState.Dominated;
+
+    /// <summary>
     /// Places a prism on this map instance.
     /// </summary>
     public void PlacePrism(Player player)
@@ -31,8 +41,13 @@ public partial class MapInstance
     {
         if (ControllingPrism != null && ControllingPrism.OwnerId == player.Id)
         {
-            // simple honor tick to show the bonus mechanism
-            player.Honor += 1;
+            if (ControllingPrism.State == PrismState.UnderAttack)
+            {
+                return; // no bonus while the prism is contested
+            }
+
+            var bonus = ControllingPrism.State == PrismState.Dominated ? 2 : 1;
+            player.Honor += bonus;
         }
     }
 }


### PR DESCRIPTION
## Summary
- expand prism state enum with UnderAttack and Dominated
- expose prism status helpers and domination handling on client and server
- stop granting bonuses while prism is under attack

## Testing
- `dotnet build Framework/Intersect.Framework.Core/Intersect.Framework.Core.csproj`
- `dotnet build` *(fails: project file vendor/LiteNetLib/... not found)*
- `dotnet build Intersect.Client.Core/Intersect.Client.Core.csproj` *(fails: type or namespace name 'NetPeer' could not be found)*
- `dotnet build Intersect.Server.Core/Intersect.Server.Core.csproj` *(fails: type or namespace name 'NetManager' could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_68afcd63c10c832490a1cd4cc721920c