### PR TITLE
Clarify Set Alignment command text

### DIFF
--- a/Intersect.Editor/Forms/Editors/Events/CommandPrinter.cs
+++ b/Intersect.Editor/Forms/Editors/Events/CommandPrinter.cs
@@ -865,27 +865,16 @@ public static partial class CommandPrinter
 
     private static string GetCommandText(SetAlignmentCommand command, MapInstance map)
     {
-        var text = Strings.EventCommandList.setalignment.ToString(
-            command.Desired switch
-            {
-                Alignment.Neutral => Strings.EventCommandList.neutral,
-                Alignment.Serolf => Strings.EventCommandList.serolf,
-                Alignment.Nidraj => Strings.EventCommandList.nidraj,
-                _ => Strings.EventCommandList.neutral,
-            }
-        );
-
-        if (command.IgnoreCooldown)
+        var faction = command.Desired switch
         {
-            text += " " + Strings.EventCommandList.ignorecooldown;
-        }
+            Alignment.Neutral => Strings.EventCommandList.neutral.ToString(),
+            Alignment.Serolf => Strings.EventCommandList.serolf.ToString(),
+            Alignment.Nidraj => Strings.EventCommandList.nidraj.ToString(),
+            _ => Strings.EventCommandList.neutral.ToString(),
+        };
 
-        if (command.IgnoreGuildLock)
-        {
-            text += " " + Strings.EventCommandList.ignoreguildlock;
-        }
-
-        return text;
+        return
+            $"Set Alignment → {faction} (ignoreCooldown={command.IgnoreCooldown}, ignoreGuildLock={command.IgnoreGuildLock})";
     }
 
     private static string GetCommandText(SetAccessCommand command, MapInstance map)


### PR DESCRIPTION
## Summary
- display Set Alignment command as `Set Alignment → {Faction} (ignoreCooldown={bool}, ignoreGuildLock={bool})`
- use localized faction names

## Testing
- `dotnet test --no-restore` *(fails: project file not found / WindowsDesktop targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b37ceef62083248f7bf9a782d05c2f