### PR TITLE
Block neutral players from activating wings

### DIFF
--- a/Intersect.Server.Core/CustomChanges/PacketHandlerCustom.cs
+++ b/Intersect.Server.Core/CustomChanges/PacketHandlerCustom.cs
@@ -592,6 +592,12 @@ internal sealed partial class PacketHandler
             return;
         }
 
+        if (packet.State == WingState.On && player.Faction == Factions.Neutral)
+        {
+            PacketSender.SendChatMsg(player, Strings.Alignment.WingsNeutral, ChatMessageType.Error, CustomColors.Alerts.Error);
+            return;
+        }
+
         player.Wings = packet.State;
         PacketSender.SendEntityDataToProximity(player);
     }

--- a/Intersect.Server.Core/Localization/Strings.cs
+++ b/Intersect.Server.Core/Localization/Strings.cs
@@ -123,6 +123,9 @@ public static partial class Strings
         public readonly LocalizedString WingsOn = @"No puedes cambiar de facción mientras tus alas estén activadas.";
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString WingsNeutral = @"No puedes activar tus alas mientras estés en la facción neutral.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public readonly LocalizedString SwapCooldown = @"Podrás cambiar el {fecha}.";
     }
 


### PR DESCRIPTION
## Summary
- prevent neutral players from turning wings on and notify them
- add `Strings.Alignment.WingsNeutral` message

## Testing
- `dotnet test Intersect.Tests.Server/Intersect.Tests.Server.csproj` *(fails: LiteNetLib types missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b47fba174c832482592d2f5e95227c