### PR TITLE
refactor: expand minimap zoom options

### DIFF
--- a/Framework/Intersect.Framework.Core/Config/MinimapOptions.cs
+++ b/Framework/Intersect.Framework.Core/Config/MinimapOptions.cs
@@ -25,6 +25,8 @@ public partial class MinimapOptions
     private const float BaseDpi = 96f;
     private const int MinTileLength = 4;
     private const int MaxTileLength = 32;
+    private const int MinZoomLimit = 1;
+    private const int MaxZoomLimit = 1000;
 
     /// <summary>
     /// Returns the minimap tile size scaled for the provided DPI and
@@ -43,24 +45,24 @@ public partial class MinimapOptions
     }
 
     /// <summary>
-    /// Configures the minimum zoom level (0 - 100)
+    /// Configures the minimum zoom level.
     /// </summary>
-    public byte MinimumZoom { get; set; } = 5;
+    public int MinimumZoom { get; set; } = 20;
 
     /// <summary>
-    /// Configures the maximum zoom level (0 - 100)
+    /// Configures the maximum zoom level.
     /// </summary>
-    public byte MaximumZoom { get; set; } = 100;
+    public int MaximumZoom { get; set; } = 220;
 
     /// <summary>
-    /// Configures the default zoom level (0 - 100)
+    /// Configures the default zoom level.
     /// </summary>
-    public byte DefaultZoom { get; set; } = 25;
+    public int DefaultZoom { get; set; } = 100;
 
     /// <summary>
     /// Configures the amount to zoom by each step.
     /// </summary>
-    public byte ZoomStep { get; set; } = 5;
+    public int ZoomStep { get; set; } = 10;
 
     /// <summary>
     /// Configures the images used within the minimap. If any are left blank the system will default to its color.
@@ -122,15 +124,8 @@ public partial class MinimapOptions
     /// </summary>
     public void Validate()
     {
-        if (MinimumZoom is < 0 or > 100)
-        {
-            MinimumZoom = 0;
-        }
-
-        if (MaximumZoom is < 0 or > 100)
-        {
-            MaximumZoom = 100;
-        }
+        MinimumZoom = Math.Clamp(MinimumZoom, MinZoomLimit, MaxZoomLimit);
+        MaximumZoom = Math.Clamp(MaximumZoom, MinZoomLimit, MaxZoomLimit);
 
         if (MinimumZoom > MaximumZoom)
         {

--- a/Intersect.Tests/Config/MinimapOptionsTests.cs
+++ b/Intersect.Tests/Config/MinimapOptionsTests.cs
@@ -22,9 +22,9 @@ public class MinimapOptionsTests
         }));
     }
 
-    [TestCase((byte)10, (byte)50, (byte)5, (byte)10)]
-    [TestCase((byte)10, (byte)50, (byte)55, (byte)50)]
-    public void Validate_ClampsDefaultZoom(byte minimum, byte maximum, byte defaultZoom, byte expected)
+    [TestCase(20, 220, 10, 20)]
+    [TestCase(20, 220, 250, 220)]
+    public void Validate_ClampsDefaultZoom(int minimum, int maximum, int defaultZoom, int expected)
     {
         var options = new MinimapOptions
         {


### PR DESCRIPTION
## Summary
- expand minimap zoom settings to integer-based values with wider defaults
- validate zoom bounds and ensure default falls within range
- adjust minimap option unit tests for new zoom limits

## Testing
- `dotnet test Intersect.Tests/Intersect.Tests.csproj` *(fails: type or namespace 'Items' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b62e7ca4a08324aec0680a654ad421