### PR TITLE
feat: add conquest service and faction bonus hooks

### DIFF
--- a/Intersect.Server.Core/Services/Prisms/ConquestService.cs
+++ b/Intersect.Server.Core/Services/Prisms/ConquestService.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Intersect.Framework.Core.GameObjects.Prisms;
+using Intersect.Server.Core.Services;
+using Intersect.Server.Database.Prisms;
+using Intersect.Server.Entities;
+using Intersect.Server.Maps;
+using Microsoft.EntityFrameworkCore;
+
+namespace Intersect.Server.Services.Prisms;
+
+/// <summary>
+/// Handles capturing and destroying of prisms and any related bonuses.
+/// </summary>
+public sealed class ConquestService : IConquestService
+{
+    private readonly IPrismRepository _repository;
+    private readonly IFactionBonusApplier _bonusApplier;
+
+    public ConquestService(IPrismRepository repository, IFactionBonusApplier bonusApplier)
+    {
+        _repository = repository;
+        _bonusApplier = bonusApplier;
+    }
+
+    /// <summary>
+    /// Captures the prism for the captor's faction and applies any area bonuses.
+    /// </summary>
+    public async Task CaptureAsync(MapInstance map, Player captor, CancellationToken cancellationToken = default)
+    {
+        if (map?.ControllingPrism == null || captor == null)
+        {
+            return;
+        }
+
+        var prism = map.ControllingPrism;
+        prism.Owner = captor.Faction;
+        prism.State = PrismState.Dominated;
+
+        var bonus = await _repository.FactionAreaBonuses
+            .FirstOrDefaultAsync(b => b.PrismId == prism.Id, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (bonus == null)
+        {
+            bonus = new FactionAreaBonus
+            {
+                PrismId = prism.Id,
+                Faction = (int)captor.Faction,
+                Bonus = 0,
+            };
+            _repository.FactionAreaBonuses.Add(bonus);
+        }
+        else
+        {
+            _bonusApplier.ClearBonus(prism.Id);
+            bonus.Faction = (int)captor.Faction;
+        }
+
+        await _repository.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        _bonusApplier.ApplyBonus(bonus);
+
+        // Award honor for capturing the prism
+        HonorService.AdjustHonor(captor, 50);
+    }
+
+    /// <summary>
+    /// Destroys the prism removing any associated bonuses.
+    /// </summary>
+    public async Task DestroyAsync(MapInstance map, Player destroyer, CancellationToken cancellationToken = default)
+    {
+        if (map?.ControllingPrism == null)
+        {
+            return;
+        }
+
+        var prism = map.ControllingPrism;
+
+        var bonus = await _repository.FactionAreaBonuses
+            .FirstOrDefaultAsync(b => b.PrismId == prism.Id, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (bonus != null)
+        {
+            _bonusApplier.ClearBonus(prism.Id);
+            _repository.FactionAreaBonuses.Remove(bonus);
+        }
+
+        map.ControllingPrism = null;
+        _repository.Prisms.Remove(prism);
+        await _repository.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        if (destroyer != null)
+        {
+            HonorService.AdjustHonor(destroyer, 25);
+        }
+    }
+}
+

--- a/Intersect.Server.Core/Services/Prisms/FactionAreaBonusApplier.cs
+++ b/Intersect.Server.Core/Services/Prisms/FactionAreaBonusApplier.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Concurrent;
+using Intersect.Server.Database.Prisms;
+using Intersect.Server.Entities;
+using Intersect.Server.Maps;
+
+namespace Intersect.Server.Services.Prisms;
+
+/// <summary>
+/// Simple in-memory implementation of <see cref="IFactionBonusApplier"/> that tracks
+/// <see cref="FactionAreaBonus"/> entries and applies them to calculations.
+/// </summary>
+public sealed class FactionAreaBonusApplier : IFactionBonusApplier
+{
+    private readonly ConcurrentDictionary<Guid, FactionAreaBonus> _bonuses = new();
+
+    public float ApplyDropBonus(Player player, float value)
+    {
+        return Apply(player, value);
+    }
+
+    public float ApplyGatherBonus(Player player, float value)
+    {
+        return Apply(player, value);
+    }
+
+    public float ApplyCraftBonus(Player player, float value)
+    {
+        return Apply(player, value);
+    }
+
+    public void ClearBonus(Guid prismId)
+    {
+        _bonuses.TryRemove(prismId, out _);
+    }
+
+    public void ApplyBonus(FactionAreaBonus bonus)
+    {
+        _bonuses[bonus.PrismId] = bonus;
+    }
+
+    private float Apply(Player player, float value)
+    {
+        if (player == null)
+        {
+            return value;
+        }
+
+        if (!MapController.TryGetInstanceFromMap(player.MapId, player.MapInstanceId, out var instance))
+        {
+            return value;
+        }
+
+        var prism = instance.ControllingPrism;
+        if (prism == null)
+        {
+            return value;
+        }
+
+        if (!_bonuses.TryGetValue(prism.Id, out var bonus))
+        {
+            return value;
+        }
+
+        if (bonus.Faction != (int)player.Faction)
+        {
+            return value;
+        }
+
+        return value * (1 + bonus.Bonus / 100f);
+    }
+}
+

--- a/Intersect.Server.Core/Services/Prisms/IConquestService.cs
+++ b/Intersect.Server.Core/Services/Prisms/IConquestService.cs
@@ -1,0 +1,14 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Intersect.Framework.Core.GameObjects.Prisms;
+using Intersect.Server.Entities;
+using Intersect.Server.Maps;
+
+namespace Intersect.Server.Services.Prisms;
+
+public interface IConquestService
+{
+    Task CaptureAsync(MapInstance map, Player captor, CancellationToken cancellationToken = default);
+    Task DestroyAsync(MapInstance map, Player destroyer, CancellationToken cancellationToken = default);
+}
+

--- a/Intersect.Server.Core/Services/Prisms/IFactionBonusApplier.cs
+++ b/Intersect.Server.Core/Services/Prisms/IFactionBonusApplier.cs
@@ -1,0 +1,40 @@
+using System;
+using Intersect.Server.Entities;
+using Intersect.Server.Database.Prisms;
+
+namespace Intersect.Server.Services.Prisms;
+
+/// <summary>
+/// Applies faction based area bonuses to various calculations.
+/// </summary>
+public interface IFactionBonusApplier
+{
+    /// <summary>
+    /// Applies the bonus multiplier for item drop calculations.
+    /// </summary>
+    /// <param name="player">Player for which the calculation is occurring.</param>
+    /// <param name="value">Base value.</param>
+    /// <returns>Modified value including any faction bonus.</returns>
+    float ApplyDropBonus(Player player, float value);
+
+    /// <summary>
+    /// Applies the bonus multiplier for resource gathering calculations.
+    /// </summary>
+    float ApplyGatherBonus(Player player, float value);
+
+    /// <summary>
+    /// Applies the bonus multiplier for crafting calculations.
+    /// </summary>
+    float ApplyCraftBonus(Player player, float value);
+
+    /// <summary>
+    /// Clears any cached bonus for the specified prism.
+    /// </summary>
+    void ClearBonus(Guid prismId);
+
+    /// <summary>
+    /// Applies a faction area bonus making it available for future calculations.
+    /// </summary>
+    void ApplyBonus(FactionAreaBonus bonus);
+}
+


### PR DESCRIPTION
## Summary
- implement ConquestService for prism capture and destruction with honor rewards
- add faction bonus applier with drop, gathering, and crafting hooks

## Testing
- `dotnet test` *(fails: project references missing LiteNetLib / dockpanelsuite)*


------
https://chatgpt.com/codex/tasks/task_e_68afd1d3818c8324bf9d411acdb92bf6