### PR TITLE
Add resource category support for minimap and map UI

### DIFF
--- a/Framework/Intersect.Framework.Core/Config/MinimapOptions.cs
+++ b/Framework/Intersect.Framework.Core/Config/MinimapOptions.cs
@@ -122,7 +122,14 @@ public partial class MinimapOptions
         public Color MyEntity { get; set; } = Color.Red;
         public Color Npc { get; set; } = Color.Orange;
         public Color Event { get; set; } = Color.Blue;
-        public Dictionary<string, Color> Resource { get; set; } = new() { { "None", Color.White } };
+        public Dictionary<JobType, Color> Resource { get; set; } = new()
+        {
+            { JobType.None, Color.White },
+            { JobType.Lumberjack, Color.SaddleBrown },
+            { JobType.Mining, Color.Gray },
+            { JobType.Farming, Color.Green },
+            { JobType.Fishing, Color.CornflowerBlue },
+        };
         public Color Default { get; set; } = Color.Magenta;
     }
 
@@ -133,7 +140,14 @@ public partial class MinimapOptions
         public string MyEntity { get; set; } = "minimap_me.png";
         public string Npc { get; set; } = "minimap_npc.png";
         public string Event { get; set; } = "minimap_event.png";
-        public Dictionary<string, string> Resource { get; set; } = new() { { "None", "minimap_resource_none.png" } };
+        public Dictionary<JobType, string> Resource { get; set; } = new()
+        {
+            { JobType.None, "minimap_resource_none.png" },
+            { JobType.Lumberjack, "minimap_resource_wood.png" },
+            { JobType.Mining, "minimap_resource_mine.png" },
+            { JobType.Farming, "minimap_resource_herb.png" },
+            { JobType.Fishing, "minimap_resource_fish.png" },
+        };
         public string Default { get; set; } = "minimap_npc.png";
     }
 }

--- a/Intersect.Client.Core/Interface/Game/Map/MapFilters.cs
+++ b/Intersect.Client.Core/Interface/Game/Map/MapFilters.cs
@@ -167,7 +167,7 @@ public class MapFilters
             result.IntersectWith(set);
         }
 
-        return result;
+        return result.Where(e => IsFilterEnabled(e.Type));
     }
 }
 

--- a/Intersect.Client.Core/Interface/Game/Map/MinimapWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Map/MinimapWindow.cs
@@ -8,6 +8,7 @@ using Intersect.Client.Framework.Gwen.Control.EventArguments;
 using Intersect.Client.General;
 using Intersect.Client.Localization;
 using Intersect.Client.Maps;
+using Intersect.Config;
 using Intersect.Enums;
 using Intersect.GameObjects;
 using System;
@@ -436,42 +437,16 @@ namespace Intersect.Client.Interface.Game.Map
                         }
                         break;
                     case EntityType.Resource:
-                        // This relies on users configuring it PROPERLY.
-                        var tool = ((Resource)entity).Descriptor?.Tool ?? -1;
-                        var texSet = false;
-                        var colSet = false;
-                        // Is the tool a valid one to get the string version for?
-                        if (tool >= 0 && tool < Options.Instance.Equipment.ToolTypes.Count)
+                        var job = ((Resource)entity).Descriptor?.Jobs ?? JobType.None;
+                        if (MapPreferences.Instance.ActiveFilters.TryGetValue(job.ToString(), out var enabled) && !enabled)
                         {
-                            // Get the actual tool type from the server configuration.
-                            var toolType = Options.Instance.Equipment.ToolTypes[tool];
-
-                            // Attempt to get our color from the plugin configuration.
-                            if (minimapColorOptions.Resource.TryGetValue(toolType, out color))
-                            {
-                                colSet = true;
-                            }
-                            // Attempt to get our texture from the plugin configuration.
-                            if (minimapImageOptions.Resource.TryGetValue(toolType, out texture))
-                            {
-                                texSet = true;
-                            }
+                            continue;
                         }
-                        // Is it a None tool?
-                        else if (tool == -1)
-                        {
-                            color = minimapColorOptions.Resource["None"];
-                            colSet = true;
-                            texture = minimapImageOptions.Resource["None"];
-                            texSet = true;
-                        }
-                        // Have we managed to set our color? If not, set to default.
-                        if (!colSet)
+                        if (!minimapColorOptions.Resource.TryGetValue(job, out color))
                         {
                             color = minimapColorOptions.Default;
                         }
-                        // Have we managed to set our texture? If not, set to blank.
-                        if (!texSet)
+                        if (!minimapImageOptions.Resource.TryGetValue(job, out texture))
                         {
                             texture = minimapImageOptions.Default;
                         }

--- a/Intersect.Client.Core/Interface/Game/Map/WorldMapWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Map/WorldMapWindow.cs
@@ -9,6 +9,7 @@ using Intersect.Client.Framework.Gwen.Control.EventArguments;
 using Intersect.Client.Interface.Game.Map;
 using Intersect;
 using Intersect.Client.Framework.Input;
+using Intersect.Config;
 
 namespace Intersect.Client.Interface.Game.Map;
 
@@ -43,7 +44,28 @@ public class WorldMapWindow
         _canvas = new MapCanvas(this, _window, "MapImage");
         _legend = new MapLegend(_window);
         _filters = new MapFilters(_window);
+        _filters.AddFilter(JobType.Lumberjack.ToString(), "Madera");
+        _filters.AddFilter(JobType.Mining.ToString(), "Mina");
+        _filters.AddFilter(JobType.Farming.ToString(), "Hierbas");
+        _filters.AddFilter(JobType.Fishing.ToString(), "Pesca");
         _filters.SearchSubmitted += OnSearchSubmitted;
+        var colors = Options.Instance.Minimap.MinimapColors.Resource;
+        if (colors.TryGetValue(JobType.Lumberjack, out var lumberjackColor))
+        {
+            _legend.AddEntry("Madera", lumberjackColor);
+        }
+        if (colors.TryGetValue(JobType.Mining, out var miningColor))
+        {
+            _legend.AddEntry("Mina", miningColor);
+        }
+        if (colors.TryGetValue(JobType.Farming, out var farmingColor))
+        {
+            _legend.AddEntry("Hierbas", farmingColor);
+        }
+        if (colors.TryGetValue(JobType.Fishing, out var fishingColor))
+        {
+            _legend.AddEntry("Pesca", fishingColor);
+        }
 
         _tooltip = new Label(_window, "Tooltip");
         _tooltip.IsHidden = true;


### PR DESCRIPTION
## Summary
- categorize minimap resource colors and icons by job type
- render resources with category lookup and default fallback
- add category filters and legend entries to world map UI
- filter map search results by active categories

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4b56127ec8324a58d96c94df8c18c