### PR TITLE
fix(editor): validate module levels and disable save on errors

### DIFF
--- a/Intersect.Editor/Forms/Editors/frmPrisms.cs
+++ b/Intersect.Editor/Forms/Editors/frmPrisms.cs
@@ -196,6 +196,11 @@ public partial class FrmPrisms : Form
             })
             .ToList();
 
+        if (modules.Any(m => m.Level < 1 || m.Level > 3))
+        {
+            errors.Add("El nivel de cada módulo debe estar entre 1 y 3.");
+        }
+
         if (modules.Count > MaxModules)
         {
             errors.Add($"No se pueden agregar más de {MaxModules} módulos.");
@@ -206,7 +211,9 @@ public partial class FrmPrisms : Form
             errors.Add("No se permiten módulos duplicados.");
         }
 
-        if (errors.Any())
+        var hasErrors = errors.Any();
+        btnSave.Enabled = !hasErrors;
+        if (hasErrors)
         {
             MessageBox.Show(string.Join("\n", errors), "Errores", MessageBoxButtons.OK, MessageBoxIcon.Warning);
             return;


### PR DESCRIPTION
## Summary
- ensure prism module levels stay within 1-3
- disable save button when validation errors exist

## Testing
- `dotnet build Intersect.Editor/Intersect.Editor.csproj` (fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)


------
https://chatgpt.com/codex/tasks/task_e_68b31315cf588324a97dace8f59e887e