### PR TITLE
feat: display next faction change cooldown

### DIFF
--- a/Intersect.Client.Core/Entities/Player.cs
+++ b/Intersect.Client.Core/Entities/Player.cs
@@ -74,6 +74,8 @@ public partial class Player : Entity, IPlayer
 
     public DateTime LastFactionSwapAt { get; set; }
 
+    public DateTime? NextFactionChangeAt { get; set; }
+
     IReadOnlyList<IFriendInstance> IPlayer.Friends => Friends;
 
     public List<IFriendInstance> Friends { get; set; } = [];

--- a/Intersect.Client.Core/Interface/Game/FactionWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/FactionWindow.cs
@@ -28,6 +28,7 @@ public sealed class FactionWindow : Window
     private readonly Label _factionLabel;
     private readonly Label _honorLabel;
     private readonly Label _gradeLabel;
+    private readonly Label _cooldownLabel;
     private readonly Button _wingsButton;
     // Honor bar
     private readonly Base _honorBarBg;
@@ -124,6 +125,15 @@ public sealed class FactionWindow : Window
         };
         _gradeLabel.SetPosition(0, y);
         _gradeLabel.SetSize(content.Width, RowHMedium);
+        y += RowHMedium + 4;
+
+        _cooldownLabel = new Label(content, "CooldownLabel")
+        {
+            Text = string.Empty,
+            TextColor = Color.FromArgb(210, 210, 210)
+        };
+        _cooldownLabel.SetPosition(0, y);
+        _cooldownLabel.SetSize(content.Width, RowHMedium);
         y += RowHMedium + 6;
 
         // Botón Wings
@@ -168,6 +178,16 @@ public sealed class FactionWindow : Window
 
         var grade = (FactionGrade)Math.Clamp(me.Grade, 0, (int)FactionGrade.Legend);
         _gradeLabel.Text = $"Grado: {grade}";
+
+        if (me.NextFactionChangeAt.HasValue)
+        {
+            _cooldownLabel.Text = $"Próximo cambio: {me.NextFactionChangeAt:dd/MM HH:mm}";
+            _cooldownLabel.Show();
+        }
+        else
+        {
+            _cooldownLabel.Hide();
+        }
 
         LayoutHonorBar(me.Honor);
         UpdateWingsButton(me.Wings);

--- a/Intersect.Client.Core/Interface/Game/MenuContainer.cs
+++ b/Intersect.Client.Core/Interface/Game/MenuContainer.cs
@@ -417,6 +417,11 @@ public partial class MenuContainer : Panel
         }
     }
 
+    public void RefreshFactionWindow()
+    {
+        _factionWindow.Refresh();
+    }
+
     public void ToggleInventoryWindow()
     {
         if (_inventoryWindow.IsVisibleInTree)

--- a/Intersect.Client.Core/Networking/PacketHandler.cs
+++ b/Intersect.Client.Core/Networking/PacketHandler.cs
@@ -2476,6 +2476,7 @@ internal sealed partial class PacketHandler
         if (Globals.Me != null)
         {
             Globals.Me.Faction = packet.NewAlignment;
+            Globals.Me.NextFactionChangeAt = packet.NextAllowedChangeAt;
         }
 
         if (!string.IsNullOrWhiteSpace(packet.Message))
@@ -2485,6 +2486,8 @@ internal sealed partial class PacketHandler
                 alertType: packet.Success ? AlertType.Information : AlertType.Error
             );
         }
+
+        Interface.Interface.GameUi.GameMenu?.RefreshFactionWindow();
     }
 
 }


### PR DESCRIPTION
## Summary
- track when the player can next change factions
- display cooldown date in faction window
- refresh faction UI after alignment change responses

## Testing
- `dotnet build` *(fails: project file "/workspace/Broken_Reborn/vendor/LiteNetLib/LiteNetLib/LiteNetLib.csproj" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b47c5aed8c83248b759539dbdb15dd