### PR TITLE
Fix MessagePack key conflict in JoinGamePacket

### DIFF
--- a/Framework/Intersect.Framework.Core/Network/Packets/Server/JoinGamePacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Server/JoinGamePacket.cs
@@ -17,6 +17,6 @@ public partial class JoinGamePacket : AbstractTimedPacket
         MapDiscovery = discovery;
     }
 
-    [Key(0)]
+    [Key(3)]
     public Dictionary<Guid, byte[]> MapDiscovery { get; set; }
 }


### PR DESCRIPTION
## Summary
- assign MapDiscovery field a unique MessagePack key to avoid conflicts with AbstractTimedPacket base keys

## Testing
- `dotnet build Framework/Intersect.Framework.Core/Intersect.Framework.Core.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4c3cffe348324a9d041549ad8b252