### PR TITLE
Track prism battle contributions

### DIFF
--- a/Intersect.Server.Core/Services/Prisms/IConquestService.cs
+++ b/Intersect.Server.Core/Services/Prisms/IConquestService.cs
@@ -9,6 +9,7 @@ namespace Intersect.Server.Services.Prisms;
 public interface IConquestService
 {
     Task CaptureAsync(MapInstance map, Player captor, CancellationToken cancellationToken = default);
+    Task DefendAsync(MapInstance map, CancellationToken cancellationToken = default);
     Task DestroyAsync(MapInstance map, Player destroyer, CancellationToken cancellationToken = default);
 }
 

--- a/Intersect.Server.Core/Services/Prisms/PrismService.cs
+++ b/Intersect.Server.Core/Services/Prisms/PrismService.cs
@@ -63,6 +63,14 @@ internal static class PrismService
         var previousState = prism.State;
         var inWindow = IsInVulnerabilityWindow(prism, now);
 
+        if (prism.State == PrismState.UnderAttack)
+        {
+            foreach (var player in map.GetPlayers())
+            {
+                PrismCombatService.RecordPresence(prism, player);
+            }
+        }
+
         switch (prism.State)
         {
             case PrismState.Placed:
@@ -126,7 +134,10 @@ internal static class PrismService
 
             if (previousState == PrismState.UnderAttack && prism.State != PrismState.UnderAttack)
             {
-                PrismCombatService.BattleEnded();
+                var conquestService = Bootstrapper.Context?.Services
+                    .FirstOrDefault(s => s is IConquestService) as IConquestService;
+                _ = conquestService?.DefendAsync(map);
+                PrismCombatService.BattleEnded(prism);
             }
 
             Broadcast(map);


### PR DESCRIPTION
## Summary
- Track prism battle contributions for damage, presence and heals
- Distribute honor based on contribution when prisms are captured, defended or destroyed
- Persist prism battle and contribution records after each fight

## Testing
- `dotnet build` *(fails: vendor project file missing)*
- `dotnet test` *(fails: vendor project file missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b31eaf52888324a1a759f6157c1881