### PR TITLE
Fix layout helpers for WorldMapWindow

### DIFF
--- a/Intersect.Client.Core/Interface/Game/Map/MapFilters.cs
+++ b/Intersect.Client.Core/Interface/Game/Map/MapFilters.cs
@@ -176,5 +176,15 @@ public class MapFilters
 
         return result.Where(e => IsFilterEnabled(e.Type));
     }
+
+    /// <summary>
+    /// Sets the location of the filter panel.
+    /// </summary>
+    public void SetPosition(int x, int y) => _panel.SetPosition(x, y);
+
+    /// <summary>
+    /// Sets the size of the filter panel.
+    /// </summary>
+    public void SetSize(int width, int height) => _panel.SetSize(width, height);
 }
 

--- a/Intersect.Client.Core/Interface/Game/Map/MapLegend.cs
+++ b/Intersect.Client.Core/Interface/Game/Map/MapLegend.cs
@@ -29,5 +29,25 @@ public class MapLegend
         label.Dock = Pos.Top;
         _entries.Add(label);
     }
+
+    /// <summary>
+    /// Exposes the underlying panel's position for layout logic.
+    /// </summary>
+    public int Y => _panel.Y;
+
+    /// <summary>
+    /// Exposes the underlying panel's height for layout logic.
+    /// </summary>
+    public int Height => _panel.Height;
+
+    /// <summary>
+    /// Sets the location of the legend panel.
+    /// </summary>
+    public void SetPosition(int x, int y) => _panel.SetPosition(x, y);
+
+    /// <summary>
+    /// Sets the size of the legend panel.
+    /// </summary>
+    public void SetSize(int width, int height) => _panel.SetSize(width, height);
 }
 

--- a/Intersect.Client.Core/Interface/Game/Map/WorldMapWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Map/WorldMapWindow.cs
@@ -138,12 +138,17 @@ public sealed class WorldMapWindow : Window
         _initialized = true;
 
     }
-    protected override void OnResized(int x, int y, int width, int height)
+
+    protected override void OnResized(Base control, EventArgs args)
     {
-        base.OnResized(x, y, width, height);
-        if (!_initialized) return;
+        base.OnResized(control, args);
+        if (!_initialized)
+        {
+            return;
+        }
+
         ApplyLayout();
-        // Recalcular clamp con el tamaño nuevo
+        // Recalculate clamp with new size
         ClampPosition();
     }
 


### PR DESCRIPTION
## Summary
- expose size/position helpers on MapLegend and MapFilters
- fix WorldMapWindow resize handling to apply layout and clamp

## Testing
- `dotnet build Intersect.Client.Core/Intersect.Client.Core.csproj` *(fails: DeliveryMethod missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b5056c38808324b079842b0c57ce13