### PR TITLE
feat: sync minimap discoveries

### DIFF
--- a/Framework/Intersect.Framework.Core/Config/MapOptions.cs
+++ b/Framework/Intersect.Framework.Core/Config/MapOptions.cs
@@ -181,6 +181,11 @@ public partial class MapOptions
     /// </summary>
     public bool ZDimensionVisible { get; set; }
 
+    /// <summary>
+    /// Radius, in tiles, around the player that will be marked as discovered.
+    /// </summary>
+    public int DiscoveryRadius { get; set; } = 8;
+
     #endregion Configurable Properties
 
     [OnDeserialized]

--- a/Framework/Intersect.Framework.Core/Network/Packets/Client/MapDiscoveriesPacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Client/MapDiscoveriesPacket.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections.Generic;
+using Intersect.Network.Packets;
+using MessagePack;
+
+namespace Intersect.Network.Packets.Client;
+
+[MessagePackObject]
+public partial class MapDiscoveriesPacket : IntersectPacket
+{
+    public MapDiscoveriesPacket()
+    {
+    }
+
+    public MapDiscoveriesPacket(Dictionary<Guid, byte[]> discoveries)
+    {
+        Discoveries = discoveries;
+    }
+
+    [Key(0)]
+    public Dictionary<Guid, byte[]> Discoveries { get; set; } = new();
+}

--- a/Intersect.Client.Core/Interface/Game/Map/MinimapWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Map/MinimapWindow.cs
@@ -21,6 +21,7 @@ using System.Linq;
 using Intersect;
 using Intersect.Framework.Core.GameObjects.Mapping.Tilesets;
 using Intersect.Framework.Core.GameObjects.Maps;
+using Intersect.Client.Networking;
 namespace Intersect.Client.Interface.Game.Map
 {
     public sealed class MinimapWindow : Window
@@ -49,6 +50,8 @@ namespace Intersect.Client.Interface.Game.Map
         // Throttle dynamic overlay updates to ~4Hz
         private DateTime _lastOverlayUpdate = DateTime.MinValue;
         private static readonly TimeSpan OverlayInterval = TimeSpan.FromMilliseconds(250);
+        private DateTime _lastDiscoverySync = DateTime.MinValue;
+        private static readonly TimeSpan DiscoverySyncInterval = TimeSpan.FromSeconds(30);
         // Constructors
         public MinimapWindow(Base parent) : base(parent, Strings.Minimap.Title, false, "MinimapWindow")
         {
@@ -147,10 +150,23 @@ namespace Intersect.Client.Interface.Game.Map
                 Console.WriteLine("_minimapTileSize is null in UpdateMinimap.");
                 return;
             }
-            for (var dx = -1; dx <= 1; dx++)
+            var now = DateTime.UtcNow;
+            if (now - _lastDiscoverySync >= DiscoverySyncInterval)
             {
-                for (var dy = -1; dy <= 1; dy++)
+                SyncDiscoveries();
+            }
+
+            var radius = Options.Instance.Map.DiscoveryRadius;
+            var radiusSq = radius * radius;
+            for (var dx = -radius; dx <= radius; dx++)
+            {
+                for (var dy = -radius; dy <= radius; dy++)
                 {
+                    if (dx * dx + dy * dy > radiusSq)
+                    {
+                        continue;
+                    }
+
                     Globals.DiscoverTile(mapInstance.Id, player.X + dx, player.Y + dy);
                 }
             }
@@ -180,6 +196,8 @@ namespace Intersect.Client.Interface.Game.Map
                     }
                 }
                 _redrawMaps = true;
+                SyncDiscoveries();
+                Globals.LoadDiscoveries(Globals.MapDiscoveries.ToDictionary(k => k.Key, v => v.Value.Data));
             }
 
             var newLocations = GenerateEntityInfo(allEntities, player);
@@ -631,6 +649,14 @@ namespace Intersect.Client.Interface.Game.Map
         private IGameRenderTexture GenerateMapRenderTexture()
         {
             return GenerateRenderTexture(1);
+        }
+
+        private void SyncDiscoveries()
+        {
+            PacketSender.SendMapDiscoveries(
+                Globals.MapDiscoveries.ToDictionary(k => k.Key, v => v.Value.Data)
+            );
+            _lastDiscoverySync = DateTime.UtcNow;
         }
         private void MZoomOutButton_Clicked(Base sender, MouseButtonState arguments)
         {

--- a/Intersect.Client.Core/Networking/PacketHandler.cs
+++ b/Intersect.Client.Core/Networking/PacketHandler.cs
@@ -203,6 +203,12 @@ internal sealed partial class PacketHandler
         Globals.JoiningGame = true;
     }
 
+    //MapDiscoveriesPacket
+    public void HandlePacket(IPacketSender packetSender, MapDiscoveriesPacket packet)
+    {
+        Globals.LoadDiscoveries(packet.Discoveries ?? new Dictionary<Guid, byte[]>());
+    }
+
     public void HandlePacket(IPacketSender packetSender, MapAreaPacket packet)
     {
         foreach (var map in packet.Maps)
@@ -354,6 +360,10 @@ internal sealed partial class PacketHandler
     public void HandlePacket(IPacketSender packetSender, MapPacket packet)
     {
         HandleMap(packetSender, packet);
+        if (packet.MapId == Globals.Me?.MapId)
+        {
+            Globals.LoadDiscoveries(Globals.MapDiscoveries.ToDictionary(k => k.Key, v => v.Value.Data));
+        }
         Player.FetchNewMaps();
     }
 

--- a/Intersect.Client.Core/Networking/PacketSender.cs
+++ b/Intersect.Client.Core/Networking/PacketSender.cs
@@ -13,6 +13,7 @@ using Intersect.Framework.Core.GameObjects.Maps;
 using Intersect.Models;
 using Intersect.Network.Packets.Client;
 using System.Collections.Generic;
+using System;
 using Intersect.Network.Packets;
 using AdminAction = Intersect.Admin.Actions.AdminAction;
 
@@ -35,6 +36,11 @@ public static partial class PacketSender
     public static void SendLogout(bool characterSelect = false)
     {
         Network.SendPacket(new LogoutPacket(characterSelect));
+    }
+
+    public static void SendMapDiscoveries(Dictionary<Guid, byte[]> discoveries)
+    {
+        Network.SendPacket(new MapDiscoveriesPacket(discoveries));
     }
 
     public static void SendNeedMap(params ObjectCacheKey<MapDescriptor>[] cacheKeys)

--- a/Intersect.Server.Core/Entities/Player.cs
+++ b/Intersect.Server.Core/Entities/Player.cs
@@ -817,7 +817,29 @@ public partial class Player : Entity
             Monitor.TryEnter(EntityLock, ref lockObtained);
             if (lockObtained)
             {
-                DiscoverTile(MapId, X, Y);
+                var mapOptions = Options.Instance.Map;
+                var radius = mapOptions.DiscoveryRadius;
+                var radiusSq = radius * radius;
+                for (var dx = -radius; dx <= radius; dx++)
+                {
+                    for (var dy = -radius; dy <= radius; dy++)
+                    {
+                        if (dx * dx + dy * dy > radiusSq)
+                        {
+                            continue;
+                        }
+
+                        var tx = X + dx;
+                        var ty = Y + dy;
+
+                        if (tx < 0 || ty < 0 || tx >= mapOptions.MapWidth || ty >= mapOptions.MapHeight)
+                        {
+                            continue;
+                        }
+
+                        DiscoverTile(MapId, tx, ty);
+                    }
+                }
                 if (Client == null) //Client logged out
                 {
                     if (CombatTimer < Timing.Global.Milliseconds)

--- a/Intersect.Server.Core/Networking/PacketHandler.cs
+++ b/Intersect.Server.Core/Networking/PacketHandler.cs
@@ -29,6 +29,8 @@ using Intersect.Network.Packets.Server;
 using Intersect.Server.Core;
 using Intersect.Server.Services;
 using Microsoft.Extensions.Logging;
+using Intersect.Framework.Core.Collections;
+using Intersect.Config;
 using ChatMsgPacket = Intersect.Network.Packets.Client.ChatMsgPacket;
 using LoginPacket = Intersect.Network.Packets.Client.LoginPacket;
 using PartyInvitePacket = Intersect.Network.Packets.Client.PartyInvitePacket;
@@ -504,6 +506,26 @@ internal sealed partial class PacketHandler
         {
             PacketSender.SendPing(client, false);
         }
+    }
+
+    //MapDiscoveriesPacket
+    public void HandlePacket(Client client, MapDiscoveriesPacket packet)
+    {
+        if (client?.Entity is not Player player || packet.Discoveries == null)
+        {
+            return;
+        }
+
+        foreach (var kvp in packet.Discoveries)
+        {
+            player.MapDiscoveries[kvp.Key] = new BitGrid(
+                Options.Instance.Map.MapWidth,
+                Options.Instance.Map.MapHeight,
+                kvp.Value
+            );
+        }
+
+        player.Save();
     }
 
     //LoginPacket


### PR DESCRIPTION
## Summary
- persist map discoveries per character and share with client
- configure discovery radius and sync with server
- refresh minimap discovery data on map change

## Testing
- `dotnet test` *(fails: project file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4fd08dd248324bbba87a6bc0483a5