### PR TITLE
Add alignment change request/response packets

### DIFF
--- a/Framework/Intersect.Framework.Core/Network/Packets/Client/SetAlignmentRequestPacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Client/SetAlignmentRequestPacket.cs
@@ -1,0 +1,22 @@
+using Intersect.Enums;
+using MessagePack;
+
+namespace Intersect.Network.Packets.Client;
+
+[MessagePackObject]
+public partial class SetAlignmentRequestPacket : IntersectPacket
+{
+    // Parameterless constructor for MessagePack
+    public SetAlignmentRequestPacket()
+    {
+    }
+
+    public SetAlignmentRequestPacket(Alignment desired)
+    {
+        Desired = desired;
+    }
+
+    [Key(0)]
+    public Alignment Desired { get; set; }
+}
+

--- a/Framework/Intersect.Framework.Core/Network/Packets/Server/SetAlignmentResponsePacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Server/SetAlignmentResponsePacket.cs
@@ -1,0 +1,35 @@
+using System;
+using Intersect.Enums;
+using MessagePack;
+
+namespace Intersect.Network.Packets.Server;
+
+[MessagePackObject]
+public partial class SetAlignmentResponsePacket : IntersectPacket
+{
+    // Parameterless constructor for MessagePack
+    public SetAlignmentResponsePacket()
+    {
+    }
+
+    public SetAlignmentResponsePacket(bool success, string message, Alignment newAlignment, DateTime? nextAllowedChangeAt)
+    {
+        Success = success;
+        Message = message;
+        NewAlignment = newAlignment;
+        NextAllowedChangeAt = nextAllowedChangeAt;
+    }
+
+    [Key(0)]
+    public bool Success { get; set; }
+
+    [Key(1)]
+    public string Message { get; set; } = string.Empty;
+
+    [Key(2)]
+    public Alignment NewAlignment { get; set; }
+
+    [Key(3)]
+    public DateTime? NextAllowedChangeAt { get; set; }
+}
+

--- a/Intersect.Client.Core/Networking/PacketHandler.cs
+++ b/Intersect.Client.Core/Networking/PacketHandler.cs
@@ -2493,6 +2493,23 @@ internal sealed partial class PacketHandler
         }
     }
 
+    //SetAlignmentResponsePacket
+    public void HandlePacket(IPacketSender packetSender, SetAlignmentResponsePacket packet)
+    {
+        if (Globals.Me != null)
+        {
+            Globals.Me.Faction = packet.NewAlignment;
+        }
+
+        if (!string.IsNullOrWhiteSpace(packet.Message))
+        {
+            Interface.Interface.ShowAlert(
+                packet.Message,
+                packet.Success ? AlertType.Information : AlertType.Error
+            );
+        }
+    }
+
     private static void HandlePrism(PrismUpdatePacket packet)
     {
         var map = MapInstance.Get(packet.MapId);

--- a/Intersect.Client.Core/Networking/PacketSender.cs
+++ b/Intersect.Client.Core/Networking/PacketSender.cs
@@ -143,6 +143,11 @@ public static partial class PacketSender
         Network.SendPacket(new ToggleWingsPacket(state));
     }
 
+    public static void SendSetAlignment(Alignment alignment)
+    {
+        Network.SendPacket(new SetAlignmentRequestPacket(alignment));
+    }
+
     public static void SendPrismAttack(Guid mapId)
     {
         Network.SendPacket(new PrismAttackPacket(mapId));

--- a/Intersect.Server.Core/Networking/PacketHandler.cs
+++ b/Intersect.Server.Core/Networking/PacketHandler.cs
@@ -3259,5 +3259,11 @@ internal sealed partial class PacketHandler
         }
     }
 
+    //SetAlignmentRequestPacket
+    public void HandlePacket(Client client, SetAlignmentRequestPacket packet)
+    {
+        // Alignment change handling to be implemented
+    }
+
     #endregion
 }


### PR DESCRIPTION
## Summary
- add SetAlignmentRequestPacket and SetAlignmentResponsePacket
- wire up packet handlers and client sender for alignment changes

## Testing
- `dotnet test` *(fails: project file "/workspace/Broken_Reborn/vendor/LiteNetLib/LiteNetLib/LiteNetLib.csproj" was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b331d6010883249fa9f5ca883a43e0