### PR TITLE
fix: handle new server variables

### DIFF
--- a/Intersect.Server.Core/Database/DbInterface.cs
+++ b/Intersect.Server.Core/Database/DbInterface.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using System.Data.Common;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Reflection;
 using System.Security.Cryptography;
 using System.Text;
@@ -2022,7 +2023,15 @@ public static partial class DbInterface
                     var serverVar = variable.Value;
                     if (serverVar != null)
                     {
-                        context.ServerVariables.Update(variable.Value);
+                        var exists = context.ServerVariables.Any(v => v.Id == serverVar.Id);
+                        if (exists)
+                        {
+                            context.ServerVariables.Update(serverVar);
+                        }
+                        else
+                        {
+                            context.ServerVariables.Add(serverVar);
+                        }
                     }
                     UpdatedServerVariables.TryRemove(variable.Key, out ServerVariableDescriptor obj);
                 }


### PR DESCRIPTION
## Summary
- check whether server variables already exist before updating
- add missing LINQ import

## Testing
- `dotnet build Intersect.Server.Core/Intersect.Server.Core.csproj --no-restore`
- `dotnet test Intersect.Tests.Server/Intersect.Tests.Server.csproj --no-restore` *(fails: Could not find a part of the path 'Intersect.Network/bin/Release/keys/network.handshake.bkey.pub')*

------
https://chatgpt.com/codex/tasks/task_e_68b65eee6ad48324b1ccd709107d1f16