### PR TITLE
Add server MapDiscoveries packet and update handler

### DIFF
--- a/Framework/Intersect.Framework.Core/Network/Packets/Server/MapDiscoveriesPacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Server/MapDiscoveriesPacket.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+using Intersect.Network.Packets;
+using MessagePack;
+
+namespace Intersect.Network.Packets.Server;
+
+[MessagePackObject]
+public partial class MapDiscoveriesPacket : IntersectPacket
+{
+    public MapDiscoveriesPacket()
+    {
+    }
+
+    public MapDiscoveriesPacket(Dictionary<Guid, byte[]> discoveries)
+    {
+        Discoveries = discoveries;
+    }
+
+    [Key(0)]
+    public Dictionary<Guid, byte[]> Discoveries { get; set; } = new();
+}
+


### PR DESCRIPTION
## Summary
- add server-side MapDiscoveriesPacket definition
- handle discoveries with server packet in client PacketHandler without importing client packets

## Testing
- `dotnet test Intersect.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*
- `dotnet build Intersect.Client.Core/Intersect.Client.Core.csproj` *(fails: CS0103 names 'Layer' and 'AlwaysOnTop' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b51649a5bc83248e703c233482a988