### PR TITLE
Align player faction with guild on membership

### DIFF
--- a/Intersect.Server.Core/Database/PlayerData/Players/Guild.cs
+++ b/Intersect.Server.Core/Database/PlayerData/Players/Guild.cs
@@ -315,6 +315,24 @@ public partial class Guild
             return false;
         }
 
+        if (player.Faction == Alignment.Neutral && guildFaction != Alignment.Neutral)
+        {
+            player.Faction = guildFaction;
+            player.Save();
+            PacketSender.SendChatMsg(player, Strings.Guilds.FactionApplied, ChatMessageType.Guild);
+
+            if (player.Faction != guildFaction)
+            {
+                PacketSender.SendChatMsg(player, Strings.Guilds.DifferentFaction, ChatMessageType.Guild);
+                if (initiator != null)
+                {
+                    PacketSender.SendChatMsg(initiator, Strings.Guilds.InviteDifferentFaction, ChatMessageType.Guild);
+                }
+
+                return false;
+            }
+        }
+
         try
         {
             // Save the guild before adding a new player

--- a/Intersect.Server.Core/Localization/Strings.cs
+++ b/Intersect.Server.Core/Localization/Strings.cs
@@ -833,6 +833,9 @@ public static partial class Strings
         public readonly LocalizedString DifferentFaction = @"Your faction does not match the guild's faction.";
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString FactionApplied = @"Your faction has been changed to match the guild's.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public readonly LocalizedString Promoted = @"{00} has been promoted to {01}!";
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]


### PR DESCRIPTION
## Summary
- ensure neutral players assume guild faction when joining and persist the change
- notify players of applied faction and add localization string

## Testing
- `dotnet test Intersect.Tests.Server/Intersect.Tests.Server.csproj --verbosity normal` *(fails: NetDataReader and other LiteNetLib types not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b381586be883249ed649aecb47d4de