### PR TITLE
Verify prism domination for bonuses and account for modules

### DIFF
--- a/Framework/Intersect.Framework.Core/GameObjects/Prisms/PrismModule.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Prisms/PrismModule.cs
@@ -22,6 +22,8 @@ public class PrismModule
 public enum PrismModuleType
 {
     Vision,
-    Prospecting
+    Prospecting,
+    Crafting,
+    GuardBoost
 }
 


### PR DESCRIPTION
## Summary
- apply area bonuses only when prisms are dominated and owned by the player
- extend prism modules with crafting and guard boost
- include prospecting and crafting modules when calculating area bonuses

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b327033bc0832491f60e3b2fcb2b7b