### PR TITLE
Smooth minimap view transitions

### DIFF
--- a/Intersect.Client.Core/Interface/Game/Map/MinimapWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Map/MinimapWindow.cs
@@ -34,6 +34,8 @@ namespace Intersect.Client.Interface.Game.Map
         private bool _redrawMaps;
         private bool _redrawEntities;
         private int _zoomLevel;
+        private int _viewX;
+        private int _viewY;
         private Dictionary<MapPosition, MapInstance?> _mapGrid = DictionaryPool<MapPosition, MapInstance?>.Rent();
 
         // Cached entity information per map id
@@ -473,9 +475,13 @@ namespace Intersect.Client.Interface.Game.Map
             var centerY = (_renderTexture.Height / 3) + (player.Y * _minimapTileSize.Y);
             var displayW = (int)(_renderTexture.Width * (_zoomLevel / 100f));
             var displayH = (int)(_renderTexture.Height * (_zoomLevel / 100f));
-            var x = Math.Clamp(centerX - (displayW / 2), 0, _renderTexture.Width - displayW);
-            var y = Math.Clamp(centerY - (displayH / 2), 0, _renderTexture.Height - displayH);
-            _minimap.SetTextureRect(x, y, displayW, displayH);
+            var targetX = Math.Clamp(centerX - (displayW / 2), 0, _renderTexture.Width - displayW);
+            var targetY = Math.Clamp(centerY - (displayH / 2), 0, _renderTexture.Height - displayH);
+            _viewX = (int)(_viewX + (targetX - _viewX) * 0.15f);
+            _viewY = (int)(_viewY + (targetY - _viewY) * 0.15f);
+            _viewX = Math.Clamp(_viewX, 0, _renderTexture.Width - displayW);
+            _viewY = Math.Clamp(_viewY, 0, _renderTexture.Height - displayH);
+            _minimap.SetTextureRect(_viewX, _viewY, displayW, displayH);
         }
         private void DrawMinimap()
         {


### PR DESCRIPTION
## Summary
- add persistent view origin for minimap
- ease minimap panning toward target viewport

## Testing
- `dotnet build Intersect.Client.Core/Intersect.Client.Core.csproj` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8f662c400832486dc6b567192bd80