### PR TITLE
Validate prism attacks with prism identifiers

### DIFF
--- a/Framework/Intersect.Framework.Core/Network/Packets/Client/PrismAttackPacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Client/PrismAttackPacket.cs
@@ -10,11 +10,15 @@ public partial class PrismAttackPacket : IntersectPacket
     {
     }
 
-    public PrismAttackPacket(Guid mapId)
+    public PrismAttackPacket(Guid mapId, Guid prismId)
     {
         MapId = mapId;
+        PrismId = prismId;
     }
 
     [Key(0)]
     public Guid MapId { get; set; }
+
+    [Key(1)]
+    public Guid PrismId { get; set; }
 }

--- a/Intersect.Client.Core/Maps/Prisms/PrismVisual.cs
+++ b/Intersect.Client.Core/Maps/Prisms/PrismVisual.cs
@@ -42,6 +42,7 @@ public class PrismVisual
     }
 
     public Guid MapId => _info.MapId;
+    public Guid PrismId => _info.Id;
     public int X => _info.X;
     public int Y => _info.Y;
     public bool TintByFaction => _info.TintByFaction;

--- a/Intersect.Client.Core/Maps/Prisms/PrismVisualManager.cs
+++ b/Intersect.Client.Core/Maps/Prisms/PrismVisualManager.cs
@@ -58,7 +58,7 @@ public static class PrismVisualManager
         {
             if (visual.HitTest(x, y))
             {
-                PacketSender.SendPrismAttack(visual.MapId);
+                PacketSender.SendPrismAttack(visual.MapId, visual.PrismId);
                 return true;
             }
         }

--- a/Intersect.Client.Core/Networking/PacketSender.cs
+++ b/Intersect.Client.Core/Networking/PacketSender.cs
@@ -148,9 +148,9 @@ public static partial class PacketSender
         Network.SendPacket(new SetAlignmentRequestPacket(alignment));
     }
 
-    public static void SendPrismAttack(Guid mapId)
+    public static void SendPrismAttack(Guid mapId, Guid prismId)
     {
-        Network.SendPacket(new PrismAttackPacket(mapId));
+        Network.SendPacket(new PrismAttackPacket(mapId, prismId));
     }
 
     public static void SendActivateEvent(Guid eventId)

--- a/Intersect.Server.Core/Networking/PacketHandler.cs
+++ b/Intersect.Server.Core/Networking/PacketHandler.cs
@@ -1467,13 +1467,18 @@ internal sealed partial class PacketHandler
             return;
         }
 
+        if (packet.MapId != player.MapId)
+        {
+            return;
+        }
+
         if (!MapController.TryGetInstanceFromMap(player.MapId, player.MapInstanceId, out var mapInstance))
         {
             return;
         }
 
         var prism = mapInstance.ControllingPrism;
-        if (prism == null || prism.Owner == player.Faction)
+        if (prism == null || prism.Owner == player.Faction || prism.Id != packet.PrismId)
         {
             return;
         }


### PR DESCRIPTION
## Summary
- include PrismId in PrismAttackPacket
- send prism id in client prism attack requests
- validate prism id when handling prism attack on server

## Testing
- `dotnet test` *(fails: project file "/workspace/Broken_Reborn/vendor/LiteNetLib/LiteNetLib/LiteNetLib.csproj" was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3bc42f63483249fdfe2580f43bf3f