### PR TITLE
feat: add alignment messaging helper

### DIFF
--- a/Intersect.Server.Core/Entities/Events/CommandProcessing.cs
+++ b/Intersect.Server.Core/Entities/Events/CommandProcessing.cs
@@ -2394,12 +2394,23 @@ public static partial class CommandProcessing
         var result = AlignmentService.TrySetAlignment(player, command.Desired, options);
         if (result.Success)
         {
-            PacketSender.SendChatMsg(player, $"Alignment changed to {player.Faction}.", ChatMessageType.Notice);
+            var message = Strings.Alignment.ChangedTo.ToString(player.Faction);
+            if (result.NextAllowedChangeAt.HasValue)
+            {
+                var cooldown = AlignmentService.GetMessage("cooldown", result.NextAllowedChangeAt);
+                if (!string.IsNullOrEmpty(cooldown))
+                {
+                    message += $" {cooldown}";
+                }
+            }
+
+            PacketSender.SendChatMsg(player, message, ChatMessageType.Notice);
             PacketSender.SendEntityDataToProximity(player);
         }
         else
         {
-            var message = result.Message ?? "Unable to change alignment.";
+            var message = AlignmentService.GetMessage(result.Message!, result.NextAllowedChangeAt)
+                          ?? "Unable to change alignment.";
             PacketSender.SendChatMsg(player, message, ChatMessageType.Error);
         }
     }

--- a/Intersect.Server.Core/Localization/Strings.cs
+++ b/Intersect.Server.Core/Localization/Strings.cs
@@ -114,7 +114,7 @@ public static partial class Strings
         public readonly LocalizedString ChangedTo = @"Ahora perteneces a {00}.";
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-        public readonly LocalizedString AlreadyInFaction = @"Ya perteneces a {00}.";
+        public readonly LocalizedString AlreadyInFaction = @"Ya perteneces a esta facción.";
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public readonly LocalizedString GuildMismatch = @"Tu gremio pertenece a una facción distinta.";
@@ -123,7 +123,7 @@ public static partial class Strings
         public readonly LocalizedString WingsOn = @"No puedes cambiar de facción mientras tus alas estén activadas.";
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-        public readonly LocalizedString SwapCooldown = @"No puedes cambiar de facción nuevamente hasta {fecha}.";
+        public readonly LocalizedString SwapCooldown = @"Podrás cambiar el {fecha}.";
     }
 
     public sealed partial class BagNamespace : LocaleNamespace
@@ -1538,6 +1538,8 @@ public static partial class Strings
 
         public readonly AccountNamespace Account = new AccountNamespace();
 
+        public readonly AlignmentNamespace Alignment = new AlignmentNamespace();
+
         public readonly BagNamespace Bags = new BagNamespace();
 
         public readonly BankNamespace Banks = new BankNamespace();
@@ -1615,6 +1617,8 @@ public static partial class Strings
     #region Namespace Exposure
 
     public static AccountNamespace Account => Root.Account;
+
+    public static AlignmentNamespace Alignment => Root.Alignment;
 
     public static BagNamespace Bags => Root.Bags;
 

--- a/Intersect.Server.Core/Networking/PacketHandler.cs
+++ b/Intersect.Server.Core/Networking/PacketHandler.cs
@@ -3307,9 +3307,23 @@ internal sealed partial class PacketHandler
         }
 
         var result = AlignmentService.TrySetAlignment(player, packet.Desired);
+
+        var message = result.Success
+            ? Strings.Alignment.ChangedTo.ToString(result.NewAlignment)
+            : AlignmentService.GetMessage(result.Message!, result.NextAllowedChangeAt) ?? string.Empty;
+
+        if (result.Success && result.NextAllowedChangeAt.HasValue)
+        {
+            var cooldown = AlignmentService.GetMessage("cooldown", result.NextAllowedChangeAt);
+            if (!string.IsNullOrEmpty(cooldown))
+            {
+                message += $" {cooldown}";
+            }
+        }
+
         var response = new SetAlignmentResponsePacket(
             result.Success,
-            result.Message,
+            message,
             result.NewAlignment,
             result.NextAllowedChangeAt
         );

--- a/Intersect.Server.Core/Services/AlignmentService.cs
+++ b/Intersect.Server.Core/Services/AlignmentService.cs
@@ -3,6 +3,7 @@ using Intersect.Config;
 using Intersect.Enums;
 using Intersect.Server.Database;
 using Intersect.Server.Entities;
+using Intersect.Server.Localization;
 
 namespace Intersect.Server.Services;
 
@@ -61,6 +62,20 @@ public static class AlignmentService
         context.SaveChanges();
 
         return new Result(true, null, p.Faction, now + cooldown);
+    }
+
+    public static string? GetMessage(string code, DateTime? nextAllowed)
+    {
+        return code switch
+        {
+            "same" => Strings.Alignment.AlreadyInFaction.ToString(),
+            "guild" => Strings.Alignment.GuildMismatch.ToString(),
+            "wings" => Strings.Alignment.WingsOn.ToString(),
+            "cooldown" when nextAllowed.HasValue =>
+                Strings.Alignment.SwapCooldown.ToString()
+                    .Replace("{fecha}", nextAllowed.Value.ToLocalTime().ToString("g")),
+            _ => null,
+        };
     }
 }
 


### PR DESCRIPTION
## Summary
- centralize alignment-related messages in `AlignmentService.GetMessage`
- show localized alignment change responses and cooldown info
- expose `Strings.Alignment` for server-side localization

## Testing
- `dotnet test` *(fails: project file vendor/LiteNetLib/LiteNetLib.csproj not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b37280db9c8324a1b1917f9e8313f9