### PR TITLE
Fix prism compilation errors

### DIFF
--- a/Intersect.Client.Core/Interface/Game/MenuContainer.cs
+++ b/Intersect.Client.Core/Interface/Game/MenuContainer.cs
@@ -423,7 +423,7 @@ public partial class MenuContainer : Panel
 
     public void ToggleFactionWindow()
     {
-        if (_factionWindow.IsVisible())
+        if (_factionWindow.IsVisibleInTree)
         {
             _factionWindow.Hide();
         }

--- a/Intersect.Server.Core/Maps/MapInstance.Prisms.cs
+++ b/Intersect.Server.Core/Maps/MapInstance.Prisms.cs
@@ -13,7 +13,7 @@ public partial class MapInstance
     /// <summary>
     /// Prism currently controlling this map instance, if any.
     /// </summary>
-    public AlignmentPrism? ControllingPrism { get; private set; }
+    public AlignmentPrism? ControllingPrism { get; internal set; }
 
     /// <summary>
     /// True if the controlling prism is under attack.

--- a/Intersect.Server.Core/Services/Prisms/ConquestService.cs
+++ b/Intersect.Server.Core/Services/Prisms/ConquestService.cs
@@ -88,8 +88,16 @@ public sealed class ConquestService : IConquestService
             _repository.FactionAreaBonuses.Remove(bonus);
         }
 
+        var dbPrism = await _repository.Prisms
+            .FindAsync(new object[] { prism.Id }, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (dbPrism != null)
+        {
+            _repository.Prisms.Remove(dbPrism);
+        }
+
         map.ControllingPrism = null;
-        _repository.Prisms.Remove(prism);
         await _repository.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
         if (destroyer != null)


### PR DESCRIPTION
## Summary
- use `IsVisibleInTree` when toggling the faction window to avoid missing method
- expose `MapInstance.ControllingPrism` setter and clean up prism removal
- remove controlling prism by id before clearing

## Testing
- `dotnet build Intersect.Server.Core/Intersect.Server.Core.csproj -c Release` *(fails: The type or namespace name 'LiteNetLib' could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2271130b883248dee8929b879ca71