### PR TITLE
fix: guard against null inventory items in crafting window

### DIFF
--- a/Intersect.Client.Core/Interface/Game/Crafting/CraftingWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Crafting/CraftingWindow.cs
@@ -228,6 +228,11 @@ public partial class CraftingWindow : Window
         Dictionary<Guid, int> inventoryItemsByDescriptorId = [];
         foreach (var item in player.Inventory)
         {
+            if (item is null)
+            {
+                continue;
+            }
+
             var inventoryItemDescriptorId = item.ItemId;
             var currentQuantity = inventoryItemsByDescriptorId.GetValueOrDefault(inventoryItemDescriptorId, 0);
             inventoryItemsByDescriptorId[inventoryItemDescriptorId] = currentQuantity + item.Quantity;


### PR DESCRIPTION
## Summary
- avoid null reference when enumerating player inventory in CraftingWindow
- use pattern matching for clarity

## Testing
- `dotnet test Intersect.Tests/Intersect.Tests.csproj` (fails: error CS0234: The type or namespace name 'Items' does not exist)


------
https://chatgpt.com/codex/tasks/task_e_68b4b32c6c6c83249103ad36546be8ce