### PR TITLE
Add prism services, options, and scheduler

### DIFF
--- a/Framework/Intersect.Framework.Core/Config/Options.cs
+++ b/Framework/Intersect.Framework.Core/Config/Options.cs
@@ -224,6 +224,8 @@ public partial record Options
 
     public ItemOptions Items { get; set; } = new();
 
+    public PrismOptions Prism { get; set; } = new();
+
     #endregion Other Game Properties
 
     #endregion Configuration Properties

--- a/Framework/Intersect.Framework.Core/Config/PrismOptions.cs
+++ b/Framework/Intersect.Framework.Core/Config/PrismOptions.cs
@@ -1,0 +1,29 @@
+using System;
+
+namespace Intersect.Config;
+
+/// <summary>
+///     Configuration options for alignment prisms.
+/// </summary>
+public class PrismOptions
+{
+    /// <summary>
+    ///     Base amount of hit points a prism has at level 1.
+    /// </summary>
+    public int BaseHp { get; set; } = 1000;
+
+    /// <summary>
+    ///     Additional hit points gained per prism level.
+    /// </summary>
+    public int HpPerLevel { get; set; } = 100;
+
+    /// <summary>
+    ///     Seconds after placement until the prism becomes vulnerable.
+    /// </summary>
+    public int MaturationSeconds { get; set; } = 300;
+
+    /// <summary>
+    ///     Seconds after the last hit before the prism battle ends.
+    /// </summary>
+    public int AttackCooldownSeconds { get; set; } = 30;
+}

--- a/Framework/Intersect.Framework.Core/GameObjects/Prisms/VulnerabilityWindow.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Prisms/VulnerabilityWindow.cs
@@ -1,6 +1,45 @@
+using System;
+
 namespace Intersect.Framework.Core.GameObjects.Prisms;
 
+/// <summary>
+/// Represents a weekly window in which a prism can be attacked.
+/// </summary>
 public class VulnerabilityWindow
 {
+    /// <summary>
+    /// Day of week when this window applies.
+    /// </summary>
+    public DayOfWeek Day { get; set; }
+
+    /// <summary>
+    /// Start time of day for the window.
+    /// </summary>
+    public TimeSpan Start { get; set; }
+
+    /// <summary>
+    /// End time of day for the window.
+    /// </summary>
+    public TimeSpan End { get; set; }
+
+    /// <summary>
+    ///     Determines if the supplied time falls within this window.
+    /// </summary>
+    public bool Contains(DateTime time)
+    {
+        if (time.DayOfWeek != Day)
+        {
+            return false;
+        }
+
+        var tod = time.TimeOfDay;
+        if (Start <= End)
+        {
+            return tod >= Start && tod <= End;
+        }
+
+        // Overnight window
+        return tod >= Start || tod <= End;
+    }
 }
 

--- a/Intersect.Server.Core/Jobs/PrismScheduler.cs
+++ b/Intersect.Server.Core/Jobs/PrismScheduler.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Intersect.Server.Entities;
+using Intersect.Server.Maps;
+using Intersect.Server.Services.Prisms;
+
+namespace Intersect.Server.Jobs;
+
+internal static class PrismScheduler
+{
+    private static Timer? _timer;
+    private static readonly TimeSpan Interval = TimeSpan.FromSeconds(1);
+
+    public static void Start()
+    {
+        _timer ??= new Timer(Tick, null, Interval, Interval);
+    }
+
+    private static void Tick(object? state)
+    {
+        var visited = new HashSet<Guid>();
+        foreach (var player in Player.OnlinePlayers)
+        {
+            if (player == null || visited.Contains(player.MapInstanceId))
+            {
+                continue;
+            }
+
+            visited.Add(player.MapInstanceId);
+
+            if (!MapController.TryGetInstanceFromMap(player.MapId, player.MapInstanceId, out var mapInstance))
+            {
+                continue;
+            }
+
+            PrismService.TickState(mapInstance);
+        }
+    }
+}

--- a/Intersect.Server.Core/Services/Prisms/PrismCombatService.cs
+++ b/Intersect.Server.Core/Services/Prisms/PrismCombatService.cs
@@ -1,0 +1,33 @@
+using System;
+using Intersect.Framework.Core.GameObjects.Prisms;
+using Intersect.Server.Entities;
+using Intersect.Server.Maps;
+
+namespace Intersect.Server.Services.Prisms;
+
+internal static class PrismCombatService
+{
+    public static void ApplyDamage(MapInstance map, AlignmentPrism prism, int amount, Player attacker)
+    {
+        if (prism == null || amount <= 0)
+        {
+            return;
+        }
+
+        prism.Hp = Math.Max(0, prism.Hp - amount);
+        prism.LastHitAt = DateTime.UtcNow;
+
+        if (prism.State != PrismState.UnderAttack)
+        {
+            prism.State = PrismState.UnderAttack;
+            prism.CurrentBattleId ??= Guid.NewGuid();
+        }
+
+        if (prism.Hp <= 0)
+        {
+            prism.State = PrismState.Destroyed;
+        }
+
+        PrismService.Broadcast(map);
+    }
+}

--- a/Intersect.Server.Core/Services/Prisms/PrismService.cs
+++ b/Intersect.Server.Core/Services/Prisms/PrismService.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Linq;
+using Intersect.Config;
+using Intersect.Framework.Core.GameObjects.Prisms;
+using Intersect.Server.Entities;
+using Intersect.Server.Maps;
+using Intersect.Server.Networking;
+
+namespace Intersect.Server.Services.Prisms;
+
+internal static class PrismService
+{
+    public static AlignmentPrism PlacePrism(Player player, MapInstance map)
+    {
+        var options = Options.Instance.Prism;
+        var maxHp = options.BaseHp + options.HpPerLevel * Math.Max(0, player?.Level - 1 ?? 0);
+        var now = DateTime.UtcNow;
+
+        var prism = new AlignmentPrism
+        {
+            Id = Guid.NewGuid(),
+            Owner = player.Faction,
+            State = PrismState.Placed,
+            MapId = map.MapInstanceId,
+            PlacedAt = now,
+            MaturationEndsAt = now.AddSeconds(options.MaturationSeconds),
+            Level = player.Level,
+            MaxHp = maxHp,
+            Hp = maxHp,
+        };
+
+        map.ControllingPrism = prism;
+        Broadcast(map);
+        return prism;
+    }
+
+    public static void TickState(MapInstance map)
+    {
+        var prism = map.ControllingPrism;
+        if (prism == null)
+        {
+            return;
+        }
+
+        var now = DateTime.UtcNow;
+        var changed = false;
+
+        switch (prism.State)
+        {
+            case PrismState.Placed:
+                if (prism.MaturationEndsAt.HasValue && now >= prism.MaturationEndsAt.Value)
+                {
+                    prism.State = PrismState.Vulnerable;
+                    changed = true;
+                }
+                break;
+            case PrismState.UnderAttack:
+                if (prism.Hp <= 0)
+                {
+                    prism.State = PrismState.Destroyed;
+                    changed = true;
+                }
+                else if (prism.LastHitAt.HasValue &&
+                         (now - prism.LastHitAt.Value).TotalSeconds >= Options.Instance.Prism.AttackCooldownSeconds)
+                {
+                    prism.State = PrismState.Dominated;
+                    changed = true;
+                }
+                break;
+        }
+
+        if (changed)
+        {
+            Broadcast(map);
+        }
+    }
+
+    public static bool IsInVulnerabilityWindow(AlignmentPrism prism, DateTime time)
+    {
+        if (prism.Windows == null || prism.Windows.Count == 0)
+        {
+            return true;
+        }
+
+        return prism.Windows.Any(window => window.Contains(time));
+    }
+
+    public static void Broadcast(MapInstance map)
+    {
+        foreach (var player in map.GetPlayers())
+        {
+            PacketSender.SendAreaPacket(player);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add PrismOptions config and expose through Options
- create PrismService and PrismCombatService for placement and combat
- implement vulnerability window helper and periodic PrismScheduler job

## Testing
- `dotnet build Intersect.Server.Core/Intersect.Server.Core.csproj --no-restore` *(fails: missing LiteNetLib types)*

------
https://chatgpt.com/codex/tasks/task_e_68afcfb4ae708324a69c003695922b9c