### PR TITLE
Add POI rendering and scaling options to minimap

### DIFF
--- a/Framework/Intersect.Framework.Core/Config/MinimapOptions.cs
+++ b/Framework/Intersect.Framework.Core/Config/MinimapOptions.cs
@@ -65,6 +65,44 @@ public partial class MinimapOptions
     public int ZoomStep { get; set; } = 10;
 
     /// <summary>
+    /// Scales entity icons when drawn on the minimap.
+    /// </summary>
+    public float IconScale { get; set; } = 1.25f;
+
+    /// <summary>
+    /// Scales point of interest icons when drawn on the minimap.
+    /// </summary>
+    public float PoiIconScale { get; set; } = 1.5f;
+
+    /// <summary>
+    /// Maps point of interest types to their icon texture keys.
+    /// </summary>
+    public Dictionary<string, string> PoiIcons { get; set; } = new()
+    {
+        ["Bank"] = "poi_bank",
+        ["Blacksmith"] = "poi_blacksmith",
+        ["Jeweler"] = "poi_jeweler",
+        ["Farming"] = "poi_farming",
+        ["Mining"] = "poi_mining",
+        ["Lumberjack"] = "poi_lumberjack",
+        ["Fishing"] = "poi_fishing",
+        ["Hunter"] = "poi_hunter",
+        ["Cooking"] = "poi_cooking",
+        ["Smithing"] = "poi_smithing",
+        ["Alchemy"] = "poi_alchemy",
+        ["Crafting"] = "poi_crafting",
+        ["Jewerly"] = "poi_jewerly",
+        ["Tanner"] = "poi_tanner",
+        ["Tailoring"] = "poi_tailoring",
+        ["Portal"] = "poi_portal",
+        ["Tower"] = "poi_tower",
+        ["Inn"] = "poi_inn",
+        ["Market"] = "poi_market",
+        ["Shop"] = "poi_shop",
+        ["Default"] = "poi_default"
+    };
+
+    /// <summary>
     /// Configures the images used within the minimap. If any are left blank the system will default to its color.
     /// </summary>
     public Images MinimapImages { get; set; } = new();

--- a/Intersect.Client.Core/Interface/Game/Map/MapPoi.cs
+++ b/Intersect.Client.Core/Interface/Game/Map/MapPoi.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace Intersect.Client.Interface.Game.Map
+{
+    public class MapPoi
+    {
+        public Guid MapId { get; set; }
+        public int X { get; set; }
+        public int Y { get; set; }
+        public string PoiType { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
+    }
+}


### PR DESCRIPTION
## Summary
- add icon scale and POI icon settings to minimap options
- render point-of-interest icons on the minimap and scale entity icons
- introduce `MapPoi` model and API to set map POIs

## Testing
- `dotnet test` *(fails: project files missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b65fd53dfc8324805e4c37cea8acfa