### PR TITLE
Restore default minimap layers when missing

### DIFF
--- a/Framework/Intersect.Framework.Core/Config/MinimapOptions.cs
+++ b/Framework/Intersect.Framework.Core/Config/MinimapOptions.cs
@@ -66,6 +66,17 @@ public partial class MinimapOptions
     [OnDeserialized]
     internal void OnDeserializedMethod(StreamingContext context)
     {
+        if (RenderLayers.Count == 0)
+        {
+            RenderLayers.AddRange([
+                "Ground",
+                "Mask 1",
+                "Mask 2",
+                "Fringe 1",
+                "Fringe 2",
+            ]);
+        }
+
         Validate();
     }
 

--- a/Intersect.Tests/Config/MinimapOptionsTests.cs
+++ b/Intersect.Tests/Config/MinimapOptionsTests.cs
@@ -1,0 +1,25 @@
+using Intersect.Config;
+using Newtonsoft.Json;
+using NUnit.Framework;
+
+namespace Intersect.Tests.Config;
+
+public class MinimapOptionsTests
+{
+    [Test]
+    public void DeserializingWithoutRenderLayers_RestoresDefaultLayers()
+    {
+        var json = "{}";
+        var options = JsonConvert.DeserializeObject<MinimapOptions>(json);
+
+        Assert.That(options.RenderLayers, Is.EqualTo(new[]
+        {
+            "Ground",
+            "Mask 1",
+            "Mask 2",
+            "Fringe 1",
+            "Fringe 2",
+        }));
+    }
+}
+


### PR DESCRIPTION
## Summary
- restore default minimap render layers if deserialized config omits them
- add test ensuring defaults are restored when RenderLayers is absent

## Testing
- `dotnet test Intersect.Tests/Intersect.Tests.csproj` *(fails: LiteNetLib types missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b4ab6dd1988324971695c484aa2685