### PR TITLE
Scale minimap tiles based on DPI with bounds

### DIFF
--- a/Framework/Intersect.Framework.Core/Config/MinimapOptions.cs
+++ b/Framework/Intersect.Framework.Core/Config/MinimapOptions.cs
@@ -17,6 +17,26 @@ public partial class MinimapOptions
     /// </summary>
     public Point TileSize { get; set; } = new(8, 8);
 
+    private const float BaseDpi = 96f;
+    private const int MinTileLength = 4;
+    private const int MaxTileLength = 32;
+
+    /// <summary>
+    /// Returns the minimap tile size scaled for the provided DPI and
+    /// clamped to a sensible visible range.
+    /// </summary>
+    public Point GetScaledTileSize(float dpi)
+    {
+        var scale = dpi / BaseDpi;
+        var scaledX = (int)MathF.Round(TileSize.X * scale);
+        var scaledY = (int)MathF.Round(TileSize.Y * scale);
+
+        scaledX = Math.Clamp(scaledX, MinTileLength, MaxTileLength);
+        scaledY = Math.Clamp(scaledY, MinTileLength, MaxTileLength);
+
+        return new Point(scaledX, scaledY);
+    }
+
     /// <summary>
     /// Configures the minimum zoom level (0 - 100)
     /// </summary>

--- a/Intersect.Client.Core/Interface/Game/Map/MinimapWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Map/MinimapWindow.cs
@@ -11,6 +11,7 @@ using Intersect.Client.General;
 using Intersect.Client.Localization;
 using Intersect.Client.Core.Controls;
 using Intersect.Client.Maps;
+using Intersect.Client.MonoGame.NativeInterop;
 using Intersect.Config;
 using Intersect.Enums;
 using Intersect.GameObjects;
@@ -53,7 +54,8 @@ namespace Intersect.Client.Interface.Game.Map
         {
             DisableResizing();
             _zoomLevel = Options.Instance.Minimap.DefaultZoom;
-            _minimapTileSize = Options.Instance.Minimap.TileSize;
+            var dpi = Sdl2.GetDisplayDpi();
+            _minimapTileSize = Options.Instance.Minimap.GetScaledTileSize(dpi);
             _minimap = new ImagePanel(this, "MinimapContainer");
             _zoomInButton = new Button(_minimap, "ZoomInButton");
             _zoomOutButton = new Button(_minimap, "ZoomOutButton");

--- a/Intersect.Client.Core/MonoGame/NativeInterop/Sdl2.Display.cs
+++ b/Intersect.Client.Core/MonoGame/NativeInterop/Sdl2.Display.cs
@@ -1,0 +1,35 @@
+using System.Runtime.InteropServices;
+
+namespace Intersect.Client.MonoGame.NativeInterop;
+
+public partial class Sdl2
+{
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    private unsafe delegate int SDL_GetDisplayDPI_d(int displayIndex, float* ddpi, float* hdpi, float* vdpi);
+
+    private static SDL_GetDisplayDPI_d? SDL_GetDisplayDPI_f =
+        Loader.Functions.LoadFunction<SDL_GetDisplayDPI_d>(nameof(SDL_GetDisplayDPI));
+
+    public static unsafe bool TryGetDisplayDpi(int displayIndex, out float ddpi, out float hdpi, out float vdpi)
+    {
+        ddpi = hdpi = vdpi = 0f;
+        if (SDL_GetDisplayDPI_f == null)
+        {
+            return false;
+        }
+
+        fixed (float* ddpiPtr = &ddpi)
+        fixed (float* hdpiPtr = &hdpi)
+        fixed (float* vdpiPtr = &vdpi)
+        {
+            return SDL_GetDisplayDPI_f(displayIndex, ddpiPtr, hdpiPtr, vdpiPtr) == 0;
+        }
+    }
+
+    public static float GetDisplayDpi(int displayIndex = 0)
+    {
+        return TryGetDisplayDpi(displayIndex, out var ddpi, out var hdpi, out var vdpi)
+            ? (ddpi > 0 ? ddpi : (hdpi + vdpi) / 2f)
+            : 96f;
+    }
+}

--- a/Intersect.Tests/Config/MinimapOptionsTests.cs
+++ b/Intersect.Tests/Config/MinimapOptionsTests.cs
@@ -37,5 +37,20 @@ public class MinimapOptionsTests
 
         Assert.That(options.DefaultZoom, Is.EqualTo(expected));
     }
+
+    [TestCase(96f, 8)]   // 1080p
+    [TestCase(144f, 12)] // 1440p
+    [TestCase(192f, 16)] // 4K
+    [TestCase(48f, 4)]   // Below minimum
+    [TestCase(384f, 32)] // Above maximum
+    public void GetScaledTileSize_ScalesAndClamps(float dpi, int expected)
+    {
+        var options = new MinimapOptions();
+
+        var size = options.GetScaledTileSize(dpi);
+
+        Assert.That(size.X, Is.EqualTo(expected));
+        Assert.That(size.Y, Is.EqualTo(expected));
+    }
 }
 


### PR DESCRIPTION
## Summary
- scale minimap tile size based on display DPI
- clamp minimap tile size to keep icons readable
- add tests for scaled/clamped minimap tile sizes

## Testing
- `dotnet test Intersect.Tests/Intersect.Tests.csproj -p:EnableWindowsTargeting=true` *(fails: MessagePack analyzer error)*

------
https://chatgpt.com/codex/tasks/task_e_68b4c1a72a548324b3990a8c801ecc09