### PR TITLE
feat(editor): add set alignment event command

### DIFF
--- a/Intersect.Editor/Forms/Editors/Events/CommandPrinter.cs
+++ b/Intersect.Editor/Forms/Editors/Events/CommandPrinter.cs
@@ -863,6 +863,31 @@ public static partial class CommandPrinter
             : Strings.EventCommandList.female);
     }
 
+    private static string GetCommandText(SetAlignmentCommand command, MapInstance map)
+    {
+        var text = Strings.EventCommandList.setalignment.ToString(
+            command.Desired switch
+            {
+                Alignment.Neutral => Strings.EventCommandList.neutral,
+                Alignment.Serolf => Strings.EventCommandList.serolf,
+                Alignment.Nidraj => Strings.EventCommandList.nidraj,
+                _ => Strings.EventCommandList.neutral,
+            }
+        );
+
+        if (command.IgnoreCooldown)
+        {
+            text += " " + Strings.EventCommandList.ignorecooldown;
+        }
+
+        if (command.IgnoreGuildLock)
+        {
+            text += " " + Strings.EventCommandList.ignoreguildlock;
+        }
+
+        return text;
+    }
+
     private static string GetCommandText(SetAccessCommand command, MapInstance map)
     {
         switch (command.Access)

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_SetAlignment.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_SetAlignment.Designer.cs
@@ -1,0 +1,150 @@
+using DarkUI.Controls;
+
+namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
+{
+    partial class EventCommandSetAlignment
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.grpSetAlignment = new DarkGroupBox();
+            this.cmbAlignment = new DarkComboBox();
+            this.lblAlignment = new System.Windows.Forms.Label();
+            this.chkIgnoreCooldown = new DarkCheckBox();
+            this.chkIgnoreGuildLock = new DarkCheckBox();
+            this.btnCancel = new DarkButton();
+            this.btnSave = new DarkButton();
+            this.grpSetAlignment.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // grpSetAlignment
+            // 
+            this.grpSetAlignment.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            this.grpSetAlignment.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            this.grpSetAlignment.Controls.Add(this.cmbAlignment);
+            this.grpSetAlignment.Controls.Add(this.lblAlignment);
+            this.grpSetAlignment.Controls.Add(this.chkIgnoreCooldown);
+            this.grpSetAlignment.Controls.Add(this.chkIgnoreGuildLock);
+            this.grpSetAlignment.Controls.Add(this.btnCancel);
+            this.grpSetAlignment.Controls.Add(this.btnSave);
+            this.grpSetAlignment.ForeColor = System.Drawing.Color.Gainsboro;
+            this.grpSetAlignment.Location = new System.Drawing.Point(3, 3);
+            this.grpSetAlignment.Name = "grpSetAlignment";
+            this.grpSetAlignment.Size = new System.Drawing.Size(176, 126);
+            this.grpSetAlignment.TabIndex = 17;
+            this.grpSetAlignment.TabStop = false;
+            this.grpSetAlignment.Text = "Set Alignment";
+            // 
+            // cmbAlignment
+            // 
+            this.cmbAlignment.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            this.cmbAlignment.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            this.cmbAlignment.BorderStyle = System.Windows.Forms.ButtonBorderStyle.Solid;
+            this.cmbAlignment.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
+            this.cmbAlignment.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmbAlignment.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.cmbAlignment.FormattingEnabled = true;
+            this.cmbAlignment.Items.AddRange(new object[] {
+            "Neutral",
+            "Serolf",
+            "Nidraj"});
+            this.cmbAlignment.Location = new System.Drawing.Point(68, 19);
+            this.cmbAlignment.Name = "cmbAlignment";
+            this.cmbAlignment.Size = new System.Drawing.Size(103, 21);
+            this.cmbAlignment.TabIndex = 22;
+            // 
+            // lblAlignment
+            // 
+            this.lblAlignment.AutoSize = true;
+            this.lblAlignment.Location = new System.Drawing.Point(4, 22);
+            this.lblAlignment.Name = "lblAlignment";
+            this.lblAlignment.Size = new System.Drawing.Size(58, 13);
+            this.lblAlignment.TabIndex = 21;
+            this.lblAlignment.Text = "Alignment:";
+            // 
+            // chkIgnoreCooldown
+            // 
+            this.chkIgnoreCooldown.AutoSize = true;
+            this.chkIgnoreCooldown.Location = new System.Drawing.Point(7, 46);
+            this.chkIgnoreCooldown.Name = "chkIgnoreCooldown";
+            this.chkIgnoreCooldown.Size = new System.Drawing.Size(106, 17);
+            this.chkIgnoreCooldown.TabIndex = 23;
+            this.chkIgnoreCooldown.Text = "Ignore Cooldown";
+            // 
+            // chkIgnoreGuildLock
+            // 
+            this.chkIgnoreGuildLock.AutoSize = true;
+            this.chkIgnoreGuildLock.Location = new System.Drawing.Point(7, 66);
+            this.chkIgnoreGuildLock.Name = "chkIgnoreGuildLock";
+            this.chkIgnoreGuildLock.Size = new System.Drawing.Size(116, 17);
+            this.chkIgnoreGuildLock.TabIndex = 24;
+            this.chkIgnoreGuildLock.Text = "Ignore Guild Lock";
+            // 
+            // btnCancel
+            // 
+            this.btnCancel.Location = new System.Drawing.Point(89, 97);
+            this.btnCancel.Name = "btnCancel";
+            this.btnCancel.Padding = new System.Windows.Forms.Padding(5);
+            this.btnCancel.Size = new System.Drawing.Size(75, 23);
+            this.btnCancel.TabIndex = 26;
+            this.btnCancel.Text = "Cancel";
+            this.btnCancel.Click += new System.EventHandler(this.btnCancel_Click);
+            // 
+            // btnSave
+            // 
+            this.btnSave.Location = new System.Drawing.Point(7, 97);
+            this.btnSave.Name = "btnSave";
+            this.btnSave.Padding = new System.Windows.Forms.Padding(5);
+            this.btnSave.Size = new System.Drawing.Size(75, 23);
+            this.btnSave.TabIndex = 25;
+            this.btnSave.Text = "Ok";
+            this.btnSave.Click += new System.EventHandler(this.btnSave_Click);
+            // 
+            // EventCommandSetAlignment
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoSize = true;
+            this.BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
+            this.Controls.Add(this.grpSetAlignment);
+            this.Name = "EventCommandSetAlignment";
+            this.Size = new System.Drawing.Size(182, 132);
+            this.grpSetAlignment.ResumeLayout(false);
+            this.grpSetAlignment.PerformLayout();
+            this.ResumeLayout(false);
+        }
+
+        #endregion
+
+        private DarkGroupBox grpSetAlignment;
+        private DarkComboBox cmbAlignment;
+        private System.Windows.Forms.Label lblAlignment;
+        private DarkCheckBox chkIgnoreCooldown;
+        private DarkCheckBox chkIgnoreGuildLock;
+        private DarkButton btnCancel;
+        private DarkButton btnSave;
+    }
+}

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_SetAlignment.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_SetAlignment.cs
@@ -1,0 +1,52 @@
+using Intersect.Editor.Localization;
+using Intersect.Enums;
+using Intersect.Framework.Core.GameObjects.Events.Commands;
+
+namespace Intersect.Editor.Forms.Editors.Events.Event_Commands;
+
+public partial class EventCommandSetAlignment : UserControl
+{
+    private readonly FrmEvent mEventEditor;
+
+    private SetAlignmentCommand mMyCommand;
+
+    public EventCommandSetAlignment(SetAlignmentCommand refCommand, FrmEvent editor)
+    {
+        InitializeComponent();
+        mMyCommand = refCommand;
+        mEventEditor = editor;
+        InitLocalization();
+        cmbAlignment.SelectedIndex = (int)mMyCommand.Desired;
+        chkIgnoreCooldown.Checked = mMyCommand.IgnoreCooldown;
+        chkIgnoreGuildLock.Checked = mMyCommand.IgnoreGuildLock;
+    }
+
+    private void InitLocalization()
+    {
+        grpSetAlignment.Text = Strings.EventSetAlignment.title;
+        lblAlignment.Text = Strings.EventSetAlignment.label;
+        cmbAlignment.Items.Clear();
+        for (var i = 0; i < Strings.EventSetAlignment.alignments.Count; i++)
+        {
+            cmbAlignment.Items.Add(Strings.EventSetAlignment.alignments[i]);
+        }
+
+        chkIgnoreCooldown.Text = Strings.EventSetAlignment.IgnoreCooldown;
+        chkIgnoreGuildLock.Text = Strings.EventSetAlignment.IgnoreGuildLock;
+        btnSave.Text = Strings.EventSetAlignment.okay;
+        btnCancel.Text = Strings.EventSetAlignment.cancel;
+    }
+
+    private void btnSave_Click(object sender, EventArgs e)
+    {
+        mMyCommand.Desired = (Alignment)cmbAlignment.SelectedIndex;
+        mMyCommand.IgnoreCooldown = chkIgnoreCooldown.Checked;
+        mMyCommand.IgnoreGuildLock = chkIgnoreGuildLock.Checked;
+        mEventEditor.FinishCommandEdit();
+    }
+
+    private void btnCancel_Click(object sender, EventArgs e)
+    {
+        mEventEditor.CancelCommandEdit();
+    }
+}

--- a/Intersect.Editor/Forms/Editors/Events/frmEvent.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/Events/frmEvent.Designer.cs
@@ -58,6 +58,8 @@ namespace Intersect.Editor.Forms.Editors.Events
             var treeNode22 = new TreeNode("Change Player Color");
             var treeNode23 = new TreeNode("Change Face");
             var treeNode24 = new TreeNode("Change Gender");
+            var treeNode78 = new TreeNode("Set Alignment");
+            var treeNode79 = new TreeNode("Alignment", new TreeNode[] { treeNode78 });
             var treeNode25 = new TreeNode("Set Access");
             var treeNode26 = new TreeNode("Change Class");
             var treeNode27 = new TreeNode("Equip/Unequip Item");
@@ -67,7 +69,7 @@ namespace Intersect.Editor.Forms.Editors.Events
             var treeNode31 = new TreeNode("Reset Stat Point Allocations");
             var treeNode32 = new TreeNode("Cast Spell On");
             var treeNode77 = new TreeNode("Change Bestiary");
-            var treeNode33 = new TreeNode("Player Control", new TreeNode[] { treeNode14, treeNode15, treeNode16, treeNode17, treeNode18, treeNode19, treeNode20, treeNode21, treeNode22, treeNode23, treeNode24, treeNode25, treeNode26, treeNode27, treeNode28, treeNode29, treeNode30, treeNode31, treeNode32, treeNode77 });
+            var treeNode33 = new TreeNode("Player Control", new TreeNode[] { treeNode14, treeNode15, treeNode16, treeNode17, treeNode18, treeNode19, treeNode20, treeNode21, treeNode22, treeNode23, treeNode24, treeNode79, treeNode25, treeNode26, treeNode27, treeNode28, treeNode29, treeNode30, treeNode31, treeNode32, treeNode77 });
             var treeNode34 = new TreeNode("Warp Player");
             var treeNode35 = new TreeNode("Set Move Route");
             var treeNode36 = new TreeNode("Wait for Route Completion");
@@ -902,6 +904,10 @@ namespace Intersect.Editor.Forms.Editors.Events
             treeNode23.Text = "Change Face";
             treeNode24.Name = "changegender";
             treeNode24.Text = "Change Gender";
+            treeNode78.Name = "setalignment";
+            treeNode78.Text = "Set Alignment";
+            treeNode79.Name = "alignment";
+            treeNode79.Text = "Alignment";
             treeNode25.Name = "setaccess";
             treeNode25.Text = "Set Access";
             treeNode26.Name = "setclass";

--- a/Intersect.Editor/Forms/Editors/Events/frmEvent.cs
+++ b/Intersect.Editor/Forms/Editors/Events/frmEvent.cs
@@ -611,6 +611,10 @@ public partial class FrmEvent : Form
                 tmpCommand = new ChangeGenderCommand();
 
                 break;
+            case EventCommandType.SetAlignment:
+                tmpCommand = new SetAlignmentCommand();
+
+                break;
             case EventCommandType.ChangeNameColor:
                 tmpCommand = new ChangeNameColorCommand();
 
@@ -1309,6 +1313,10 @@ public partial class FrmEvent : Form
                 break;
             case EventCommandType.ChangeGender:
                 cmdWindow = new EventCommandChangeGender((ChangeGenderCommand)command, this);
+
+                break;
+            case EventCommandType.SetAlignment:
+                cmdWindow = new EventCommandSetAlignment((SetAlignmentCommand)command, this);
 
                 break;
             case EventCommandType.ChangeNameColor:

--- a/Intersect.Editor/Intersect.Editor.csproj
+++ b/Intersect.Editor/Intersect.Editor.csproj
@@ -327,6 +327,12 @@
     <Compile Update="Forms\Editors\Events\Event Commands\EventCommand_SetAccess.Designer.cs">
       <DependentUpon>EventCommand_SetAccess.cs</DependentUpon>
     </Compile>
+    <Compile Update="Forms\Editors\Events\Event Commands\EventCommand_SetAlignment.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Update="Forms\Editors\Events\Event Commands\EventCommand_SetAlignment.Designer.cs">
+      <DependentUpon>EventCommand_SetAlignment.cs</DependentUpon>
+    </Compile>
     <Compile Update="Forms\Editors\Events\Event Commands\EventCommand_SetClass.cs">
       <SubType>UserControl</SubType>
     </Compile>

--- a/Intersect.Editor/Localization/Strings.cs
+++ b/Intersect.Editor/Localization/Strings.cs
@@ -2256,6 +2256,18 @@ Tick timer saved in server config.json.";
 
         public static LocalizedString setgender = @"Set Player Gender to {00}";
 
+        public static LocalizedString setalignment = @"Set Player Alignment to {00}";
+
+        public static LocalizedString neutral = @"Neutral";
+
+        public static LocalizedString serolf = @"Serolf";
+
+        public static LocalizedString nidraj = @"Nidraj";
+
+        public static LocalizedString ignorecooldown = @"(Ignore Cooldown)";
+
+        public static LocalizedString ignoreguildlock = @"(Ignore Guild Lock)";
+
         public static LocalizedString setlevel = @"Set Player Level To: {00}";
 
         public static LocalizedString setsprite = @"Set Player Sprite to {00}";
@@ -3401,6 +3413,30 @@ Tick timer saved in server config.json.";
         public static LocalizedString okay = @"Ok";
 
         public static LocalizedString title = @"Set Access";
+
+    }
+
+    public partial struct EventSetAlignment
+    {
+
+        public static LocalizedString cancel = @"Cancel";
+
+        public static LocalizedString label = @"Alignment:";
+
+        public static LocalizedString okay = @"Ok";
+
+        public static LocalizedString title = @"Set Alignment";
+
+        public static Dictionary<int, LocalizedString> alignments = new Dictionary<int, LocalizedString>
+        {
+            {0, @"Neutral"},
+            {1, @"Serolf"},
+            {2, @"Nidraj"},
+        };
+
+        public static LocalizedString IgnoreCooldown = @"Ignore Cooldown?";
+
+        public static LocalizedString IgnoreGuildLock = @"Ignore Guild Lock?";
 
     }
 


### PR DESCRIPTION
## Summary
- add Set Alignment event command with dropdown and optional ignore flags
- wire command into event editor and command printer
- localize strings and include in project

## Testing
- `dotnet build Intersect.Editor/Intersect.Editor.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b36017c9dc83248446aaa40ae4c230