### PR TITLE
Clamp minimap icon scale and document options

### DIFF
--- a/Documentation/MinimapOptions.md
+++ b/Documentation/MinimapOptions.md
@@ -1,0 +1,10 @@
+# Minimap Options
+
+## IconScale
+
+Adjusts the size of entity icons displayed on the minimap. Values below `0.8` are clamped to `0.8` to ensure icons remain visible.
+
+## PoiIconScale
+
+Controls the size of point of interest icons on the minimap. This value is applied directly without clamping.
+

--- a/Framework/Intersect.Framework.Core/Config/MinimapOptions.cs
+++ b/Framework/Intersect.Framework.Core/Config/MinimapOptions.cs
@@ -65,7 +65,8 @@ public partial class MinimapOptions
     public int ZoomStep { get; set; } = 10;
 
     /// <summary>
-    /// Scales entity icons when drawn on the minimap.
+    /// Scales entity icons when drawn on the minimap. Values below 0.8 are
+    /// clamped to 0.8 to keep icons visible.
     /// </summary>
     public float IconScale { get; set; } = 1.25f;
 

--- a/Intersect.Client.Core/Interface/Game/Map/MinimapWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Map/MinimapWindow.cs
@@ -73,6 +73,11 @@ namespace Intersect.Client.Interface.Game.Map
             }
         }
 
+        internal static float ClampIconScale(float scale)
+        {
+            return Math.Max(0.8f, scale);
+        }
+
         // Throttle dynamic overlay updates to ~4Hz
         private DateTime _lastOverlayUpdate = DateTime.MinValue;
         private static readonly TimeSpan OverlayInterval = TimeSpan.FromMilliseconds(250);
@@ -453,7 +458,7 @@ namespace Intersect.Client.Interface.Game.Map
                 return;
             }
 
-            var iconScale = Options.Instance.Minimap.IconScale;
+            var scale = ClampIconScale(Options.Instance.Minimap.IconScale);
 
             foreach (var entity in cachedEntityInfo)
             {
@@ -470,8 +475,8 @@ namespace Intersect.Client.Interface.Game.Map
                     }
                 }
 
-                var drawWidth = (int)(_minimapTileSize.X * iconScale);
-                var drawHeight = (int)(_minimapTileSize.Y * iconScale);
+                var drawWidth = (int)(_minimapTileSize.X * scale);
+                var drawHeight = (int)(_minimapTileSize.Y * scale);
                 var drawX = entity.Position.X * _minimapTileSize.X + (_minimapTileSize.X - drawWidth) / 2;
                 var drawY = entity.Position.Y * _minimapTileSize.Y + (_minimapTileSize.Y - drawHeight) / 2;
 

--- a/Intersect.Tests.Client/MinimapWindowTests.cs
+++ b/Intersect.Tests.Client/MinimapWindowTests.cs
@@ -1,0 +1,33 @@
+using Intersect;
+using Intersect.Client.Interface.Game.Map;
+using NUnit.Framework;
+
+namespace Intersect.Tests.Client;
+
+public class MinimapWindowTests
+{
+    [TestCase(0.5f, 12)]
+    [TestCase(1f, 16)]
+    [TestCase(2f, 32)]
+    public void ClampIconScale_ScalesEntityIcons(float configScale, int expectedSize)
+    {
+        var scale = MinimapWindow.ClampIconScale(configScale);
+        var tileSize = new Point(16, 16);
+        var width = (int)(tileSize.X * scale);
+        var height = (int)(tileSize.Y * scale);
+        Assert.That(width, Is.EqualTo(expectedSize));
+        Assert.That(height, Is.EqualTo(expectedSize));
+    }
+
+    [TestCase(0.5f, 8)]
+    [TestCase(1.5f, 24)]
+    public void PoiIconScale_ScalesIcons(float poiScale, int expectedSize)
+    {
+        var tileSize = new Point(16, 16);
+        var width = (int)(tileSize.X * poiScale);
+        var height = (int)(tileSize.Y * poiScale);
+        Assert.That(width, Is.EqualTo(expectedSize));
+        Assert.That(height, Is.EqualTo(expectedSize));
+    }
+}
+


### PR DESCRIPTION
## Summary
- clamp minimap entity icon scale to minimum of 0.8
- document icon scaling options
- add unit tests for icon and POI scaling

## Testing
- `dotnet test Intersect.Tests.Client/Intersect.Tests.Client.csproj` *(fails: type or namespace name 'DeliveryMethod' could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_68b662306b008324bdeebc5c1e00eaaa