### PR TITLE
feat: keep minimap visible and click-through

### DIFF
--- a/Intersect.Client.Core/Interface/Game/GameInterface.cs
+++ b/Intersect.Client.Core/Interface/Game/GameInterface.cs
@@ -829,7 +829,10 @@ internal sealed class MapUIManager
     public MapUIManager(Canvas canvas, MenuContainer menu)
     {
         _menu = menu;
-        _minimapWindow = new MinimapWindow(canvas);
+        _minimapWindow = new MinimapWindow(canvas)
+        {
+            IsClickThrough = true,
+        };
         _worldMapWindow = new WorldMapWindow(canvas);
     }
 
@@ -872,7 +875,6 @@ internal sealed class MapUIManager
             return;
         }
 
-        _menu.HideWindows();
         _minimapWindow.Show();
     }
 

--- a/Intersect.Client.Core/Interface/Game/Map/MinimapWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Map/MinimapWindow.cs
@@ -45,6 +45,17 @@ namespace Intersect.Client.Interface.Game.Map
         private readonly Button _worldMapButton;
         private static readonly GameContentManager ContentManager = Globals.ContentManager;
         private volatile bool _initialized;
+        private bool _isClickThrough;
+
+        public bool IsClickThrough
+        {
+            get => _isClickThrough;
+            set
+            {
+                _isClickThrough = value;
+                MouseInputEnabled = !value;
+            }
+        }
 
         // Throttle dynamic overlay updates to ~4Hz
         private DateTime _lastOverlayUpdate = DateTime.MinValue;
@@ -53,6 +64,8 @@ namespace Intersect.Client.Interface.Game.Map
         public MinimapWindow(Base parent) : base(parent, Strings.Minimap.Title, false, "MinimapWindow")
         {
             DisableResizing();
+            Layer = "HUDTop";
+            AlwaysOnTop = true;
             _zoomLevel = Options.Instance.Minimap.DefaultZoom;
             var dpi = Sdl2.GetDisplayDpi();
             _minimapTileSize = Options.Instance.Minimap.GetScaledTileSize(dpi);
@@ -108,6 +121,26 @@ namespace Intersect.Client.Interface.Game.Map
         public void Hide()
         {
             IsHidden = true;
+        }
+
+        protected override void OnMouseDown(MouseButton mouseButton, Point mousePosition, bool userAction = true)
+        {
+            if (IsClickThrough)
+            {
+                return;
+            }
+
+            base.OnMouseDown(mouseButton, mousePosition, userAction);
+        }
+
+        protected override void OnMouseUp(MouseButton mouseButton, Point mousePosition, bool userAction = true)
+        {
+            if (IsClickThrough)
+            {
+                return;
+            }
+
+            base.OnMouseUp(mouseButton, mousePosition, userAction);
         }
         // Private Methods
         private void UpdateMinimap(Player player, Dictionary<Guid, Entity> allEntities)


### PR DESCRIPTION
## Summary
- place the minimap on the HUDTop overlay and keep it always on top
- add optional click-through mode to the minimap window
- initialize minimap as click-through and avoid hiding other windows when opened

## Testing
- `dotnet build Intersect.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4fc84d4ac8324a8eed4a40f249ba3