### PR TITLE
Fix DataGridView column declarations in FrmPrisms

### DIFF
--- a/Intersect.Editor/Forms/Editors/frmPrisms.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/frmPrisms.Designer.cs
@@ -206,11 +206,9 @@ namespace Intersect.Editor.Forms.Editors
     };
             colDay.HeaderText = "Day";
             colDay.Items.AddRange(Enum.GetValues(typeof(DayOfWeek)).Cast<object>().ToArray());
-            var colStart = new DataGridViewTextBoxColumn();
-            colStart.Name = "colStart";
-            // 
+            //
             // colStart
-            // 
+            //
             colStart.HeaderText = "Start";
             colStart.Name = "colStart";
             // 
@@ -234,21 +232,19 @@ namespace Intersect.Editor.Forms.Editors
             // colType
             // 
             colType.DataSource = new PrismModuleType[]
-    {
-    PrismModuleType.Vision,
-    PrismModuleType.Prospecting,
-    PrismModuleType.Crafting,
-    PrismModuleType.GuardBoost
-    };
-       
-            // 
+            {
+                PrismModuleType.Vision,
+                PrismModuleType.Prospecting,
+                PrismModuleType.Crafting,
+                PrismModuleType.GuardBoost
+            };
+            colType.HeaderText = "Type";
+            colType.Items.AddRange(Enum.GetValues(typeof(PrismModuleType)).Cast<object>().ToArray());
+            //
             // colLevel
-            // 
-               colType.HeaderText = "Type";
-  colType.Items.AddRange(Enum.GetValues(typeof(PrismModuleType)).Cast<object>().ToArray());
-            var colLevel = new DataGridViewTextBoxColumn();
-            colLevel.Name = "colLevel";
+            //
             colLevel.HeaderText = "Level";
+            colLevel.Name = "colLevel";
            
             // 
             // nudAreaX


### PR DESCRIPTION
## Summary
- fix colStart/colLevel declarations to use class fields instead of hidden locals in `FrmPrisms` designer
- properly set DataGridView column headers and items

## Testing
- `dotnet build Intersect.Editor/Intersect.Editor.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3b247087c832494256a3a28d21ff3