### PR TITLE
feat: add visual prism settings

### DIFF
--- a/Intersect.Client.Core/Interface/Game/PrismHud.cs
+++ b/Intersect.Client.Core/Interface/Game/PrismHud.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Drawing;
-using System.Linq;
 using Intersect.Client.Framework.Gwen.Control;
 using Intersect.Client.General;
 using Intersect.Client.Maps;
@@ -56,22 +55,10 @@ public class PrismHud : ImagePanel
             return;
         }
 
-        var radius = Options.Instance.Prism.HudDisplayRadius;
-        if (radius > 0 && Globals.Me != null)
-        {
-            var prism = PrismConfig.Prisms.FirstOrDefault(p => p.MapId == map.Id);
-            if (prism != null)
-            {
-                var dx = Globals.Me.X - prism.X;
-                var dy = Globals.Me.Y - prism.Y;
-                if (Math.Sqrt(dx * dx + dy * dy) > radius)
-                {
-                    Hide();
-                    return;
-                }
-            }
-        }
-
+        // Prism positions are now provided by the server and the client no longer
+        // relies on local prism configuration data. Without direct access to the
+        // prism coordinates we cannot perform a radius check here, so simply
+        // display the HUD whenever the map contains prism information.
         Show();
 
         var color = map.PrismOwner switch

--- a/Intersect.Editor/Forms/Editors/frmPrisms.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/frmPrisms.Designer.cs
@@ -40,6 +40,17 @@ namespace Intersect.Editor.Forms.Editors
         private System.Windows.Forms.Label lblAreaH;
         private Intersect.Editor.Forms.Controls.MapPicker mapPicker;
 
+        private DarkGroupBox grpVisual;
+        private DarkComboBox cmbIdleAnimation;
+        private DarkComboBox cmbVulnerableAnimation;
+        private DarkComboBox cmbUnderAttackAnimation;
+        private DarkCheckBox chkTintByFaction;
+        private DarkNumericUpDown nudSpriteOffsetY;
+        private System.Windows.Forms.Label lblIdleAnimation;
+        private System.Windows.Forms.Label lblVulnerableAnimation;
+        private System.Windows.Forms.Label lblUnderAttackAnimation;
+        private System.Windows.Forms.Label lblSpriteOffsetY;
+
         protected override void Dispose(bool disposing)
         {
             if (disposing && (components != null))
@@ -100,6 +111,16 @@ namespace Intersect.Editor.Forms.Editors
             toolStripSeparator3 = new ToolStripSeparator();
             toolStripItemUndo = new ToolStripButton();
             mapPicker = new Intersect.Editor.Forms.Controls.MapPicker();
+            grpVisual = new DarkGroupBox();
+            cmbIdleAnimation = new DarkComboBox();
+            cmbVulnerableAnimation = new DarkComboBox();
+            cmbUnderAttackAnimation = new DarkComboBox();
+            chkTintByFaction = new DarkCheckBox();
+            nudSpriteOffsetY = new DarkNumericUpDown();
+            lblIdleAnimation = new Label();
+            lblVulnerableAnimation = new Label();
+            lblUnderAttackAnimation = new Label();
+            lblSpriteOffsetY = new Label();
             ((System.ComponentModel.ISupportInitialize)nudX).BeginInit();
             ((System.ComponentModel.ISupportInitialize)nudY).BeginInit();
             ((System.ComponentModel.ISupportInitialize)nudLevel).BeginInit();
@@ -109,6 +130,7 @@ namespace Intersect.Editor.Forms.Editors
             ((System.ComponentModel.ISupportInitialize)nudAreaY).BeginInit();
             ((System.ComponentModel.ISupportInitialize)nudAreaW).BeginInit();
             ((System.ComponentModel.ISupportInitialize)nudAreaH).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)nudSpriteOffsetY).BeginInit();
             toolStrip.SuspendLayout();
             SuspendLayout();
             // 
@@ -587,6 +609,118 @@ namespace Intersect.Editor.Forms.Editors
             mapPicker.Name = "mapPicker";
             mapPicker.Size = new Size(390, 439);
             mapPicker.TabIndex = 27;
+
+            // grpVisual
+            //
+            grpVisual.Controls.Add(lblIdleAnimation);
+            grpVisual.Controls.Add(cmbIdleAnimation);
+            grpVisual.Controls.Add(lblVulnerableAnimation);
+            grpVisual.Controls.Add(cmbVulnerableAnimation);
+            grpVisual.Controls.Add(lblUnderAttackAnimation);
+            grpVisual.Controls.Add(cmbUnderAttackAnimation);
+            grpVisual.Controls.Add(chkTintByFaction);
+            grpVisual.Controls.Add(lblSpriteOffsetY);
+            grpVisual.Controls.Add(nudSpriteOffsetY);
+            grpVisual.ForeColor = System.Drawing.Color.Gainsboro;
+            grpVisual.Location = new System.Drawing.Point(251, 270);
+            grpVisual.Name = "grpVisual";
+            grpVisual.Size = new Size(300, 192);
+            grpVisual.TabIndex = 28;
+            grpVisual.TabStop = false;
+            grpVisual.Text = "Visual";
+
+            // lblIdleAnimation
+            //
+            lblIdleAnimation.AutoSize = true;
+            lblIdleAnimation.Location = new System.Drawing.Point(6, 22);
+            lblIdleAnimation.Name = "lblIdleAnimation";
+            lblIdleAnimation.Size = new Size(88, 15);
+            lblIdleAnimation.TabIndex = 0;
+            lblIdleAnimation.Text = "Idle Animation";
+
+            // cmbIdleAnimation
+            //
+            cmbIdleAnimation.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            cmbIdleAnimation.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            cmbIdleAnimation.DrawMode = DrawMode.OwnerDrawFixed;
+            cmbIdleAnimation.DropDownStyle = ComboBoxStyle.DropDownList;
+            cmbIdleAnimation.ForeColor = System.Drawing.Color.Gainsboro;
+            cmbIdleAnimation.Location = new System.Drawing.Point(9, 40);
+            cmbIdleAnimation.Name = "cmbIdleAnimation";
+            cmbIdleAnimation.Size = new Size(280, 24);
+            cmbIdleAnimation.TabIndex = 1;
+
+            // lblVulnerableAnimation
+            //
+            lblVulnerableAnimation.AutoSize = true;
+            lblVulnerableAnimation.Location = new System.Drawing.Point(6, 67);
+            lblVulnerableAnimation.Name = "lblVulnerableAnimation";
+            lblVulnerableAnimation.Size = new Size(123, 15);
+            lblVulnerableAnimation.TabIndex = 2;
+            lblVulnerableAnimation.Text = "Vulnerable Animation";
+
+            // cmbVulnerableAnimation
+            //
+            cmbVulnerableAnimation.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            cmbVulnerableAnimation.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            cmbVulnerableAnimation.DrawMode = DrawMode.OwnerDrawFixed;
+            cmbVulnerableAnimation.DropDownStyle = ComboBoxStyle.DropDownList;
+            cmbVulnerableAnimation.ForeColor = System.Drawing.Color.Gainsboro;
+            cmbVulnerableAnimation.Location = new System.Drawing.Point(9, 85);
+            cmbVulnerableAnimation.Name = "cmbVulnerableAnimation";
+            cmbVulnerableAnimation.Size = new Size(280, 24);
+            cmbVulnerableAnimation.TabIndex = 3;
+
+            // lblUnderAttackAnimation
+            //
+            lblUnderAttackAnimation.AutoSize = true;
+            lblUnderAttackAnimation.Location = new System.Drawing.Point(6, 112);
+            lblUnderAttackAnimation.Name = "lblUnderAttackAnimation";
+            lblUnderAttackAnimation.Size = new Size(145, 15);
+            lblUnderAttackAnimation.TabIndex = 4;
+            lblUnderAttackAnimation.Text = "Under Attack Animation";
+
+            // cmbUnderAttackAnimation
+            //
+            cmbUnderAttackAnimation.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            cmbUnderAttackAnimation.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            cmbUnderAttackAnimation.DrawMode = DrawMode.OwnerDrawFixed;
+            cmbUnderAttackAnimation.DropDownStyle = ComboBoxStyle.DropDownList;
+            cmbUnderAttackAnimation.ForeColor = System.Drawing.Color.Gainsboro;
+            cmbUnderAttackAnimation.Location = new System.Drawing.Point(9, 130);
+            cmbUnderAttackAnimation.Name = "cmbUnderAttackAnimation";
+            cmbUnderAttackAnimation.Size = new Size(280, 24);
+            cmbUnderAttackAnimation.TabIndex = 5;
+
+            // chkTintByFaction
+            //
+            chkTintByFaction.AutoSize = true;
+            chkTintByFaction.Location = new System.Drawing.Point(9, 160);
+            chkTintByFaction.Name = "chkTintByFaction";
+            chkTintByFaction.Size = new Size(105, 19);
+            chkTintByFaction.TabIndex = 6;
+            chkTintByFaction.Text = "Tint by faction";
+            chkTintByFaction.Checked = false;
+
+            // lblSpriteOffsetY
+            //
+            lblSpriteOffsetY.AutoSize = true;
+            lblSpriteOffsetY.Location = new System.Drawing.Point(170, 161);
+            lblSpriteOffsetY.Name = "lblSpriteOffsetY";
+            lblSpriteOffsetY.Size = new Size(87, 15);
+            lblSpriteOffsetY.TabIndex = 7;
+            lblSpriteOffsetY.Text = "Sprite OffsetY";
+
+            // nudSpriteOffsetY
+            //
+            nudSpriteOffsetY.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            nudSpriteOffsetY.ForeColor = System.Drawing.Color.Gainsboro;
+            nudSpriteOffsetY.Location = new System.Drawing.Point(260, 159);
+            nudSpriteOffsetY.Maximum = new decimal(new int[] { 1000, 0, 0, 0 });
+            nudSpriteOffsetY.Minimum = new decimal(new int[] { 1000, 0, 0, int.MinValue });
+            nudSpriteOffsetY.Name = "nudSpriteOffsetY";
+            nudSpriteOffsetY.Size = new Size(60, 23);
+            nudSpriteOffsetY.TabIndex = 8;
             // 
             // FrmPrisms
             // 
@@ -599,6 +733,7 @@ namespace Intersect.Editor.Forms.Editors
             Controls.Add(btnDelete);
             Controls.Add(btnAdd);
             Controls.Add(mapPicker);
+            Controls.Add(grpVisual);
             Controls.Add(lblAreaH);
             Controls.Add(nudAreaH);
             Controls.Add(lblAreaW);
@@ -638,6 +773,7 @@ namespace Intersect.Editor.Forms.Editors
             ((System.ComponentModel.ISupportInitialize)nudAreaY).EndInit();
             ((System.ComponentModel.ISupportInitialize)nudAreaW).EndInit();
             ((System.ComponentModel.ISupportInitialize)nudAreaH).EndInit();
+            ((System.ComponentModel.ISupportInitialize)nudSpriteOffsetY).EndInit();
             toolStrip.ResumeLayout(false);
             toolStrip.PerformLayout();
             ResumeLayout(false);

--- a/Intersect.Editor/Forms/Editors/frmPrisms.cs
+++ b/Intersect.Editor/Forms/Editors/frmPrisms.cs
@@ -8,6 +8,8 @@ using Intersect.Framework.Core.GameObjects.Maps.MapList;
 using Intersect.Editor.Forms;
 using Intersect.Editor.General;
 using Intersect.Editor.Core;
+using Intersect.Framework.Core.GameObjects.Animations;
+using Intersect.Editor.Localization;
 
 
 namespace Intersect.Editor.Forms.Editors;
@@ -26,6 +28,18 @@ public partial class FrmPrisms : Form
         nudY.Maximum = Options.Instance.Map.MapHeight - 1;
         nudX.ValueChanged += NudXY_ValueChanged;
         nudY.ValueChanged += NudXY_ValueChanged;
+
+        cmbIdleAnimation.Items.Clear();
+        cmbVulnerableAnimation.Items.Clear();
+        cmbUnderAttackAnimation.Items.Clear();
+        cmbIdleAnimation.Items.Add(Strings.General.None);
+        cmbVulnerableAnimation.Items.Add(Strings.General.None);
+        cmbUnderAttackAnimation.Items.Add(Strings.General.None);
+        var animNames = AnimationDescriptor.Names;
+        cmbIdleAnimation.Items.AddRange(animNames);
+        cmbVulnerableAnimation.Items.AddRange(animNames);
+        cmbUnderAttackAnimation.Items.AddRange(animNames);
+
         LoadList();
     }
 
@@ -94,6 +108,12 @@ public partial class FrmPrisms : Form
         nudAreaY.Value = p.Area.Y;
         nudAreaW.Value = p.Area.Width;
         nudAreaH.Value = p.Area.Height;
+
+        cmbIdleAnimation.SelectedIndex = AnimationDescriptor.ListIndex(p.IdleAnimationId) + 1;
+        cmbVulnerableAnimation.SelectedIndex = AnimationDescriptor.ListIndex(p.VulnerableAnimationId) + 1;
+        cmbUnderAttackAnimation.SelectedIndex = AnimationDescriptor.ListIndex(p.UnderAttackAnimationId) + 1;
+        chkTintByFaction.Checked = p.TintByFaction;
+        nudSpriteOffsetY.Value = p.SpriteOffsetY;
     }
 
     private void btnAdd_Click(object sender, EventArgs e)
@@ -254,6 +274,12 @@ public partial class FrmPrisms : Form
             Width = areaW,
             Height = areaH
         };
+
+        p.IdleAnimationId = AnimationDescriptor.IdFromList(cmbIdleAnimation.SelectedIndex - 1);
+        p.VulnerableAnimationId = AnimationDescriptor.IdFromList(cmbVulnerableAnimation.SelectedIndex - 1);
+        p.UnderAttackAnimationId = AnimationDescriptor.IdFromList(cmbUnderAttackAnimation.SelectedIndex - 1);
+        p.TintByFaction = chkTintByFaction.Checked;
+        p.SpriteOffsetY = (int)nudSpriteOffsetY.Value;
 
         var selectedId = p.Id;
         PrismConfig.Save();

--- a/Intersect.Server.Core/Core/Bootstrapper.cs
+++ b/Intersect.Server.Core/Core/Bootstrapper.cs
@@ -11,7 +11,6 @@ using Intersect.Framework.Core.GameObjects.Items;
 using Intersect.Framework.Core.GameObjects;
 using Intersect.Framework.Core.GameObjects.Maps;
 using Intersect.Framework.Core.GameObjects.NPCs;
-using Intersect.Framework.Core.GameObjects.Prisms;
 using Intersect.Framework.Logging;
 using Intersect.Framework.SystemInformation;
 using Intersect.GameObjects;
@@ -21,7 +20,6 @@ using Intersect.Plugins.Contexts;
 using Intersect.Plugins.Helpers;
 using Intersect.Server.Database;
 using Intersect.Server.Database.PlayerData;
-using Intersect.Server.Database.Prisms;
 using Intersect.Server.Database.PlayerData.Players;
 using Intersect.Server.Entities;
 using Intersect.Server.General;
@@ -31,11 +29,9 @@ using Intersect.Server.Networking;
 using Intersect.Server.Plugins;
 using Intersect.Threading;
 using Intersect.Utilities;
-using System.Linq;
 using Microsoft.Extensions.Logging;
 using Serilog;
 
-using AlignmentPrismEntity = Intersect.Server.Database.Prisms.AlignmentPrism;
 
 namespace Intersect.Server.Core;
 
@@ -304,7 +300,6 @@ internal static class Bootstrapper
             return false;
         }
 
-        SyncPrismsFromConfiguration();
 
         Time.Update();
 
@@ -330,66 +325,6 @@ internal static class Bootstrapper
         }
 
         return true;
-    }
-
-    private static void SyncPrismsFromConfiguration()
-    {
-        using var context = DbInterface.CreatePlayerContext(readOnly: false);
-        IPrismRepository? repository = context switch
-        {
-            SqlitePlayerContext sqlite => new SqlitePrismRepository(sqlite),
-            _ => null,
-        };
-
-        if (repository == null)
-        {
-            return;
-        }
-
-        var shouldSync = Options.Instance.Prism.SyncOnStartup || !repository.Prisms.Any();
-        if (!shouldSync)
-        {
-            return;
-        }
-
-        repository.Prisms.RemoveRange(repository.Prisms.ToArray());
-
-        foreach (var prism in PrismConfig.Prisms)
-        {
-            var dbPrism = new AlignmentPrismEntity
-            {
-                Id = prism.Id,
-                MapId = prism.MapId,
-                Faction = (int)prism.Owner,
-                State = prism.State,
-                X = prism.X,
-                Y = prism.Y,
-                PlacedAt = prism.PlacedAt,
-                MaturationEndsAt = prism.MaturationEndsAt,
-                Level = prism.Level,
-                Hp = prism.Hp,
-                LastHitAt = prism.LastHitAt,
-                MaxHp = prism.MaxHp,
-                CurrentBattleId = prism.CurrentBattleId,
-                Windows = prism.Windows
-                    .Select(w => new VulnerabilityWindow { Day = w.Day, Start = w.Start, End = w.End })
-                    .ToList(),
-                Modules = prism.Modules
-                    .Select(m => new PrismModule { Type = m.Type, Level = m.Level })
-                    .ToList(),
-                Area = new PrismArea
-                {
-                    X = prism.Area.X,
-                    Y = prism.Area.Y,
-                    Width = prism.Area.Width,
-                    Height = prism.Area.Height,
-                },
-            };
-
-            repository.Prisms.Add(dbPrism);
-        }
-
-        repository.SaveChangesAsync().GetAwaiter().GetResult();
     }
 
     private static void PrintIntroduction()

--- a/Intersect.Server.Core/Database/Prisms/AlignmentPrism.cs
+++ b/Intersect.Server.Core/Database/Prisms/AlignmentPrism.cs
@@ -84,5 +84,30 @@ public partial class AlignmentPrism
     /// Area influenced by the prism.
     /// </summary>
     public PrismArea Area { get; set; } = new();
+
+    /// <summary>
+    /// Animation to display while the prism is idle.
+    /// </summary>
+    public Guid? IdleAnimationId { get; set; } = Guid.Empty;
+
+    /// <summary>
+    /// Animation to display while the prism is vulnerable.
+    /// </summary>
+    public Guid? VulnerableAnimationId { get; set; } = Guid.Empty;
+
+    /// <summary>
+    /// Animation to display when the prism is under attack.
+    /// </summary>
+    public Guid? UnderAttackAnimationId { get; set; } = Guid.Empty;
+
+    /// <summary>
+    /// Indicates whether the prism sprite should be tinted by the owning faction.
+    /// </summary>
+    public bool TintByFaction { get; set; } = false;
+
+    /// <summary>
+    /// Vertical offset applied to the prism sprite.
+    /// </summary>
+    public int SpriteOffsetY { get; set; } = 0;
 }
 


### PR DESCRIPTION
## Summary
- remove client hud's dependency on local prism config
- allow editing prism visuals like animations, faction tint and sprite offset
- drop server bootstrapper prism config sync and persist new prism visual fields

## Testing
- `dotnet build Intersect.Client.Core/Intersect.Client.Core.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3b927a7f883248694d380085eb774