### PR TITLE
Clamp minimap zoom preference

### DIFF
--- a/Intersect.Client.Core/Interface/Game/Map/MinimapWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Map/MinimapWindow.cs
@@ -140,7 +140,19 @@ namespace Intersect.Client.Interface.Game.Map
         }
         public void Show()
         {
-            SetZoom(MapPreferences.Instance.MinimapZoom, false);
+            var minimapOptions = Options.Instance.Minimap;
+            var minZoom = minimapOptions.MinimumZoom;
+            var maxZoom = minimapOptions.MaximumZoom;
+            var prefZoom = MapPreferences.Instance.MinimapZoom;
+
+            if (prefZoom <= 0)
+            {
+                prefZoom = minimapOptions.DefaultZoom;
+            }
+
+            var clampedPref = Math.Clamp(prefZoom, minZoom, maxZoom);
+
+            SetZoom(clampedPref, persist: true);
             IsHidden = false;
         }
         public bool IsVisible()


### PR DESCRIPTION
## Summary
- enforce min/max bounds and default fallback for minimap zoom preference
- persist clamped zoom when opening the minimap

## Testing
- `dotnet test` *(fails: project file vendor/LiteNetLib/LiteNetLib.csproj not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b62d9f824c8324a97415c6e8621838