### PR TITLE
Remove world map window and references

### DIFF
--- a/Intersect.Client.Core/Core/Input.cs
+++ b/Intersect.Client.Core/Core/Input.cs
@@ -153,10 +153,6 @@ public static partial class Input
             {
                 gameUi.UnfocusChat = true;
             }
-            else if (gameUi.MapUIManager.IsWorldMapOpen)
-            {
-                gameUi.MapUIManager.CloseWorldMap();
-            }
             else if (gameUi.CloseMostRecentWindow())
             {
                 // We've closed our window, don't do anything else. :)
@@ -359,7 +355,14 @@ public static partial class Input
                             break;
 
                         case Control.OpenMinimap:
-                            Interface.Interface.GameUi.MapUIManager.ToggleWorldMap();
+                            if (Interface.Interface.GameUi.MapUIManager.IsMinimapOpen)
+                            {
+                                Interface.Interface.GameUi.MapUIManager.CloseMinimap();
+                            }
+                            else
+                            {
+                                Interface.Interface.GameUi.MapUIManager.OpenMinimap();
+                            }
                             break;
 
                         case Control.TargetParty1:

--- a/Intersect.Client.Core/Interface/Game/GameInterface.cs
+++ b/Intersect.Client.Core/Interface/Game/GameInterface.cs
@@ -172,7 +172,7 @@ public partial class GameInterface : MutableInterface
     {
         mChatBox = new Chatbox(GameCanvas, this);
         GameMenu = new MenuContainer(GameCanvas);
-        MapUIManager = new MapUIManager(GameCanvas, GameMenu);
+        MapUIManager = new MapUIManager(GameCanvas);
         Hotbar = new HotBarWindow(GameCanvas);
         PlayerBox = new EntityBox(GameCanvas, EntityType.Player, Globals.Me, true);
         PlayerBox.SetEntity(Globals.Me);
@@ -743,12 +743,6 @@ public partial class GameInterface : MutableInterface
             closedWindows = true;
         }
 
-        if (MapUIManager.IsWorldMapOpen)
-        {
-            MapUIManager.CloseWorldMap();
-            closedWindows = true;
-        }
-
         if (GameMenu != null && GameMenu.HasWindowsOpen())
         {
             GameMenu.CloseAllWindows();
@@ -824,7 +818,6 @@ public partial class GameInterface : MutableInterface
         CloseCraftingTable();
         CloseShop();
         CloseTrading();
-        MapUIManager.CloseWorldMap();
         MapUIManager.CloseMinimap();
         _bestiaryWindow?.Hide();
         _bestiaryWindow = null;
@@ -872,20 +865,14 @@ public partial class GameInterface : MutableInterface
 internal sealed class MapUIManager
 {
     private readonly MinimapWindow _minimapWindow;
-    private readonly WorldMapWindow _worldMapWindow;
-    private readonly MenuContainer _menu;
 
-    public MapUIManager(Canvas canvas, MenuContainer menu)
+    public MapUIManager(Canvas canvas)
     {
-        _menu = menu;
         _minimapWindow = new MinimapWindow(canvas)
         {
             IsClickThrough = true,
         };
-        _worldMapWindow = new WorldMapWindow(canvas);
     }
-
-    public bool IsWorldMapOpen => _worldMapWindow.IsVisible();
 
     public bool IsMinimapOpen => _minimapWindow.IsVisible();
 
@@ -898,29 +885,6 @@ internal sealed class MapUIManager
     public void Update()
     {
         _minimapWindow.Update();
-    }
-
-    public void OpenWorldMap()
-    {
-        _menu.HideWindows();
-        _worldMapWindow.Show();
-    }
-
-    public void CloseWorldMap()
-    {
-        _worldMapWindow.Hide();
-    }
-
-    public void ToggleWorldMap()
-    {
-        if (_worldMapWindow.IsVisible())
-        {
-            _worldMapWindow.Hide();
-        }
-        else
-        {
-            OpenWorldMap();
-        }
     }
 
     public void OpenMinimap()

--- a/Intersect.Client.Core/Interface/Game/MenuContainer.cs
+++ b/Intersect.Client.Core/Interface/Game/MenuContainer.cs
@@ -507,7 +507,6 @@ public partial class MenuContainer : Panel
 
         _guildWindow.Hide();
         _factionWindow.Hide();
-        Interface.GameUi.MapUIManager.CloseWorldMap();
     }
 
     public bool HasWindowsOpen()
@@ -520,7 +519,6 @@ public partial class MenuContainer : Panel
                           _partyWindow.IsVisible() ||
                           _guildWindow.IsVisibleInTree ||
                           _factionWindow.IsVisibleInTree ||
-                          Interface.GameUi.MapUIManager.IsWorldMapOpen ||
         mJobsWindow.IsVisible();
         return windowsOpen;
     }


### PR DESCRIPTION
## Summary
- drop world map UI hooks and manage only minimap
- clean up menu and input to exclude world map references

## Testing
- `dotnet test` *(fails: project file vendor/LiteNetLib/LiteNetLib.csproj not found)*
- `dotnet build Intersect.Client.Core/Intersect.Client.Core.csproj` *(fails: missing LiteNetLib types)*

------
https://chatgpt.com/codex/tasks/task_e_68b52c0cb45c8324a5b4bf7331860956