### PR TITLE
Add prism health and vulnerability info

### DIFF
--- a/Framework/Intersect.Framework.Core/Network/Packets/Server/PrismUpdatePacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Server/PrismUpdatePacket.cs
@@ -1,3 +1,4 @@
+using System;
 using Intersect.Enums;
 using Intersect.Framework.Core.GameObjects.Prisms;
 using MessagePack;
@@ -12,11 +13,14 @@ public partial class PrismUpdatePacket : IntersectPacket
     {
     }
 
-    public PrismUpdatePacket(Guid mapId, Alignment owner, PrismState state)
+    public PrismUpdatePacket(Guid mapId, Alignment owner, PrismState state, int hp, int maxHp, DateTime? nextVulnerabilityStart)
     {
         MapId = mapId;
         Owner = owner;
         State = state;
+        Hp = hp;
+        MaxHp = maxHp;
+        NextVulnerabilityStart = nextVulnerabilityStart;
     }
 
     [Key(0)]
@@ -27,4 +31,13 @@ public partial class PrismUpdatePacket : IntersectPacket
 
     [Key(2)]
     public PrismState State { get; set; }
+
+    [Key(3)]
+    public int Hp { get; set; }
+
+    [Key(4)]
+    public int MaxHp { get; set; }
+
+    [Key(5)]
+    public DateTime? NextVulnerabilityStart { get; set; }
 }

--- a/Intersect.Client.Core/Maps/MapInstance.Prisms.cs
+++ b/Intersect.Client.Core/Maps/MapInstance.Prisms.cs
@@ -1,3 +1,4 @@
+using System;
 using Intersect.Enums;
 using Intersect.Framework.Core.GameObjects.Prisms;
 
@@ -27,4 +28,19 @@ public partial class MapInstance
     /// True if the prism has been dominated.
     /// </summary>
     public bool PrismDominated => PrismState == PrismState.Dominated;
+
+    /// <summary>
+    /// Current health of the controlling prism.
+    /// </summary>
+    public int PrismHp { get; set; }
+
+    /// <summary>
+    /// Maximum health of the controlling prism.
+    /// </summary>
+    public int PrismMaxHp { get; set; }
+
+    /// <summary>
+    /// Start time of the next vulnerability window, if any.
+    /// </summary>
+    public DateTime? PrismNextVulnerabilityStart { get; set; }
 }

--- a/Intersect.Client.Core/Networking/PacketHandler.cs
+++ b/Intersect.Client.Core/Networking/PacketHandler.cs
@@ -2494,6 +2494,9 @@ internal sealed partial class PacketHandler
 
         map.PrismOwner = packet.Owner;
         map.PrismState = packet.State;
+        map.PrismHp = packet.Hp;
+        map.PrismMaxHp = packet.MaxHp;
+        map.PrismNextVulnerabilityStart = packet.NextVulnerabilityStart;
     }
 
 }

--- a/Intersect.Server.Core/Networking/PacketSender.cs
+++ b/Intersect.Server.Core/Networking/PacketSender.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
@@ -33,6 +34,7 @@ using Intersect.Server.General;
 using Intersect.Server.Localization;
 using Intersect.Server.Maps;
 using Intersect.Server.Classes.Maps;
+using Intersect.Server.Services.Prisms;
 using Intersect.Utilities;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
@@ -190,7 +192,8 @@ public static partial class PacketSender
                 var prism = instance.ControllingPrism;
                 if (prism != null)
                 {
-                    prisms.Add(new PrismUpdatePacket(prism.MapId, prism.Owner, prism.State));
+                    var nextStart = PrismService.GetNextVulnerabilityStart(prism, DateTime.UtcNow);
+                    prisms.Add(new PrismUpdatePacket(prism.MapId, prism.Owner, prism.State, prism.Hp, prism.MaxHp, nextStart));
                 }
             }
         }

--- a/Intersect.Server.Core/Services/Prisms/PrismService.cs
+++ b/Intersect.Server.Core/Services/Prisms/PrismService.cs
@@ -138,6 +138,33 @@ internal static class PrismService
         return prism.Windows.Any(window => window.Contains(time));
     }
 
+    public static DateTime? GetNextVulnerabilityStart(AlignmentPrism prism, DateTime now)
+    {
+        if (prism.Windows == null || prism.Windows.Count == 0)
+        {
+            return null;
+        }
+
+        DateTime? next = null;
+        foreach (var window in prism.Windows)
+        {
+            var daysUntil = ((int)window.Day - (int)now.DayOfWeek + 7) % 7;
+            var candidate = now.Date.AddDays(daysUntil).Add(window.Start);
+
+            if (candidate <= now)
+            {
+                candidate = candidate.AddDays(7);
+            }
+
+            if (next == null || candidate < next)
+            {
+                next = candidate;
+            }
+        }
+
+        return next;
+    }
+
     public static void Broadcast(MapInstance map)
     {
         foreach (var player in map.GetPlayers())


### PR DESCRIPTION
## Summary
- track prism HP, maximum HP, and next vulnerability start in PrismUpdatePacket
- include new prism data when sending area packets from server
- update client handling to store prism health and timing data

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b25ebdb1dc8324ac6b49bf4a484236