### PR TITLE
Fix prism editor combo box initialization

### DIFF
--- a/Intersect.Editor/Forms/Controls/MapPicker.cs
+++ b/Intersect.Editor/Forms/Controls/MapPicker.cs
@@ -51,6 +51,14 @@ public class MapPicker : UserControl
         UpdateImage();
     }
 
+    public void SelectTile(Guid mapId, int x, int y)
+    {
+        SetMap(mapId);
+        _hoverX = x;
+        _hoverY = y;
+        _picture.Invalidate();
+    }
+
     private void UpdateImage()
     {
         if (_mapImage == null)

--- a/Intersect.Editor/Forms/Editors/frmPrisms.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/frmPrisms.Designer.cs
@@ -9,6 +9,7 @@ namespace Intersect.Editor.Forms.Editors
         private System.ComponentModel.IContainer components = null;
         private System.Windows.Forms.ListBox lstPrisms;
         private System.Windows.Forms.TextBox txtMapId;
+        private DarkButton btnPickPos;
         private DarkNumericUpDown nudX;
         private DarkNumericUpDown nudY;
         private DarkNumericUpDown nudLevel;
@@ -55,6 +56,7 @@ namespace Intersect.Editor.Forms.Editors
             var resources = new System.ComponentModel.ComponentResourceManager(typeof(FrmPrisms));
             lstPrisms = new ListBox();
             txtMapId = new TextBox();
+            btnPickPos = new DarkButton();
             nudX = new DarkNumericUpDown();
             nudY = new DarkNumericUpDown();
             nudLevel = new DarkNumericUpDown();
@@ -128,9 +130,19 @@ namespace Intersect.Editor.Forms.Editors
             txtMapId.Name = "txtMapId";
             txtMapId.Size = new Size(233, 23);
             txtMapId.TabIndex = 1;
-            // 
+            //
+            // btnPickPos
+            //
+            btnPickPos.Location = new System.Drawing.Point(497, 38);
+            btnPickPos.Margin = new Padding(4, 3, 4, 3);
+            btnPickPos.Name = "btnPickPos";
+            btnPickPos.Size = new Size(60, 23);
+            btnPickPos.TabIndex = 2;
+            btnPickPos.Text = "...";
+            btnPickPos.Click += btnPickPos_Click;
+            //
             // nudX
-            // 
+            //
             nudX.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
             nudX.ForeColor = System.Drawing.Color.Gainsboro;
             nudX.Location = new System.Drawing.Point(257, 72);
@@ -597,6 +609,7 @@ namespace Intersect.Editor.Forms.Editors
             Controls.Add(nudX);
             Controls.Add(lblMapId);
             Controls.Add(txtMapId);
+            Controls.Add(btnPickPos);
             Controls.Add(lstPrisms);
             ForeColor = SystemColors.ControlLightLight;
             Margin = new Padding(4, 3, 4, 3);

--- a/Intersect.Editor/Forms/Editors/frmPrisms.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/frmPrisms.Designer.cs
@@ -1,4 +1,6 @@
 using DarkUI.Controls;
+using System;
+using System.Linq;
 using System.Windows.Forms;
 using Intersect.Framework.Core.GameObjects.Prisms;
 
@@ -189,7 +191,7 @@ namespace Intersect.Editor.Forms.Editors
             var colDay = new DataGridViewComboBoxColumn();
             colDay.Name = "colDay";
             colDay.HeaderText = "Day";
-            colDay.DataSource = Enum.GetValues(typeof(DayOfWeek));
+            colDay.Items.AddRange(Enum.GetValues(typeof(DayOfWeek)).Cast<object>().ToArray());
             var colStart = new DataGridViewTextBoxColumn();
             colStart.Name = "colStart";
             colStart.HeaderText = "Start";
@@ -211,7 +213,7 @@ namespace Intersect.Editor.Forms.Editors
             var colType = new DataGridViewComboBoxColumn();
             colType.Name = "colType";
             colType.HeaderText = "Type";
-            colType.DataSource = Enum.GetValues(typeof(PrismModuleType));
+            colType.Items.AddRange(Enum.GetValues(typeof(PrismModuleType)).Cast<object>().ToArray());
             var colLevel = new DataGridViewTextBoxColumn();
             colLevel.Name = "colLevel";
             colLevel.HeaderText = "Level";

--- a/Intersect.Editor/Forms/Editors/frmPrisms.cs
+++ b/Intersect.Editor/Forms/Editors/frmPrisms.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Windows.Forms;
 using Intersect.Config;
 using Intersect.Framework.Core.GameObjects.Prisms;
+using Intersect.Framework.Core.GameObjects.Maps.MapList;
 using Intersect.Editor.Forms;
 using Intersect.Editor.General;
 using Intersect.Editor.Core;
@@ -14,6 +15,7 @@ namespace Intersect.Editor.Forms.Editors;
 public partial class FrmPrisms : Form
 {
     private const int MaxModules = 3;
+    private List<AlignmentPrism> _sortedPrisms = new();
     public FrmPrisms()
     {
         InitializeComponent();
@@ -22,21 +24,36 @@ public partial class FrmPrisms : Form
         mapPicker.SetMap(Globals.CurrentMap?.Id ?? Guid.Empty);
         nudX.Maximum = Options.Instance.Map.MapWidth - 1;
         nudY.Maximum = Options.Instance.Map.MapHeight - 1;
+        nudX.ValueChanged += NudXY_ValueChanged;
+        nudY.ValueChanged += NudXY_ValueChanged;
         LoadList();
     }
 
     private void LoadList()
     {
+        var items = PrismConfig.Prisms
+            .Select(p => new
+            {
+                Prism = p,
+                MapName = MapList.List.FindMap(p.MapId)?.Name ?? p.MapId.ToString()
+            })
+            .OrderBy(i => i.MapName)
+            .ThenBy(i => i.Prism.X)
+            .ThenBy(i => i.Prism.Y)
+            .ToList();
+
+        _sortedPrisms = items.Select(i => i.Prism).ToList();
+
         lstPrisms.Items.Clear();
-        foreach (var p in PrismConfig.Prisms)
+        foreach (var item in items)
         {
-            lstPrisms.Items.Add($"{p.MapId} ({p.X},{p.Y})");
+            lstPrisms.Items.Add($"{item.MapName} ({item.Prism.X},{item.Prism.Y})");
         }
     }
 
     private AlignmentPrism? SelectedPrism =>
-        lstPrisms.SelectedIndex >= 0 && lstPrisms.SelectedIndex < PrismConfig.Prisms.Count
-            ? PrismConfig.Prisms[lstPrisms.SelectedIndex]
+        lstPrisms.SelectedIndex >= 0 && lstPrisms.SelectedIndex < _sortedPrisms.Count
+            ? _sortedPrisms[lstPrisms.SelectedIndex]
             : null;
 
     private void lstPrisms_SelectedIndexChanged(object sender, EventArgs e) => LoadSelected();
@@ -50,9 +67,10 @@ public partial class FrmPrisms : Form
         }
 
         txtMapId.Text = p.MapId.ToString();
+        ApplyMapBounds(p.MapId);
         nudX.Value = p.X;
         nudY.Value = p.Y;
-        mapPicker.SetMap(p.MapId);
+        mapPicker.SelectTile(p.MapId, p.X, p.Y);
         nudLevel.Value = p.Level;
 
         dgvWindows.Rows.Clear();
@@ -83,7 +101,7 @@ public partial class FrmPrisms : Form
         var prism = new AlignmentPrism { Id = Guid.NewGuid() };
         PrismConfig.Prisms.Add(prism);
         LoadList();
-        lstPrisms.SelectedIndex = PrismConfig.Prisms.Count - 1;
+        lstPrisms.SelectedIndex = _sortedPrisms.IndexOf(prism);
     }
 
     private void btnDelete_Click(object sender, EventArgs e)
@@ -237,10 +255,11 @@ public partial class FrmPrisms : Form
             Height = areaH
         };
 
-        var index = lstPrisms.SelectedIndex;
+        var selectedId = p.Id;
         PrismConfig.Save();
         PrismConfig.Load();
         LoadList();
+        var index = _sortedPrisms.FindIndex(prism => prism.Id == selectedId);
         if (index >= 0 && index < lstPrisms.Items.Count)
         {
             lstPrisms.SelectedIndex = index;
@@ -303,12 +322,66 @@ public partial class FrmPrisms : Form
             nudAreaX.Value = selector.GetX();
             nudAreaY.Value = selector.GetY();
         }
-}
+    }
+
+    private void btnPickPos_Click(object? sender, EventArgs e)
+    {
+        var selector = new FrmWarpSelection();
+        List<Guid>? restrict = null;
+        if (Guid.TryParse(txtMapId.Text, out var currMap) && currMap != Guid.Empty)
+        {
+            restrict = new List<Guid> { currMap };
+        }
+
+        selector.InitForm(true, restrict);
+        if (!Guid.TryParse(txtMapId.Text, out var mapId))
+        {
+            mapId = Globals.CurrentMap?.Id ?? Guid.Empty;
+        }
+
+        selector.SelectTile(mapId, (int)nudX.Value, (int)nudY.Value);
+        selector.ShowDialog();
+
+        if (selector.GetResult())
+        {
+            var pickedMap = selector.GetMap();
+            var x = selector.GetX();
+            var y = selector.GetY();
+
+            txtMapId.Text = pickedMap.ToString();
+            ApplyMapBounds(pickedMap);
+            nudX.Value = Math.Max(nudX.Minimum, Math.Min(nudX.Maximum, x));
+            nudY.Value = Math.Max(nudY.Minimum, Math.Min(nudY.Maximum, y));
+
+            mapPicker.SelectTile(pickedMap, x, y);
+        }
+    }
+
+    private void NudXY_ValueChanged(object? sender, EventArgs e)
+    {
+        if (!Guid.TryParse(txtMapId.Text, out var mapId) || mapId == Guid.Empty)
+        {
+            return;
+        }
+
+        ApplyMapBounds(mapId);
+        mapPicker.SelectTile(mapId, (int)nudX.Value, (int)nudY.Value);
+    }
+
+    private void ApplyMapBounds(Guid mapId)
+    {
+        var maxW = Options.Instance.Map.MapWidth;
+        var maxH = Options.Instance.Map.MapHeight;
+
+        nudX.Maximum = Math.Max(0, maxW - 1);
+        nudY.Maximum = Math.Max(0, maxH - 1);
+    }
+
     private void MapPickerOnTileSelected(Guid mapId, int x, int y)
     {
         txtMapId.Text = mapId.ToString();
+        ApplyMapBounds(mapId);
         nudX.Value = Math.Max(nudX.Minimum, Math.Min(nudX.Maximum, x));
         nudY.Value = Math.Max(nudY.Minimum, Math.Min(nudY.Maximum, y));
-
     }
 }


### PR DESCRIPTION
## Summary
- box enum values before populating vulnerability window and module type combo boxes

## Testing
- `dotnet build Intersect.Editor/Intersect.Editor.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3a7d4c3d083248407ccedfce385d3