### PR TITLE
Add MapUIManager.ToggleMinimap and adjust escape handling

### DIFF
--- a/Intersect.Client.Core/Core/Input.cs
+++ b/Intersect.Client.Core/Core/Input.cs
@@ -153,10 +153,6 @@ public static partial class Input
             {
                 gameUi.UnfocusChat = true;
             }
-            else if (gameUi.MapUIManager.IsWorldMapOpen)
-            {
-                gameUi.MapUIManager.CloseWorldMap();
-            }
             else if (gameUi.CloseMostRecentWindow())
             {
                 // We've closed our window, don't do anything else. :)
@@ -359,7 +355,7 @@ public static partial class Input
                             break;
 
                         case Control.OpenMinimap:
-                            Interface.Interface.GameUi.MapUIManager.ToggleWorldMap();
+                            Interface.Interface.GameUi.MapUIManager.ToggleMinimap();
                             break;
 
                         case Control.TargetParty1:

--- a/Intersect.Client.Core/Interface/Game/GameInterface.cs
+++ b/Intersect.Client.Core/Interface/Game/GameInterface.cs
@@ -937,4 +937,16 @@ internal sealed class MapUIManager
     {
         _minimapWindow.Hide();
     }
+
+    public void ToggleMinimap()
+    {
+        if (_minimapWindow.IsVisible())
+        {
+            _minimapWindow.Hide();
+        }
+        else
+        {
+            OpenMinimap();
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Toggle the minimap via MapUIManager instead of the world map hotkey
- Remove world map checks from escape menu handling

## Testing
- `dotnet test` *(fails: project file '/workspace/Broken_Reborn/vendor/LiteNetLib/LiteNetLib/LiteNetLib.csproj' was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b52c2352388324bde1ab0061cea383