### PR TITLE
refactor: prune unused world map preferences

### DIFF
--- a/Intersect.Client.Core/Interface/Game/Map/MapFilters.cs
+++ b/Intersect.Client.Core/Interface/Game/Map/MapFilters.cs
@@ -50,22 +50,6 @@ public class MapFilters
     {
         var cb = new Checkbox(_panel) { Text = label, IsChecked = true };
         cb.Dock = Pos.Top;
-
-        // Apply stored preference if available.
-        if (MapPreferences.Instance.ActiveFilters.TryGetValue(key, out var enabled))
-        {
-            cb.IsChecked = enabled;
-        }
-        else
-        {
-            MapPreferences.UpdateFilter(key, cb.IsChecked);
-        }
-
-        cb.CheckChanged += (_, args) =>
-        {
-            MapPreferences.UpdateFilter(key, cb.IsChecked);
-        };
-
         _filters[key] = cb;
     }
 

--- a/Intersect.Client.Core/Interface/Game/Map/MapPreferences.cs
+++ b/Intersect.Client.Core/Interface/Game/Map/MapPreferences.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-using Intersect;
 using Intersect.Client.General;
 using Intersect.Client.Framework.Database;
 using Newtonsoft.Json;
@@ -7,8 +5,8 @@ using Newtonsoft.Json;
 namespace Intersect.Client.Interface.Game.Map;
 
 /// <summary>
-/// Stores user map preferences such as minimap zoom, world map filters, and the last
-/// position/zoom of the world map window. Handles serialization to the client database.
+/// Stores user map preferences such as minimap zoom. Handles serialization to the client
+/// database.
 /// </summary>
 public class MapPreferences
 {
@@ -18,21 +16,6 @@ public class MapPreferences
     /// The last zoom level used by the minimap window.
     /// </summary>
     public int MinimapZoom { get; set; } = Options.Instance?.Minimap.DefaultZoom ?? 0;
-
-    /// <summary>
-    /// Active world map filters keyed by filter identifier.
-    /// </summary>
-    public Dictionary<string, bool> ActiveFilters { get; set; } = new();
-
-    /// <summary>
-    /// The last canvas position of the world map window.
-    /// </summary>
-    public Point WorldMapPosition { get; set; } = Point.Empty;
-
-    /// <summary>
-    /// The last zoom level of the world map window.
-    /// </summary>
-    public float WorldMapZoom { get; set; } = 1f;
 
     /// <summary>
     /// The loaded instance of <see cref="MapPreferences" />.
@@ -80,35 +63,5 @@ public class MapPreferences
         Save();
     }
 
-    /// <summary>
-    /// Update the world map canvas position preference and persist it.
-    /// </summary>
-    /// <param name="position">New position for the world map canvas.</param>
-    public static void UpdateWorldMapPosition(Point position)
-    {
-        Instance.WorldMapPosition = position;
-        Save();
-    }
-
-    /// <summary>
-    /// Update the world map zoom preference and persist it.
-    /// </summary>
-    /// <param name="zoom">New world map zoom level.</param>
-    public static void UpdateWorldMapZoom(float zoom)
-    {
-        Instance.WorldMapZoom = zoom;
-        Save();
-    }
-
-    /// <summary>
-    /// Update a world map filter preference and persist it.
-    /// </summary>
-    /// <param name="key">Filter identifier.</param>
-    /// <param name="enabled">Whether the filter is enabled.</param>
-    public static void UpdateFilter(string key, bool enabled)
-    {
-        Instance.ActiveFilters[key] = enabled;
-        Save();
-    }
 }
 

--- a/Intersect.Client.Core/Interface/Game/Map/MinimapWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Map/MinimapWindow.cs
@@ -628,10 +628,6 @@ namespace Intersect.Client.Interface.Game.Map
 
                     case EntityType.Resource:
                         var job = ((Resource)entity).Descriptor?.Jobs ?? JobType.None;
-                        if (MapPreferences.Instance.ActiveFilters.TryGetValue(job.ToString(), out var enabled) && !enabled)
-                        {
-                            continue;
-                        }
 
                         if (!minimapColorOptions.Resource.TryGetValue(job, out color))
                         {

--- a/Intersect.Client.Core/Interface/Game/Map/WorldMapWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Map/WorldMapWindow.cs
@@ -115,20 +115,18 @@ public sealed class WorldMapWindow : Window
         _filters.AddFilter(JobType.Farming.ToString(), "Hierbas");
         _filters.AddFilter(JobType.Fishing.ToString(), "Pesca");
 
-        // Preferencias guardadas (zoom y posición)
+        // Valores iniciales del canvas
         _baseWidth = _canvas.Width;
         _baseHeight = _canvas.Height;
 
-        _zoom = Math.Clamp(MapPreferences.Instance.WorldMapZoom, MinZoom, MaxZoom);
+        _zoom = 1f;
         _canvas.SetBounds(
-            MapPreferences.Instance.WorldMapPosition.X,
-            MapPreferences.Instance.WorldMapPosition.Y,
+            0,
+            0,
             (int)(_baseWidth * _zoom),
             (int)(_baseHeight * _zoom)
         );
         ClampPosition();
-        MapPreferences.UpdateWorldMapZoom(_zoom);
-        MapPreferences.UpdateWorldMapPosition(new Point(_canvas.X, _canvas.Y));
 
         // Tooltip oculto por defecto
         _tooltip.IsHidden = true;
@@ -278,7 +276,6 @@ public sealed class WorldMapWindow : Window
     {
         _dragging = false;
         ClampPosition();
-        MapPreferences.UpdateWorldMapPosition(new Point(_canvas.X, _canvas.Y));
     }
 
     private int ClampX(int x) => Math.Clamp(x, Width - (int)(_baseWidth * _zoom), 0);
@@ -328,9 +325,6 @@ public sealed class WorldMapWindow : Window
 
         _canvas.SetBounds(newX, newY, newWidth, newHeight);
         ClampPosition();
-
-        MapPreferences.UpdateWorldMapZoom(_zoom);
-        MapPreferences.UpdateWorldMapPosition(new Point(_canvas.X, _canvas.Y));
     }
 
     private void CenterOn(Point pos)
@@ -338,7 +332,6 @@ public sealed class WorldMapWindow : Window
         var targetX = ClampX(Width / 2 - pos.X);
         var targetY = ClampY(Height / 2 - pos.Y);
         _canvas.SetPosition(targetX, targetY);
-        MapPreferences.UpdateWorldMapPosition(new Point(_canvas.X, _canvas.Y));
     }
 
     private void MinimapButton_Clicked(Base sender, MouseButtonState args)


### PR DESCRIPTION
## Summary
- drop deprecated world map preference fields and update methods
- stop persisting world map filter state and resource filtering
- simplify world map window initialization to default bounds

## Testing
- `dotnet build Intersect.Client.Core/Intersect.Client.Core.csproj` *(fails: NetPeer not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b627ea66c88324bf1a5ac065f3e9e2