### PR TITLE
Add visual state fields to AlignmentPrism

### DIFF
--- a/Intersect.Server.Core/Core/Bootstrapper.cs
+++ b/Intersect.Server.Core/Core/Bootstrapper.cs
@@ -361,11 +361,16 @@ internal static class Bootstrapper
                 Id = prism.Id,
                 MapId = prism.MapId,
                 Faction = (int)prism.Owner,
+                State = prism.State,
                 X = prism.X,
                 Y = prism.Y,
+                PlacedAt = prism.PlacedAt,
+                MaturationEndsAt = prism.MaturationEndsAt,
                 Level = prism.Level,
                 Hp = prism.Hp,
+                LastHitAt = prism.LastHitAt,
                 MaxHp = prism.MaxHp,
+                CurrentBattleId = prism.CurrentBattleId,
                 Windows = prism.Windows
                     .Select(w => new VulnerabilityWindow { Day = w.Day, Start = w.Start, End = w.End })
                     .ToList(),

--- a/Intersect.Server.Core/Database/PlayerData/PlayerContext.cs
+++ b/Intersect.Server.Core/Database/PlayerData/PlayerContext.cs
@@ -165,6 +165,12 @@ public abstract partial class PlayerContext : IntersectDbContext<PlayerContext>,
         {
             var jsonOptions = new JsonSerializerOptions();
 
+            entity.Property(p => p.State);
+            entity.Property(p => p.PlacedAt);
+            entity.Property(p => p.MaturationEndsAt);
+            entity.Property(p => p.LastHitAt);
+            entity.Property(p => p.CurrentBattleId);
+
             entity.Property(p => p.Windows)
                 .HasConversion(
                     v => JsonSerializer.Serialize(v, jsonOptions),

--- a/Intersect.Server.Core/Database/Prisms/AlignmentPrism.cs
+++ b/Intersect.Server.Core/Database/Prisms/AlignmentPrism.cs
@@ -21,6 +21,11 @@ public partial class AlignmentPrism
     public int Faction { get; set; }
 
     /// <summary>
+    /// Current state of the prism.
+    /// </summary>
+    public PrismState State { get; set; }
+
+    /// <summary>
     /// X-coordinate where the prism resides on the map.
     /// </summary>
     public int X { get; set; }
@@ -29,6 +34,16 @@ public partial class AlignmentPrism
     /// Y-coordinate where the prism resides on the map.
     /// </summary>
     public int Y { get; set; }
+
+    /// <summary>
+    /// Date and time when the prism was placed.
+    /// </summary>
+    public DateTime PlacedAt { get; set; }
+
+    /// <summary>
+    /// Time when the maturation period ends and the prism becomes vulnerable.
+    /// </summary>
+    public DateTime? MaturationEndsAt { get; set; }
 
     /// <summary>
     /// Current level of the prism.
@@ -41,9 +56,19 @@ public partial class AlignmentPrism
     public int Hp { get; set; }
 
     /// <summary>
+    /// Time when the prism was last hit.
+    /// </summary>
+    public DateTime? LastHitAt { get; set; }
+
+    /// <summary>
     /// Maximum hit points of the prism.
     /// </summary>
     public int MaxHp { get; set; }
+
+    /// <summary>
+    /// Identifier of the current battle if the prism is under attack.
+    /// </summary>
+    public Guid? CurrentBattleId { get; set; }
 
     /// <summary>
     /// Vulnerability windows in which the prism can be attacked.

--- a/Intersect.Server.Core/Services/Prisms/PrismService.cs
+++ b/Intersect.Server.Core/Services/Prisms/PrismService.cs
@@ -36,6 +36,8 @@ internal static class PrismService
             Level = player.Level,
             MaxHp = maxHp,
             Hp = maxHp,
+            LastHitAt = null,
+            CurrentBattleId = null,
         };
 
         map.ControllingPrism = prism;


### PR DESCRIPTION
## Summary
- track prism state, timestamps, and battle identifier in database entity
- map new prism fields in `PlayerContext`
- seed and populate new prism fields during placement and configuration sync

## Testing
- `dotnet test` *(fails: The project file "/workspace/Broken_Reborn/vendor/LiteNetLib/LiteNetLib/LiteNetLib.csproj" was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3b51fc6688324bfcdbabed9db1345