### PR TITLE
Fix prism editor combo box initialization

### DIFF
--- a/Intersect.Editor/Forms/Editors/frmPrisms.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/frmPrisms.Designer.cs
@@ -1,4 +1,5 @@
 using DarkUI.Controls;
+using System;
 using System.Windows.Forms;
 using Intersect.Framework.Core.GameObjects.Prisms;
 
@@ -189,7 +190,7 @@ namespace Intersect.Editor.Forms.Editors
             var colDay = new DataGridViewComboBoxColumn();
             colDay.Name = "colDay";
             colDay.HeaderText = "Day";
-            colDay.DataSource = Enum.GetValues(typeof(DayOfWeek));
+            colDay.Items.AddRange((object[])Enum.GetValues(typeof(DayOfWeek)));
             var colStart = new DataGridViewTextBoxColumn();
             colStart.Name = "colStart";
             colStart.HeaderText = "Start";
@@ -211,7 +212,7 @@ namespace Intersect.Editor.Forms.Editors
             var colType = new DataGridViewComboBoxColumn();
             colType.Name = "colType";
             colType.HeaderText = "Type";
-            colType.DataSource = Enum.GetValues(typeof(PrismModuleType));
+            colType.Items.AddRange((object[])Enum.GetValues(typeof(PrismModuleType)));
             var colLevel = new DataGridViewTextBoxColumn();
             colLevel.Name = "colLevel";
             colLevel.HeaderText = "Level";


### PR DESCRIPTION
## Summary
- avoid modifying DataGridViewComboBox items when a DataSource is set in prism editor
- populate combo box columns via Items.AddRange for DayOfWeek and PrismModuleType

## Testing
- `dotnet build Intersect.Editor/Intersect.Editor.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3a7d4c3d083248407ccedfce385d3