### PR TITLE
Handle escape key window closing and modal minimap

### DIFF
--- a/Intersect.Client.Core/Core/Input.cs
+++ b/Intersect.Client.Core/Core/Input.cs
@@ -153,9 +153,13 @@ public static partial class Input
             {
                 gameUi.UnfocusChat = true;
             }
-            else if (gameUi.CloseAllWindows())
+            else if (gameUi.MapUIManager.IsWorldMapOpen)
             {
-                // We've closed our windows, don't do anything else. :)
+                gameUi.MapUIManager.CloseWorldMap();
+            }
+            else if (gameUi.CloseMostRecentWindow())
+            {
+                // We've closed our window, don't do anything else. :)
             }
             else if (Globals.Me is {} me && me.TargetId != default && me.Status.All(s => s.Type != SpellEffect.Taunt))
             {

--- a/Intersect.Client.Core/Interface/Game/GameInterface.cs
+++ b/Intersect.Client.Core/Interface/Game/GameInterface.cs
@@ -27,6 +27,8 @@ using Intersect.GameObjects;
 using Microsoft.Extensions.Logging;
 using Intersect.Framework.Core.GameObjects.Items;
 using Intersect.Client.Interface.Game.Spells;
+using Intersect.Client.Framework.Gwen.ControlInternal;
+using System.Linq;
 
 namespace Intersect.Client.Interface.Game;
 
@@ -459,6 +461,7 @@ public partial class GameInterface : MutableInterface
 
         GameMenu?.Update(mShouldUpdateQuestLog);
         MapUIManager.Update();
+        MapUIManager.MinimapClickThrough = !GameCanvas.Children.Any(child => child is Modal);
         mShouldUpdateQuestLog = false;
         Hotbar?.Update();
         EscapeMenu.Update();
@@ -746,12 +749,6 @@ public partial class GameInterface : MutableInterface
             closedWindows = true;
         }
 
-        if (MapUIManager.IsMinimapOpen)
-        {
-            MapUIManager.CloseMinimap();
-            closedWindows = true;
-        }
-
         if (GameMenu != null && GameMenu.HasWindowsOpen())
         {
             GameMenu.CloseAllWindows();
@@ -765,6 +762,58 @@ public partial class GameInterface : MutableInterface
         }
 
         return closedWindows;
+    }
+
+    public bool CloseMostRecentWindow()
+    {
+        if (_bagWindow != null && _bagWindow.IsVisibleInTree)
+        {
+            CloseBagWindow();
+            return true;
+        }
+
+        if (mTradingWindow != null && mTradingWindow.IsVisible())
+        {
+            CloseTrading();
+            return true;
+        }
+
+        if (_bankWindow is { IsVisibleInTree: true })
+        {
+            CloseBank();
+            return true;
+        }
+
+        if (mCraftingWindow is { IsVisibleInTree: true, IsCrafting: false })
+        {
+            CloseCraftingTable();
+            return true;
+        }
+
+        if (_shopWindow is { IsVisibleInTree: true })
+        {
+            CloseShop();
+            return true;
+        }
+
+        if (_bestiaryWindow is { IsVisibleInTree: true })
+        {
+            _bestiaryWindow.Hide();
+            return true;
+        }
+
+        if (GameMenu != null && GameMenu.CloseMostRecentWindow())
+        {
+            return true;
+        }
+
+        if (TargetContextMenu.IsVisibleInTree)
+        {
+            TargetContextMenu.ToggleHidden();
+            return true;
+        }
+
+        return false;
     }
 
     //Dispose
@@ -839,6 +888,12 @@ internal sealed class MapUIManager
     public bool IsWorldMapOpen => _worldMapWindow.IsVisible();
 
     public bool IsMinimapOpen => _minimapWindow.IsVisible();
+
+    public bool MinimapClickThrough
+    {
+        get => _minimapWindow.IsClickThrough;
+        set => _minimapWindow.IsClickThrough = value;
+    }
 
     public void Update()
     {

--- a/Intersect.Client.Core/Interface/Game/MenuContainer.cs
+++ b/Intersect.Client.Core/Interface/Game/MenuContainer.cs
@@ -508,7 +508,6 @@ public partial class MenuContainer : Panel
         _guildWindow.Hide();
         _factionWindow.Hide();
         Interface.GameUi.MapUIManager.CloseWorldMap();
-        Interface.GameUi.MapUIManager.CloseMinimap();
     }
 
     public bool HasWindowsOpen()
@@ -522,9 +521,67 @@ public partial class MenuContainer : Panel
                           _guildWindow.IsVisibleInTree ||
                           _factionWindow.IsVisibleInTree ||
                           Interface.GameUi.MapUIManager.IsWorldMapOpen ||
-                          Interface.GameUi.MapUIManager.IsMinimapOpen ||
         mJobsWindow.IsVisible();
         return windowsOpen;
+    }
+
+    public bool CloseMostRecentWindow()
+    {
+        if (_characterWindow.IsVisible())
+        {
+            _characterWindow.Hide();
+            return true;
+        }
+
+        if (_friendsWindow.IsVisible)
+        {
+            _friendsWindow.Hide();
+            return true;
+        }
+
+        if (_inventoryWindow.IsVisibleInTree)
+        {
+            _inventoryWindow.Hide();
+            return true;
+        }
+
+        if (_questsWindow.IsVisible())
+        {
+            _questsWindow.Hide();
+            return true;
+        }
+
+        if (_spellsWindow.IsVisibleInTree)
+        {
+            _spellsWindow.Hide();
+            return true;
+        }
+
+        if (_partyWindow.IsVisible())
+        {
+            _partyWindow.Hide();
+            return true;
+        }
+
+        if (_guildWindow.IsVisibleInTree)
+        {
+            _guildWindow.Hide();
+            return true;
+        }
+
+        if (_factionWindow.IsVisibleInTree)
+        {
+            _factionWindow.Hide();
+            return true;
+        }
+
+        if (mJobsWindow.IsVisible())
+        {
+            mJobsWindow.Hide();
+            return true;
+        }
+
+        return false;
     }
 
 


### PR DESCRIPTION
## Summary
- Close world map or most recent window when pressing Escape while keeping minimap visible
- Stop CloseAllWindows from hiding the minimap
- Disable minimap interaction while modals are open without hiding it

## Testing
- `dotnet test` *(fails: project file "vendor/LiteNetLib/LiteNetLib/LiteNetLib.csproj" was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b507eb60688324b99b7bd842a686f4