### PR TITLE
feat(editor): add map picker to prism editor

### DIFF
--- a/Intersect.Editor/Forms/Controls/MapPicker.cs
+++ b/Intersect.Editor/Forms/Controls/MapPicker.cs
@@ -1,0 +1,148 @@
+using System;
+using System.Drawing;
+using System.Windows.Forms;
+using Intersect.Config;
+using Intersect.Editor.Core;
+using Intersect.Editor.General;
+
+namespace Intersect.Editor.Forms.Controls;
+
+public class MapPicker : UserControl
+{
+    private readonly AutoDragPanel _container;
+    private readonly PictureBox _picture;
+    private Image? _mapImage;
+    private float _zoom = 1f;
+    private int _hoverX = -1;
+    private int _hoverY = -1;
+
+    public MapPicker()
+    {
+        _container = new AutoDragPanel
+        {
+            Dock = DockStyle.Fill,
+            AutoScroll = true
+        };
+
+        _picture = new PictureBox
+        {
+            Location = new Point(0, 0)
+        };
+
+        _picture.Paint += Picture_Paint;
+        _picture.MouseMove += Picture_MouseMove;
+        _picture.MouseDown += Picture_MouseDown;
+        _picture.MouseWheel += Picture_MouseWheel;
+        _picture.MouseEnter += (_, _) => _picture.Focus();
+
+        _container.Controls.Add(_picture);
+        Controls.Add(_container);
+    }
+
+    public Guid MapId { get; private set; } = Guid.Empty;
+
+    public event Action<Guid, int, int>? TileSelected;
+
+    public void SetMap(Guid mapId)
+    {
+        MapId = mapId;
+        _mapImage?.Dispose();
+        _mapImage = mapId != Guid.Empty ? Database.LoadMapCacheLegacy(mapId, -1) : null;
+        UpdateImage();
+    }
+
+    private void UpdateImage()
+    {
+        if (_mapImage == null)
+        {
+            _picture.Image = null;
+            return;
+        }
+
+        _picture.Image = _mapImage;
+        _picture.Width = (int)(_mapImage.Width * _zoom);
+        _picture.Height = (int)(_mapImage.Height * _zoom);
+        _picture.Invalidate();
+    }
+
+    private void Picture_Paint(object? sender, PaintEventArgs e)
+    {
+        if (_hoverX < 0 || _hoverY < 0)
+        {
+            return;
+        }
+
+        var tileW = Options.Instance.Map.TileWidth;
+        var tileH = Options.Instance.Map.TileHeight;
+        var rect = new Rectangle(
+            (int)(_hoverX * tileW * _zoom),
+            (int)(_hoverY * tileH * _zoom),
+            (int)(tileW * _zoom),
+            (int)(tileH * _zoom));
+
+        using var brush = new SolidBrush(Color.FromArgb(80, Color.White));
+        e.Graphics.FillRectangle(brush, rect);
+        e.Graphics.DrawRectangle(Pens.White, rect);
+    }
+
+    private void Picture_MouseMove(object? sender, MouseEventArgs e)
+    {
+        if (_mapImage == null)
+        {
+            _hoverX = _hoverY = -1;
+            return;
+        }
+
+        var tileW = Options.Instance.Map.TileWidth * _zoom;
+        var tileH = Options.Instance.Map.TileHeight * _zoom;
+        var x = (int)(e.X / tileW);
+        var y = (int)(e.Y / tileH);
+        if (x < 0 || y < 0 || x >= Options.Instance.Map.MapWidth || y >= Options.Instance.Map.MapHeight)
+        {
+            _hoverX = _hoverY = -1;
+        }
+        else
+        {
+            _hoverX = x;
+            _hoverY = y;
+        }
+
+        _picture.Invalidate();
+    }
+
+    private void Picture_MouseDown(object? sender, MouseEventArgs e)
+    {
+        if (e.Button != MouseButtons.Left)
+        {
+            return;
+        }
+
+        if (_hoverX >= 0 && _hoverY >= 0)
+        {
+            TileSelected?.Invoke(MapId, _hoverX, _hoverY);
+        }
+    }
+
+    private void Picture_MouseWheel(object? sender, MouseEventArgs e)
+    {
+        if (_mapImage == null)
+        {
+            return;
+        }
+
+        var oldZoom = _zoom;
+        if (e.Delta > 0)
+        {
+            _zoom = Math.Min(4f, _zoom + 0.1f);
+        }
+        else if (e.Delta < 0)
+        {
+            _zoom = Math.Max(0.2f, _zoom - 0.1f);
+        }
+
+        if (Math.Abs(_zoom - oldZoom) > 0.001f)
+        {
+            UpdateImage();
+        }
+    }
+}

--- a/Intersect.Editor/Forms/Editors/frmPrisms.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/frmPrisms.Designer.cs
@@ -29,6 +29,7 @@ namespace Intersect.Editor.Forms.Editors
         private System.Windows.Forms.Label lblAreaY;
         private System.Windows.Forms.Label lblAreaW;
         private System.Windows.Forms.Label lblAreaH;
+        private Intersect.Editor.Forms.Controls.MapPicker mapPicker;
 
         protected override void Dispose(bool disposing)
         {
@@ -79,6 +80,7 @@ namespace Intersect.Editor.Forms.Editors
             toolStripItemPaste = new ToolStripButton();
             toolStripSeparator3 = new ToolStripSeparator();
             toolStripItemUndo = new ToolStripButton();
+            mapPicker = new Intersect.Editor.Forms.Controls.MapPicker();
             ((System.ComponentModel.ISupportInitialize)nudX).BeginInit();
             ((System.ComponentModel.ISupportInitialize)nudY).BeginInit();
             ((System.ComponentModel.ISupportInitialize)nudLevel).BeginInit();
@@ -348,9 +350,18 @@ namespace Intersect.Editor.Forms.Editors
             lblAreaH.Size = new Size(43, 15);
             lblAreaH.TabIndex = 20;
             lblAreaH.Text = "Area H";
-            // 
+            //
+            // mapPicker
+            //
+            mapPicker.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right;
+            mapPicker.Location = new System.Drawing.Point(502, 72);
+            mapPicker.Margin = new Padding(4, 3, 4, 3);
+            mapPicker.Name = "mapPicker";
+            mapPicker.Size = new Size(300, 336);
+            mapPicker.TabIndex = 27;
+            //
             // toolStrip
-            // 
+            //
             toolStrip.AutoSize = false;
             toolStrip.BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
             toolStrip.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
@@ -464,6 +475,7 @@ namespace Intersect.Editor.Forms.Editors
             Controls.Add(btnSave);
             Controls.Add(btnDelete);
             Controls.Add(btnAdd);
+            Controls.Add(mapPicker);
             Controls.Add(lblAreaH);
             Controls.Add(nudAreaH);
             Controls.Add(lblAreaW);

--- a/Intersect.Editor/Forms/Editors/frmPrisms.cs
+++ b/Intersect.Editor/Forms/Editors/frmPrisms.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Windows.Forms;
 using Intersect.Config;
 using Intersect.Framework.Core.GameObjects.Prisms;
+using Intersect.Editor.General;
 
 namespace Intersect.Editor.Forms.Editors;
 
@@ -12,6 +13,10 @@ public partial class FrmPrisms : Form
     {
         InitializeComponent();
         Icon = Program.Icon;
+        mapPicker.TileSelected += MapPickerOnTileSelected;
+        mapPicker.SetMap(Globals.CurrentMap?.Id ?? Guid.Empty);
+        nudX.Maximum = Options.Instance.Map.MapWidth - 1;
+        nudY.Maximum = Options.Instance.Map.MapHeight - 1;
         LoadList();
     }
 
@@ -42,6 +47,7 @@ public partial class FrmPrisms : Form
         txtMapId.Text = p.MapId.ToString();
         nudX.Value = p.X;
         nudY.Value = p.Y;
+        mapPicker.SetMap(p.MapId);
         nudLevel.Value = p.Level;
         txtWindows.Lines = p.Windows.Select(w => $"{w.Day}|{w.Start:hh\\:mm}|{w.End:hh\\:mm}").ToArray();
         txtModules.Lines = p.Modules.Select(m => m.Name).ToArray();
@@ -112,5 +118,12 @@ public partial class FrmPrisms : Form
 
         PrismConfig.Save();
         LoadList();
+    }
+
+    private void MapPickerOnTileSelected(Guid mapId, int x, int y)
+    {
+        txtMapId.Text = mapId.ToString();
+        nudX.Value = Math.Max(nudX.Minimum, Math.Min(nudX.Maximum, x));
+        nudY.Value = Math.Max(nudY.Minimum, Math.Min(nudY.Maximum, y));
     }
 }


### PR DESCRIPTION
## Summary
- add reusable map picker control with zoom and tile hover preview
- integrate map picker into prism editor to update MapId and coordinates

## Testing
- `dotnet test Intersect.Tests.Editor/Intersect.Tests.Editor.csproj` *(fails: project restore only, no tests executed)*

------
https://chatgpt.com/codex/tasks/task_e_68b22e20727c832490eca01214da0345