### PR TITLE
Clamp minimap default zoom within bounds

### DIFF
--- a/Framework/Intersect.Framework.Core/Config/MinimapOptions.cs
+++ b/Framework/Intersect.Framework.Core/Config/MinimapOptions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 using Newtonsoft.Json;
@@ -95,10 +96,12 @@ public partial class MinimapOptions
             MaximumZoom = 100;
         }
 
-        if (DefaultZoom is < 0 or > 100)
+        if (MinimumZoom > MaximumZoom)
         {
-            DefaultZoom = 0;
+            MaximumZoom = MinimumZoom;
         }
+
+        DefaultZoom = Math.Clamp(DefaultZoom, MinimumZoom, MaximumZoom);
     }
 
     public class Colors

--- a/Intersect.Tests/Config/MinimapOptionsTests.cs
+++ b/Intersect.Tests/Config/MinimapOptionsTests.cs
@@ -21,5 +21,21 @@ public class MinimapOptionsTests
             "Fringe 2",
         }));
     }
+
+    [TestCase((byte)10, (byte)50, (byte)5, (byte)10)]
+    [TestCase((byte)10, (byte)50, (byte)55, (byte)50)]
+    public void Validate_ClampsDefaultZoom(byte minimum, byte maximum, byte defaultZoom, byte expected)
+    {
+        var options = new MinimapOptions
+        {
+            MinimumZoom = minimum,
+            MaximumZoom = maximum,
+            DefaultZoom = defaultZoom,
+        };
+
+        options.Validate();
+
+        Assert.That(options.DefaultZoom, Is.EqualTo(expected));
+    }
 }
 


### PR DESCRIPTION
## Summary
- clamp `MinimapOptions.DefaultZoom` to be within `MinimumZoom` and `MaximumZoom`
- add tests ensuring the default zoom respects configured limits

## Testing
- `dotnet build Framework/Intersect.Framework.Core/Intersect.Framework.Core.csproj`
- `dotnet test Intersect.Tests/Intersect.Tests.csproj` *(fails: The type or namespace name 'Items' does not exist in the namespace 'Intersect.GameObjects')*


------
https://chatgpt.com/codex/tasks/task_e_68b4acdc4e5483249bf8d1cf1b059f9e