### PR TITLE
Fix crash when dropping equipped items

### DIFF
--- a/Intersect.Client.Core/Entities/Player.cs
+++ b/Intersect.Client.Core/Entities/Player.cs
@@ -34,6 +34,7 @@ using Intersect.GameObjects;
 using Intersect.Network.Packets.Server;
 using Intersect.Utilities;
 using Microsoft.Extensions.Logging;
+using System.Linq;
 
 namespace Intersect.Client.Entities;
 
@@ -103,6 +104,15 @@ public partial class Player : Entity, IPlayer
         // Si la cantidad es 0 o el descriptor es inválido, limpiamos el slot
         if (quantity <= 0 || !ItemDescriptor.TryGet(descriptorId, out _))
         {
+            // Si este slot estaba equipado, lo removemos de MyEquipment para evitar referencias nulas
+            foreach (var kvp in MyEquipment.ToList())
+            {
+                if (kvp.Value.Remove(slotIndex) && kvp.Value.Count == 0)
+                {
+                    MyEquipment.Remove(kvp.Key);
+                }
+            }
+
             Inventory[slotIndex] = null;
             InventoryUpdated?.Invoke(this, slotIndex);
             return;


### PR DESCRIPTION
## Summary
- remove dropped inventory slot from equipment list to avoid null references

## Testing
- `dotnet test` *(fails: Restore canceled)*
- `dotnet build Intersect.Client.Core/Intersect.Client.Core.csproj` *(fails: Type must be marked with MessagePackObjectAttribute)*

------
https://chatgpt.com/codex/tasks/task_e_68bb7e24b980832497fa517e859685b8