### PR TITLE
Add zone and subzone models and map references

### DIFF
--- a/Framework/Intersect.Framework.Core/GameObjects/Maps/MapDescriptor.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Maps/MapDescriptor.cs
@@ -316,6 +316,14 @@ public partial class MapDescriptor : DatabaseObject<MapDescriptor>
 
     public MapZone ZoneType { get; set; } = MapZone.Normal;
 
+    [Column("ZoneId")]
+    [JsonProperty]
+    public Guid? ZoneId { get; set; }
+
+    [Column("SubzoneId")]
+    [JsonProperty]
+    public Guid? SubzoneId { get; set; }
+
     public int PlayerLightSize { get; set; } = 300;
 
     public byte PlayerLightIntensity { get; set; } = 255;

--- a/Framework/Intersect.Framework.Core/GameObjects/Zones/Subzone.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Zones/Subzone.cs
@@ -1,0 +1,30 @@
+using System;
+using System.ComponentModel.DataAnnotations.Schema;
+using Intersect.GameObjects;
+using Intersect.Models;
+using Newtonsoft.Json;
+
+namespace Intersect.Framework.Core.GameObjects.Zones;
+
+public partial class Subzone : DatabaseObject<Subzone>
+{
+    public Subzone()
+    {
+    }
+
+    [JsonConstructor]
+    public Subzone(Guid id) : base(id)
+    {
+    }
+
+    public string Name { get; set; } = string.Empty;
+
+    [Column("ZoneId")]
+    [JsonProperty]
+    public Guid ZoneId { get; set; }
+
+    public ZoneFlags Flags { get; set; } = ZoneFlags.None;
+
+    public ZoneModifiers Modifiers { get; set; } = ZoneModifiers.None;
+}
+

--- a/Framework/Intersect.Framework.Core/GameObjects/Zones/Zone.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Zones/Zone.cs
@@ -1,0 +1,25 @@
+using System;
+using Intersect.GameObjects;
+using Intersect.Models;
+using Newtonsoft.Json;
+
+namespace Intersect.Framework.Core.GameObjects.Zones;
+
+public partial class Zone : DatabaseObject<Zone>
+{
+    public Zone()
+    {
+    }
+
+    [JsonConstructor]
+    public Zone(Guid id) : base(id)
+    {
+    }
+
+    public string Name { get; set; } = string.Empty;
+
+    public ZoneFlags Flags { get; set; } = ZoneFlags.None;
+
+    public ZoneModifiers Modifiers { get; set; } = ZoneModifiers.None;
+}
+

--- a/Framework/Intersect.Framework.Core/GameObjects/Zones/ZoneFlags.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Zones/ZoneFlags.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace Intersect.Framework.Core.GameObjects.Zones;
+
+[Flags]
+public enum ZoneFlags
+{
+    None = 0,
+}
+

--- a/Framework/Intersect.Framework.Core/GameObjects/Zones/ZoneModifiers.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Zones/ZoneModifiers.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace Intersect.Framework.Core.GameObjects.Zones;
+
+[Flags]
+public enum ZoneModifiers
+{
+    None = 0,
+}
+

--- a/Intersect.Server.Core/Database/GameData/GameContext.cs
+++ b/Intersect.Server.Core/Database/GameData/GameContext.cs
@@ -10,6 +10,7 @@ using Intersect.Framework.Core.GameObjects.NPCs;
 using Intersect.Framework.Core.GameObjects.PlayerClass;
 using Intersect.Framework.Core.GameObjects.Resources;
 using Intersect.Framework.Core.GameObjects.Variables;
+using Intersect.Framework.Core.GameObjects.Zones;
 using Intersect.GameObjects;
 using Intersect.Server.Database.GameData.Migrations;
 using Intersect.Server.Maps;
@@ -51,6 +52,11 @@ public abstract partial class GameContext : IntersectDbContext<GameContext>, IGa
     public DbSet<MapController> Maps { get; set; }
 
     public DbSet<MapList> MapFolders { get; set; }
+
+    //Zones
+    public DbSet<Zone> Zones { get; set; }
+
+    public DbSet<Subzone> Subzones { get; set; }
 
     //NPCs
     public DbSet<NPCDescriptor> Npcs { get; set; }

--- a/Intersect.Server.Core/Database/GameData/IGameContext.cs
+++ b/Intersect.Server.Core/Database/GameData/IGameContext.cs
@@ -9,6 +9,7 @@ using Intersect.Framework.Core.GameObjects.NPCs;
 using Intersect.Framework.Core.GameObjects.PlayerClass;
 using Intersect.Framework.Core.GameObjects.Resources;
 using Intersect.Framework.Core.GameObjects.Variables;
+using Intersect.Framework.Core.GameObjects.Zones;
 using Intersect.GameObjects;
 using Intersect.Server.Maps;
 using Microsoft.EntityFrameworkCore;
@@ -36,6 +37,10 @@ public interface IGameContext : IDbContext
     DbSet<MapController> Maps { get; set; }
 
     DbSet<MapList> MapFolders { get; set; }
+
+    DbSet<Zone> Zones { get; set; }
+
+    DbSet<Subzone> Subzones { get; set; }
 
     DbSet<NPCDescriptor> Npcs { get; set; }
 


### PR DESCRIPTION
## Summary
- define zone and subzone models with flags and modifiers
- link maps to zones via nullable identifiers
- expose zones and subzones via database context sets

## Testing
- `dotnet build` *(fails: project files not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9132977448324bf37c2cae4abfc5f