### PR TITLE
Add minimap toggle and world map buttons

### DIFF
--- a/Intersect.Client.Core/Core/Input.cs
+++ b/Intersect.Client.Core/Core/Input.cs
@@ -355,8 +355,24 @@ public static partial class Input
                             break;
 
                         case Control.OpenMinimap:
-                            Interface.Interface.GameUi.GameMenu?.ToggleMinimapWindow();
+                        {
+                            var gameMenu = Interface.Interface.GameUi.GameMenu;
+                            if (gameMenu == null)
+                            {
+                                break;
+                            }
+
+                            if (gameMenu.IsWorldMapVisible())
+                            {
+                                gameMenu.ToggleWorldMapWindow();
+                            }
+                            else
+                            {
+                                gameMenu.ToggleMinimapWindow();
+                            }
+
                             break;
+                        }
 
                         case Control.TargetParty1:
                             Globals.Me?.TargetPartyMember(0);

--- a/Intersect.Client.Core/Interface/Game/Map/MinimapWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Map/MinimapWindow.cs
@@ -5,8 +5,11 @@ using Intersect.Client.Framework.File_Management;
 using Intersect.Client.Framework.Graphics;
 using Intersect.Client.Framework.Gwen.Control;
 using Intersect.Client.Framework.Gwen.Control.EventArguments;
+using Intersect.Client.Framework.Input;
+using Intersect.Client.Framework.GenericClasses;
 using Intersect.Client.General;
 using Intersect.Client.Localization;
+using Intersect.Client.Core.Controls;
 using Intersect.Client.Maps;
 using Intersect.Config;
 using Intersect.Enums;
@@ -36,6 +39,7 @@ namespace Intersect.Client.Interface.Game.Map
         private readonly ImagePanel _minimap;
         private readonly Button _zoomInButton;
         private readonly Button _zoomOutButton;
+        private readonly Button _worldMapButton;
         private static readonly GameContentManager ContentManager = Globals.ContentManager;
         private volatile bool _initialized;
         // Constructors
@@ -47,10 +51,14 @@ namespace Intersect.Client.Interface.Game.Map
             _minimap = new ImagePanel(this, "MinimapContainer");
             _zoomInButton = new Button(_minimap, "ZoomInButton");
             _zoomOutButton = new Button(_minimap, "ZoomOutButton");
+            _worldMapButton = new Button(_minimap, "WorldMapButton");
             _zoomInButton.Clicked += MZoomInButton_Clicked;
             _zoomInButton.SetToolTipText(Strings.Minimap.ZoomIn);
             _zoomOutButton.Clicked += MZoomOutButton_Clicked;
             _zoomOutButton.SetToolTipText(Strings.Minimap.ZoomOut);
+            _worldMapButton.Clicked += OpenWorldMapButton_Clicked;
+            var keyHint = GetMinimapKeyHint();
+            _worldMapButton.SetToolTipText(string.IsNullOrEmpty(keyHint) ? Strings.WorldMap.Title : $"{Strings.WorldMap.Title} ({keyHint})");
             _whiteTexture = Graphics.Renderer.WhitePixel;
             _renderTexture = GenerateBaseRenderTexture();
         }
@@ -506,6 +514,28 @@ namespace Intersect.Client.Interface.Game.Map
             );
             MapPreferences.Instance.MinimapZoom = _zoomLevel;
             MapPreferences.Save();
+        }
+
+        private void OpenWorldMapButton_Clicked(Base sender, MouseButtonState arguments)
+        {
+            Interface.Interface.GameUi.GameMenu?.ToggleWorldMapWindow();
+        }
+
+        private static string GetMinimapKeyHint()
+        {
+            if (!Controls.Controls.ActiveControls.TryGetMappingFor(Control.OpenMinimap, out var mapping) ||
+                mapping.Bindings.Length == 0)
+            {
+                return string.Empty;
+            }
+
+            var binding = mapping.Bindings[0];
+            if (binding.Key == Keys.None)
+            {
+                return string.Empty;
+            }
+
+            return Strings.Keys.FormatKeyName(binding.Modifier, binding.Key);
         }
         private enum MapPosition
         {

--- a/Intersect.Client.Core/Interface/Game/MenuContainer.cs
+++ b/Intersect.Client.Core/Interface/Game/MenuContainer.cs
@@ -35,6 +35,7 @@ public partial class MenuContainer : Panel
     private readonly Button _characterButton;
     private readonly CharacterWindow _characterWindow;
     private readonly MinimapWindow _minimapWindow;
+    private readonly WorldMapWindow _worldMapWindow;
 
     private readonly ImagePanel _questsButtonContainer;
     private readonly Button _questsButton;
@@ -308,6 +309,7 @@ public partial class MenuContainer : Panel
         _guildWindow = new GuildWindow(gameCanvas: gameCanvas);
         mJobsWindow= new JobsWindow(gameCanvas: gameCanvas);
         _minimapWindow = new MinimapWindow(gameCanvas);
+        _worldMapWindow = new WorldMapWindow(gameCanvas);
 
     }
 
@@ -353,6 +355,7 @@ public partial class MenuContainer : Panel
         _spellsWindow.Hide();
         _guildWindow.Hide();
         _minimapWindow.Hide();
+        _worldMapWindow.Hide();
         _factionWindow.Hide();
         mJobsWindow.Hide();
     }
@@ -388,6 +391,21 @@ public partial class MenuContainer : Panel
             _minimapWindow.Show();
         }
     }
+
+    public void ToggleWorldMapWindow()
+    {
+        if (_worldMapWindow.IsVisible())
+        {
+            _worldMapWindow.Hide();
+        }
+        else
+        {
+            HideWindows();
+            _worldMapWindow.Show();
+        }
+    }
+
+    public bool IsWorldMapVisible() => _worldMapWindow.IsVisible();
 
     public bool ToggleFriendsWindow()
     {

--- a/Intersect.Client.Core/Localization/Strings.cs
+++ b/Intersect.Client.Core/Localization/Strings.cs
@@ -3101,6 +3101,12 @@ If you are sure you want to hand over your guild enter '\c{{#ff8080}}{02}\c{{}}'
         public static LocalizedString ZoomOut = @"Zoom Out";
     }
 
+    public partial struct WorldMap
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Title = @"World Map";
+    }
+
     public partial struct EscapeMenu
     {
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]


### PR DESCRIPTION
## Summary
- Ensure minimap hotkey toggles world map or minimap based on current state
- Add world map/minimap buttons with key hints
- Include localized string for world map

## Testing
- `dotnet build` *(fails: LiteNetLib.csproj missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b4b863f0dc83248b7511355a975f84