### PR TITLE
Persist honor decay for online players

### DIFF
--- a/Intersect.Server.Core/Services/HonorDecayService.cs
+++ b/Intersect.Server.Core/Services/HonorDecayService.cs
@@ -55,6 +55,9 @@ internal static class HonorDecayService
 
             online.Honor = HonorService.DecayTowardsZero(online.Honor, decayPercent);
             online.Grade = HonorService.CalculateGrade(online.Honor);
+
+            context.Players.Update(online);
+            await context.SaveChangesAsync().ConfigureAwait(false);
         }
 
         SetLastRun(now);


### PR DESCRIPTION
## Summary
- Update online players' honor decay to save each player to database
- Reuse a single PlayerContext across honor decay processing

## Testing
- `dotnet test -p:EnableWindowsTargeting=true` *(fails: warning but no tests executed)*

------
https://chatgpt.com/codex/tasks/task_e_68b47ee7ad4c8324b3d137608e3a82e9