### PR TITLE
Add SetAlignment event command

### DIFF
--- a/Framework/Intersect.Framework.Core/GameObjects/Events/Commands/SetAlignmentCommand.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Events/Commands/SetAlignmentCommand.cs
@@ -1,0 +1,29 @@
+using System.IO;
+using Intersect.Enums;
+
+namespace Intersect.Framework.Core.GameObjects.Events.Commands;
+
+public partial class SetAlignmentCommand : EventCommand
+{
+    public override EventCommandType Type { get; } = EventCommandType.SetAlignment;
+
+    public Alignment Desired { get; set; } = Alignment.Neutral;
+
+    public bool IgnoreCooldown { get; set; }
+
+    public bool IgnoreGuildLock { get; set; }
+
+    public void Serialize(BinaryWriter writer)
+    {
+        writer.Write((int)Desired);
+        writer.Write(IgnoreCooldown);
+        writer.Write(IgnoreGuildLock);
+    }
+
+    public void Deserialize(BinaryReader reader)
+    {
+        Desired = (Alignment)reader.ReadInt32();
+        IgnoreCooldown = reader.ReadBoolean();
+        IgnoreGuildLock = reader.ReadBoolean();
+    }
+}

--- a/Framework/Intersect.Framework.Core/GameObjects/Events/EventCommandType.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Events/EventCommandType.cs
@@ -45,9 +45,11 @@ public enum EventCommandType
 
     ChangeFace,
 
-    ChangeGender,
+    ChangeGender = 21,
 
-    SetAccess,
+    SetAlignment = 60,
+
+    SetAccess = 22,
 
     //Movement,
     WarpPlayer,


### PR DESCRIPTION
## Summary
- add event command for changing player alignment with optional cooldown and guild lock overrides
- extend EventCommandType with SetAlignment value

## Testing
- `dotnet build Framework/Intersect.Framework.Core/Intersect.Framework.Core.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68b33f0232088324ba33e99920745d24