### PR TITLE
Add waypoint sharing and map markers

### DIFF
--- a/Framework/Intersect.Framework.Core/Network/Packets/Client/WaypointClearPacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Client/WaypointClearPacket.cs
@@ -1,0 +1,23 @@
+using Intersect.Enums;
+using Intersect.Network.Packets;
+using MessagePack;
+
+namespace Intersect.Network.Packets.Client;
+
+[MessagePackObject]
+public partial class WaypointClearPacket : IntersectPacket
+{
+    // Parameterless constructor for MessagePack
+    public WaypointClearPacket()
+    {
+    }
+
+    public WaypointClearPacket(WaypointScope scope)
+    {
+        Scope = scope;
+    }
+
+    [Key(0)]
+    public WaypointScope Scope { get; set; }
+}
+

--- a/Framework/Intersect.Framework.Core/Network/Packets/Client/WaypointSetPacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Client/WaypointSetPacket.cs
@@ -1,0 +1,31 @@
+using Intersect.Enums;
+using Intersect.Network.Packets;
+using MessagePack;
+
+namespace Intersect.Network.Packets.Client;
+
+[MessagePackObject]
+public partial class WaypointSetPacket : IntersectPacket
+{
+    // Parameterless constructor for MessagePack
+    public WaypointSetPacket()
+    {
+    }
+
+    public WaypointSetPacket(int x, int y, WaypointScope scope)
+    {
+        X = x;
+        Y = y;
+        Scope = scope;
+    }
+
+    [Key(0)]
+    public int X { get; set; }
+
+    [Key(1)]
+    public int Y { get; set; }
+
+    [Key(2)]
+    public WaypointScope Scope { get; set; }
+}
+

--- a/Framework/Intersect.Framework.Core/Network/Packets/Server/WaypointClearPacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Server/WaypointClearPacket.cs
@@ -1,0 +1,23 @@
+using Intersect.Enums;
+using Intersect.Network.Packets;
+using MessagePack;
+
+namespace Intersect.Network.Packets.Server;
+
+[MessagePackObject]
+public partial class WaypointClearPacket : IntersectPacket
+{
+    // Parameterless constructor for MessagePack
+    public WaypointClearPacket()
+    {
+    }
+
+    public WaypointClearPacket(WaypointScope scope)
+    {
+        Scope = scope;
+    }
+
+    [Key(0)]
+    public WaypointScope Scope { get; set; }
+}
+

--- a/Framework/Intersect.Framework.Core/Network/Packets/Server/WaypointSetPacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Server/WaypointSetPacket.cs
@@ -1,0 +1,31 @@
+using Intersect.Enums;
+using Intersect.Network.Packets;
+using MessagePack;
+
+namespace Intersect.Network.Packets.Server;
+
+[MessagePackObject]
+public partial class WaypointSetPacket : IntersectPacket
+{
+    // Parameterless constructor for MessagePack
+    public WaypointSetPacket()
+    {
+    }
+
+    public WaypointSetPacket(int x, int y, WaypointScope scope)
+    {
+        X = x;
+        Y = y;
+        Scope = scope;
+    }
+
+    [Key(0)]
+    public int X { get; set; }
+
+    [Key(1)]
+    public int Y { get; set; }
+
+    [Key(2)]
+    public WaypointScope Scope { get; set; }
+}
+

--- a/Framework/Intersect.Framework.Core/WaypointScope.cs
+++ b/Framework/Intersect.Framework.Core/WaypointScope.cs
@@ -1,0 +1,9 @@
+namespace Intersect.Enums;
+
+public enum WaypointScope
+{
+    Local = 0,
+    Party = 1,
+    Guild = 2,
+}
+

--- a/Intersect.Client.Core/Interface/Game/Map/WaypointLayer.cs
+++ b/Intersect.Client.Core/Interface/Game/Map/WaypointLayer.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Intersect;
+using Intersect.Client.Framework.Gwen.Control;
+using Intersect.Client.Framework.Graphics;
+using Intersect.Enums;
+
+namespace Intersect.Client.Interface.Game.Map;
+
+public sealed class WaypointLayer
+{
+    private sealed class Waypoint
+    {
+        public ImagePanel Panel = null!;
+        public DateTime Expire;
+        public WaypointScope Scope;
+    }
+
+    private readonly Base _parent;
+    private readonly List<Waypoint> _waypoints = new();
+
+    public WaypointLayer(Base parent)
+    {
+        _parent = parent;
+    }
+
+    public void AddWaypoint(Point pos, WaypointScope scope)
+    {
+        var panel = new ImagePanel(_parent, "Waypoint");
+        panel.SetPosition(pos.X - panel.Width / 2, pos.Y - panel.Height / 2);
+        panel.RenderColor = ScopeToColor(scope);
+        panel.IsHidden = false;
+        _waypoints.Add(new Waypoint
+        {
+            Panel = panel,
+            Expire = DateTime.UtcNow + GetTtl(scope),
+            Scope = scope,
+        });
+    }
+
+    public void Clear(WaypointScope scope)
+    {
+        foreach (var wp in _waypoints.Where(w => w.Scope == scope).ToList())
+        {
+            wp.Panel.Dispose();
+            _waypoints.Remove(wp);
+        }
+    }
+
+    public void Update()
+    {
+        var now = DateTime.UtcNow;
+        foreach (var wp in _waypoints.ToList())
+        {
+            if (now >= wp.Expire)
+            {
+                wp.Panel.Dispose();
+                _waypoints.Remove(wp);
+            }
+        }
+    }
+
+    private static Color ScopeToColor(WaypointScope scope) => scope switch
+    {
+        WaypointScope.Party => Color.Green,
+        WaypointScope.Guild => Color.Blue,
+        _ => Color.Yellow,
+    };
+
+    private static TimeSpan GetTtl(WaypointScope scope) => scope switch
+    {
+        WaypointScope.Guild => TimeSpan.FromSeconds(30),
+        _ => TimeSpan.FromSeconds(20),
+    };
+}
+

--- a/Intersect.Client.Core/Interface/Game/Map/WorldMapWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Map/WorldMapWindow.cs
@@ -9,6 +9,10 @@ using Intersect.Client.Framework.Gwen.Control.EventArguments;
 using Intersect.Client.Interface.Game.Map;
 using Intersect;
 using Intersect.Client.Framework.Input;
+using Intersect.Client.General;
+using Intersect.Client.Networking;
+using Intersect.Client.Framework.GenericClasses;
+using Intersect.Enums;
 
 namespace Intersect.Client.Interface.Game.Map;
 
@@ -22,8 +26,8 @@ public class WorldMapWindow
     private readonly MapLegend _legend;
     private readonly MapFilters _filters;
     private readonly Label _tooltip;
-    private readonly ImagePanel _waypoint;
     private readonly List<ImagePanel> _searchHighlights = new();
+    public static WaypointLayer? Waypoints { get; private set; }
 
     private float _zoom = 1f;
     private const float MinZoom = 0.25f;
@@ -48,8 +52,7 @@ public class WorldMapWindow
         _tooltip = new Label(_window, "Tooltip");
         _tooltip.IsHidden = true;
 
-        _waypoint = new ImagePanel(_canvas, "Waypoint");
-        _waypoint.IsHidden = true;
+        Waypoints = new WaypointLayer(_canvas);
 
         _window.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
 
@@ -78,8 +81,17 @@ public class WorldMapWindow
 
     private void OnMapDoubleClicked(Point pos)
     {
-        _waypoint.SetPosition(pos.X - _waypoint.Width / 2, pos.Y - _waypoint.Height / 2);
-        _waypoint.IsHidden = false;
+        var shift = Globals.InputManager.IsKeyDown(Keys.Shift);
+        if (shift)
+        {
+            Waypoints?.AddWaypoint(pos, WaypointScope.Party);
+            PacketSender.SendWaypointSet(pos.X, pos.Y, WaypointScope.Party);
+            PacketSender.SendWaypointSet(pos.X, pos.Y, WaypointScope.Guild);
+        }
+        else
+        {
+            Waypoints?.AddWaypoint(pos, WaypointScope.Local);
+        }
     }
 
     internal void BeginDrag(Point pos)
@@ -255,6 +267,12 @@ public class WorldMapWindow
             {
                 _window.OnMapDoubleClicked(mousePosition);
             }
+        }
+
+        protected override void Think()
+        {
+            base.Think();
+            Waypoints?.Update();
         }
     }
 }

--- a/Intersect.Client.Core/Networking/PacketHandler.cs
+++ b/Intersect.Client.Core/Networking/PacketHandler.cs
@@ -36,6 +36,8 @@ using Intersect.Localization;
 using Microsoft.Extensions.Logging;
 using System.Linq;
 using Intersect.Framework.Core.GameObjects.Spells;
+using Intersect.Client.Interface.Game.Map;
+using Intersect;
 
 namespace Intersect.Client.Networking;
 
@@ -2488,6 +2490,18 @@ internal sealed partial class PacketHandler
         }
 
         Interface.Interface.GameUi.GameMenu?.RefreshFactionWindow();
+    }
+
+    //WaypointSetPacket
+    public void HandlePacket(IPacketSender packetSender, Intersect.Network.Packets.Server.WaypointSetPacket packet)
+    {
+        WorldMapWindow.Waypoints?.AddWaypoint(new Point(packet.X, packet.Y), packet.Scope);
+    }
+
+    //WaypointClearPacket
+    public void HandlePacket(IPacketSender packetSender, Intersect.Network.Packets.Server.WaypointClearPacket packet)
+    {
+        WorldMapWindow.Waypoints?.Clear(packet.Scope);
     }
 
 }

--- a/Intersect.Client.Core/Networking/PacketSender.cs
+++ b/Intersect.Client.Core/Networking/PacketSender.cs
@@ -154,6 +154,16 @@ public static partial class PacketSender
         Network.SendPacket(new ActivateEventPacket(eventId));
     }
 
+    public static void SendWaypointSet(int x, int y, WaypointScope scope)
+    {
+        Network.SendPacket(new WaypointSetPacket(x, y, scope));
+    }
+
+    public static void SendWaypointClear(WaypointScope scope)
+    {
+        Network.SendPacket(new WaypointClearPacket(scope));
+    }
+
     public static void SendEventResponse(byte response, Dialog ed)
     {
         Globals.EventDialogs.Remove(ed);

--- a/Intersect.Server/Networking/NetworkedPacketHandler.cs
+++ b/Intersect.Server/Networking/NetworkedPacketHandler.cs
@@ -1323,4 +1323,74 @@ internal sealed partial class NetworkedPacketHandler
         }
 
         #endregion
+
+    //WaypointSetPacket
+    public void HandlePacket(Client client, WaypointSetPacket packet)
+    {
+        if (client?.Entity is not Player player)
+        {
+            return;
+        }
+
+        switch (packet.Scope)
+        {
+            case WaypointScope.Party:
+                if (player.Party != null)
+                {
+                    foreach (var member in player.Party.Where(m => m != player))
+                    {
+                        member.SendPacket(new Network.Packets.Server.WaypointSetPacket(packet.X, packet.Y, WaypointScope.Party));
+                    }
+                }
+                break;
+            case WaypointScope.Guild:
+                if (player.Guild?.Members != null)
+                {
+                    foreach (var memberId in player.Guild.Members.Keys)
+                    {
+                        var member = Player.Find(memberId);
+                        if (member != null && member != player)
+                        {
+                            member.SendPacket(new Network.Packets.Server.WaypointSetPacket(packet.X, packet.Y, WaypointScope.Guild));
+                        }
+                    }
+                }
+                break;
+        }
+    }
+
+    //WaypointClearPacket
+    public void HandlePacket(Client client, WaypointClearPacket packet)
+    {
+        if (client?.Entity is not Player player)
+        {
+            return;
+        }
+
+        switch (packet.Scope)
+        {
+            case WaypointScope.Party:
+                if (player.Party != null)
+                {
+                    foreach (var member in player.Party.Where(m => m != player))
+                    {
+                        member.SendPacket(new Network.Packets.Server.WaypointClearPacket(WaypointScope.Party));
+                    }
+                }
+                break;
+            case WaypointScope.Guild:
+                if (player.Guild?.Members != null)
+                {
+                    foreach (var memberId in player.Guild.Members.Keys)
+                    {
+                        var member = Player.Find(memberId);
+                        if (member != null && member != player)
+                        {
+                            member.SendPacket(new Network.Packets.Server.WaypointClearPacket(WaypointScope.Guild));
+                        }
+                    }
+                }
+                break;
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- add WaypointScope enum and network packets for setting/clearing waypoints
- handle waypoint packets on client and server
- draw expiring waypoints with WaypointLayer and shift-double click broadcast

## Testing
- `dotnet test` *(fails: project file "/workspace/Broken_Reborn/vendor/LiteNetLib/LiteNetLib/LiteNetLib.csproj" was not found)*
- `dotnet build Intersect.Client.Core/Intersect.Client.Core.csproj` *(fails: missing LiteNetLib types in Intersect.Network)*

------
https://chatgpt.com/codex/tasks/task_e_68b4b359feb0832492219cafd04fb0f1