### PR TITLE
Add alignment PvP engagement checks

### DIFF
--- a/Intersect.Server.Core/Entities/Entity.cs
+++ b/Intersect.Server.Core/Entities/Entity.cs
@@ -2100,6 +2100,20 @@ public abstract partial class Entity : IEntity
             return;
         }
 
+        if (this is Player attacker && enemy is Player victim)
+        {
+            var (ok, reason) = AlignmentPvPService.CanEngage(attacker, victim);
+            if (!ok)
+            {
+                if (!string.IsNullOrEmpty(reason))
+                {
+                    PacketSender.SendChatMsg(attacker, reason, ChatMessageType.Error);
+                }
+
+                return;
+            }
+        }
+
         //Let's save the entity's vitals before they takes damage to use in lifesteal/manasteal
         var enemyVitals = enemy.GetVitals();
         var invulnerable = enemy.CachedStatuses.Any(status => status.Type == SpellEffect.Invulnerable);

--- a/Intersect.Server.Core/Entities/Player.cs
+++ b/Intersect.Server.Core/Entities/Player.cs
@@ -2002,6 +2002,20 @@ public partial class Player : Entity
                 return friendly;
             }
 
+            if (!friendly)
+            {
+                var (ok, reason) = AlignmentPvPService.CanEngage(this, player);
+                if (!ok)
+                {
+                    if (!string.IsNullOrEmpty(reason))
+                    {
+                        PacketSender.SendChatMsg(this, reason, ChatMessageType.Error);
+                    }
+
+                    return false;
+                }
+            }
+
             // Only count safe zones and friendly fire if its a dangerous spell! (If one has been used)
             // Projectiles are ignored here, because we can always fire those.. Whether they hit or not is a problem for later.
             if (!friendly && (spell?.Combat?.TargetType != SpellTargetType.Self && spell?.Combat?.TargetType != SpellTargetType.AoE && spell?.SpellType == SpellType.CombatSpell))

--- a/Intersect.Server.Core/Services/AlignmentPvPService.cs
+++ b/Intersect.Server.Core/Services/AlignmentPvPService.cs
@@ -15,6 +15,51 @@ internal static class AlignmentPvPService
     private const int UnfairLevelPenalty = 5;
     private static readonly TimeSpan RewardCooldown = TimeSpan.FromMinutes(5);
 
+    public static (bool ok, string reason) CanEngage(Player attacker, Player victim)
+    {
+        if (attacker == null || victim == null)
+        {
+            return (false, "");
+        }
+
+        if (attacker == victim)
+        {
+            return (false, "No puedes atacarte a ti mismo.");
+        }
+
+        if (attacker.Honor < 0 || victim.Honor < 0)
+        {
+            return (true, string.Empty);
+        }
+
+        if (attacker.Wings != WingState.On)
+        {
+            return (false, "Debes activar tus alas para combatir.");
+        }
+
+        if (victim.Wings != WingState.On)
+        {
+            return (false, "Ese jugador no tiene las alas activadas.");
+        }
+
+        if (attacker.Faction == Factions.Neutral)
+        {
+            return (false, "Debes pertenecer a una facción para combatir.");
+        }
+
+        if (victim.Faction == Factions.Neutral)
+        {
+            return (false, "No puedes atacar jugadores neutrales.");
+        }
+
+        if (attacker.Faction == victim.Faction)
+        {
+            return (false, "No puedes atacar a miembros de tu facción.");
+        }
+
+        return (true, string.Empty);
+    }
+
     public static void HandleKill(Player killer, Player victim)
     {
         if (killer == null || victim == null || killer == victim)


### PR DESCRIPTION
## Summary
- add CanEngage to AlignmentPvPService for faction/wings PvP rules
- verify CanEngage before player attacks, spells, and AoE damage
- block damage in Attack when players fail PvP checks and notify attacker

## Testing
- `dotnet test` *(fails: project file "/workspace/Broken_Reborn/vendor/LiteNetLib/LiteNetLib/LiteNetLib.csproj" was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b47c6f596883249fbb680036891176