### PR TITLE
Guard against nullable Guid usage in prism editor

### DIFF
--- a/Intersect.Editor/Forms/Controls/MapPicker.cs
+++ b/Intersect.Editor/Forms/Controls/MapPicker.cs
@@ -51,6 +51,14 @@ public class MapPicker : UserControl
         UpdateImage();
     }
 
+    public void SelectTile(Guid mapId, int x, int y)
+    {
+        SetMap(mapId);
+        _hoverX = x;
+        _hoverY = y;
+        _picture.Invalidate();
+    }
+
     private void UpdateImage()
     {
         if (_mapImage == null)

--- a/Intersect.Editor/Forms/Editors/frmPrisms.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/frmPrisms.Designer.cs
@@ -9,6 +9,7 @@ namespace Intersect.Editor.Forms.Editors
         private System.ComponentModel.IContainer components = null;
         private System.Windows.Forms.ListBox lstPrisms;
         private System.Windows.Forms.TextBox txtMapId;
+        private DarkButton btnPickPos;
         private DarkNumericUpDown nudX;
         private DarkNumericUpDown nudY;
         private DarkNumericUpDown nudLevel;
@@ -55,6 +56,7 @@ namespace Intersect.Editor.Forms.Editors
             var resources = new System.ComponentModel.ComponentResourceManager(typeof(FrmPrisms));
             lstPrisms = new ListBox();
             txtMapId = new TextBox();
+            btnPickPos = new DarkButton();
             nudX = new DarkNumericUpDown();
             nudY = new DarkNumericUpDown();
             nudLevel = new DarkNumericUpDown();
@@ -128,9 +130,19 @@ namespace Intersect.Editor.Forms.Editors
             txtMapId.Name = "txtMapId";
             txtMapId.Size = new Size(233, 23);
             txtMapId.TabIndex = 1;
-            // 
+            //
+            // btnPickPos
+            //
+            btnPickPos.Location = new System.Drawing.Point(497, 38);
+            btnPickPos.Margin = new Padding(4, 3, 4, 3);
+            btnPickPos.Name = "btnPickPos";
+            btnPickPos.Size = new Size(60, 23);
+            btnPickPos.TabIndex = 2;
+            btnPickPos.Text = "...";
+            btnPickPos.Click += btnPickPos_Click;
+            //
             // nudX
-            // 
+            //
             nudX.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
             nudX.ForeColor = System.Drawing.Color.Gainsboro;
             nudX.Location = new System.Drawing.Point(257, 72);
@@ -597,6 +609,7 @@ namespace Intersect.Editor.Forms.Editors
             Controls.Add(nudX);
             Controls.Add(lblMapId);
             Controls.Add(txtMapId);
+            Controls.Add(btnPickPos);
             Controls.Add(lstPrisms);
             ForeColor = SystemColors.ControlLightLight;
             Margin = new Padding(4, 3, 4, 3);


### PR DESCRIPTION
## Summary
- Avoid passing nullable map identifiers to MapPicker by storing non-null Guid before calling `SetMap`
- Ensure area picker, position selector and coordinate sync parse map IDs into Guid variables before use

## Testing
- `dotnet build Intersect.Editor/Intersect.Editor.csproj -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3a17278348324aaa07ba763ff0f75