### PR TITLE
Add zone selection to map properties

### DIFF
--- a/Framework/Intersect.Framework.Core/GameObjects/Maps/MapDescriptor.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Maps/MapDescriptor.cs
@@ -160,6 +160,9 @@ public partial class MapDescriptor : DatabaseObject<MapDescriptor>
 
                 EventIds?.Clear();
                 EventIds?.AddRange(mapDescriptor.EventIds?.ToArray() ?? []);
+
+                ZoneId = mapDescriptor.ZoneId;
+                SubzoneId = mapDescriptor.SubzoneId;
             }
         }
     }

--- a/Intersect.Editor/Forms/DockingElements/frmMapProperties.Designer.cs
+++ b/Intersect.Editor/Forms/DockingElements/frmMapProperties.Designer.cs
@@ -30,10 +30,17 @@
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(FrmMapProperties));
             this.gridMapProperties = new System.Windows.Forms.PropertyGrid();
+            this.pnlZones = new System.Windows.Forms.Panel();
+            this.btnEditZones = new System.Windows.Forms.Button();
+            this.cmbSubarea = new System.Windows.Forms.ComboBox();
+            this.lblSubarea = new System.Windows.Forms.Label();
+            this.cmbArea = new System.Windows.Forms.ComboBox();
+            this.lblArea = new System.Windows.Forms.Label();
+            this.pnlZones.SuspendLayout();
             this.SuspendLayout();
-            // 
+            //
             // gridMapProperties
-            // 
+            //
             this.gridMapProperties.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
             this.gridMapProperties.CategoryForeColor = System.Drawing.Color.Gainsboro;
             this.gridMapProperties.CategorySplitterColor = System.Drawing.Color.FromArgb(((int)(((byte)(51)))), ((int)(((byte)(51)))), ((int)(((byte)(51)))));
@@ -47,26 +54,90 @@
             this.gridMapProperties.HelpBorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(51)))), ((int)(((byte)(51)))), ((int)(((byte)(51)))));
             this.gridMapProperties.HelpForeColor = System.Drawing.Color.Gainsboro;
             this.gridMapProperties.LineColor = System.Drawing.Color.FromArgb(((int)(((byte)(49)))), ((int)(((byte)(51)))), ((int)(((byte)(53)))));
-            this.gridMapProperties.Location = new System.Drawing.Point(0, 0);
+            this.gridMapProperties.Location = new System.Drawing.Point(0, 90);
             this.gridMapProperties.Name = "gridMapProperties";
-            this.gridMapProperties.Size = new System.Drawing.Size(154, 140);
+            this.gridMapProperties.Size = new System.Drawing.Size(154, 110);
             this.gridMapProperties.TabIndex = 0;
             this.gridMapProperties.ToolbarVisible = false;
             this.gridMapProperties.ViewBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
             this.gridMapProperties.ViewBorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(51)))), ((int)(((byte)(51)))), ((int)(((byte)(51)))));
             this.gridMapProperties.ViewForeColor = System.Drawing.Color.Gainsboro;
-            // 
+            //
+            // pnlZones
+            //
+            this.pnlZones.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
+            this.pnlZones.Controls.Add(this.btnEditZones);
+            this.pnlZones.Controls.Add(this.cmbSubarea);
+            this.pnlZones.Controls.Add(this.lblSubarea);
+            this.pnlZones.Controls.Add(this.cmbArea);
+            this.pnlZones.Controls.Add(this.lblArea);
+            this.pnlZones.Dock = System.Windows.Forms.DockStyle.Top;
+            this.pnlZones.Location = new System.Drawing.Point(0, 0);
+            this.pnlZones.Name = "pnlZones";
+            this.pnlZones.Size = new System.Drawing.Size(154, 90);
+            this.pnlZones.TabIndex = 1;
+            //
+            // btnEditZones
+            //
+            this.btnEditZones.Location = new System.Drawing.Point(3, 62);
+            this.btnEditZones.Name = "btnEditZones";
+            this.btnEditZones.Size = new System.Drawing.Size(148, 23);
+            this.btnEditZones.TabIndex = 4;
+            this.btnEditZones.Text = "Edit Zones";
+            this.btnEditZones.UseVisualStyleBackColor = true;
+            //
+            // cmbSubarea
+            //
+            this.cmbSubarea.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmbSubarea.FormattingEnabled = true;
+            this.cmbSubarea.Location = new System.Drawing.Point(58, 33);
+            this.cmbSubarea.Name = "cmbSubarea";
+            this.cmbSubarea.Size = new System.Drawing.Size(93, 21);
+            this.cmbSubarea.TabIndex = 3;
+            //
+            // lblSubarea
+            //
+            this.lblSubarea.AutoSize = true;
+            this.lblSubarea.ForeColor = System.Drawing.Color.Gainsboro;
+            this.lblSubarea.Location = new System.Drawing.Point(3, 36);
+            this.lblSubarea.Name = "lblSubarea";
+            this.lblSubarea.Size = new System.Drawing.Size(52, 13);
+            this.lblSubarea.TabIndex = 2;
+            this.lblSubarea.Text = "Subarea";
+            //
+            // cmbArea
+            //
+            this.cmbArea.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmbArea.FormattingEnabled = true;
+            this.cmbArea.Location = new System.Drawing.Point(58, 6);
+            this.cmbArea.Name = "cmbArea";
+            this.cmbArea.Size = new System.Drawing.Size(93, 21);
+            this.cmbArea.TabIndex = 1;
+            //
+            // lblArea
+            //
+            this.lblArea.AutoSize = true;
+            this.lblArea.ForeColor = System.Drawing.Color.Gainsboro;
+            this.lblArea.Location = new System.Drawing.Point(3, 9);
+            this.lblArea.Name = "lblArea";
+            this.lblArea.Size = new System.Drawing.Size(32, 13);
+            this.lblArea.TabIndex = 0;
+            this.lblArea.Text = "Area";
+            //
             // frmMapProperties
-            // 
+            //
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(154, 140);
+            this.ClientSize = new System.Drawing.Size(154, 200);
             this.CloseButton = false;
             this.CloseButtonVisible = false;
             this.Controls.Add(this.gridMapProperties);
+            this.Controls.Add(this.pnlZones);
             this.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.Name = "FrmMapProperties";
             this.Text = "Map Properties";
+            this.pnlZones.ResumeLayout(false);
+            this.pnlZones.PerformLayout();
             this.ResumeLayout(false);
 
         }
@@ -74,5 +145,11 @@
         #endregion
 
         private System.Windows.Forms.PropertyGrid gridMapProperties;
+        private System.Windows.Forms.Panel pnlZones;
+        private System.Windows.Forms.Button btnEditZones;
+        private System.Windows.Forms.ComboBox cmbSubarea;
+        private System.Windows.Forms.Label lblSubarea;
+        private System.Windows.Forms.ComboBox cmbArea;
+        private System.Windows.Forms.Label lblArea;
     }
 }

--- a/Intersect.Editor/Forms/DockingElements/frmMapProperties.cs
+++ b/Intersect.Editor/Forms/DockingElements/frmMapProperties.cs
@@ -1,6 +1,12 @@
-﻿using Intersect.Editor.Core;
+﻿using System;
+using System.Linq;
+using System.Windows.Forms;
+using Intersect.Editor.Core;
 using Intersect.Editor.Localization;
 using Intersect.Editor.Maps;
+using Intersect.Editor.Networking;
+using Intersect.Enums;
+using Intersect.Framework.Core.GameObjects.Zones;
 using WeifenLuo.WinFormsUI.Docking;
 
 namespace Intersect.Editor.Forms.DockingElements;
@@ -14,12 +20,18 @@ public partial class FrmMapProperties : DockContent
 
     public UpdateProperties UpdatePropertiesDelegate;
 
+    private MapProperties mProperties;
+
     public FrmMapProperties()
     {
         InitializeComponent();
         Icon = Program.Icon;
 
         UpdatePropertiesDelegate = Update;
+
+        cmbArea.SelectedIndexChanged += CmbArea_SelectedIndexChanged;
+        cmbSubarea.SelectedIndexChanged += CmbSubarea_SelectedIndexChanged;
+        btnEditZones.Click += BtnEditZones_Click;
     }
 
     public void Init(MapInstance map)
@@ -31,13 +43,93 @@ public partial class FrmMapProperties : DockContent
             return;
         }
 
-        gridMapProperties.SelectedObject = new MapProperties(map);
+        mProperties = new MapProperties(map);
+        gridMapProperties.SelectedObject = mProperties;
         InitLocalization();
+        LoadZones();
     }
 
     private void InitLocalization()
     {
         Text = Strings.MapProperties.title;
+    }
+
+    private void LoadZones()
+    {
+        cmbArea.SelectedIndexChanged -= CmbArea_SelectedIndexChanged;
+        cmbSubarea.SelectedIndexChanged -= CmbSubarea_SelectedIndexChanged;
+
+        var zones = Zone.Lookup.OrderBy(z => z.Value?.Name).Select(z => z.Value).ToList();
+        zones.Insert(0, new Zone(Guid.Empty) { Name = Strings.General.None });
+        cmbArea.DisplayMember = nameof(Zone.Name);
+        cmbArea.ValueMember = nameof(Zone.Id);
+        cmbArea.DataSource = zones;
+
+        if (mProperties?.ZoneId != null)
+        {
+            cmbArea.SelectedValue = mProperties.ZoneId;
+        }
+        else
+        {
+            cmbArea.SelectedIndex = 0;
+        }
+
+        LoadSubzones();
+
+        cmbArea.SelectedIndexChanged += CmbArea_SelectedIndexChanged;
+        cmbSubarea.SelectedIndexChanged += CmbSubarea_SelectedIndexChanged;
+    }
+
+    private void LoadSubzones()
+    {
+        cmbSubarea.SelectedIndexChanged -= CmbSubarea_SelectedIndexChanged;
+
+        var zoneId = mProperties?.ZoneId ?? Guid.Empty;
+        var subzones = Subzone.Lookup.Where(s => s.Value?.ZoneId == zoneId)
+            .OrderBy(s => s.Value?.Name)
+            .Select(s => s.Value)
+            .ToList();
+        subzones.Insert(0, new Subzone(Guid.Empty) { Name = Strings.General.None, ZoneId = zoneId });
+        cmbSubarea.DisplayMember = nameof(Subzone.Name);
+        cmbSubarea.ValueMember = nameof(Subzone.Id);
+        cmbSubarea.DataSource = subzones;
+
+        if (mProperties?.SubzoneId != null)
+        {
+            cmbSubarea.SelectedValue = mProperties.SubzoneId;
+        }
+        else
+        {
+            cmbSubarea.SelectedIndex = 0;
+        }
+
+        cmbSubarea.SelectedIndexChanged += CmbSubarea_SelectedIndexChanged;
+    }
+
+    private void CmbArea_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        if (cmbArea.SelectedItem is not Zone zone || mProperties == null)
+        {
+            return;
+        }
+
+        mProperties.ZoneId = zone.Id == Guid.Empty ? null : zone.Id;
+        LoadSubzones();
+    }
+
+    private void CmbSubarea_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        if (cmbSubarea.SelectedItem is not Subzone sub || mProperties == null)
+        {
+            return;
+        }
+
+        mProperties.SubzoneId = sub.Id == Guid.Empty ? null : sub.Id;
+    }
+
+    private void BtnEditZones_Click(object sender, EventArgs e)
+    {
+        PacketSender.SendOpenEditor(GameObjectType.Zone);
     }
 
     public void Update()

--- a/Intersect.Editor/Maps/MapProperties.cs
+++ b/Intersect.Editor/Maps/MapProperties.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel;
+﻿using System;
+using System.ComponentModel;
 using Intersect.Editor.Content;
 using Intersect.Editor.General;
 using Intersect.Editor.Localization;
@@ -60,6 +61,40 @@ partial class MapProperties
 
     [Browsable(false)]
     public Guid MapId => mMyMap.Id;
+
+    [Browsable(false)]
+    public Guid? ZoneId
+    {
+        get => mMyMap.ZoneId;
+        set
+        {
+            if (mMyMap.ZoneId != value)
+            {
+                Globals.MapEditorWindow.PrepUndoState();
+                mMyMap.ZoneId = value;
+                if (value == null)
+                {
+                    mMyMap.SubzoneId = null;
+                }
+                Globals.MapEditorWindow.AddUndoState();
+            }
+        }
+    }
+
+    [Browsable(false)]
+    public Guid? SubzoneId
+    {
+        get => mMyMap.SubzoneId;
+        set
+        {
+            if (mMyMap.SubzoneId != value)
+            {
+                Globals.MapEditorWindow.PrepUndoState();
+                mMyMap.SubzoneId = value;
+                Globals.MapEditorWindow.AddUndoState();
+            }
+        }
+    }
 
     [CustomCategory("general"), CustomDescription("namedesc"), CustomDisplayName("name"), DefaultValue("New Map")]
     public string Name


### PR DESCRIPTION
## Summary
- add area and subarea combo boxes with zone editor access in map properties
- store selected zone and subzone on maps
- copy zone identifiers in map descriptor cloning

## Testing
- `dotnet build Intersect.Editor/Intersect.Editor.csproj` *(fails: command not found)*
- `apt-get update` *(fails: Invalid response from proxy: 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ba4746b7588324914d49799c9f1f56