### PR TITLE
Add alignment swap cooldown option

### DIFF
--- a/Framework/Intersect.Framework.Core/Config/AlignmentOptions.cs
+++ b/Framework/Intersect.Framework.Core/Config/AlignmentOptions.cs
@@ -1,0 +1,9 @@
+namespace Intersect.Config;
+
+public partial class AlignmentOptions
+{
+    /// <summary>
+    /// Number of days a player must wait before swapping alignment again.
+    /// </summary>
+    public int SwapCooldownDays { get; set; } = 7;
+}

--- a/Framework/Intersect.Framework.Core/Config/Options.cs
+++ b/Framework/Intersect.Framework.Core/Config/Options.cs
@@ -224,6 +224,8 @@ public partial record Options
 
     public ItemOptions Items { get; set; } = new();
 
+    public AlignmentOptions Alignment { get; set; } = new();
+
     public PrismOptions Prism { get; set; } = new();
 
     #endregion Other Game Properties

--- a/Intersect.Server.Core/Services/AlignmentService.cs
+++ b/Intersect.Server.Core/Services/AlignmentService.cs
@@ -23,7 +23,7 @@ public static class AlignmentService
     {
         apply ??= new AlignmentApplyOptions();
 
-        var cooldown = Options.Instance.Prism.AlignmentSwapCooldown;
+        var cooldown = TimeSpan.FromDays(Options.Instance.Alignment.SwapCooldownDays);
         var now = DateTime.UtcNow;
         var nextAllowed = p.LastFactionSwapAt + cooldown;
 


### PR DESCRIPTION
## Summary
- add configurable alignment swap cooldown days
- expose alignment options in main options
- apply alignment cooldown in alignment service

## Testing
- `dotnet build Framework/Intersect.Framework.Core/Intersect.Framework.Core.csproj`
- `dotnet test Intersect.Tests/Intersect.Tests.csproj` *(fails: NetPacketReader not found)*
- `dotnet build Intersect.Server.Core/Intersect.Server.Core.csproj` *(fails: NetDataReader not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b35efa40c08324bd5485b9aaf7b2b0