### PR TITLE
feat(client): persist map preferences

### DIFF
--- a/Intersect.Client.Core/Interface/Game/Map/MapFilters.cs
+++ b/Intersect.Client.Core/Interface/Game/Map/MapFilters.cs
@@ -3,6 +3,7 @@ using Intersect.Client.Framework.Gwen;
 using Intersect.Client.Framework.Gwen.Control;
 using Intersect.Client.Framework.Gwen.Control.EventArguments;
 
+
 namespace Intersect.Client.Interface.Game.Map;
 
 /// <summary>
@@ -35,6 +36,24 @@ public class MapFilters
     {
         var cb = new Checkbox(_panel) { Text = label, IsChecked = true };
         cb.Dock = Pos.Top;
+
+        // Apply stored preference if available.
+        if (MapPreferences.Instance.ActiveFilters.TryGetValue(key, out var enabled))
+        {
+            cb.IsChecked = enabled;
+        }
+        else
+        {
+            MapPreferences.Instance.ActiveFilters[key] = cb.IsChecked;
+            MapPreferences.Save();
+        }
+
+        cb.CheckChanged += (_, args) =>
+        {
+            MapPreferences.Instance.ActiveFilters[key] = cb.IsChecked;
+            MapPreferences.Save();
+        };
+
         _filters[key] = cb;
     }
 

--- a/Intersect.Client.Core/Interface/Game/Map/MapPreferences.cs
+++ b/Intersect.Client.Core/Interface/Game/Map/MapPreferences.cs
@@ -1,0 +1,72 @@
+using System.Collections.Generic;
+using Intersect.Client.General;
+using Intersect.Client.Framework.Database;
+using Newtonsoft.Json;
+
+namespace Intersect.Client.Interface.Game.Map;
+
+/// <summary>
+/// Stores user map preferences such as minimap zoom, world map filters, and the last
+/// position/zoom of the world map window. Handles serialization to the client database.
+/// </summary>
+public class MapPreferences
+{
+    private const string PreferenceKey = nameof(MapPreferences);
+
+    /// <summary>
+    /// The last zoom level used by the minimap window.
+    /// </summary>
+    public int MinimapZoom { get; set; } = Options.Instance?.Minimap.DefaultZoom ?? 0;
+
+    /// <summary>
+    /// Active world map filters keyed by filter identifier.
+    /// </summary>
+    public Dictionary<string, bool> ActiveFilters { get; set; } = new();
+
+    /// <summary>
+    /// The last canvas position of the world map window.
+    /// </summary>
+    public Point WorldMapPosition { get; set; } = Point.Empty;
+
+    /// <summary>
+    /// The last zoom level of the world map window.
+    /// </summary>
+    public float WorldMapZoom { get; set; } = 1f;
+
+    /// <summary>
+    /// The loaded instance of <see cref="MapPreferences" />.
+    /// </summary>
+    public static MapPreferences Instance { get; private set; } = new();
+
+    /// <summary>
+    /// Load preferences from the client database.
+    /// </summary>
+    public static void Load()
+    {
+        var json = Globals.Database.LoadPreference(PreferenceKey);
+        if (string.IsNullOrEmpty(json))
+        {
+            Instance = new MapPreferences();
+            return;
+        }
+
+        try
+        {
+            Instance = JsonConvert.DeserializeObject<MapPreferences>(json) ?? new MapPreferences();
+        }
+        catch
+        {
+            Instance = new MapPreferences();
+        }
+    }
+
+    /// <summary>
+    /// Persist preferences to the client database.
+    /// </summary>
+    public static void Save()
+    {
+        var json = JsonConvert.SerializeObject(Instance);
+        Globals.Database.SavePreference(PreferenceKey, json);
+    }
+}
+

--- a/Intersect.Client.Core/Interface/Game/Map/MinimapWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Map/MinimapWindow.cs
@@ -70,6 +70,11 @@ namespace Intersect.Client.Interface.Game.Map
         }
         public void Show()
         {
+            _zoomLevel = Math.Clamp(
+                MapPreferences.Instance.MinimapZoom,
+                Options.Instance.Minimap.MinimumZoom,
+                Options.Instance.Minimap.MaximumZoom
+            );
             IsHidden = false;
         }
         public bool IsVisible()
@@ -511,13 +516,21 @@ namespace Intersect.Client.Interface.Game.Map
         }
         private void MZoomOutButton_Clicked(Base sender, MouseButtonState arguments)
         {
-            _zoomLevel = Math.Min(_zoomLevel + Options.Instance.Minimap.ZoomStep,
-                Options.Instance.Minimap.MaximumZoom);
+            _zoomLevel = Math.Min(
+                _zoomLevel + Options.Instance.Minimap.ZoomStep,
+                Options.Instance.Minimap.MaximumZoom
+            );
+            MapPreferences.Instance.MinimapZoom = _zoomLevel;
+            MapPreferences.Save();
         }
         private void MZoomInButton_Clicked(Base sender, MouseButtonState arguments)
         {
-            _zoomLevel = Math.Max(_zoomLevel - Options.Instance.Minimap.ZoomStep,
-                Options.Instance.Minimap.MinimumZoom);
+            _zoomLevel = Math.Max(
+                _zoomLevel - Options.Instance.Minimap.ZoomStep,
+                Options.Instance.Minimap.MinimumZoom
+            );
+            MapPreferences.Instance.MinimapZoom = _zoomLevel;
+            MapPreferences.Save();
         }
         private enum MapPosition
         {

--- a/Intersect.Client.Core/Interface/Game/Map/WorldMapWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Map/WorldMapWindow.cs
@@ -44,6 +44,17 @@ public class WorldMapWindow
         _waypoint.IsHidden = true;
 
         _window.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
+
+        // Apply stored preferences for zoom and position.
+        var baseWidth = _canvas.Width;
+        var baseHeight = _canvas.Height;
+        _zoom = Math.Clamp(MapPreferences.Instance.WorldMapZoom, MinZoom, MaxZoom);
+        _canvas.SetBounds(
+            MapPreferences.Instance.WorldMapPosition.X,
+            MapPreferences.Instance.WorldMapPosition.Y,
+            (int)(baseWidth * _zoom),
+            (int)(baseHeight * _zoom)
+        );
     }
 
     private void OnMapClicked(Point pos)
@@ -69,6 +80,8 @@ public class WorldMapWindow
     internal void EndDrag()
     {
         _dragging = false;
+        MapPreferences.Instance.WorldMapPosition = new Point(_canvas.X, _canvas.Y);
+        MapPreferences.Save();
     }
 
     internal void DragBy(int dx, int dy)
@@ -109,6 +122,9 @@ public class WorldMapWindow
             newWidth,
             newHeight
         );
+        MapPreferences.Instance.WorldMapZoom = _zoom;
+        MapPreferences.Instance.WorldMapPosition = new Point(_canvas.X, _canvas.Y);
+        MapPreferences.Save();
     }
 
     private class MapCanvas : ImagePanel

--- a/Intersect.Client.Core/MonoGame/IntersectGame.cs
+++ b/Intersect.Client.Core/MonoGame/IntersectGame.cs
@@ -27,6 +27,7 @@ using Intersect.Framework.SystemInformation;
 using Intersect.Framework.Utilities;
 using Microsoft.Extensions.Logging;
 using Exception = System.Exception;
+using Intersect.Client.Interface.Game.Map;
 
 namespace Intersect.Client.MonoGame;
 
@@ -104,6 +105,7 @@ internal partial class IntersectGame : Game
 
         // Load configuration.
         Globals.Database.LoadPreferences();
+        MapPreferences.Load();
 
         Window.IsBorderless = Context.StartupOptions.BorderlessWindow;
 


### PR DESCRIPTION
## Summary
- remember minimap zoom, world map position/zoom, and filter states
- load map preferences on startup and apply to map windows
- update stored preferences whenever the user changes zoom, position, or filters

## Testing
- `dotnet test` *(fails: project files missing for vendor dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68b4abb17e7c83249efba89f870468af