### PR TITLE
Cycle world map search results on Enter

### DIFF
--- a/Intersect.Client.Core/Interface/Game/Map/MapFilters.cs
+++ b/Intersect.Client.Core/Interface/Game/Map/MapFilters.cs
@@ -76,6 +76,8 @@ public class MapFilters
 
     public string SearchText => _searchBox.Text;
 
+    public bool SearchFocused => _searchBox.HasFocus;
+
     /// <summary>
     /// Represents an item that can be searched for on the world map.
     /// </summary>


### PR DESCRIPTION
## Summary
- track search results and current index in world map
- handle Enter to cycle through map search results
- expose search box focus state for keyboard handling

## Testing
- `dotnet test` *(fails: project file vendor/LiteNetLib/LiteNetLib.csproj was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b50f11976883249960e17368a0bec8