### PR TITLE
feat: enhance map bestiary integration

### DIFF
--- a/Intersect.Client.Core/Interface/Game/Bestiary/BeastTile.cs
+++ b/Intersect.Client.Core/Interface/Game/Bestiary/BeastTile.cs
@@ -8,6 +8,7 @@ using Intersect.Client.Core;
 using Intersect.Client.Framework.Content;
 using System;
 using Intersect.Client.Framework.Input;
+using System.Collections.Generic;
 
 namespace Intersect.Client.Interface.Game.Bestiary
 {
@@ -119,6 +120,10 @@ namespace Intersect.Client.Interface.Game.Bestiary
                 _icon.Texture = null;
                 _icon.IsHidden = true;
             }
+
+            var tooltipLines = new List<string> { $"Nivel sugerido: {desc.Level}" };
+
+            SetToolTipText(string.Join("\n", tooltipLines));
         }
 
 

--- a/Intersect.Client.Core/Interface/Game/Map/MapFilters.cs
+++ b/Intersect.Client.Core/Interface/Game/Map/MapFilters.cs
@@ -5,6 +5,7 @@ using Intersect;
 using Intersect.Client.Framework.Gwen;
 using Intersect.Client.Framework.Gwen.Control;
 using Intersect.Client.Framework.Gwen.Control.EventArguments;
+using Intersect.Client.Framework.GenericClasses;
 
 
 namespace Intersect.Client.Interface.Game.Map;
@@ -80,7 +81,13 @@ public class MapFilters
     /// <summary>
     /// Represents an item that can be searched for on the world map.
     /// </summary>
-    public record MapSearchEntry(string Name, string Type, IReadOnlyList<string> Tags, Point Position);
+    public record MapSearchEntry(
+        string Name,
+        string Type,
+        IReadOnlyList<string> Tags,
+        Rectangle Area,
+        Guid? NpcId = null
+    );
 
     private static IEnumerable<string> Tokenize(string text)
     {

--- a/Intersect.Client.Core/Interface/Game/Map/WorldMapWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Map/WorldMapWindow.cs
@@ -2,13 +2,16 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Intersect.Client.Core;
+using Intersect.Client.Core.Controllers;
 using Intersect.Client.Framework.File_Management;
 using Intersect.Client.Framework.Gwen.Control;
 using Intersect.Client.Framework.Gwen.Input;
 using Intersect.Client.Framework.Gwen.Control.EventArguments;
+using Intersect.Client.Framework.GenericClasses;
 using Intersect.Client.Interface.Game.Map;
 using Intersect;
 using Intersect.Client.Framework.Input;
+using Intersect.Framework.Core.GameObjects.NPCs;
 
 namespace Intersect.Client.Interface.Game.Map;
 
@@ -71,9 +74,7 @@ public class WorldMapWindow
 
     private void OnMapClicked(Point pos)
     {
-        _tooltip.Text = $"{pos.X}, {pos.Y}";
-        _tooltip.SetPosition(pos.X + 5, pos.Y + 5);
-        _tooltip.IsHidden = false;
+        _tooltip.IsHidden = true;
     }
 
     private void OnMapDoubleClicked(Point pos)
@@ -176,25 +177,28 @@ public class WorldMapWindow
         }
         _searchHighlights.Clear();
 
-        var results = _filters.Search(query).ToList();
+        var results = _filters.Search(query)
+            .Where(r => r.NpcId == null || BestiaryController.HasUnlock(r.NpcId.Value, BestiaryUnlock.Kill))
+            .ToList();
         if (results.Count == 0)
         {
             return;
         }
 
         var first = results[0];
-        CenterOn(first.Position);
+        var center = new Point(first.Area.X + first.Area.Width / 2, first.Area.Y + first.Area.Height / 2);
+        CenterOn(center);
 
         _tooltip.Text = first.Name;
-        _tooltip.SetPosition(first.Position.X + 5, first.Position.Y + 5);
+        _tooltip.SetPosition(center.X + 5, center.Y + 5);
         _tooltip.IsHidden = false;
 
         foreach (var result in results)
         {
-            var circle = new ImagePanel(_canvas, "SearchHighlight");
-            circle.SetBounds(result.Position.X - 8, result.Position.Y - 8, 16, 16);
-            circle.IsHidden = false;
-            _searchHighlights.Add(circle);
+            var area = new ImagePanel(_canvas, "SearchHighlight");
+            area.SetBounds(result.Area.X, result.Area.Y, result.Area.Width, result.Area.Height);
+            area.IsHidden = false;
+            _searchHighlights.Add(area);
         }
     }
 


### PR DESCRIPTION
## Summary
- gate world map search highlights behind bestiary unlocks
- index NPC identifiers in map search entries
- show only suggested level in mob tooltips

## Testing
- `dotnet build Intersect.Client.Core/Intersect.Client.Core.csproj` *(fails: missing LiteNetLib types)*

------
https://chatgpt.com/codex/tasks/task_e_68b4b36be2fc83249c515321b1299c85