### PR TITLE
Add prism scheduler interval and damage cap options

### DIFF
--- a/Framework/Intersect.Framework.Core/Config/PrismOptions.cs
+++ b/Framework/Intersect.Framework.Core/Config/PrismOptions.cs
@@ -26,4 +26,14 @@ public class PrismOptions
     ///     Seconds after the last hit before the prism battle ends.
     /// </summary>
     public int AttackCooldownSeconds { get; set; } = 30;
+
+    /// <summary>
+    ///     Maximum damage a single player can inflict per scheduler tick.
+    /// </summary>
+    public int DamageCapPerTick { get; set; } = 50;
+
+    /// <summary>
+    ///     Interval in seconds between scheduler ticks.
+    /// </summary>
+    public int SchedulerIntervalSeconds { get; set; } = 1;
 }

--- a/Intersect.Editor/Forms/Editors/frmPrismOptions.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/frmPrismOptions.Designer.cs
@@ -13,11 +13,15 @@ namespace Intersect.Editor.Forms.Editors
         private DarkNumericUpDown nudHpPerLevel;
         private DarkNumericUpDown nudMaturationSeconds;
         private DarkNumericUpDown nudAttackCooldown;
+        private DarkNumericUpDown nudDamageCapPerTick;
+        private DarkNumericUpDown nudSchedulerIntervalSeconds;
         private DarkButton btnSave;
         private System.Windows.Forms.Label lblBaseHp;
         private System.Windows.Forms.Label lblHpPerLevel;
         private System.Windows.Forms.Label lblMaturation;
         private System.Windows.Forms.Label lblCooldown;
+        private System.Windows.Forms.Label lblDamageCapPerTick;
+        private System.Windows.Forms.Label lblSchedulerInterval;
 
         /// <summary>
         /// Clean up any resources being used.
@@ -44,15 +48,21 @@ namespace Intersect.Editor.Forms.Editors
             nudHpPerLevel = new DarkNumericUpDown();
             nudMaturationSeconds = new DarkNumericUpDown();
             nudAttackCooldown = new DarkNumericUpDown();
+            nudDamageCapPerTick = new DarkNumericUpDown();
+            nudSchedulerIntervalSeconds = new DarkNumericUpDown();
             btnSave = new DarkButton();
             lblBaseHp = new Label();
             lblHpPerLevel = new Label();
             lblMaturation = new Label();
             lblCooldown = new Label();
+            lblDamageCapPerTick = new Label();
+            lblSchedulerInterval = new Label();
             ((System.ComponentModel.ISupportInitialize)nudBaseHp).BeginInit();
             ((System.ComponentModel.ISupportInitialize)nudHpPerLevel).BeginInit();
             ((System.ComponentModel.ISupportInitialize)nudMaturationSeconds).BeginInit();
             ((System.ComponentModel.ISupportInitialize)nudAttackCooldown).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)nudDamageCapPerTick).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)nudSchedulerIntervalSeconds).BeginInit();
             SuspendLayout();
             // 
             // nudBaseHp
@@ -102,15 +112,39 @@ namespace Intersect.Editor.Forms.Editors
             nudAttackCooldown.Size = new Size(117, 23);
             nudAttackCooldown.TabIndex = 6;
             nudAttackCooldown.Value = new decimal(new int[] { 0, 0, 0, 0 });
-            // 
+            //
+            // nudDamageCapPerTick
+            //
+            nudDamageCapPerTick.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            nudDamageCapPerTick.ForeColor = System.Drawing.Color.Gainsboro;
+            nudDamageCapPerTick.Location = new System.Drawing.Point(14, 152);
+            nudDamageCapPerTick.Margin = new Padding(4, 3, 4, 3);
+            nudDamageCapPerTick.Maximum = new decimal(new int[] { 100000, 0, 0, 0 });
+            nudDamageCapPerTick.Name = "nudDamageCapPerTick";
+            nudDamageCapPerTick.Size = new Size(117, 23);
+            nudDamageCapPerTick.TabIndex = 8;
+            nudDamageCapPerTick.Value = new decimal(new int[] { 0, 0, 0, 0 });
+            //
+            // nudSchedulerIntervalSeconds
+            //
+            nudSchedulerIntervalSeconds.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            nudSchedulerIntervalSeconds.ForeColor = System.Drawing.Color.Gainsboro;
+            nudSchedulerIntervalSeconds.Location = new System.Drawing.Point(14, 187);
+            nudSchedulerIntervalSeconds.Margin = new Padding(4, 3, 4, 3);
+            nudSchedulerIntervalSeconds.Maximum = new decimal(new int[] { 100000, 0, 0, 0 });
+            nudSchedulerIntervalSeconds.Name = "nudSchedulerIntervalSeconds";
+            nudSchedulerIntervalSeconds.Size = new Size(117, 23);
+            nudSchedulerIntervalSeconds.TabIndex = 10;
+            nudSchedulerIntervalSeconds.Value = new decimal(new int[] { 0, 0, 0, 0 });
+            //
             // btnSave
-            // 
-            btnSave.Location = new System.Drawing.Point(14, 152);
+            //
+            btnSave.Location = new System.Drawing.Point(14, 221);
             btnSave.Margin = new Padding(4, 3, 4, 3);
             btnSave.Name = "btnSave";
             btnSave.Padding = new Padding(6, 6, 6, 6);
             btnSave.Size = new Size(88, 27);
-            btnSave.TabIndex = 8;
+            btnSave.TabIndex = 12;
             btnSave.Text = "Save";
             btnSave.Click += btnSave_Click;
             // 
@@ -153,14 +187,38 @@ namespace Intersect.Editor.Forms.Editors
             lblCooldown.Size = new Size(78, 15);
             lblCooldown.TabIndex = 7;
             lblCooldown.Text = "Cooldown (s)";
-            // 
+            //
+            // lblDamageCapPerTick
+            //
+            lblDamageCapPerTick.AutoSize = true;
+            lblDamageCapPerTick.Location = new System.Drawing.Point(138, 154);
+            lblDamageCapPerTick.Margin = new Padding(4, 0, 4, 0);
+            lblDamageCapPerTick.Name = "lblDamageCapPerTick";
+            lblDamageCapPerTick.Size = new Size(111, 15);
+            lblDamageCapPerTick.TabIndex = 9;
+            lblDamageCapPerTick.Text = "Damage Cap/Tick";
+            //
+            // lblSchedulerInterval
+            //
+            lblSchedulerInterval.AutoSize = true;
+            lblSchedulerInterval.Location = new System.Drawing.Point(138, 189);
+            lblSchedulerInterval.Margin = new Padding(4, 0, 4, 0);
+            lblSchedulerInterval.Name = "lblSchedulerInterval";
+            lblSchedulerInterval.Size = new Size(133, 15);
+            lblSchedulerInterval.TabIndex = 11;
+            lblSchedulerInterval.Text = "Scheduler Interval (s)";
+            //
             // FrmPrismOptions
-            // 
+            //
             AutoScaleDimensions = new SizeF(7F, 15F);
             AutoScaleMode = AutoScaleMode.Font;
             BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
-            ClientSize = new Size(280, 196);
+            ClientSize = new Size(280, 266);
             Controls.Add(btnSave);
+            Controls.Add(lblSchedulerInterval);
+            Controls.Add(nudSchedulerIntervalSeconds);
+            Controls.Add(lblDamageCapPerTick);
+            Controls.Add(nudDamageCapPerTick);
             Controls.Add(lblCooldown);
             Controls.Add(nudAttackCooldown);
             Controls.Add(lblMaturation);
@@ -181,6 +239,8 @@ namespace Intersect.Editor.Forms.Editors
             ((System.ComponentModel.ISupportInitialize)nudHpPerLevel).EndInit();
             ((System.ComponentModel.ISupportInitialize)nudMaturationSeconds).EndInit();
             ((System.ComponentModel.ISupportInitialize)nudAttackCooldown).EndInit();
+            ((System.ComponentModel.ISupportInitialize)nudDamageCapPerTick).EndInit();
+            ((System.ComponentModel.ISupportInitialize)nudSchedulerIntervalSeconds).EndInit();
             ResumeLayout(false);
             PerformLayout();
         }

--- a/Intersect.Editor/Forms/Editors/frmPrismOptions.cs
+++ b/Intersect.Editor/Forms/Editors/frmPrismOptions.cs
@@ -17,6 +17,8 @@ public partial class FrmPrismOptions : Form
         nudHpPerLevel.Value = Options.Instance.Prism.HpPerLevel;
         nudMaturationSeconds.Value = Options.Instance.Prism.MaturationSeconds;
         nudAttackCooldown.Value = Options.Instance.Prism.AttackCooldownSeconds;
+        nudDamageCapPerTick.Value = Options.Instance.Prism.DamageCapPerTick;
+        nudSchedulerIntervalSeconds.Value = Options.Instance.Prism.SchedulerIntervalSeconds;
     }
 
     private void btnSave_Click(object sender, EventArgs e)
@@ -25,6 +27,8 @@ public partial class FrmPrismOptions : Form
         Options.Instance.Prism.HpPerLevel = (int)nudHpPerLevel.Value;
         Options.Instance.Prism.MaturationSeconds = (int)nudMaturationSeconds.Value;
         Options.Instance.Prism.AttackCooldownSeconds = (int)nudAttackCooldown.Value;
+        Options.Instance.Prism.DamageCapPerTick = (int)nudDamageCapPerTick.Value;
+        Options.Instance.Prism.SchedulerIntervalSeconds = (int)nudSchedulerIntervalSeconds.Value;
         Options.SaveToDisk();
         Close();
     }

--- a/Intersect.Server.Core/Jobs/PrismScheduler.cs
+++ b/Intersect.Server.Core/Jobs/PrismScheduler.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading;
+using Intersect.Config;
 using Intersect.Server.Entities;
 using Intersect.Server.Maps;
 using Intersect.Server.Services.Prisms;
@@ -10,11 +11,11 @@ namespace Intersect.Server.Jobs;
 internal static class PrismScheduler
 {
     private static Timer? _timer;
-    private static readonly TimeSpan Interval = TimeSpan.FromSeconds(1);
 
     public static void Start()
     {
-        _timer ??= new Timer(Tick, null, Interval, Interval);
+        var interval = TimeSpan.FromSeconds(Options.Instance.Prism.SchedulerIntervalSeconds);
+        _timer ??= new Timer(Tick, null, interval, interval);
     }
 
     private static void Tick(object? state)

--- a/Intersect.Server.Core/Services/Prisms/PrismCombatService.cs
+++ b/Intersect.Server.Core/Services/Prisms/PrismCombatService.cs
@@ -10,9 +10,6 @@ namespace Intersect.Server.Services.Prisms;
 
 internal static class PrismCombatService
 {
-    // Maximum damage a single player can inflict per tick.
-    private const int DamageCapPerTick = 50;
-
     // Tracks damage dealt by players to prisms within the current tick window.
     private static readonly ConcurrentDictionary<(Guid PrismId, Guid AttackerId), (DateTime TickStart, int Damage)>
         DamageTracker = new();
@@ -43,7 +40,7 @@ internal static class PrismCombatService
 
         // Apply diminishing returns on repeated hits by the same player.
         var key = (prism.Id, attacker.Id);
-        var tickDuration = TimeSpan.FromSeconds(1);
+        var tickDuration = TimeSpan.FromSeconds(Options.Instance.Prism.SchedulerIntervalSeconds);
         var record = DamageTracker.GetOrAdd(key, _ => (now, 0));
 
         if (now - record.TickStart > tickDuration)
@@ -51,7 +48,7 @@ internal static class PrismCombatService
             record = (now, 0);
         }
 
-        var remaining = DamageCapPerTick - record.Damage;
+        var remaining = Options.Instance.Prism.DamageCapPerTick - record.Damage;
         if (remaining <= 0)
         {
             return;


### PR DESCRIPTION
## Summary
- Allow configuring prism damage cap per tick and scheduler interval
- Use prism options in combat service and scheduler
- Add editor controls for new prism settings

## Testing
- `dotnet build Intersect.Server.Core/Intersect.Server.Core.csproj` *(fails: missing LiteNetLib types)*
- `dotnet build Intersect.Editor/Intersect.Editor.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b25bb5b1988324ad7db81377a73bec