### PR TITLE
Use base map ID for prism placement

### DIFF
--- a/Intersect.Server.Core/Maps/MapInstance.Prisms.cs
+++ b/Intersect.Server.Core/Maps/MapInstance.Prisms.cs
@@ -35,7 +35,7 @@ public partial class MapInstance
             Id = Guid.NewGuid(),
             Owner = player.Faction,
             State = PrismState.Placed,
-            MapId = MapInstanceId,
+            MapId = MapId,
             PlacedAt = DateTime.UtcNow,
             X = player.X,
             Y = player.Y,

--- a/Intersect.Server.Core/Maps/MapInstance.cs
+++ b/Intersect.Server.Core/Maps/MapInstance.cs
@@ -98,6 +98,11 @@ public partial class MapInstance : IMapInstance
     public Guid MapInstanceId { get; set; }
 
     /// <summary>
+    /// The ID of the base map for this instance.
+    /// </summary>
+    public Guid MapId => mMapController.Id;
+
+    /// <summary>
     /// The last time the <see cref="Core.LogicService.LogicThread"/> made a call to <see cref="Update(long)"/>.
     /// <remarks>
     /// This is used to determine when enough time has passed to cleanup this instance (remove it from it's parent <see cref="MapController"/>).

--- a/Intersect.Server.Core/Services/Prisms/PrismService.cs
+++ b/Intersect.Server.Core/Services/Prisms/PrismService.cs
@@ -28,7 +28,7 @@ internal static class PrismService
             Id = Guid.NewGuid(),
             Owner = player.Faction,
             State = PrismState.Placed,
-            MapId = map.MapInstanceId,
+            MapId = map.MapId,
             X = player?.X ?? 0,
             Y = player?.Y ?? 0,
             PlacedAt = now,
@@ -42,7 +42,7 @@ internal static class PrismService
         Logger.LogInformation(
             "Prism {PrismId} placed on map {MapId} by {PlayerId} at {Time}",
             prism.Id,
-            map.MapInstanceId,
+            map.MapId,
             player?.Id,
             now
         );


### PR DESCRIPTION
## Summary
- expose base map ID from MapInstance
- use base map ID when placing prisms

## Testing
- `dotnet test Intersect.Tests.Server/Intersect.Tests.Server.csproj -p:GenerateNetworkKeys=true` *(fails: 'Assert' does not contain a definition for 'NotNull')*


------
https://chatgpt.com/codex/tasks/task_e_68b31316ff688324bd462901285f6387