### PR TITLE
feat: auto-save map preferences

### DIFF
--- a/Intersect.Client.Core/Interface/Game/Map/MapFilters.cs
+++ b/Intersect.Client.Core/Interface/Game/Map/MapFilters.cs
@@ -58,14 +58,12 @@ public class MapFilters
         }
         else
         {
-            MapPreferences.Instance.ActiveFilters[key] = cb.IsChecked;
-            MapPreferences.Save();
+            MapPreferences.UpdateFilter(key, cb.IsChecked);
         }
 
         cb.CheckChanged += (_, args) =>
         {
-            MapPreferences.Instance.ActiveFilters[key] = cb.IsChecked;
-            MapPreferences.Save();
+            MapPreferences.UpdateFilter(key, cb.IsChecked);
         };
 
         _filters[key] = cb;

--- a/Intersect.Client.Core/Interface/Game/Map/MapPreferences.cs
+++ b/Intersect.Client.Core/Interface/Game/Map/MapPreferences.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Intersect;
 using Intersect.Client.General;
 using Intersect.Client.Framework.Database;
 using Newtonsoft.Json;
@@ -67,6 +68,47 @@ public class MapPreferences
     {
         var json = JsonConvert.SerializeObject(Instance);
         Globals.Database.SavePreference(PreferenceKey, json);
+    }
+
+    /// <summary>
+    /// Update the minimap zoom preference and persist it.
+    /// </summary>
+    /// <param name="zoom">New minimap zoom level.</param>
+    public static void UpdateMinimapZoom(int zoom)
+    {
+        Instance.MinimapZoom = zoom;
+        Save();
+    }
+
+    /// <summary>
+    /// Update the world map canvas position preference and persist it.
+    /// </summary>
+    /// <param name="position">New position for the world map canvas.</param>
+    public static void UpdateWorldMapPosition(Point position)
+    {
+        Instance.WorldMapPosition = position;
+        Save();
+    }
+
+    /// <summary>
+    /// Update the world map zoom preference and persist it.
+    /// </summary>
+    /// <param name="zoom">New world map zoom level.</param>
+    public static void UpdateWorldMapZoom(float zoom)
+    {
+        Instance.WorldMapZoom = zoom;
+        Save();
+    }
+
+    /// <summary>
+    /// Update a world map filter preference and persist it.
+    /// </summary>
+    /// <param name="key">Filter identifier.</param>
+    /// <param name="enabled">Whether the filter is enabled.</param>
+    public static void UpdateFilter(string key, bool enabled)
+    {
+        Instance.ActiveFilters[key] = enabled;
+        Save();
     }
 }
 

--- a/Intersect.Client.Core/Interface/Game/Map/MinimapWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Map/MinimapWindow.cs
@@ -210,8 +210,7 @@ namespace Intersect.Client.Interface.Game.Map
                 );
             }
 
-            MapPreferences.Instance.MinimapZoom = _zoomLevel;
-            MapPreferences.Save();
+            MapPreferences.UpdateMinimapZoom(_zoomLevel);
 
             return true;
         }
@@ -767,8 +766,7 @@ namespace Intersect.Client.Interface.Game.Map
                 _zoomLevel + Options.Instance.Minimap.ZoomStep,
                 Options.Instance.Minimap.MaximumZoom
             );
-            MapPreferences.Instance.MinimapZoom = _zoomLevel;
-            MapPreferences.Save();
+            MapPreferences.UpdateMinimapZoom(_zoomLevel);
         }
         private void MZoomInButton_Clicked(Base sender, MouseButtonState arguments)
         {
@@ -776,8 +774,7 @@ namespace Intersect.Client.Interface.Game.Map
                 _zoomLevel - Options.Instance.Minimap.ZoomStep,
                 Options.Instance.Minimap.MinimumZoom
             );
-            MapPreferences.Instance.MinimapZoom = _zoomLevel;
-            MapPreferences.Save();
+            MapPreferences.UpdateMinimapZoom(_zoomLevel);
         }
 
         private void OpenWorldMapButton_Clicked(Base sender, MouseButtonState arguments)

--- a/Intersect.Client.Core/Interface/Game/Map/WorldMapWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Map/WorldMapWindow.cs
@@ -122,9 +122,8 @@ public sealed class WorldMapWindow : Window
             (int)(_baseHeight * _zoom)
         );
         ClampPosition();
-        MapPreferences.Instance.WorldMapZoom = _zoom;
-        MapPreferences.Instance.WorldMapPosition = new Point(_canvas.X, _canvas.Y);
-        MapPreferences.Save();
+        MapPreferences.UpdateWorldMapZoom(_zoom);
+        MapPreferences.UpdateWorldMapPosition(new Point(_canvas.X, _canvas.Y));
 
         // Tooltip oculto por defecto
         _tooltip.IsHidden = true;
@@ -273,8 +272,7 @@ public sealed class WorldMapWindow : Window
     {
         _dragging = false;
         ClampPosition();
-        MapPreferences.Instance.WorldMapPosition = new Point(_canvas.X, _canvas.Y);
-        MapPreferences.Save();
+        MapPreferences.UpdateWorldMapPosition(new Point(_canvas.X, _canvas.Y));
     }
 
     private int ClampX(int x) => Math.Clamp(x, Width - (int)(_baseWidth * _zoom), 0);
@@ -325,9 +323,8 @@ public sealed class WorldMapWindow : Window
         _canvas.SetBounds(newX, newY, newWidth, newHeight);
         ClampPosition();
 
-        MapPreferences.Instance.WorldMapZoom = _zoom;
-        MapPreferences.Instance.WorldMapPosition = new Point(_canvas.X, _canvas.Y);
-        MapPreferences.Save();
+        MapPreferences.UpdateWorldMapZoom(_zoom);
+        MapPreferences.UpdateWorldMapPosition(new Point(_canvas.X, _canvas.Y));
     }
 
     private void CenterOn(Point pos)
@@ -335,8 +332,7 @@ public sealed class WorldMapWindow : Window
         var targetX = ClampX(Width / 2 - pos.X);
         var targetY = ClampY(Height / 2 - pos.Y);
         _canvas.SetPosition(targetX, targetY);
-        MapPreferences.Instance.WorldMapPosition = new Point(_canvas.X, _canvas.Y);
-        MapPreferences.Save();
+        MapPreferences.UpdateWorldMapPosition(new Point(_canvas.X, _canvas.Y));
     }
 
     private void MinimapButton_Clicked(Base sender, MouseButtonState args)


### PR DESCRIPTION
## Summary
- add helper methods in `MapPreferences` that save after each update
- use update helpers when changing minimap zoom, world map position/zoom and filters

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b507e31cf48324aab9fb3e7129d94e