### PR TITLE
Rename map discovery packets to request and response

### DIFF
--- a/Framework/Intersect.Framework.Core/Network/Packets/Client/MapDiscoveriesRequestPacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Client/MapDiscoveriesRequestPacket.cs
@@ -6,13 +6,13 @@ using MessagePack;
 namespace Intersect.Network.Packets.Client;
 
 [MessagePackObject]
-public partial class MapDiscoveriesPacket : IntersectPacket
+public partial class MapDiscoveriesRequestPacket : IntersectPacket
 {
-    public MapDiscoveriesPacket()
+    public MapDiscoveriesRequestPacket()
     {
     }
 
-    public MapDiscoveriesPacket(Dictionary<Guid, byte[]> discoveries)
+    public MapDiscoveriesRequestPacket(Dictionary<Guid, byte[]> discoveries)
     {
         Discoveries = discoveries;
     }

--- a/Framework/Intersect.Framework.Core/Network/Packets/Server/MapDiscoveriesResponsePacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Server/MapDiscoveriesResponsePacket.cs
@@ -6,13 +6,13 @@ using MessagePack;
 namespace Intersect.Network.Packets.Server;
 
 [MessagePackObject]
-public partial class MapDiscoveriesPacket : IntersectPacket
+public partial class MapDiscoveriesResponsePacket : IntersectPacket
 {
-    public MapDiscoveriesPacket()
+    public MapDiscoveriesResponsePacket()
     {
     }
 
-    public MapDiscoveriesPacket(Dictionary<Guid, byte[]> discoveries)
+    public MapDiscoveriesResponsePacket(Dictionary<Guid, byte[]> discoveries)
     {
         Discoveries = discoveries;
     }

--- a/Intersect.Client.Core/Interface/Game/Map/MinimapWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Map/MinimapWindow.cs
@@ -796,7 +796,7 @@ namespace Intersect.Client.Interface.Game.Map
 
         private void SyncDiscoveries()
         {
-            PacketSender.SendMapDiscoveries(
+            PacketSender.SendMapDiscoveriesRequest(
                 Globals.MapDiscoveries.ToDictionary(k => k.Key, v => v.Value.Data)
             );
             _lastDiscoverySync = DateTime.UtcNow;

--- a/Intersect.Client.Core/Networking/PacketHandler.cs
+++ b/Intersect.Client.Core/Networking/PacketHandler.cs
@@ -203,8 +203,8 @@ internal sealed partial class PacketHandler
         Globals.JoiningGame = true;
     }
 
-    //MapDiscoveriesPacket
-    public void HandlePacket(IPacketSender packetSender, MapDiscoveriesPacket packet)
+    //MapDiscoveriesResponsePacket
+    public void HandlePacket(IPacketSender packetSender, MapDiscoveriesResponsePacket packet)
     {
         Globals.LoadDiscoveries(packet.Discoveries ?? new Dictionary<Guid, byte[]>());
     }

--- a/Intersect.Client.Core/Networking/PacketSender.cs
+++ b/Intersect.Client.Core/Networking/PacketSender.cs
@@ -38,9 +38,9 @@ public static partial class PacketSender
         Network.SendPacket(new LogoutPacket(characterSelect));
     }
 
-    public static void SendMapDiscoveries(Dictionary<Guid, byte[]> discoveries)
+    public static void SendMapDiscoveriesRequest(Dictionary<Guid, byte[]> discoveries)
     {
-        Network.SendPacket(new MapDiscoveriesPacket(discoveries));
+        Network.SendPacket(new MapDiscoveriesRequestPacket(discoveries));
     }
 
     public static void SendNeedMap(params ObjectCacheKey<MapDescriptor>[] cacheKeys)

--- a/Intersect.Server.Core/Networking/PacketHandler.cs
+++ b/Intersect.Server.Core/Networking/PacketHandler.cs
@@ -508,8 +508,8 @@ internal sealed partial class PacketHandler
         }
     }
 
-     //MapDiscoveriesPacket
-    public void HandlePacket(Client client, MapDiscoveriesPacket packet)
+     //MapDiscoveriesRequestPacket
+    public void HandlePacket(Client client, MapDiscoveriesRequestPacket packet)
     {
         if (client?.Entity is not Player player || packet.Discoveries == null)
         {


### PR DESCRIPTION
## Summary
- rename map discovery packets to MapDiscoveriesRequestPacket and MapDiscoveriesResponsePacket
- update client/server handlers and sender to use new packet names

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets missing)*
- `dotnet test Intersect.Tests/Intersect.Tests.csproj` *(fails: Intersect.GameObjects.Items namespace missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b51a5ac77883248d3cfe9740cbc8eb