### PR TITLE
fix: guard against null inventory items in crafting window

### DIFF
--- a/Intersect.Client.Core/Interface/Game/Crafting/CraftingWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Crafting/CraftingWindow.cs
@@ -219,15 +219,20 @@ public partial class CraftingWindow : Window
         mItems.Clear();
         mValues.Clear();
 
-        if (Globals.Me is not { } player)
+        if (Globals.Me is not { Inventory: { } inventory })
         {
             return;
         }
 
         // Quickly Look through the inventory and create a catalog of what items we have, and how many
         Dictionary<Guid, int> inventoryItemsByDescriptorId = [];
-        foreach (var item in player.Inventory)
+        foreach (var item in inventory)
         {
+            if (item is null)
+            {
+                continue;
+            }
+
             var inventoryItemDescriptorId = item.ItemId;
             var currentQuantity = inventoryItemsByDescriptorId.GetValueOrDefault(inventoryItemDescriptorId, 0);
             inventoryItemsByDescriptorId[inventoryItemDescriptorId] = currentQuantity + item.Quantity;


### PR DESCRIPTION
## Summary
- avoid null reference when enumerating player inventory in CraftingWindow
- gracefully bail if player inventory is unavailable

## Testing
- `dotnet test Intersect.Tests/Intersect.Tests.csproj` (fails: error CS0246: The type or namespace name 'NetLogLevel' could not be found)

------
https://chatgpt.com/codex/tasks/task_e_68b4b32c6c6c83249103ad36546be8ce