### PR TITLE
Refine prism state handling and conquest triggers

### DIFF
--- a/Framework/Intersect.Framework.Core/Config/PrismOptions.cs
+++ b/Framework/Intersect.Framework.Core/Config/PrismOptions.cs
@@ -26,4 +26,9 @@ public class PrismOptions
     ///     Seconds after the last hit before the prism battle ends.
     /// </summary>
     public int AttackCooldownSeconds { get; set; } = 30;
+
+    /// <summary>
+    ///     If true, prisms are captured for the attacker's faction instead of being destroyed when their HP is depleted.
+    /// </summary>
+    public bool CaptureInsteadOfDestroy { get; set; } = true;
 }


### PR DESCRIPTION
## Summary
- Add `CaptureInsteadOfDestroy` option for prism conquest behavior
- Refine `PrismService.TickState` to manage dominated/vulnerable states based on windows
- Trigger conquest capture or destruction when prisms fall or are destroyed

## Testing
- `dotnet test` *(fails: LiteNetLib/LiteNetLib.csproj not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b25bc3ba808324a3ec9d696f49a403