### PR TITLE
feat: add client prisms

### DIFF
--- a/Intersect.Client.Core/Core/Input.cs
+++ b/Intersect.Client.Core/Core/Input.cs
@@ -11,6 +11,7 @@ using Intersect.Client.Interface;
 using Intersect.Client.Interface.Game;
 using Intersect.Client.Interface.Shared;
 using Intersect.Client.Maps;
+using Intersect.Client.Maps.Prisms;
 using Intersect.Client.Networking;
 using Intersect.Configuration;
 using Intersect.Enums;
@@ -502,6 +503,11 @@ public static partial class Input
         }
 
         if (modifier == Keys.None && mouseButton == MouseButton.Left && Globals.Me.TryTarget())
+        {
+            return;
+        }
+
+        if (modifier == Keys.None && mouseButton == MouseButton.Left && PrismVisualManager.TryClickAttack())
         {
             return;
         }

--- a/Intersect.Client.Core/Maps/MapInstance.cs
+++ b/Intersect.Client.Core/Maps/MapInstance.cs
@@ -27,6 +27,7 @@ using Intersect.Network.Packets.Server;
 using Intersect.Utilities;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
+using Intersect.Client.Maps.Prisms;
 
 namespace Intersect.Client.Maps;
 
@@ -992,6 +993,7 @@ public partial class MapInstance : MapDescriptor, IGameObject<Guid, MapInstance>
                 );
             }
         }
+        PrismVisualManager.Draw(this);
 
         //Add lights to our darkness texture
         foreach (var light in Lights)

--- a/Intersect.Client.Core/Maps/Prisms/PrismVisual.cs
+++ b/Intersect.Client.Core/Maps/Prisms/PrismVisual.cs
@@ -1,0 +1,190 @@
+using System;
+using System.Linq;
+using Intersect.Client.Framework.GenericClasses;
+using Intersect.Client.Framework.Graphics;
+using Intersect.Client.General;
+using Intersect.Enums;
+using Intersect.Framework.Core.GameObjects.Animations;
+using Intersect.Framework.Core.GameObjects.Prisms;
+using Intersect.Utilities;
+using Intersect.Client.Maps;
+using Color = Microsoft.Xna.Framework.Color;
+
+namespace Intersect.Client.Maps.Prisms;
+
+public class PrismVisual
+{
+    private readonly AlignmentPrism _info;
+    private readonly AnimationDescriptor? _idle;
+    private readonly AnimationDescriptor? _vulnerable;
+    private readonly AnimationDescriptor? _underAttack;
+
+    private long _stateStart = Timing.Global.Milliseconds;
+    private FloatRect _bounds;
+
+    public PrismVisual(AlignmentPrism info)
+    {
+        _info = info;
+        if (info.IdleAnimationId.HasValue && info.IdleAnimationId != Guid.Empty)
+        {
+            _idle = AnimationDescriptor.Get(info.IdleAnimationId.Value);
+        }
+
+        if (info.VulnerableAnimationId.HasValue && info.VulnerableAnimationId != Guid.Empty)
+        {
+            _vulnerable = AnimationDescriptor.Get(info.VulnerableAnimationId.Value);
+        }
+
+        if (info.UnderAttackAnimationId.HasValue && info.UnderAttackAnimationId != Guid.Empty)
+        {
+            _underAttack = AnimationDescriptor.Get(info.UnderAttackAnimationId.Value);
+        }
+    }
+
+    public Guid MapId => _info.MapId;
+    public int X => _info.X;
+    public int Y => _info.Y;
+    public bool TintByFaction => _info.TintByFaction;
+    public int SpriteOffsetY => _info.SpriteOffsetY;
+
+    public Factions Owner { get; private set; } = Factions.Neutral;
+    public PrismState State { get; private set; } = PrismState.Placed;
+    public int Hp { get; private set; }
+    public int MaxHp { get; private set; }
+
+    private AnimationDescriptor? DescriptorForState => State switch
+    {
+        PrismState.UnderAttack => _underAttack ?? _vulnerable ?? _idle,
+        PrismState.Vulnerable => _vulnerable ?? _idle,
+        _ => _idle,
+    };
+
+    public void Update(Factions owner, PrismState state, int hp, int maxHp)
+    {
+        Owner = owner;
+        Hp = hp;
+        MaxHp = maxHp;
+        if (State != state)
+        {
+            State = state;
+            _stateStart = Timing.Global.Milliseconds;
+        }
+    }
+
+    private static Color GetFactionColor(Factions faction) => faction switch
+    {
+        Factions.Serolf => Color.Blue,
+        Factions.Nidraj => Color.Red,
+        _ => Color.White,
+    };
+
+    public void Draw(MapInstance map)
+    {
+        var descriptor = DescriptorForState;
+        if (descriptor == null)
+        {
+            return;
+        }
+
+        _bounds = FloatRect.Empty;
+
+        DrawLayer(map, descriptor.Lower);
+        DrawLayer(map, descriptor.Upper);
+
+        DrawHp();
+    }
+
+    private void DrawLayer(MapInstance map, AnimationLayer layer)
+    {
+        if (string.IsNullOrWhiteSpace(layer.Sprite))
+        {
+            return;
+        }
+
+        var tex = Globals.ContentManager.GetTexture(Framework.Content.TextureType.Animation, layer.Sprite);
+        if (tex == null)
+        {
+            return;
+        }
+
+        var frameCount = Math.Max(1, layer.FrameCount);
+        var xFrames = Math.Max(1, layer.XFrames);
+        var yFrames = Math.Max(1, layer.YFrames);
+        var frameSpeed = Math.Max(1, layer.FrameSpeed);
+        var frame = (int)((Timing.Global.Milliseconds - _stateStart) / frameSpeed) % frameCount;
+
+        var frameWidth = tex.Width / xFrames;
+        var frameHeight = tex.Height / yFrames;
+
+        var worldX = map.X + X * Options.Instance.Map.TileWidth + Options.Instance.Map.TileWidth / 2;
+        var worldY = map.Y + Y * Options.Instance.Map.TileHeight + Options.Instance.Map.TileHeight / 2 + SpriteOffsetY;
+
+        var src = new FloatRect(
+            frame % xFrames * frameWidth,
+            (float)Math.Floor(frame / (double)xFrames) * frameHeight,
+            frameWidth,
+            frameHeight
+        );
+
+        var dest = new FloatRect(worldX - frameWidth / 2f, worldY - frameHeight / 2f, frameWidth, frameHeight);
+
+        var color = TintByFaction ? GetFactionColor(Owner) : Color.White;
+        Graphics.DrawGameTexture(tex, src, dest, color);
+
+        if (_bounds.Width == 0 && _bounds.Height == 0)
+        {
+            _bounds = dest;
+        }
+        else
+        {
+            _bounds = FloatRect.FromLtrb(
+                Math.Min(_bounds.Left, dest.Left),
+                Math.Min(_bounds.Top, dest.Top),
+                Math.Max(_bounds.Right, dest.Right),
+                Math.Max(_bounds.Bottom, dest.Bottom)
+            );
+        }
+    }
+
+    private void DrawHp()
+    {
+        if (MaxHp <= 0)
+        {
+            return;
+        }
+
+        var hpBackground = Globals.ContentManager.GetTexture(Framework.Content.TextureType.Misc, "hpbackground.png");
+        var hpForeground = Globals.ContentManager.GetTexture(Framework.Content.TextureType.Misc, "hpbar.png");
+        var bounding = GameTexture.GetBoundingTexture(BoundsComparison.Height, hpBackground, hpForeground);
+
+        var x = (int)Math.Ceiling(_bounds.Left + _bounds.Width / 2f);
+        var y = (int)Math.Ceiling(_bounds.Top) - 2 - bounding.Height / 2;
+
+        var hpFillWidth = hpForeground != null && MaxHp > 0
+            ? (int)(hpForeground.Width * (Hp / (float)MaxHp))
+            : 0;
+
+        if (hpBackground != null)
+        {
+            Graphics.DrawGameTexture(
+                hpBackground,
+                new FloatRect(0, 0, hpBackground.Width, hpBackground.Height),
+                new FloatRect(x - hpBackground.Width / 2f, y - hpBackground.Height / 2f, hpBackground.Width, hpBackground.Height),
+                Color.White
+            );
+        }
+
+        if (hpForeground != null)
+        {
+            Graphics.DrawGameTexture(
+                hpForeground,
+                new FloatRect(0, 0, hpFillWidth, hpForeground.Height),
+                new FloatRect(x - hpForeground.Width / 2f, y - hpForeground.Height / 2f, hpFillWidth, hpForeground.Height),
+                Color.White
+            );
+        }
+    }
+
+    public bool HitTest(int worldX, int worldY) => _bounds.Contains(worldX, worldY);
+}
+

--- a/Intersect.Client.Core/Maps/Prisms/PrismVisualManager.cs
+++ b/Intersect.Client.Core/Maps/Prisms/PrismVisualManager.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Intersect.Client.Framework.Graphics;
+using Intersect.Client.General;
+using Intersect.Client.Maps;
+using Intersect.Client.Networking;
+using Intersect.Config;
+using Intersect.Network.Packets.Server;
+
+namespace Intersect.Client.Maps.Prisms;
+
+public static class PrismVisualManager
+{
+    private static readonly Dictionary<Guid, PrismVisual> Prisms = new();
+
+    public static void Synchronize(PrismListPacket packet)
+    {
+        Prisms.Clear();
+        foreach (var prism in packet.Prisms)
+        {
+            Update(prism);
+        }
+    }
+
+    public static void Update(PrismUpdatePacket packet)
+    {
+        if (!Prisms.TryGetValue(packet.MapId, out var visual))
+        {
+            var info = PrismConfig.Prisms.FirstOrDefault(p => p.MapId == packet.MapId);
+            if (info == null)
+            {
+                return;
+            }
+
+            visual = new PrismVisual(info);
+            Prisms[packet.MapId] = visual;
+        }
+
+        visual.Update(packet.Owner, packet.State, packet.Hp, packet.MaxHp);
+    }
+
+    public static void Draw(MapInstance map)
+    {
+        if (Prisms.TryGetValue(map.Id, out var visual))
+        {
+            visual.Draw(map);
+        }
+    }
+
+    public static bool TryClickAttack()
+    {
+        var mouse = Graphics.ConvertToWorldPoint(Globals.InputManager.GetMousePosition());
+        var x = (int)mouse.X;
+        var y = (int)mouse.Y;
+
+        foreach (var visual in Prisms.Values)
+        {
+            if (visual.HitTest(x, y))
+            {
+                PacketSender.SendPrismAttack(visual.MapId);
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/Intersect.Client.Core/Networking/PacketHandler.cs
+++ b/Intersect.Client.Core/Networking/PacketHandler.cs
@@ -11,6 +11,7 @@ using Intersect.Client.Interface.Menu;
 using Intersect.Client.Items;
 using Intersect.Client.Localization;
 using Intersect.Client.Maps;
+using Intersect.Client.Maps.Prisms;
 using Intersect.Configuration;
 using Intersect.Core;
 using Intersect.Enums;
@@ -2473,18 +2474,20 @@ internal sealed partial class PacketHandler
     //PrismListPacket
     public void HandlePacket(IPacketSender packetSender, PrismListPacket packet)
     {
+        PrismVisualManager.Synchronize(packet);
         foreach (var prism in packet.Prisms)
         {
             HandlePrism(prism);
         }
 
-       Interface. Interface.GameUi.ConquestWindow.Refresh();
+        Interface.Interface.GameUi.ConquestWindow.Refresh();
         Interface.Interface.GameUi.PrismHud.Refresh(Globals.Me?.MapInstance as MapInstance);
     }
 
     //PrismUpdatePacket
     public void HandlePacket(IPacketSender packetSender, PrismUpdatePacket packet)
     {
+        PrismVisualManager.Update(packet);
         HandlePrism(packet);
         Interface.Interface.GameUi.ConquestWindow.Refresh();
         if (Globals.Me?.MapId == packet.MapId)


### PR DESCRIPTION
## Summary
- add prism visual to render conquered areas
- manage prism visuals with synchronization and clicking logic
- hook prism visuals into map drawing and input handling

## Testing
- `apt-get update`
- `apt-get install -y dotnet-sdk-8.0`
- `dotnet build Intersect.Client.Core/Intersect.Client.Core.csproj` *(fails: NetPeer not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3b953a0d483249b768c69123d485f