### PR TITLE
Add zone editor with modifiers and flags

### DIFF
--- a/Framework/Intersect.Framework.Core/Descriptors/GameObjectType.cs
+++ b/Framework/Intersect.Framework.Core/Descriptors/GameObjectType.cs
@@ -9,6 +9,7 @@ using Intersect.Framework.Core.GameObjects.Maps;
 using Intersect.Framework.Core.GameObjects.NPCs;
 using Intersect.Framework.Core.GameObjects.PlayerClass;
 using Intersect.Framework.Core.GameObjects.Resources;
+using Intersect.Framework.Core.GameObjects.Zones;
 using Intersect.Framework.Core.GameObjects.Variables;
 using Intersect.GameObjects;
 
@@ -75,4 +76,10 @@ public enum GameObjectType
 
     [GameObjectInfo(typeof(SetDescriptor), "sets")]
     Sets,
+
+    [GameObjectInfo(typeof(Zone), "zones")]
+    Zone,
+
+    [GameObjectInfo(typeof(Subzone), "subzones")]
+    Subzone,
 }

--- a/Framework/Intersect.Framework.Core/GameObjects/Zones/Subzone.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Zones/Subzone.cs
@@ -23,8 +23,10 @@ public partial class Subzone : DatabaseObject<Subzone>
     [JsonProperty]
     public Guid ZoneId { get; set; }
 
-    public ZoneFlags Flags { get; set; } = ZoneFlags.None;
+    // When null, the subzone inherits its parent's flags.
+    public ZoneFlags? Flags { get; set; }
 
-    public ZoneModifiers Modifiers { get; set; } = ZoneModifiers.None;
+    // When null, the subzone inherits its parent's modifiers.
+    public ZoneModifiers? Modifiers { get; set; }
 }
 

--- a/Framework/Intersect.Framework.Core/GameObjects/Zones/Zone.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Zones/Zone.cs
@@ -20,6 +20,6 @@ public partial class Zone : DatabaseObject<Zone>
 
     public ZoneFlags Flags { get; set; } = ZoneFlags.None;
 
-    public ZoneModifiers Modifiers { get; set; } = ZoneModifiers.None;
+    public ZoneModifiers Modifiers { get; set; } = new ZoneModifiers();
 }
 

--- a/Framework/Intersect.Framework.Core/GameObjects/Zones/ZoneFlags.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Zones/ZoneFlags.cs
@@ -6,5 +6,14 @@ namespace Intersect.Framework.Core.GameObjects.Zones;
 public enum ZoneFlags
 {
     None = 0,
+
+    // Players cannot engage in PVP combat inside this zone.
+    NoPvp = 1 << 0,
+
+    // Trading between players is disabled.
+    NoTrading = 1 << 1,
+
+    // Players may safely log out without delay.
+    SafeLogout = 1 << 2,
 }
 

--- a/Framework/Intersect.Framework.Core/GameObjects/Zones/ZoneModifiers.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Zones/ZoneModifiers.cs
@@ -2,9 +2,19 @@ using System;
 
 namespace Intersect.Framework.Core.GameObjects.Zones;
 
-[Flags]
-public enum ZoneModifiers
+/// <summary>
+///     Numerical modifiers applied within a zone or subzone.
+///     Values are stored as percentages where 100 represents the default rate.
+/// </summary>
+public class ZoneModifiers
 {
-    None = 0,
-}
+    /// <summary>
+    ///     Experience gain rate percentage.
+    /// </summary>
+    public int ExperienceRate { get; set; } = 100;
 
+    /// <summary>
+    ///     Gold drop rate percentage.
+    /// </summary>
+    public int GoldRate { get; set; } = 100;
+}

--- a/Intersect.Editor/Forms/Editors/frmZoneEditor.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/frmZoneEditor.Designer.cs
@@ -1,0 +1,255 @@
+using DarkUI.Controls;
+
+namespace Intersect.Editor.Forms.Editors
+{
+    partial class FrmZoneEditor
+    {
+        private System.ComponentModel.IContainer components = null;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        private void InitializeComponent()
+        {
+            components = new System.ComponentModel.Container();
+            var resources = new System.ComponentModel.ComponentResourceManager(typeof(FrmZoneEditor));
+            pnlContainer = new System.Windows.Forms.Panel();
+            treeZones = new System.Windows.Forms.TreeView();
+            chkOverrideFlags = new System.Windows.Forms.CheckBox();
+            grpFlags = new DarkGroupBox();
+            chkOverrideModifiers = new System.Windows.Forms.CheckBox();
+            grpModifiers = new DarkGroupBox();
+            btnSave = new DarkButton();
+            btnCancel = new DarkButton();
+            toolStrip = new DarkToolStrip();
+            toolStripItemNew = new System.Windows.Forms.ToolStripButton();
+            toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
+            toolStripItemDelete = new System.Windows.Forms.ToolStripButton();
+            toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
+            btnAlphabetical = new System.Windows.Forms.ToolStripButton();
+            toolStripSeparator4 = new System.Windows.Forms.ToolStripSeparator();
+            toolStripItemCopy = new System.Windows.Forms.ToolStripButton();
+            toolStripItemPaste = new System.Windows.Forms.ToolStripButton();
+            toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
+            toolStripItemUndo = new System.Windows.Forms.ToolStripButton();
+            pnlContainer.SuspendLayout();
+            toolStrip.SuspendLayout();
+            SuspendLayout();
+            //
+            // pnlContainer
+            //
+            pnlContainer.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
+            pnlContainer.Controls.Add(btnCancel);
+            pnlContainer.Controls.Add(btnSave);
+            pnlContainer.Controls.Add(grpModifiers);
+            pnlContainer.Controls.Add(chkOverrideModifiers);
+            pnlContainer.Controls.Add(grpFlags);
+            pnlContainer.Controls.Add(chkOverrideFlags);
+            pnlContainer.Controls.Add(treeZones);
+            pnlContainer.Location = new System.Drawing.Point(0, 29);
+            pnlContainer.Name = "pnlContainer";
+            pnlContainer.Size = new System.Drawing.Size(484, 392);
+            pnlContainer.TabIndex = 1;
+            //
+            // treeZones
+            //
+            treeZones.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            treeZones.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            treeZones.Dock = System.Windows.Forms.DockStyle.Left;
+            treeZones.ForeColor = System.Drawing.Color.Gainsboro;
+            treeZones.Location = new System.Drawing.Point(0, 0);
+            treeZones.Name = "treeZones";
+            treeZones.Size = new System.Drawing.Size(200, 392);
+            treeZones.TabIndex = 0;
+            //
+            // chkOverrideFlags
+            //
+            chkOverrideFlags.AutoSize = true;
+            chkOverrideFlags.Location = new System.Drawing.Point(210, 10);
+            chkOverrideFlags.Name = "chkOverrideFlags";
+            chkOverrideFlags.Size = new System.Drawing.Size(103, 19);
+            chkOverrideFlags.TabIndex = 1;
+            chkOverrideFlags.Text = "Override Flags";
+            chkOverrideFlags.UseVisualStyleBackColor = true;
+            //
+            // grpFlags
+            //
+            grpFlags.Location = new System.Drawing.Point(210, 35);
+            grpFlags.Name = "grpFlags";
+            grpFlags.Size = new System.Drawing.Size(260, 150);
+            grpFlags.TabIndex = 2;
+            grpFlags.TabStop = false;
+            grpFlags.Text = "Flags";
+            //
+            // chkOverrideModifiers
+            //
+            chkOverrideModifiers.AutoSize = true;
+            chkOverrideModifiers.Location = new System.Drawing.Point(210, 190);
+            chkOverrideModifiers.Name = "chkOverrideModifiers";
+            chkOverrideModifiers.Size = new System.Drawing.Size(127, 19);
+            chkOverrideModifiers.TabIndex = 3;
+            chkOverrideModifiers.Text = "Override Modifiers";
+            chkOverrideModifiers.UseVisualStyleBackColor = true;
+            //
+            // grpModifiers
+            //
+            grpModifiers.Location = new System.Drawing.Point(210, 215);
+            grpModifiers.Name = "grpModifiers";
+            grpModifiers.Size = new System.Drawing.Size(260, 120);
+            grpModifiers.TabIndex = 4;
+            grpModifiers.TabStop = false;
+            grpModifiers.Text = "Modifiers";
+            //
+            // btnSave
+            //
+            btnSave.Location = new System.Drawing.Point(210, 350);
+            btnSave.Name = "btnSave";
+            btnSave.Size = new System.Drawing.Size(80, 23);
+            btnSave.TabIndex = 5;
+            btnSave.Text = "Save";
+            //
+            // btnCancel
+            //
+            btnCancel.Location = new System.Drawing.Point(300, 350);
+            btnCancel.Name = "btnCancel";
+            btnCancel.Size = new System.Drawing.Size(80, 23);
+            btnCancel.TabIndex = 6;
+            btnCancel.Text = "Cancel";
+            //
+            // toolStrip
+            //
+            toolStrip.AutoSize = false;
+            toolStrip.BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
+            toolStrip.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { toolStripItemNew, toolStripSeparator1, toolStripItemDelete, toolStripSeparator2, btnAlphabetical, toolStripSeparator4, toolStripItemCopy, toolStripItemPaste, toolStripSeparator3, toolStripItemUndo });
+            toolStrip.Location = new System.Drawing.Point(0, 0);
+            toolStrip.Name = "toolStrip";
+            toolStrip.Padding = new System.Windows.Forms.Padding(6, 0, 1, 0);
+            toolStrip.Size = new System.Drawing.Size(484, 29);
+            toolStrip.TabIndex = 0;
+            toolStrip.Text = "toolStrip1";
+            //
+            // toolStripItemNew
+            //
+            toolStripItemNew.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            toolStripItemNew.Enabled = false;
+            toolStripItemNew.Image = (System.Drawing.Image)resources.GetObject("toolStripItemNew.Image");
+            toolStripItemNew.ImageTransparentColor = System.Drawing.Color.Magenta;
+            toolStripItemNew.Name = "toolStripItemNew";
+            toolStripItemNew.Size = new System.Drawing.Size(23, 26);
+            toolStripItemNew.Text = "New";
+            //
+            // toolStripSeparator1
+            //
+            toolStripSeparator1.Name = "toolStripSeparator1";
+            toolStripSeparator1.Size = new System.Drawing.Size(6, 29);
+            //
+            // toolStripItemDelete
+            //
+            toolStripItemDelete.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            toolStripItemDelete.Enabled = false;
+            toolStripItemDelete.Image = (System.Drawing.Image)resources.GetObject("toolStripItemDelete.Image");
+            toolStripItemDelete.ImageTransparentColor = System.Drawing.Color.Magenta;
+            toolStripItemDelete.Name = "toolStripItemDelete";
+            toolStripItemDelete.Size = new System.Drawing.Size(23, 26);
+            toolStripItemDelete.Text = "Delete";
+            //
+            // toolStripSeparator2
+            //
+            toolStripSeparator2.Name = "toolStripSeparator2";
+            toolStripSeparator2.Size = new System.Drawing.Size(6, 29);
+            //
+            // btnAlphabetical
+            //
+            btnAlphabetical.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            btnAlphabetical.Enabled = false;
+            btnAlphabetical.Image = (System.Drawing.Image)resources.GetObject("btnAlphabetical.Image");
+            btnAlphabetical.ImageTransparentColor = System.Drawing.Color.Magenta;
+            btnAlphabetical.Name = "btnAlphabetical";
+            btnAlphabetical.Size = new System.Drawing.Size(23, 26);
+            btnAlphabetical.Text = "Alphabetical";
+            //
+            // toolStripSeparator4
+            //
+            toolStripSeparator4.Name = "toolStripSeparator4";
+            toolStripSeparator4.Size = new System.Drawing.Size(6, 29);
+            //
+            // toolStripItemCopy
+            //
+            toolStripItemCopy.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            toolStripItemCopy.Enabled = false;
+            toolStripItemCopy.Image = (System.Drawing.Image)resources.GetObject("toolStripItemCopy.Image");
+            toolStripItemCopy.ImageTransparentColor = System.Drawing.Color.Magenta;
+            toolStripItemCopy.Name = "toolStripItemCopy";
+            toolStripItemCopy.Size = new System.Drawing.Size(23, 26);
+            toolStripItemCopy.Text = "Copy";
+            //
+            // toolStripItemPaste
+            //
+            toolStripItemPaste.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            toolStripItemPaste.Enabled = false;
+            toolStripItemPaste.Image = (System.Drawing.Image)resources.GetObject("toolStripItemPaste.Image");
+            toolStripItemPaste.ImageTransparentColor = System.Drawing.Color.Magenta;
+            toolStripItemPaste.Name = "toolStripItemPaste";
+            toolStripItemPaste.Size = new System.Drawing.Size(23, 26);
+            toolStripItemPaste.Text = "Paste";
+            //
+            // toolStripSeparator3
+            //
+            toolStripSeparator3.Name = "toolStripSeparator3";
+            toolStripSeparator3.Size = new System.Drawing.Size(6, 29);
+            //
+            // toolStripItemUndo
+            //
+            toolStripItemUndo.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            toolStripItemUndo.Enabled = false;
+            toolStripItemUndo.Image = (System.Drawing.Image)resources.GetObject("toolStripItemUndo.Image");
+            toolStripItemUndo.ImageTransparentColor = System.Drawing.Color.Magenta;
+            toolStripItemUndo.Name = "toolStripItemUndo";
+            toolStripItemUndo.Size = new System.Drawing.Size(23, 26);
+            toolStripItemUndo.Text = "Undo";
+            //
+            // FrmZoneEditor
+            //
+            AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+            AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            ClientSize = new System.Drawing.Size(484, 421);
+            Controls.Add(pnlContainer);
+            Controls.Add(toolStrip);
+            Name = "FrmZoneEditor";
+            Text = "Zone Editor";
+            pnlContainer.ResumeLayout(false);
+            pnlContainer.PerformLayout();
+            toolStrip.ResumeLayout(false);
+            toolStrip.PerformLayout();
+            ResumeLayout(false);
+            PerformLayout();
+        }
+
+        private System.Windows.Forms.Panel pnlContainer;
+        private System.Windows.Forms.TreeView treeZones;
+        private System.Windows.Forms.CheckBox chkOverrideFlags;
+        private DarkGroupBox grpFlags;
+        private System.Windows.Forms.CheckBox chkOverrideModifiers;
+        private DarkGroupBox grpModifiers;
+        private DarkButton btnSave;
+        private DarkButton btnCancel;
+        private DarkToolStrip toolStrip;
+        private System.Windows.Forms.ToolStripButton toolStripItemNew;
+        private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
+        private System.Windows.Forms.ToolStripButton toolStripItemDelete;
+        private System.Windows.Forms.ToolStripSeparator toolStripSeparator2;
+        private System.Windows.Forms.ToolStripButton btnAlphabetical;
+        private System.Windows.Forms.ToolStripSeparator toolStripSeparator4;
+        private System.Windows.Forms.ToolStripButton toolStripItemCopy;
+        private System.Windows.Forms.ToolStripButton toolStripItemPaste;
+        private System.Windows.Forms.ToolStripSeparator toolStripSeparator3;
+        private System.Windows.Forms.ToolStripButton toolStripItemUndo;
+    }
+}

--- a/Intersect.Editor/Forms/Editors/frmZoneEditor.cs
+++ b/Intersect.Editor/Forms/Editors/frmZoneEditor.cs
@@ -1,0 +1,226 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows.Forms;
+using Intersect.Framework.Core.GameObjects.Zones;
+using Intersect.Editor.Networking;
+using Intersect.Enums;
+
+namespace Intersect.Editor.Forms.Editors;
+
+public partial class FrmZoneEditor : EditorForm
+{
+    private readonly Dictionary<ZoneFlags, CheckBox> _flagBoxes = new();
+    private readonly Dictionary<string, NumericUpDown> _modifierControls = new();
+
+    private Zone? _currentZone;
+    private Subzone? _currentSubzone;
+    private bool _loading;
+
+    public FrmZoneEditor()
+    {
+        ApplyHooks();
+        InitializeComponent();
+        Icon = Program.Icon;
+
+        _btnSave = btnSave;
+        _btnCancel = btnCancel;
+
+        treeZones.AfterSelect += TreeAfterSelect;
+        chkOverrideFlags.CheckedChanged += OverrideFlagsChanged;
+        chkOverrideModifiers.CheckedChanged += OverrideModifiersChanged;
+        btnSave.Click += SaveClick;
+        btnCancel.Click += CancelClick;
+
+        SetupFlagControls();
+        SetupModifierControls();
+
+        PopulateTree();
+        UpdateEditorButtons(false);
+    }
+
+    private void SetupFlagControls()
+    {
+        var y = 20;
+        foreach (ZoneFlags flag in Enum.GetValues(typeof(ZoneFlags)))
+        {
+            if (flag == ZoneFlags.None)
+            {
+                continue;
+            }
+
+            var cb = new CheckBox
+            {
+                Text = flag.ToString(),
+                Left = 5,
+                Top = y,
+                AutoSize = true
+            };
+            grpFlags.Controls.Add(cb);
+            _flagBoxes.Add(flag, cb);
+            y += 25;
+        }
+    }
+
+    private void SetupModifierControls()
+    {
+        var y = 20;
+        grpModifiers.Controls.Add(new Label { Text = "Experience Rate", Left = 5, Top = y, AutoSize = true });
+        var numExp = new NumericUpDown { Minimum = 0, Maximum = 1000, Left = 120, Top = y - 3 };
+        grpModifiers.Controls.Add(numExp);
+        _modifierControls["ExperienceRate"] = numExp;
+        y += 25;
+
+        grpModifiers.Controls.Add(new Label { Text = "Gold Rate", Left = 5, Top = y, AutoSize = true });
+        var numGold = new NumericUpDown { Minimum = 0, Maximum = 1000, Left = 120, Top = y - 3 };
+        grpModifiers.Controls.Add(numGold);
+        _modifierControls["GoldRate"] = numGold;
+    }
+
+    private void PopulateTree()
+    {
+        treeZones.Nodes.Clear();
+        foreach (var pair in Zone.Lookup.OrderBy(p => p.Value?.Name))
+        {
+            var zoneNode = new TreeNode(pair.Value?.Name ?? string.Empty) { Tag = pair.Value };
+            foreach (var sub in Subzone.Lookup.Where(z => z.Value?.ZoneId == pair.Key))
+            {
+                zoneNode.Nodes.Add(new TreeNode(sub.Value?.Name ?? string.Empty) { Tag = sub.Value });
+            }
+            treeZones.Nodes.Add(zoneNode);
+        }
+    }
+
+    public void InitEditor() => PopulateTree();
+
+    private void TreeAfterSelect(object? sender, TreeViewEventArgs e)
+    {
+        _loading = true;
+        _currentZone = e.Node.Tag as Zone;
+        _currentSubzone = e.Node.Tag as Subzone;
+        if (_currentSubzone != null)
+        {
+            _currentZone = Zone.Get(_currentSubzone.ZoneId);
+        }
+        LoadValues();
+        UpdateEditorButtons(true);
+        _loading = false;
+    }
+
+    private void LoadValues()
+    {
+        if (_currentZone == null)
+        {
+            foreach (var cb in _flagBoxes.Values) cb.Enabled = false;
+            foreach (var num in _modifierControls.Values) num.Enabled = false;
+            chkOverrideFlags.Visible = false;
+            chkOverrideModifiers.Visible = false;
+            return;
+        }
+
+        ZoneFlags flags;
+        ZoneModifiers modifiers;
+        if (_currentSubzone != null)
+        {
+            flags = _currentSubzone.Flags ?? _currentZone.Flags;
+            modifiers = _currentSubzone.Modifiers ?? _currentZone.Modifiers;
+            chkOverrideFlags.Visible = true;
+            chkOverrideModifiers.Visible = true;
+            chkOverrideFlags.Checked = _currentSubzone.Flags.HasValue;
+            chkOverrideModifiers.Checked = _currentSubzone.Modifiers != null;
+            foreach (var cb in _flagBoxes.Values)
+            {
+                cb.Enabled = _currentSubzone.Flags.HasValue;
+            }
+            foreach (var num in _modifierControls.Values)
+            {
+                num.Enabled = _currentSubzone.Modifiers != null;
+            }
+        }
+        else
+        {
+            flags = _currentZone.Flags;
+            modifiers = _currentZone.Modifiers;
+            chkOverrideFlags.Visible = false;
+            chkOverrideModifiers.Visible = false;
+            foreach (var cb in _flagBoxes.Values)
+            {
+                cb.Enabled = true;
+            }
+            foreach (var num in _modifierControls.Values)
+            {
+                num.Enabled = true;
+            }
+        }
+
+        foreach (var pair in _flagBoxes)
+        {
+            pair.Value.Checked = flags.HasFlag(pair.Key);
+        }
+
+        _modifierControls["ExperienceRate"].Value = modifiers.ExperienceRate;
+        _modifierControls["GoldRate"].Value = modifiers.GoldRate;
+    }
+
+    private void OverrideFlagsChanged(object? sender, EventArgs e)
+    {
+        if (_currentSubzone == null || _loading) return;
+        _currentSubzone.Flags = chkOverrideFlags.Checked ? _currentZone?.Flags ?? ZoneFlags.None : null;
+        LoadValues();
+    }
+
+    private void OverrideModifiersChanged(object? sender, EventArgs e)
+    {
+        if (_currentSubzone == null || _loading) return;
+        _currentSubzone.Modifiers = chkOverrideModifiers.Checked ? new ZoneModifiers() : null;
+        LoadValues();
+    }
+
+    private void SaveClick(object? sender, EventArgs e)
+    {
+        if (_currentZone == null) return;
+        if (_currentSubzone != null)
+        {
+            if (_currentSubzone.Flags.HasValue)
+            {
+                ZoneFlags flags = ZoneFlags.None;
+                foreach (var pair in _flagBoxes)
+                {
+                    if (pair.Value.Checked) flags |= pair.Key;
+                }
+                _currentSubzone.Flags = flags;
+            }
+            if (_currentSubzone.Modifiers != null)
+            {
+                _currentSubzone.Modifiers.ExperienceRate = (int)_modifierControls["ExperienceRate"].Value;
+                _currentSubzone.Modifiers.GoldRate = (int)_modifierControls["GoldRate"].Value;
+            }
+            PacketSender.SendSaveObject(_currentSubzone);
+        }
+        else
+        {
+            ZoneFlags flags = ZoneFlags.None;
+            foreach (var pair in _flagBoxes)
+            {
+                if (pair.Value.Checked) flags |= pair.Key;
+            }
+            _currentZone.Flags = flags;
+            _currentZone.Modifiers.ExperienceRate = (int)_modifierControls["ExperienceRate"].Value;
+            _currentZone.Modifiers.GoldRate = (int)_modifierControls["GoldRate"].Value;
+            PacketSender.SendSaveObject(_currentZone);
+        }
+    }
+
+    private void CancelClick(object? sender, EventArgs e)
+    {
+        LoadValues();
+    }
+
+    protected override void GameObjectUpdatedDelegate(GameObjectType type)
+    {
+        if (type == GameObjectType.Zone || type == GameObjectType.Subzone)
+        {
+            PopulateTree();
+        }
+    }
+}

--- a/Intersect.Editor/Forms/Editors/frmZoneEditor.resx
+++ b/Intersect.Editor/Forms/Editors/frmZoneEditor.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <metadata name="toolStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="toolStripItemNew.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAACMSURBVDhP7Y3BCYAwFEM7h1M4Q/fy2rUEp3AFT1UovSrR
+        /22orQpeDTxqNS8aToxxVeTVu7A4dM35DKRyHxbzUyr1oASmsd8lBXf9JtVyUGCxdCd8CKEV9QgXaqK1
+        dsc5h3t5RKX8nP1yUh1BUcn/ng/wiOgpLKLIMoNv6Ih2zT+QBu54HHiD1L/EmA2wn/hWQ4oVCwAAAABJ
+        RU5ErkJggg==
+    </value>
+  </data>
+  <data name="toolStripItemDelete.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAFbSURBVDhPrZK9SgNBFIV9AcEHSJHKwkpIZZfOSkhtZeED
+        BPQBVh9A7S2CjaYQJI2VEEyRQoTFRhEEkUCCWExk/8rxfpOZxVlmY+OBC8Pcc879mVn5NxRF0cyyLJLo
+        KqXW7LUH7iXfkxgSotkzCTm0vz9n+un8zESSJO9VExF05rOpejw51h+jO53neVxycEV4sb5qYnx0AOGG
+        HCQ5n07jB33d3tCDnS2NUZqmm0YMqgYEVeQ+opvnfk9fthomMKIbK13AjYC7M4DMHd1UTLtW5oOFhEzc
+        mS7o1NLDCJkQ94f7/tLqsMxAqg8tLQw2/fX2+tcI4fmZje3+FmBEN7y7M4PjPR+oE/PWkuswO9W55x/M
+        JxP/k/E0TkhgRGWeljxkisAjd7u7XX4yA9eiE9MNy7TpEsxPji7QlBznvEzsQFeMxogvg6vFd0YgLSlC
+        qkSWWwvhN9mLhIySxz9ZBc31XkEs1QAAAABJRU5ErkJggg==
+    </value>
+  </data>
+  <data name="btnAlphabetical.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAABrSURBVDhPnc9BCoAwDETR3rM37omyU1KcMFGJGQf+JtCH
+        Dp+ZHdw+KvNHc87dHfsqAI8BgFUl0O0V2EdlANB17s8f8X8pBeAxALAqATioJSCpylj8DfAXKAWw1koA
+        wKoS6BbAQ1XGogaMcQIneCosACuo6QAAAABJRU5ErkJggg==
+    </value>
+  </data>
+  <data name="toolStripItemCopy.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAABVSURBVDhP7YxBCgAgCAR9m///S3XxWghGUWJLdGxhkHId
+        8iIiFcHqe3TJzCGQIKfi8l6gD4RQoJ8RkKAXVr5gHOjsXAlW7BwXWH3PM0HEUYBg9SlEDZN0dAOhJqHd
+        AAAAAElFTkSuQmCC
+    </value>
+  </data>
+  <data name="toolStripItemPaste.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAACKSURBVDhP7Y3LDYAgEEQpwVKsgSoojl4swSbUCwc0Aa7q
+        4BJN+IjGo5O8ZJndGVhKxpjWWts551aih0fre+0BLaVchRAezPB2NXSSV/gVwXGYPJiVUt6ns1ghCDjn
+        UQG86w3FToVgDcWCWS9Fvi/Ao0RVAcwUjwpyhzmf4n8BFApS5HZRwRuONGMbrIJ1JIN8O2QAAAAASUVO
+        RK5CYII=
+    </value>
+  </data>
+  <data name="toolStripItemUndo.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAEfSURBVDhPjVK7DgFBFN0/4A/4AvEJfkAi0ZLoNArR6hUq
+        tUgkElGJ1jYaDYVsI9Fq2EYyin2Ua864d9g1u/YkJ5nHOfcxcy2G53nVIAiEZBSGYdn3/TnviQJnuCPL
+        BzDf3aeoDNZaPFweo0J7EVnNmSLWOMMd9GR9AyaYIXQfT702kZKIWCUIwIJSd6XX9dE2sk9XRaz5HJWg
+        HbLHAzCn9pnbURklHQ6CdnBGdnMAsDXZKSF6lhkbqITvlIdhCvBthuZvAAO1WQhRlPv0FrKAIBCjIs7+
+        84hpkF9VS5qN32iCFHSSM4FAGLifQUpCltc3mZE5j3l+uNxiYzzeODA7f8um1xa96V6baaAc3JEsG/zq
+        PMaoKLeZQa+f46ss6wVeddKu0bn3NAAAAABJRU5ErkJggg==
+    </value>
+  </data>
+</root>

--- a/Intersect.Editor/Forms/frmMain.cs
+++ b/Intersect.Editor/Forms/frmMain.cs
@@ -71,6 +71,7 @@ public partial class FrmMain : Form
 
     private FrmTime mTimeEditor;
     private frmSets mSetEditor;
+    private FrmZoneEditor mZoneEditor;
 
     //General Editting Variables
     bool mTMouseDown;
@@ -1732,6 +1733,16 @@ public partial class FrmMain : Form
                         mTimeEditor = new FrmTime();
                         mTimeEditor.InitEditor(DaylightCycleDescriptor.Instance);
                         mTimeEditor.Show();
+                    }
+
+                    break;
+                case GameObjectType.Zone:
+                case GameObjectType.Subzone:
+                    if (mZoneEditor == null || !mZoneEditor.Visible)
+                    {
+                        mZoneEditor = new FrmZoneEditor();
+                        mZoneEditor.InitEditor();
+                        mZoneEditor.Show();
                     }
 
                     break;

--- a/Intersect.Editor/Intersect.Editor.csproj
+++ b/Intersect.Editor/Intersect.Editor.csproj
@@ -116,6 +116,12 @@
     <Compile Update="Forms\frmUpdate.Designer.cs">
       <DependentUpon>frmUpdate.cs</DependentUpon>
     </Compile>
+    <Compile Update="Forms\Editors\frmZoneEditor.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Update="Forms\Editors\frmZoneEditor.Designer.cs">
+      <DependentUpon>frmZoneEditor.cs</DependentUpon>
+    </Compile>
     <Compile Update="Forms\Helpers\GridHelper.cs" />
     <Compile Update="Forms\Controls\SearchableDarkTreeView.cs">
       <SubType>UserControl</SubType>
@@ -611,6 +617,9 @@
     </EmbeddedResource>
     <EmbeddedResource Update="Forms\Editors\frmVariable.resx">
       <DependentUpon>frmVariable.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Update="Forms\Editors\frmZoneEditor.resx">
+      <DependentUpon>frmZoneEditor.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Update="Forms\Editors\frmTime.resx">
       <DependentUpon>frmTime.cs</DependentUpon>

--- a/Intersect.Editor/Networking/PacketHandler.cs
+++ b/Intersect.Editor/Networking/PacketHandler.cs
@@ -15,6 +15,7 @@ using Intersect.Framework.Core.GameObjects.Maps.MapList;
 using Intersect.Framework.Core.GameObjects.NPCs;
 using Intersect.Framework.Core.GameObjects.PlayerClass;
 using Intersect.Framework.Core.GameObjects.Resources;
+using Intersect.Framework.Core.GameObjects.Zones;
 using Intersect.Framework.Core.GameObjects.Variables;
 using Intersect.GameObjects;
 using Intersect.Network;
@@ -747,6 +748,34 @@ internal sealed partial class PacketHandler
                     var set = new SetDescriptor(id);
                     set.Load(json);
                     SetDescriptor.Lookup.Set(id, set);
+                }
+
+                break;
+            case GameObjectType.Zone:
+                if (deleted)
+                {
+                    var zone = Zone.Get(id);
+                    zone.Delete();
+                }
+                else
+                {
+                    var zone = new Zone(id);
+                    zone.Load(json);
+                    Zone.Lookup.Set(id, zone);
+                }
+
+                break;
+            case GameObjectType.Subzone:
+                if (deleted)
+                {
+                    var sub = Subzone.Get(id);
+                    sub.Delete();
+                }
+                else
+                {
+                    var sub = new Subzone(id);
+                    sub.Load(json);
+                    Subzone.Lookup.Set(id, sub);
                 }
 
                 break;


### PR DESCRIPTION
## Summary
- support custom zone data with flags and numeric modifiers
- implement Zone Editor form to manage zones and subzones with inheritance
- hook editor UI and packet handling for new zone objects
- add designer with standard toolstrip for zone editor

## Testing
- `dotnet build` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68b9159f6f5c832497556b5e34b2b472