### PR TITLE
Fix variable name shadowing in WorldMapWindow

### DIFF
--- a/Intersect.Client.Core/Interface/Game/Map/WorldMapWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Map/WorldMapWindow.cs
@@ -379,13 +379,13 @@ public sealed class WorldMapWindow : Window
         {
             _searchResultIndex = (_searchResultIndex + 1) % _searchResults.Count;
             var entry = _searchResults[_searchResultIndex];
-            var center = new Point(entry.Area.X + entry.Area.Width / 2, entry.Area.Y + entry.Area.Height / 2);
-            CenterOn(center);
+            var entryCenter = new Point(entry.Area.X + entry.Area.Width / 2, entry.Area.Y + entry.Area.Height / 2);
+            CenterOn(entryCenter);
 
             _activeEntry = entry;
-            _activeEntryCenter = center;
+            _activeEntryCenter = entryCenter;
             _tooltipLabel.Text = entry.Name;
-            _tooltip.SetPosition(center.X + 5, center.Y + 5);
+            _tooltip.SetPosition(entryCenter.X + 5, entryCenter.Y + 5);
             _tooltip.IsHidden = false;
             return;
         }


### PR DESCRIPTION
## Summary
- prevent local variable shadowing in `OnSearchSubmitted`

## Testing
- `dotnet build Intersect.Client.Core/Intersect.Client.Core.csproj` *(fails: DeliveryMethod and other LiteNetLib types missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b511d7379883249df49c7bb4d90a06