### PR TITLE
Fix minimap click-through to disable child controls

### DIFF
--- a/Intersect.Client.Core/Interface/Game/Map/MinimapWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Map/MinimapWindow.cs
@@ -57,7 +57,17 @@ namespace Intersect.Client.Interface.Game.Map
             set
             {
                 _isClickThrough = value;
-                MouseInputEnabled = !value;
+                SetMouseInputEnabledRecursive(this, !value);
+            }
+        }
+
+        private static void SetMouseInputEnabledRecursive(Base component, bool enabled)
+        {
+            component.MouseInputEnabled = enabled;
+
+            foreach (var child in component.Children)
+            {
+                SetMouseInputEnabledRecursive(child, enabled);
             }
         }
 


### PR DESCRIPTION
## Summary
- ensure minimap click-through disables the minimap container and its children

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*
- `dotnet build Intersect.Client.Core/Intersect.Client.Core.csproj` *(fails: MapDiscoveriesPacket not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b505558d0883249dcf9afad76d6947