### PR TITLE
fix: reload prism config after save

### DIFF
--- a/Framework/Intersect.Framework.Core/Config/PrismConfig.cs
+++ b/Framework/Intersect.Framework.Core/Config/PrismConfig.cs
@@ -15,7 +15,7 @@ public static class PrismConfig
     /// </summary>
     public static List<AlignmentPrism> Prisms { get; private set; } = new();
 
-    private static string PrismPath => Path.Combine(Options.ResourcesDirectory, "prisms.json");
+    private static string PrismPath => Path.Combine(Options.ResourcesDirectory, "Config", "prisms.json");
 
     /// <summary>
     ///     Loads prism definitions from disk if available.
@@ -37,9 +37,10 @@ public static class PrismConfig
     /// </summary>
     public static void Save()
     {
-        if (!Directory.Exists(Options.ResourcesDirectory))
+        var directory = Path.GetDirectoryName(PrismPath);
+        if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
         {
-            Directory.CreateDirectory(Options.ResourcesDirectory);
+            Directory.CreateDirectory(directory);
         }
 
         var json = JsonConvert.SerializeObject(Prisms, Formatting.Indented);

--- a/Intersect.Editor/Forms/Editors/frmPrisms.cs
+++ b/Intersect.Editor/Forms/Editors/frmPrisms.cs
@@ -228,8 +228,14 @@ public partial class FrmPrisms : Form
             Height = areaH
         };
 
+        var index = lstPrisms.SelectedIndex;
         PrismConfig.Save();
+        PrismConfig.Load();
         LoadList();
+        if (index >= 0 && index < lstPrisms.Items.Count)
+        {
+            lstPrisms.SelectedIndex = index;
+        }
     }
     private void btnWindowAdd_Click(object sender, EventArgs e)
     {

--- a/Intersect.Tests/Config/PrismConfigTests.cs
+++ b/Intersect.Tests/Config/PrismConfigTests.cs
@@ -1,0 +1,44 @@
+using System;
+using System.IO;
+using Intersect;
+using Intersect.Config;
+using Intersect.Framework.Core.GameObjects.Prisms;
+using NUnit.Framework;
+
+namespace Intersect.Tests.Config;
+
+public class PrismConfigTests
+{
+    [Test]
+    public void SaveAndLoad_PreservesPrisms()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tempDir);
+        var previous = Options.ResourcesDirectory;
+        Options.ResourcesDirectory = tempDir;
+
+        try
+        {
+            PrismConfig.Prisms.Clear();
+            var prism = new AlignmentPrism { Id = Guid.NewGuid(), MapId = Guid.NewGuid() };
+            PrismConfig.Prisms.Add(prism);
+
+            PrismConfig.Save();
+            PrismConfig.Prisms.Clear();
+            PrismConfig.Load();
+
+            var path = Path.Combine(tempDir, "Config", "prisms.json");
+            Assert.That(File.Exists(path), Is.True);
+            Assert.That(PrismConfig.Prisms, Has.Count.EqualTo(1));
+            Assert.That(PrismConfig.Prisms[0].Id, Is.EqualTo(prism.Id));
+        }
+        finally
+        {
+            Options.ResourcesDirectory = previous;
+            if (Directory.Exists(tempDir))
+            {
+                Directory.Delete(tempDir, true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- ensure prism config resides under Resources/Config and reload it after saving
- reload and rebind the prism editor list after persisting changes
- add regression test verifying prism config persistence

## Testing
- `dotnet build Intersect.Editor/Intersect.Editor.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*
- `dotnet test Intersect.Tests/Intersect.Tests.csproj` *(fails: missing LiteNetLib vendor dependency)*
- `dotnet test Intersect.Tests.Editor/Intersect.Tests.Editor.csproj` *(fails: missing vendor dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68b255f043048324983c718fb304ad3a