### PR TITLE
feat: add prism entities and repositories

### DIFF
--- a/Intersect.Server.Core/Database/PlayerData/PlayerContext.cs
+++ b/Intersect.Server.Core/Database/PlayerData/PlayerContext.cs
@@ -4,6 +4,7 @@ using Intersect.Server.Database.PlayerData.Migrations;
 using Intersect.Server.Database.PlayerData.Players;
 using Intersect.Server.Database.PlayerData.SeedData;
 using Intersect.Server.Entities;
+using Intersect.Server.Database.Prisms;
 using Microsoft.EntityFrameworkCore;
 
 namespace Intersect.Server.Database.PlayerData;
@@ -52,6 +53,14 @@ public abstract partial class PlayerContext : IntersectDbContext<PlayerContext>,
     public DbSet<UserVariable> User_Variables { get; set; }
     public DbSet<MailBox> Player_MailBox { get; set; }
     public DbSet<KillLog> Player_KillLogs { get; set; }
+
+    public DbSet<AlignmentPrism> Prisms { get; set; }
+
+    public DbSet<PrismBattle> PrismBattles { get; set; }
+
+    public DbSet<PrismContribution> PrismContributions { get; set; }
+
+    public DbSet<FactionAreaBonus> FactionAreaBonuses { get; set; }
 
     internal async ValueTask Commit(
         bool commit = false,
@@ -146,6 +155,11 @@ public abstract partial class PlayerContext : IntersectDbContext<PlayerContext>,
 
         modelBuilder.Entity<KillLog>().HasOne(k => k.Attacker).WithMany().OnDelete(DeleteBehavior.Restrict);
         modelBuilder.Entity<KillLog>().HasOne(k => k.Victim).WithMany().OnDelete(DeleteBehavior.Restrict);
+
+        modelBuilder.Entity<AlignmentPrism>();
+        modelBuilder.Entity<PrismBattle>().HasOne<AlignmentPrism>().WithMany().HasForeignKey(b => b.PrismId);
+        modelBuilder.Entity<FactionAreaBonus>().HasOne<AlignmentPrism>().WithMany().HasForeignKey(b => b.PrismId);
+        modelBuilder.Entity<PrismContribution>().HasOne<PrismBattle>().WithMany().HasForeignKey(c => c.BattleId);
     }
 
     public void Seed()

--- a/Intersect.Server.Core/Database/Prisms/AlignmentPrism.cs
+++ b/Intersect.Server.Core/Database/Prisms/AlignmentPrism.cs
@@ -1,0 +1,21 @@
+using System;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Intersect.Server.Database.Prisms;
+
+public partial class AlignmentPrism
+{
+    [DatabaseGenerated(DatabaseGeneratedOption.None)]
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    /// <summary>
+    /// Map identifier where the prism is located.
+    /// </summary>
+    public Guid MapId { get; set; }
+
+    /// <summary>
+    /// Faction currently owning the prism.
+    /// </summary>
+    public int Faction { get; set; }
+}
+

--- a/Intersect.Server.Core/Database/Prisms/FactionAreaBonus.cs
+++ b/Intersect.Server.Core/Database/Prisms/FactionAreaBonus.cs
@@ -1,0 +1,17 @@
+using System;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Intersect.Server.Database.Prisms;
+
+public partial class FactionAreaBonus
+{
+    [DatabaseGenerated(DatabaseGeneratedOption.None)]
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    public Guid PrismId { get; set; }
+
+    public int Faction { get; set; }
+
+    public int Bonus { get; set; }
+}
+

--- a/Intersect.Server.Core/Database/Prisms/IPrismBattleRepository.cs
+++ b/Intersect.Server.Core/Database/Prisms/IPrismBattleRepository.cs
@@ -1,0 +1,12 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+
+namespace Intersect.Server.Database.Prisms;
+
+public interface IPrismBattleRepository
+{
+    DbSet<PrismBattle> Battles { get; }
+    Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);
+}
+

--- a/Intersect.Server.Core/Database/Prisms/IPrismContributionRepository.cs
+++ b/Intersect.Server.Core/Database/Prisms/IPrismContributionRepository.cs
@@ -1,0 +1,12 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+
+namespace Intersect.Server.Database.Prisms;
+
+public interface IPrismContributionRepository
+{
+    DbSet<PrismContribution> Contributions { get; }
+    Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);
+}
+

--- a/Intersect.Server.Core/Database/Prisms/IPrismRepository.cs
+++ b/Intersect.Server.Core/Database/Prisms/IPrismRepository.cs
@@ -1,0 +1,13 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+
+namespace Intersect.Server.Database.Prisms;
+
+public interface IPrismRepository
+{
+    DbSet<AlignmentPrism> Prisms { get; }
+    DbSet<FactionAreaBonus> FactionAreaBonuses { get; }
+    Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);
+}
+

--- a/Intersect.Server.Core/Database/Prisms/PrismBattle.cs
+++ b/Intersect.Server.Core/Database/Prisms/PrismBattle.cs
@@ -1,0 +1,17 @@
+using System;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Intersect.Server.Database.Prisms;
+
+public partial class PrismBattle
+{
+    [DatabaseGenerated(DatabaseGeneratedOption.None)]
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    public Guid PrismId { get; set; }
+
+    public DateTime StartedAt { get; set; }
+
+    public DateTime? EndedAt { get; set; }
+}
+

--- a/Intersect.Server.Core/Database/Prisms/PrismContribution.cs
+++ b/Intersect.Server.Core/Database/Prisms/PrismContribution.cs
@@ -1,0 +1,17 @@
+using System;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Intersect.Server.Database.Prisms;
+
+public partial class PrismContribution
+{
+    [DatabaseGenerated(DatabaseGeneratedOption.None)]
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    public Guid BattleId { get; set; }
+
+    public Guid PlayerId { get; set; }
+
+    public int Contribution { get; set; }
+}
+

--- a/Intersect.Server.Core/Database/Prisms/SqlitePrismBattleRepository.cs
+++ b/Intersect.Server.Core/Database/Prisms/SqlitePrismBattleRepository.cs
@@ -1,0 +1,22 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Intersect.Server.Database.PlayerData;
+using Microsoft.EntityFrameworkCore;
+
+namespace Intersect.Server.Database.Prisms;
+
+public sealed class SqlitePrismBattleRepository : IPrismBattleRepository
+{
+    private readonly SqlitePlayerContext _context;
+
+    public SqlitePrismBattleRepository(SqlitePlayerContext context)
+    {
+        _context = context;
+    }
+
+    public DbSet<PrismBattle> Battles => _context.PrismBattles;
+
+    public Task<int> SaveChangesAsync(CancellationToken cancellationToken = default) =>
+        _context.SaveChangesAsync(cancellationToken);
+}
+

--- a/Intersect.Server.Core/Database/Prisms/SqlitePrismContributionRepository.cs
+++ b/Intersect.Server.Core/Database/Prisms/SqlitePrismContributionRepository.cs
@@ -1,0 +1,22 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Intersect.Server.Database.PlayerData;
+using Microsoft.EntityFrameworkCore;
+
+namespace Intersect.Server.Database.Prisms;
+
+public sealed class SqlitePrismContributionRepository : IPrismContributionRepository
+{
+    private readonly SqlitePlayerContext _context;
+
+    public SqlitePrismContributionRepository(SqlitePlayerContext context)
+    {
+        _context = context;
+    }
+
+    public DbSet<PrismContribution> Contributions => _context.PrismContributions;
+
+    public Task<int> SaveChangesAsync(CancellationToken cancellationToken = default) =>
+        _context.SaveChangesAsync(cancellationToken);
+}
+

--- a/Intersect.Server.Core/Database/Prisms/SqlitePrismRepository.cs
+++ b/Intersect.Server.Core/Database/Prisms/SqlitePrismRepository.cs
@@ -1,0 +1,24 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Intersect.Server.Database.PlayerData;
+using Microsoft.EntityFrameworkCore;
+
+namespace Intersect.Server.Database.Prisms;
+
+public sealed class SqlitePrismRepository : IPrismRepository
+{
+    private readonly SqlitePlayerContext _context;
+
+    public SqlitePrismRepository(SqlitePlayerContext context)
+    {
+        _context = context;
+    }
+
+    public DbSet<AlignmentPrism> Prisms => _context.Prisms;
+
+    public DbSet<FactionAreaBonus> FactionAreaBonuses => _context.FactionAreaBonuses;
+
+    public Task<int> SaveChangesAsync(CancellationToken cancellationToken = default) =>
+        _context.SaveChangesAsync(cancellationToken);
+}
+

--- a/Intersect.Server/Database/Prisms/MySqlPrismBattleRepository.cs
+++ b/Intersect.Server/Database/Prisms/MySqlPrismBattleRepository.cs
@@ -1,0 +1,23 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Intersect.Server.Database.PlayerData;
+using Intersect.Server.Database.Prisms;
+using Microsoft.EntityFrameworkCore;
+
+namespace Intersect.Server.Database.Prisms;
+
+public sealed class MySqlPrismBattleRepository : IPrismBattleRepository
+{
+    private readonly MySqlPlayerContext _context;
+
+    public MySqlPrismBattleRepository(MySqlPlayerContext context)
+    {
+        _context = context;
+    }
+
+    public DbSet<PrismBattle> Battles => _context.PrismBattles;
+
+    public Task<int> SaveChangesAsync(CancellationToken cancellationToken = default) =>
+        _context.SaveChangesAsync(cancellationToken);
+}
+

--- a/Intersect.Server/Database/Prisms/MySqlPrismContributionRepository.cs
+++ b/Intersect.Server/Database/Prisms/MySqlPrismContributionRepository.cs
@@ -1,0 +1,23 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Intersect.Server.Database.PlayerData;
+using Intersect.Server.Database.Prisms;
+using Microsoft.EntityFrameworkCore;
+
+namespace Intersect.Server.Database.Prisms;
+
+public sealed class MySqlPrismContributionRepository : IPrismContributionRepository
+{
+    private readonly MySqlPlayerContext _context;
+
+    public MySqlPrismContributionRepository(MySqlPlayerContext context)
+    {
+        _context = context;
+    }
+
+    public DbSet<PrismContribution> Contributions => _context.PrismContributions;
+
+    public Task<int> SaveChangesAsync(CancellationToken cancellationToken = default) =>
+        _context.SaveChangesAsync(cancellationToken);
+}
+

--- a/Intersect.Server/Database/Prisms/MySqlPrismRepository.cs
+++ b/Intersect.Server/Database/Prisms/MySqlPrismRepository.cs
@@ -1,0 +1,25 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Intersect.Server.Database.PlayerData;
+using Intersect.Server.Database.Prisms;
+using Microsoft.EntityFrameworkCore;
+
+namespace Intersect.Server.Database.Prisms;
+
+public sealed class MySqlPrismRepository : IPrismRepository
+{
+    private readonly MySqlPlayerContext _context;
+
+    public MySqlPrismRepository(MySqlPlayerContext context)
+    {
+        _context = context;
+    }
+
+    public DbSet<AlignmentPrism> Prisms => _context.Prisms;
+
+    public DbSet<FactionAreaBonus> FactionAreaBonuses => _context.FactionAreaBonuses;
+
+    public Task<int> SaveChangesAsync(CancellationToken cancellationToken = default) =>
+        _context.SaveChangesAsync(cancellationToken);
+}
+


### PR DESCRIPTION
## Summary
- add prism-related entity models
- extend player context for prism data
- create prism repositories for SQLite and MySQL providers

## Testing
- `dotnet build -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68afcf7cb504832488627d3c07798ea4