### PR TITLE
Add prism configuration UI

### DIFF
--- a/Framework/Intersect.Framework.Core/Config/Options.cs
+++ b/Framework/Intersect.Framework.Core/Config/Options.cs
@@ -269,6 +269,9 @@ public partial record Options
 
         SaveToDisk();
 
+        // Load prism configuration after ensuring the resources directory exists
+        PrismConfig.Load();
+
         return true;
     }
 
@@ -318,6 +321,9 @@ public partial record Options
             var loadedOptions = JsonConvert.DeserializeObject<Options>(data, PublicSerializerSettings);
             Instance = loadedOptions;
             OptionsLoaded?.Invoke(loadedOptions);
+
+            // Ensure prism definitions are loaded locally
+            PrismConfig.Load();
         }
         catch (Exception exception)
         {

--- a/Framework/Intersect.Framework.Core/Config/PrismConfig.cs
+++ b/Framework/Intersect.Framework.Core/Config/PrismConfig.cs
@@ -1,0 +1,48 @@
+using System.Collections.Generic;
+using System.IO;
+using Newtonsoft.Json;
+using Intersect.Framework.Core.GameObjects.Prisms;
+
+namespace Intersect.Config;
+
+/// <summary>
+///     Handles loading and saving of prism definitions that are shared by the server and client.
+/// </summary>
+public static class PrismConfig
+{
+    /// <summary>
+    ///     Collection of configured prisms.
+    /// </summary>
+    public static List<AlignmentPrism> Prisms { get; private set; } = new();
+
+    private static string PrismPath => Path.Combine(Options.ResourcesDirectory, "prisms.json");
+
+    /// <summary>
+    ///     Loads prism definitions from disk if available.
+    /// </summary>
+    public static void Load()
+    {
+        if (!File.Exists(PrismPath))
+        {
+            Prisms = new();
+            return;
+        }
+
+        var json = File.ReadAllText(PrismPath);
+        Prisms = JsonConvert.DeserializeObject<List<AlignmentPrism>>(json) ?? new();
+    }
+
+    /// <summary>
+    ///     Persists prism definitions to disk.
+    /// </summary>
+    public static void Save()
+    {
+        if (!Directory.Exists(Options.ResourcesDirectory))
+        {
+            Directory.CreateDirectory(Options.ResourcesDirectory);
+        }
+
+        var json = JsonConvert.SerializeObject(Prisms, Formatting.Indented);
+        File.WriteAllText(PrismPath, json);
+    }
+}

--- a/Framework/Intersect.Framework.Core/GameObjects/Prisms/PrismArea.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Prisms/PrismArea.cs
@@ -1,6 +1,28 @@
 namespace Intersect.Framework.Core.GameObjects.Prisms;
 
+/// <summary>
+///     Rectangular area affected by a prism.
+/// </summary>
 public class PrismArea
 {
+    /// <summary>
+    ///     X-coordinate of the top-left corner in tiles.
+    /// </summary>
+    public int X { get; set; }
+
+    /// <summary>
+    ///     Y-coordinate of the top-left corner in tiles.
+    /// </summary>
+    public int Y { get; set; }
+
+    /// <summary>
+    ///     Width of the area in tiles.
+    /// </summary>
+    public int Width { get; set; }
+
+    /// <summary>
+    ///     Height of the area in tiles.
+    /// </summary>
+    public int Height { get; set; }
 }
 

--- a/Framework/Intersect.Framework.Core/GameObjects/Prisms/PrismModule.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Prisms/PrismModule.cs
@@ -1,6 +1,14 @@
 namespace Intersect.Framework.Core.GameObjects.Prisms;
 
+/// <summary>
+///     Represents a module attached to a prism. Modules can later be expanded with
+///     additional behaviour; currently only the module name is stored.
+/// </summary>
 public class PrismModule
 {
+    /// <summary>
+    ///     Name or identifier of the module.
+    /// </summary>
+    public string Name { get; set; } = string.Empty;
 }
 

--- a/Intersect.Editor/Forms/Editors/frmPrismOptions.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/frmPrismOptions.Designer.cs
@@ -1,0 +1,181 @@
+using DarkUI.Controls;
+
+namespace Intersect.Editor.Forms.Editors
+{
+    partial class FrmPrismOptions
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        private DarkNumericUpDown nudBaseHp;
+        private DarkNumericUpDown nudHpPerLevel;
+        private DarkNumericUpDown nudMaturationSeconds;
+        private DarkNumericUpDown nudAttackCooldown;
+        private DarkButton btnSave;
+        private System.Windows.Forms.Label lblBaseHp;
+        private System.Windows.Forms.Label lblHpPerLevel;
+        private System.Windows.Forms.Label lblMaturation;
+        private System.Windows.Forms.Label lblCooldown;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.nudBaseHp = new DarkNumericUpDown();
+            this.nudHpPerLevel = new DarkNumericUpDown();
+            this.nudMaturationSeconds = new DarkNumericUpDown();
+            this.nudAttackCooldown = new DarkNumericUpDown();
+            this.btnSave = new DarkButton();
+            this.lblBaseHp = new System.Windows.Forms.Label();
+            this.lblHpPerLevel = new System.Windows.Forms.Label();
+            this.lblMaturation = new System.Windows.Forms.Label();
+            this.lblCooldown = new System.Windows.Forms.Label();
+            ((System.ComponentModel.ISupportInitialize)(this.nudBaseHp)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.nudHpPerLevel)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.nudMaturationSeconds)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.nudAttackCooldown)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // nudBaseHp
+            // 
+            this.nudBaseHp.Location = new System.Drawing.Point(12, 12);
+            this.nudBaseHp.Maximum = new decimal(new int[] {
+            100000,
+            0,
+            0,
+            0});
+            this.nudBaseHp.Name = "nudBaseHp";
+            this.nudBaseHp.Size = new System.Drawing.Size(100, 20);
+            this.nudBaseHp.TabIndex = 0;
+            // 
+            // lblBaseHp
+            // 
+            this.lblBaseHp.AutoSize = true;
+            this.lblBaseHp.Location = new System.Drawing.Point(118, 14);
+            this.lblBaseHp.Name = "lblBaseHp";
+            this.lblBaseHp.Size = new System.Drawing.Size(48, 13);
+            this.lblBaseHp.TabIndex = 1;
+            this.lblBaseHp.Text = "Base HP";
+            // 
+            // nudHpPerLevel
+            // 
+            this.nudHpPerLevel.Location = new System.Drawing.Point(12, 42);
+            this.nudHpPerLevel.Maximum = new decimal(new int[] {
+            100000,
+            0,
+            0,
+            0});
+            this.nudHpPerLevel.Name = "nudHpPerLevel";
+            this.nudHpPerLevel.Size = new System.Drawing.Size(100, 20);
+            this.nudHpPerLevel.TabIndex = 2;
+            // 
+            // lblHpPerLevel
+            // 
+            this.lblHpPerLevel.AutoSize = true;
+            this.lblHpPerLevel.Location = new System.Drawing.Point(118, 44);
+            this.lblHpPerLevel.Name = "lblHpPerLevel";
+            this.lblHpPerLevel.Size = new System.Drawing.Size(54, 13);
+            this.lblHpPerLevel.TabIndex = 3;
+            this.lblHpPerLevel.Text = "HP/Level";
+            // 
+            // nudMaturationSeconds
+            // 
+            this.nudMaturationSeconds.Location = new System.Drawing.Point(12, 72);
+            this.nudMaturationSeconds.Maximum = new decimal(new int[] {
+            100000,
+            0,
+            0,
+            0});
+            this.nudMaturationSeconds.Name = "nudMaturationSeconds";
+            this.nudMaturationSeconds.Size = new System.Drawing.Size(100, 20);
+            this.nudMaturationSeconds.TabIndex = 4;
+            // 
+            // lblMaturation
+            // 
+            this.lblMaturation.AutoSize = true;
+            this.lblMaturation.Location = new System.Drawing.Point(118, 74);
+            this.lblMaturation.Name = "lblMaturation";
+            this.lblMaturation.Size = new System.Drawing.Size(60, 13);
+            this.lblMaturation.TabIndex = 5;
+            this.lblMaturation.Text = "Mature (s)";
+            // 
+            // nudAttackCooldown
+            // 
+            this.nudAttackCooldown.Location = new System.Drawing.Point(12, 102);
+            this.nudAttackCooldown.Maximum = new decimal(new int[] {
+            100000,
+            0,
+            0,
+            0});
+            this.nudAttackCooldown.Name = "nudAttackCooldown";
+            this.nudAttackCooldown.Size = new System.Drawing.Size(100, 20);
+            this.nudAttackCooldown.TabIndex = 6;
+            // 
+            // lblCooldown
+            // 
+            this.lblCooldown.AutoSize = true;
+            this.lblCooldown.Location = new System.Drawing.Point(118, 104);
+            this.lblCooldown.Name = "lblCooldown";
+            this.lblCooldown.Size = new System.Drawing.Size(69, 13);
+            this.lblCooldown.TabIndex = 7;
+            this.lblCooldown.Text = "Cooldown (s)";
+            // 
+            // btnSave
+            // 
+            this.btnSave.Location = new System.Drawing.Point(12, 132);
+            this.btnSave.Name = "btnSave";
+            this.btnSave.Size = new System.Drawing.Size(75, 23);
+            this.btnSave.TabIndex = 8;
+            this.btnSave.Text = "Save";
+            this.btnSave.Click += new System.EventHandler(this.btnSave_Click);
+            // 
+            // FrmPrismOptions
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(240, 170);
+            this.Controls.Add(this.btnSave);
+            this.Controls.Add(this.lblCooldown);
+            this.Controls.Add(this.nudAttackCooldown);
+            this.Controls.Add(this.lblMaturation);
+            this.Controls.Add(this.nudMaturationSeconds);
+            this.Controls.Add(this.lblHpPerLevel);
+            this.Controls.Add(this.nudHpPerLevel);
+            this.Controls.Add(this.lblBaseHp);
+            this.Controls.Add(this.nudBaseHp);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
+            this.Name = "FrmPrismOptions";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.Text = "Prism Options";
+            ((System.ComponentModel.ISupportInitialize)(this.nudBaseHp)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.nudHpPerLevel)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.nudMaturationSeconds)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.nudAttackCooldown)).EndInit();
+            this.ResumeLayout(false);
+            this.PerformLayout();
+        }
+
+        #endregion
+    }
+}

--- a/Intersect.Editor/Forms/Editors/frmPrismOptions.cs
+++ b/Intersect.Editor/Forms/Editors/frmPrismOptions.cs
@@ -1,0 +1,30 @@
+using System;
+using DarkUI.Controls;
+using System.Windows.Forms;
+using Intersect.Config;
+
+namespace Intersect.Editor.Forms.Editors;
+
+public partial class FrmPrismOptions : Form
+{
+    public FrmPrismOptions()
+    {
+        InitializeComponent();
+        Icon = Program.Icon;
+
+        nudBaseHp.Value = Options.Instance.Prism.BaseHp;
+        nudHpPerLevel.Value = Options.Instance.Prism.HpPerLevel;
+        nudMaturationSeconds.Value = Options.Instance.Prism.MaturationSeconds;
+        nudAttackCooldown.Value = Options.Instance.Prism.AttackCooldownSeconds;
+    }
+
+    private void btnSave_Click(object sender, EventArgs e)
+    {
+        Options.Instance.Prism.BaseHp = (int)nudBaseHp.Value;
+        Options.Instance.Prism.HpPerLevel = (int)nudHpPerLevel.Value;
+        Options.Instance.Prism.MaturationSeconds = (int)nudMaturationSeconds.Value;
+        Options.Instance.Prism.AttackCooldownSeconds = (int)nudAttackCooldown.Value;
+        Options.SaveToDisk();
+        Close();
+    }
+}

--- a/Intersect.Editor/Forms/Editors/frmPrismOptions.resx
+++ b/Intersect.Editor/Forms/Editors/frmPrismOptions.resx
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/Intersect.Editor/Forms/Editors/frmPrisms.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/frmPrisms.Designer.cs
@@ -1,0 +1,355 @@
+using DarkUI.Controls;
+
+namespace Intersect.Editor.Forms.Editors
+{
+    partial class FrmPrisms
+    {
+        private System.ComponentModel.IContainer components = null;
+        private System.Windows.Forms.ListBox lstPrisms;
+        private System.Windows.Forms.TextBox txtMapId;
+        private DarkNumericUpDown nudX;
+        private DarkNumericUpDown nudY;
+        private DarkNumericUpDown nudLevel;
+        private System.Windows.Forms.TextBox txtWindows;
+        private System.Windows.Forms.TextBox txtModules;
+        private DarkNumericUpDown nudAreaX;
+        private DarkNumericUpDown nudAreaY;
+        private DarkNumericUpDown nudAreaW;
+        private DarkNumericUpDown nudAreaH;
+        private DarkButton btnAdd;
+        private DarkButton btnDelete;
+        private DarkButton btnSave;
+        private System.Windows.Forms.Label lblMapId;
+        private System.Windows.Forms.Label lblX;
+        private System.Windows.Forms.Label lblY;
+        private System.Windows.Forms.Label lblLevel;
+        private System.Windows.Forms.Label lblWindows;
+        private System.Windows.Forms.Label lblModules;
+        private System.Windows.Forms.Label lblAreaX;
+        private System.Windows.Forms.Label lblAreaY;
+        private System.Windows.Forms.Label lblAreaW;
+        private System.Windows.Forms.Label lblAreaH;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        private void InitializeComponent()
+        {
+            this.lstPrisms = new System.Windows.Forms.ListBox();
+            this.txtMapId = new System.Windows.Forms.TextBox();
+            this.nudX = new DarkNumericUpDown();
+            this.nudY = new DarkNumericUpDown();
+            this.nudLevel = new DarkNumericUpDown();
+            this.txtWindows = new System.Windows.Forms.TextBox();
+            this.txtModules = new System.Windows.Forms.TextBox();
+            this.nudAreaX = new DarkNumericUpDown();
+            this.nudAreaY = new DarkNumericUpDown();
+            this.nudAreaW = new DarkNumericUpDown();
+            this.nudAreaH = new DarkNumericUpDown();
+            this.btnAdd = new DarkButton();
+            this.btnDelete = new DarkButton();
+            this.btnSave = new DarkButton();
+            this.lblMapId = new System.Windows.Forms.Label();
+            this.lblX = new System.Windows.Forms.Label();
+            this.lblY = new System.Windows.Forms.Label();
+            this.lblLevel = new System.Windows.Forms.Label();
+            this.lblWindows = new System.Windows.Forms.Label();
+            this.lblModules = new System.Windows.Forms.Label();
+            this.lblAreaX = new System.Windows.Forms.Label();
+            this.lblAreaY = new System.Windows.Forms.Label();
+            this.lblAreaW = new System.Windows.Forms.Label();
+            this.lblAreaH = new System.Windows.Forms.Label();
+            ((System.ComponentModel.ISupportInitialize)(this.nudX)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.nudY)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.nudLevel)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.nudAreaX)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.nudAreaY)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.nudAreaW)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.nudAreaH)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // lstPrisms
+            // 
+            this.lstPrisms.Location = new System.Drawing.Point(10, 10);
+            this.lstPrisms.Name = "lstPrisms";
+            this.lstPrisms.Size = new System.Drawing.Size(200, 300);
+            this.lstPrisms.TabIndex = 0;
+            this.lstPrisms.SelectedIndexChanged += new System.EventHandler(this.lstPrisms_SelectedIndexChanged);
+            // 
+            // txtMapId
+            // 
+            this.txtMapId.Location = new System.Drawing.Point(220, 10);
+            this.txtMapId.Name = "txtMapId";
+            this.txtMapId.Size = new System.Drawing.Size(200, 20);
+            this.txtMapId.TabIndex = 1;
+            // 
+            // lblMapId
+            // 
+            this.lblMapId.AutoSize = true;
+            this.lblMapId.Location = new System.Drawing.Point(430, 13);
+            this.lblMapId.Name = "lblMapId";
+            this.lblMapId.Size = new System.Drawing.Size(44, 13);
+            this.lblMapId.TabIndex = 2;
+            this.lblMapId.Text = "Map Id";
+            // 
+            // nudX
+            // 
+            this.nudX.Location = new System.Drawing.Point(220, 40);
+            this.nudX.Maximum = new decimal(new int[] {
+            1000,
+            0,
+            0,
+            0});
+            this.nudX.Name = "nudX";
+            this.nudX.Size = new System.Drawing.Size(80, 20);
+            this.nudX.TabIndex = 3;
+            // 
+            // lblX
+            // 
+            this.lblX.AutoSize = true;
+            this.lblX.Location = new System.Drawing.Point(310, 42);
+            this.lblX.Name = "lblX";
+            this.lblX.Size = new System.Drawing.Size(14, 13);
+            this.lblX.TabIndex = 4;
+            this.lblX.Text = "X";
+            // 
+            // nudY
+            // 
+            this.nudY.Location = new System.Drawing.Point(220, 70);
+            this.nudY.Maximum = new decimal(new int[] {
+            1000,
+            0,
+            0,
+            0});
+            this.nudY.Name = "nudY";
+            this.nudY.Size = new System.Drawing.Size(80, 20);
+            this.nudY.TabIndex = 5;
+            // 
+            // lblY
+            // 
+            this.lblY.AutoSize = true;
+            this.lblY.Location = new System.Drawing.Point(310, 72);
+            this.lblY.Name = "lblY";
+            this.lblY.Size = new System.Drawing.Size(14, 13);
+            this.lblY.TabIndex = 6;
+            this.lblY.Text = "Y";
+            // 
+            // nudLevel
+            // 
+            this.nudLevel.Location = new System.Drawing.Point(220, 100);
+            this.nudLevel.Maximum = new decimal(new int[] {
+            100,
+            0,
+            0,
+            0});
+            this.nudLevel.Name = "nudLevel";
+            this.nudLevel.Size = new System.Drawing.Size(80, 20);
+            this.nudLevel.TabIndex = 7;
+            // 
+            // lblLevel
+            // 
+            this.lblLevel.AutoSize = true;
+            this.lblLevel.Location = new System.Drawing.Point(310, 102);
+            this.lblLevel.Name = "lblLevel";
+            this.lblLevel.Size = new System.Drawing.Size(33, 13);
+            this.lblLevel.TabIndex = 8;
+            this.lblLevel.Text = "Level";
+            // 
+            // txtWindows
+            // 
+            this.txtWindows.Location = new System.Drawing.Point(220, 130);
+            this.txtWindows.Multiline = true;
+            this.txtWindows.Name = "txtWindows";
+            this.txtWindows.Size = new System.Drawing.Size(200, 80);
+            this.txtWindows.TabIndex = 9;
+            // 
+            // lblWindows
+            // 
+            this.lblWindows.AutoSize = true;
+            this.lblWindows.Location = new System.Drawing.Point(430, 130);
+            this.lblWindows.Name = "lblWindows";
+            this.lblWindows.Size = new System.Drawing.Size(140, 13);
+            this.lblWindows.TabIndex = 10;
+            this.lblWindows.Text = "Windows (Day|HH:mm|HH:mm)";
+            // 
+            // txtModules
+            // 
+            this.txtModules.Location = new System.Drawing.Point(220, 220);
+            this.txtModules.Multiline = true;
+            this.txtModules.Name = "txtModules";
+            this.txtModules.Size = new System.Drawing.Size(200, 80);
+            this.txtModules.TabIndex = 11;
+            // 
+            // lblModules
+            // 
+            this.lblModules.AutoSize = true;
+            this.lblModules.Location = new System.Drawing.Point(430, 220);
+            this.lblModules.Name = "lblModules";
+            this.lblModules.Size = new System.Drawing.Size(47, 13);
+            this.lblModules.TabIndex = 12;
+            this.lblModules.Text = "Modules";
+            // 
+            // nudAreaX
+            // 
+            this.nudAreaX.Location = new System.Drawing.Point(220, 310);
+            this.nudAreaX.Maximum = new decimal(new int[] {
+            1000,
+            0,
+            0,
+            0});
+            this.nudAreaX.Name = "nudAreaX";
+            this.nudAreaX.Size = new System.Drawing.Size(80, 20);
+            this.nudAreaX.TabIndex = 13;
+            // 
+            // lblAreaX
+            // 
+            this.lblAreaX.AutoSize = true;
+            this.lblAreaX.Location = new System.Drawing.Point(310, 312);
+            this.lblAreaX.Name = "lblAreaX";
+            this.lblAreaX.Size = new System.Drawing.Size(40, 13);
+            this.lblAreaX.TabIndex = 14;
+            this.lblAreaX.Text = "Area X";
+            // 
+            // nudAreaY
+            // 
+            this.nudAreaY.Location = new System.Drawing.Point(220, 340);
+            this.nudAreaY.Maximum = new decimal(new int[] {
+            1000,
+            0,
+            0,
+            0});
+            this.nudAreaY.Name = "nudAreaY";
+            this.nudAreaY.Size = new System.Drawing.Size(80, 20);
+            this.nudAreaY.TabIndex = 15;
+            // 
+            // lblAreaY
+            // 
+            this.lblAreaY.AutoSize = true;
+            this.lblAreaY.Location = new System.Drawing.Point(310, 342);
+            this.lblAreaY.Name = "lblAreaY";
+            this.lblAreaY.Size = new System.Drawing.Size(40, 13);
+            this.lblAreaY.TabIndex = 16;
+            this.lblAreaY.Text = "Area Y";
+            // 
+            // nudAreaW
+            // 
+            this.nudAreaW.Location = new System.Drawing.Point(220, 370);
+            this.nudAreaW.Maximum = new decimal(new int[] {
+            1000,
+            0,
+            0,
+            0});
+            this.nudAreaW.Name = "nudAreaW";
+            this.nudAreaW.Size = new System.Drawing.Size(80, 20);
+            this.nudAreaW.TabIndex = 17;
+            // 
+            // lblAreaW
+            // 
+            this.lblAreaW.AutoSize = true;
+            this.lblAreaW.Location = new System.Drawing.Point(310, 372);
+            this.lblAreaW.Name = "lblAreaW";
+            this.lblAreaW.Size = new System.Drawing.Size(43, 13);
+            this.lblAreaW.TabIndex = 18;
+            this.lblAreaW.Text = "Area W";
+            // 
+            // nudAreaH
+            // 
+            this.nudAreaH.Location = new System.Drawing.Point(220, 400);
+            this.nudAreaH.Maximum = new decimal(new int[] {
+            1000,
+            0,
+            0,
+            0});
+            this.nudAreaH.Name = "nudAreaH";
+            this.nudAreaH.Size = new System.Drawing.Size(80, 20);
+            this.nudAreaH.TabIndex = 19;
+            // 
+            // lblAreaH
+            // 
+            this.lblAreaH.AutoSize = true;
+            this.lblAreaH.Location = new System.Drawing.Point(310, 402);
+            this.lblAreaH.Name = "lblAreaH";
+            this.lblAreaH.Size = new System.Drawing.Size(43, 13);
+            this.lblAreaH.TabIndex = 20;
+            this.lblAreaH.Text = "Area H";
+            // 
+            // btnAdd
+            // 
+            this.btnAdd.Location = new System.Drawing.Point(10, 320);
+            this.btnAdd.Name = "btnAdd";
+            this.btnAdd.Size = new System.Drawing.Size(60, 23);
+            this.btnAdd.TabIndex = 21;
+            this.btnAdd.Text = "Add";
+            this.btnAdd.Click += new System.EventHandler(this.btnAdd_Click);
+            // 
+            // btnDelete
+            // 
+            this.btnDelete.Location = new System.Drawing.Point(80, 320);
+            this.btnDelete.Name = "btnDelete";
+            this.btnDelete.Size = new System.Drawing.Size(60, 23);
+            this.btnDelete.TabIndex = 22;
+            this.btnDelete.Text = "Delete";
+            this.btnDelete.Click += new System.EventHandler(this.btnDelete_Click);
+            // 
+            // btnSave
+            // 
+            this.btnSave.Location = new System.Drawing.Point(150, 320);
+            this.btnSave.Name = "btnSave";
+            this.btnSave.Size = new System.Drawing.Size(60, 23);
+            this.btnSave.TabIndex = 23;
+            this.btnSave.Text = "Save";
+            this.btnSave.Click += new System.EventHandler(this.btnSave_Click);
+            // 
+            // FrmPrisms
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(700, 430);
+            this.Controls.Add(this.btnSave);
+            this.Controls.Add(this.btnDelete);
+            this.Controls.Add(this.btnAdd);
+            this.Controls.Add(this.lblAreaH);
+            this.Controls.Add(this.nudAreaH);
+            this.Controls.Add(this.lblAreaW);
+            this.Controls.Add(this.nudAreaW);
+            this.Controls.Add(this.lblAreaY);
+            this.Controls.Add(this.nudAreaY);
+            this.Controls.Add(this.lblAreaX);
+            this.Controls.Add(this.nudAreaX);
+            this.Controls.Add(this.lblModules);
+            this.Controls.Add(this.txtModules);
+            this.Controls.Add(this.lblWindows);
+            this.Controls.Add(this.txtWindows);
+            this.Controls.Add(this.lblLevel);
+            this.Controls.Add(this.nudLevel);
+            this.Controls.Add(this.lblY);
+            this.Controls.Add(this.nudY);
+            this.Controls.Add(this.lblX);
+            this.Controls.Add(this.nudX);
+            this.Controls.Add(this.lblMapId);
+            this.Controls.Add(this.txtMapId);
+            this.Controls.Add(this.lstPrisms);
+            this.Name = "FrmPrisms";
+            this.Text = "Prisms";
+            ((System.ComponentModel.ISupportInitialize)(this.nudX)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.nudY)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.nudLevel)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.nudAreaX)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.nudAreaY)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.nudAreaW)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.nudAreaH)).EndInit();
+            this.ResumeLayout(false);
+            this.PerformLayout();
+        }
+
+        #endregion
+    }
+}

--- a/Intersect.Editor/Forms/Editors/frmPrisms.cs
+++ b/Intersect.Editor/Forms/Editors/frmPrisms.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Linq;
+using System.Windows.Forms;
+using Intersect.Config;
+using Intersect.Framework.Core.GameObjects.Prisms;
+
+namespace Intersect.Editor.Forms.Editors;
+
+public partial class FrmPrisms : Form
+{
+    public FrmPrisms()
+    {
+        InitializeComponent();
+        Icon = Program.Icon;
+        LoadList();
+    }
+
+    private void LoadList()
+    {
+        lstPrisms.Items.Clear();
+        foreach (var p in PrismConfig.Prisms)
+        {
+            lstPrisms.Items.Add($"{p.MapId} ({p.X},{p.Y})");
+        }
+    }
+
+    private AlignmentPrism? SelectedPrism =>
+        lstPrisms.SelectedIndex >= 0 && lstPrisms.SelectedIndex < PrismConfig.Prisms.Count
+            ? PrismConfig.Prisms[lstPrisms.SelectedIndex]
+            : null;
+
+    private void lstPrisms_SelectedIndexChanged(object sender, EventArgs e) => LoadSelected();
+
+    private void LoadSelected()
+    {
+        var p = SelectedPrism;
+        if (p == null)
+        {
+            return;
+        }
+
+        txtMapId.Text = p.MapId.ToString();
+        nudX.Value = p.X;
+        nudY.Value = p.Y;
+        nudLevel.Value = p.Level;
+        txtWindows.Lines = p.Windows.Select(w => $"{w.Day}|{w.Start:hh\\:mm}|{w.End:hh\\:mm}").ToArray();
+        txtModules.Lines = p.Modules.Select(m => m.Name).ToArray();
+        nudAreaX.Value = p.Area.X;
+        nudAreaY.Value = p.Area.Y;
+        nudAreaW.Value = p.Area.Width;
+        nudAreaH.Value = p.Area.Height;
+    }
+
+    private void btnAdd_Click(object sender, EventArgs e)
+    {
+        var prism = new AlignmentPrism { Id = Guid.NewGuid() };
+        PrismConfig.Prisms.Add(prism);
+        LoadList();
+        lstPrisms.SelectedIndex = PrismConfig.Prisms.Count - 1;
+    }
+
+    private void btnDelete_Click(object sender, EventArgs e)
+    {
+        var p = SelectedPrism;
+        if (p == null)
+        {
+            return;
+        }
+
+        PrismConfig.Prisms.Remove(p);
+        LoadList();
+    }
+
+    private void btnSave_Click(object sender, EventArgs e)
+    {
+        var p = SelectedPrism;
+        if (p != null)
+        {
+            if (Guid.TryParse(txtMapId.Text, out var mapId))
+            {
+                p.MapId = mapId;
+            }
+
+            p.X = (int)nudX.Value;
+            p.Y = (int)nudY.Value;
+            p.Level = (int)nudLevel.Value;
+
+            p.Windows = txtWindows.Lines
+                .Select(line => line.Split('|'))
+                .Where(parts => parts.Length == 3 && Enum.TryParse(parts[0], true, out DayOfWeek _))
+                .Select(parts => new VulnerabilityWindow
+                {
+                    Day = Enum.Parse<DayOfWeek>(parts[0], true),
+                    Start = TimeSpan.TryParse(parts[1], out var s) ? s : TimeSpan.Zero,
+                    End = TimeSpan.TryParse(parts[2], out var e) ? e : TimeSpan.Zero
+                })
+                .ToList();
+
+            p.Modules = txtModules.Lines
+                .Where(l => !string.IsNullOrWhiteSpace(l))
+                .Select(l => new PrismModule { Name = l.Trim() })
+                .ToList();
+
+            p.Area = new PrismArea
+            {
+                X = (int)nudAreaX.Value,
+                Y = (int)nudAreaY.Value,
+                Width = (int)nudAreaW.Value,
+                Height = (int)nudAreaH.Value
+            };
+        }
+
+        PrismConfig.Save();
+        LoadList();
+    }
+}

--- a/Intersect.Editor/Forms/Editors/frmPrisms.resx
+++ b/Intersect.Editor/Forms/Editors/frmPrisms.resx
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/Intersect.Editor/Intersect.Editor.csproj
+++ b/Intersect.Editor/Intersect.Editor.csproj
@@ -459,6 +459,18 @@
     <Compile Update="Forms\Editors\frmNpc.Designer.cs">
       <DependentUpon>frmNpc.cs</DependentUpon>
     </Compile>
+    <Compile Update="Forms\Editors\frmPrismOptions.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="Forms\Editors\frmPrismOptions.Designer.cs">
+      <DependentUpon>frmPrismOptions.cs</DependentUpon>
+    </Compile>
+    <Compile Update="Forms\Editors\frmPrisms.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="Forms\Editors\frmPrisms.Designer.cs">
+      <DependentUpon>frmPrisms.cs</DependentUpon>
+    </Compile>
     <Compile Update="Forms\Editors\frmProjectile.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -587,6 +599,12 @@
     </EmbeddedResource>
     <EmbeddedResource Update="Forms\Editors\frmNpc.resx">
       <DependentUpon>frmNpc.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Update="Forms\Editors\frmPrismOptions.resx">
+      <DependentUpon>frmPrismOptions.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Update="Forms\Editors\frmPrisms.resx">
+      <DependentUpon>frmPrisms.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Update="Forms\Editors\frmProjectile.resx">
       <DependentUpon>frmProjectile.cs</DependentUpon>


### PR DESCRIPTION
## Summary
- add shared prism configuration loader/saver
- expose prism settings in editor
- allow editor to create and edit prism definitions
- refactor prism forms into designer-backed partial classes

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-6.0` *(fails: Package 'dotnet-sdk-6.0' has no installation candidate)*

------
https://chatgpt.com/codex/tasks/task_e_68b22346e070832499d73673bbb06923