### PR TITLE
Add alignment service and command handling for faction changes

### DIFF
--- a/Intersect.Server.Core/Services/AlignmentApplyOptions.cs
+++ b/Intersect.Server.Core/Services/AlignmentApplyOptions.cs
@@ -1,0 +1,9 @@
+namespace Intersect.Server.Services;
+
+public class AlignmentApplyOptions
+{
+    public bool IgnoreCooldown { get; set; }
+
+    public bool IgnoreGuildLock { get; set; }
+}
+


### PR DESCRIPTION
## Summary
- add `AlignmentApplyOptions` and `AlignmentService` to manage player faction swaps with cooldown and guild checks
- implement event command support for `SetAlignmentCommand`

## Testing
- ❌ `dotnet build Intersect.Server.Core/Intersect.Server.Core.csproj` *(dotnet: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b345b915548324b75504c7b6f54319