### PR TITLE
Fix prism window and prism services compile errors

### DIFF
--- a/Intersect.Client.Core/Interface/Game/ConquestWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/ConquestWindow.cs
@@ -33,11 +33,11 @@ public class ConquestWindow : Window
 
         _filter = new ComboBox(this, "OwnerFilter");
         _filter.SetBounds(10, 10, 120, 20);
-        _filter.AddItem("All", Filter.All);
-        _filter.AddItem("Own", Filter.Own);
-        _filter.AddItem("Rival", Filter.Rival);
-        _filter.AddItem("Neutral", Filter.Neutral);
-        _filter.Select(0);
+        _filter.AddItem("All", userData: Filter.All);
+        _filter.AddItem("Own", userData: Filter.Own);
+        _filter.AddItem("Rival", userData: Filter.Rival);
+        _filter.AddItem("Neutral", userData: Filter.Neutral);
+        _filter.SelectByUserData(Filter.All);
         _filter.ItemSelected += (_, _) => Refresh();
 
         _list = new ScrollControl(this, "PrismList");
@@ -51,7 +51,7 @@ public class ConquestWindow : Window
     public void Refresh()
     {
         _list.DeleteAllChildren();
-        var meFaction = Globals.Me?.Faction ?? Alignment.Neutral;
+        var meFaction = Globals.Me?.Faction ?? Intersect.Enums.Alignment.Neutral;
         var filter = (Filter)(_filter.SelectedItem?.UserData ?? Filter.All);
 
         var maps = MapInstance.Lookup.Values
@@ -60,8 +60,9 @@ public class ConquestWindow : Window
             .Where(map => filter switch
             {
                 Filter.Own => map.PrismOwner == meFaction,
-                Filter.Rival => map.PrismOwner != meFaction && map.PrismOwner != Alignment.Neutral,
-                Filter.Neutral => map.PrismOwner == Alignment.Neutral,
+                Filter.Rival =>
+                    map.PrismOwner != meFaction && map.PrismOwner != Intersect.Enums.Alignment.Neutral,
+                Filter.Neutral => map.PrismOwner == Intersect.Enums.Alignment.Neutral,
                 _ => true,
             })
             .OrderBy(map => map.PrismNextVulnerabilityStart ?? DateTime.MaxValue);

--- a/Intersect.Server.Core/Entities/Player.cs
+++ b/Intersect.Server.Core/Entities/Player.cs
@@ -1239,9 +1239,10 @@ public partial class Player : Entity
         CastTime = 0;
         CastTarget = null;
 
-        if (Map != null && Map.ControllingPrism != null)
+        if (MapController.TryGetInstanceFromMap(MapId, MapInstanceId, out var mapInstance)
+            && mapInstance.ControllingPrism != null)
         {
-            PrismCombatService.RecordDeath(Map.ControllingPrism, this);
+            PrismCombatService.RecordDeath(mapInstance.ControllingPrism, this);
         }
 
         //Flag death to the client

--- a/Intersect.Server.Core/Services/Prisms/ConquestService.cs
+++ b/Intersect.Server.Core/Services/Prisms/ConquestService.cs
@@ -7,6 +7,7 @@ using Intersect.Framework.Core.GameObjects.Prisms;
 using Intersect.Config;
 using Intersect.Server.Core.Services;
 using Intersect.Server.Database.Prisms;
+using GameAlignmentPrism = Intersect.Framework.Core.GameObjects.Prisms.AlignmentPrism;
 using Intersect.Server.Entities;
 using Intersect.Server.Maps;
 using Microsoft.EntityFrameworkCore;
@@ -39,7 +40,7 @@ public sealed class ConquestService : IConquestService
 
     private void DistributeRewards(
         MapInstance map,
-        AlignmentPrism prism,
+        GameAlignmentPrism prism,
         Func<PrismCombatService.Contribution, bool> filter,
         int honor
     )


### PR DESCRIPTION
## Summary
- Wire up prism filter ComboBox with user data and fully qualified alignment checks
- Record player death contributions via map instance prisms
- Disambiguate AlignmentPrism types and clean up prism combat dictionaries

## Testing
- ⚠️ `dotnet build Intersect.sln` *(missing: dotnet)*
- ⚠️ `apt-get install -y dotnet-sdk-8.0` *(package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b32aceb73c8324802433d375a6b96a