### PR TITLE
Add Prism Options menu item

### DIFF
--- a/Intersect.Editor/Forms/frmMain.Designer.cs
+++ b/Intersect.Editor/Forms/frmMain.Designer.cs
@@ -124,6 +124,7 @@ namespace Intersect.Editor.Forms
             this.menuStrip = new DarkUI.Controls.DarkMenuStrip();
             this.toolsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.packageUpdateToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.prismOptionsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.statusStrip1.SuspendLayout();
             this.toolStrip1.SuspendLayout();
             this.menuStrip.SuspendLayout();
@@ -1001,7 +1002,8 @@ namespace Intersect.Editor.Forms
             // toolsToolStripMenuItem
             // 
             this.toolsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.packageUpdateToolStripMenuItem});
+            this.packageUpdateToolStripMenuItem,
+            this.prismOptionsToolStripMenuItem});
             this.toolsToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
             this.toolsToolStripMenuItem.Name = "toolsToolStripMenuItem";
             this.toolsToolStripMenuItem.Size = new System.Drawing.Size(46, 20);
@@ -1014,9 +1016,18 @@ namespace Intersect.Editor.Forms
             this.packageUpdateToolStripMenuItem.Size = new System.Drawing.Size(159, 22);
             this.packageUpdateToolStripMenuItem.Text = "Package Update";
             this.packageUpdateToolStripMenuItem.Click += new System.EventHandler(this.packageUpdateToolStripMenuItem_Click);
-            // 
+            //
+            // prismOptionsToolStripMenuItem
+            //
+            this.prismOptionsToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
+            this.prismOptionsToolStripMenuItem.Name = "prismOptionsToolStripMenuItem";
+            this.prismOptionsToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift | System.Windows.Forms.Keys.O)));
+            this.prismOptionsToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.prismOptionsToolStripMenuItem.Text = "Prism Options";
+            this.prismOptionsToolStripMenuItem.Click += new System.EventHandler(this.prismOptionsToolStripMenuItem_Click);
+            //
             // FrmMain
-            // 
+            //
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.ClientSize = new System.Drawing.Size(1186, 675);
@@ -1130,8 +1141,9 @@ namespace Intersect.Editor.Forms
 		private ToolStripButton toolStripBtnFlipHorizontal;
 		private ToolStripButton toolStripBtnFlipVertical;
 		private ToolStripSeparator toolStripSeparator13;
-		private ToolStripMenuItem craftsEditorToolStripMenuItem;
+        private ToolStripMenuItem craftsEditorToolStripMenuItem;
         private ToolStripMenuItem packageUpdateToolStripMenuItem;
+        private ToolStripMenuItem prismOptionsToolStripMenuItem;
         private ToolStripMenuItem layersToolStripMenuItem;
         private ToolStripMenuItem hideEventsToolStripMenuItem;
     }

--- a/Intersect.Editor/Forms/frmMain.cs
+++ b/Intersect.Editor/Forms/frmMain.cs
@@ -200,6 +200,7 @@ public partial class FrmMain : Form
     {
         toolsToolStripMenuItem.Text = Strings.MainForm.tools;
         packageUpdateToolStripMenuItem.Text = Strings.MainForm.MenuToolsPackageUpdate;
+        prismOptionsToolStripMenuItem.Text = Strings.MainForm.MenuToolsPrismOptions;
     }
 
     private void InitLocalizationMenuHelp()
@@ -306,6 +307,9 @@ public partial class FrmMain : Form
 
             case Keys.Control | Keys.S:
                 toolStripBtnSaveMap_Click(null, null);
+                return;
+            case Keys.Control | Keys.Shift | Keys.O:
+                prismOptionsToolStripMenuItem_Click(null, null);
                 return;
         }
 
@@ -2022,6 +2026,12 @@ public partial class FrmMain : Form
         }
 
         return default;
+    }
+
+    private void prismOptionsToolStripMenuItem_Click(object sender, EventArgs e)
+    {
+        var prismForm = new FrmPrismOptions();
+        prismForm.ShowDialog();
     }
 
     private void packageUpdateToolStripMenuItem_Click(object sender, EventArgs e) => PackageUpdate();

--- a/Intersect.Editor/Localization/Strings.cs
+++ b/Intersect.Editor/Localization/Strings.cs
@@ -4311,6 +4311,7 @@ Tick timer saved in server config.json.";
         public static LocalizedString tools = @"Tools";
 
         public static LocalizedString MenuToolsPackageUpdate = @"Package Update";
+        public static LocalizedString MenuToolsPrismOptions = @"Prism Options";
 
         public static LocalizedString toolsdir = @"tools";
 


### PR DESCRIPTION
## Summary
- add Prism Options entry to the Tools menu with Ctrl+Shift+O shortcut
- open FrmPrismOptions dialog when the menu is selected
- localize the Prism Options label

## Testing
- `dotnet build Intersect.Editor/Intersect.Editor.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b25a3c8f8883249d4905dcfc6eb841