### PR TITLE
Add prism HUD and conquest management UI

### DIFF
--- a/Intersect.Client.Core/Interface/Game/ConquestWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/ConquestWindow.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Linq;
+using Intersect.Client.Framework.Gwen.Control;
+using Intersect.Client.Maps;
+using Intersect.Enums;
+
+namespace Intersect.Client.Interface.Game;
+
+/// <summary>
+/// Window listing known prisms and their status.
+/// </summary>
+public class ConquestWindow : Window
+{
+    private readonly ScrollControl _list;
+
+    public ConquestWindow(Canvas gameCanvas) : base(gameCanvas, nameof(ConquestWindow), false, nameof(ConquestWindow))
+    {
+        IsResizable = false;
+        SetSize(400, 300);
+
+        _list = new ScrollControl(this, "PrismList");
+        _list.EnableScroll(false, true);
+        _list.SetBounds(10, 10, 380, 280);
+    }
+
+    /// <summary>
+    /// Rebuild the list of prisms.
+    /// </summary>
+    public void Refresh()
+    {
+        _list.DeleteAllChildren();
+
+        foreach (var (_, obj) in MapInstance.Lookup)
+        {
+            if (obj is not MapInstance map || map.PrismMaxHp <= 0)
+            {
+                continue;
+            }
+
+            var vuln = map.PrismNextVulnerabilityStart?.ToLocalTime().ToString("g") ?? "N/A";
+            var label = new Label(_list)
+            {
+                Text = $"{map.Name} - {map.PrismOwner} - {map.PrismState} - {vuln}",
+                Dock = Pos.Top,
+            };
+            label.Margin = new Margin(0, 0, 0, 4);
+        }
+    }
+
+    protected override void EnsureInitialized()
+    {
+        LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
+    }
+}
+

--- a/Intersect.Client.Core/Interface/Game/GameInterface.cs
+++ b/Intersect.Client.Core/Interface/Game/GameInterface.cs
@@ -110,6 +110,8 @@ public partial class GameInterface : MutableInterface
 
     public PlayerStatusWindow PlayerStatusWindow;
 
+    public PrismHud PrismHud;
+
     private SettingsWindow GetOrCreateSettingsWindow()
     {
         _settingsWindow ??= new SettingsWindow(GameCanvas)
@@ -160,6 +162,8 @@ public partial class GameInterface : MutableInterface
 
     public MenuContainer GameMenu { get; private set; }
 
+    public ConquestWindow ConquestWindow => GameMenu.ConquestWindow;
+
     public void InitGameGui()
     {
         mChatBox = new Chatbox(GameCanvas, this);
@@ -168,6 +172,7 @@ public partial class GameInterface : MutableInterface
         PlayerBox = new EntityBox(GameCanvas, EntityType.Player, Globals.Me, true);
         PlayerBox.SetEntity(Globals.Me);
         PlayerStatusWindow = new PlayerStatusWindow(GameCanvas);
+        PrismHud = new PrismHud(GameCanvas);
         if (mPictureWindow == null)
         {
             mPictureWindow = new PictureWindow(GameCanvas);

--- a/Intersect.Client.Core/Interface/Game/MenuContainer.cs
+++ b/Intersect.Client.Core/Interface/Game/MenuContainer.cs
@@ -53,6 +53,10 @@ public partial class MenuContainer : Panel
     private readonly Button _factionButton;
     private readonly FactionWindow _factionWindow;
 
+    private readonly ImagePanel _conquestButtonContainer;
+    private readonly Button _conquestButton;
+    private readonly ConquestWindow _conquestWindow;
+
     private readonly ImagePanel _wingsButtonContainer;
     private readonly Button _wingsButton;
 
@@ -224,6 +228,26 @@ public partial class MenuContainer : Panel
         _factionWindow = new FactionWindow(gameCanvas) { IsHidden = true };
         _factionButton.Clicked += (s, e) => ToggleFactionWindow();
 
+        _conquestButtonContainer = new ImagePanel(parent: this, name: nameof(_conquestButtonContainer))
+        {
+            Dock = Pos.Left,
+            MaximumSize = new Point(x: 36, y: 36),
+            MinimumSize = new Point(x: 36, y: 36),
+            Padding = new Padding(size: 2),
+            Size = new Point(x: 36, y: 36),
+            TextureFilename = "menuitem.png",
+        };
+        _conquestButton = new Button(parent: _conquestButtonContainer, name: nameof(_conquestButton), disableText: true)
+        {
+            Alignment = [Alignments.Center],
+            Size = new Point(x: 32, y: 32),
+        };
+        _conquestButton.SetStateTexture(componentState: ComponentState.Normal, textureName: "conquesticon.png");
+        _conquestButton.SetStateTexture(componentState: ComponentState.Hovered, textureName: "conquesticon_hovered.png");
+        _conquestButton.SetToolTipText(text: "Conquest");
+        _conquestWindow = new ConquestWindow(gameCanvas) { IsHidden = true };
+        _conquestButton.Clicked += (s, e) => ToggleConquestWindow();
+
         _wingsButtonContainer = new ImagePanel(parent: this, name: nameof(_wingsButtonContainer))
         {
             Dock = Pos.Left,
@@ -365,6 +389,7 @@ public partial class MenuContainer : Panel
         _spellsWindow.Hide();
         _guildWindow.Hide();
         _factionWindow.Hide();
+        _conquestWindow.Hide();
         mJobsWindow.Hide();
     }
 
@@ -432,6 +457,20 @@ public partial class MenuContainer : Panel
             HideWindows();
             _factionWindow.Refresh();
             _factionWindow.Show();
+        }
+    }
+
+    public void ToggleConquestWindow()
+    {
+        if (_conquestWindow.IsVisibleInTree)
+        {
+            _conquestWindow.Hide();
+        }
+        else
+        {
+            HideWindows();
+            _conquestWindow.Refresh();
+            _conquestWindow.Show();
         }
     }
 
@@ -517,6 +556,8 @@ public partial class MenuContainer : Panel
         _partyWindow.Hide();
 
         _guildWindow.Hide();
+        _factionWindow.Hide();
+        _conquestWindow.Hide();
     }
 
     public bool HasWindowsOpen()
@@ -528,9 +569,13 @@ public partial class MenuContainer : Panel
                           _spellsWindow.IsVisibleInTree ||
                           _partyWindow.IsVisible() ||
                           _guildWindow.IsVisibleInTree ||
+                          _factionWindow.IsVisibleInTree ||
+                          _conquestWindow.IsVisibleInTree ||
         mJobsWindow.IsVisible();
         return windowsOpen;
     }
+
+    public ConquestWindow ConquestWindow => _conquestWindow;
 
     //Input Handlers
     private void EscapeMenuButtonClicked(Base sender, MouseButtonState arguments)

--- a/Intersect.Client.Core/Interface/Game/PrismHud.cs
+++ b/Intersect.Client.Core/Interface/Game/PrismHud.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Drawing;
+using Intersect.Client.Framework.Gwen.Control;
+using Intersect.Client.Maps;
+using Intersect.Enums;
+
+namespace Intersect.Client.Interface.Game;
+
+/// <summary>
+/// Displays prism ownership and health information for the current map.
+/// </summary>
+public class PrismHud : ImagePanel
+{
+    private readonly Label _icon;
+    private readonly ProgressBar _hpBar;
+    private readonly Label _stateLabel;
+
+    private const int BarWidth = 100;
+    private const int BarHeight = 12;
+
+    public PrismHud(Canvas gameCanvas) : base(gameCanvas, nameof(PrismHud))
+    {
+        SetPosition(10, 10);
+        SetSize(140, 40);
+        IsHidden = true;
+
+        _icon = new Label(this, "Icon")
+        {
+            Text = "⚑",
+        };
+        _icon.SetPosition(0, 0);
+
+        _hpBar = new ProgressBar(this, "HpBar")
+        {
+            AutoLabel = false,
+            IsHorizontal = true,
+        };
+        _hpBar.SetBounds(30, 5, BarWidth, BarHeight);
+
+        _stateLabel = new Label(this, "StateLabel");
+        _stateLabel.SetPosition(30, 20);
+    }
+
+    /// <summary>
+    /// Refresh the HUD contents using the provided map's prism data.
+    /// </summary>
+    public void Refresh(MapInstance? map)
+    {
+        if (map == null || map.PrismMaxHp <= 0)
+        {
+            Hide();
+            return;
+        }
+
+        Show();
+
+        var color = map.PrismOwner switch
+        {
+            Alignment.Serolf => Color.Blue,
+            Alignment.Nidraj => Color.Red,
+            _ => Color.Gray
+        };
+
+        if (map.PrismUnderAttack)
+        {
+            color = Color.Orange;
+        }
+
+        _icon.TextColor = color;
+        _hpBar.RenderColor = color;
+        _hpBar.Value = map.PrismMaxHp > 0 ? map.PrismHp / (float)map.PrismMaxHp : 0f;
+        _stateLabel.Text = $"{map.PrismOwner} - {map.PrismState}";
+    }
+}
+

--- a/Intersect.Client.Core/Networking/PacketHandler.cs
+++ b/Intersect.Client.Core/Networking/PacketHandler.cs
@@ -22,6 +22,7 @@ using Intersect.Utilities;
 using Intersect.Framework;
 using Intersect.Models;
 using Intersect.Client.Interface.Shared;
+using Intersect.Client.Interface;
 using Intersect.Framework.Core;
 using Intersect.Framework.Core.GameObjects.Animations;
 using Intersect.Framework.Core.GameObjects.Crafting;
@@ -2476,12 +2477,20 @@ internal sealed partial class PacketHandler
         {
             HandlePrism(prism);
         }
+
+        Interface.GameUi.ConquestWindow.Refresh();
+        Interface.GameUi.PrismHud.Refresh(Globals.Me?.MapInstance as MapInstance);
     }
 
     //PrismUpdatePacket
     public void HandlePacket(IPacketSender packetSender, PrismUpdatePacket packet)
     {
         HandlePrism(packet);
+        Interface.GameUi.ConquestWindow.Refresh();
+        if (Globals.Me?.MapId == packet.MapId)
+        {
+            Interface.GameUi.PrismHud.Refresh(Globals.Me.MapInstance as MapInstance);
+        }
     }
 
     private static void HandlePrism(PrismUpdatePacket packet)


### PR DESCRIPTION
## Summary
- show prism ownership and health in a new on-screen HUD
- add Conquest window with list of known prisms and statuses
- refresh HUD and window when prism packets are received

## Testing
- `dotnet build Intersect.Client.Core/Intersect.Client.Core.csproj` *(fails: UnconnectedMessageType not found)*
- `dotnet test` *(fails: vendor project files not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b262e72698832496c7ca6e09f79419