### PR TITLE
Allow prism damage outside vulnerability window for ongoing prism attacks

### DIFF
--- a/Intersect.Server.Core/Networking/PacketHandler.cs
+++ b/Intersect.Server.Core/Networking/PacketHandler.cs
@@ -1450,7 +1450,12 @@ internal sealed partial class PacketHandler
             return;
         }
 
-        if (!PrismService.IsInVulnerabilityWindow(prism, DateTime.UtcNow))
+        var now = DateTime.UtcNow;
+        var stillUnderAttack = prism.State == PrismState.UnderAttack && prism.LastHitAt.HasValue &&
+                               (now - prism.LastHitAt.Value).TotalSeconds <=
+                               Options.Instance.Prism.AttackCooldownSeconds;
+
+        if (!PrismService.IsInVulnerabilityWindow(prism, now) && !stillUnderAttack)
         {
             return;
         }


### PR DESCRIPTION
## Summary
- honor ongoing prism attacks when handling PrismAttackPacket by mirroring stillUnderAttack check
- allow damage if a prism was recently hit during attack cooldown even if outside vulnerability window

## Testing
- `dotnet test -p:EnableWindowsTargeting=true -v diag --no-restore` *(tests skipped: project lacks IsTestProject property)*

------
https://chatgpt.com/codex/tasks/task_e_68b25d8c280883248f9db2538e86ef58