### PR TITLE
feat: localize inventory sort and filter labels

### DIFF
--- a/Intersect.Client.Core/Interface/Game/Inventory/InventoryWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Inventory/InventoryWindow.cs
@@ -60,7 +60,7 @@ public partial class InventoryWindow : Window
             FontName = "source-sans-pro",
             FontSize = 12,// Tamaño de fuente
         };
-        _sortButton.SetText("Sort");
+        _sortButton.SetText(Strings.Inventory.Sort);
         _sortButton.Clicked += SortItems; // ✅ ahora ordena visualmente
 
 
@@ -73,7 +73,7 @@ public partial class InventoryWindow : Window
         };
         _typeBox.SetPosition(10, 60);
 
-        var typeAll = _typeBox.AddItem("All", userData: null);
+        var typeAll = _typeBox.AddItem(Strings.Inventory.All, userData: null);
         typeAll.Selected += (_, _) =>
         {
             _selectedType = null;
@@ -103,7 +103,7 @@ public partial class InventoryWindow : Window
         };
         _subtypeBox.SetPosition(170, 60);
 
-        var subtypeAll = _subtypeBox.AddItem("All", userData: null);
+        var subtypeAll = _subtypeBox.AddItem(Strings.Inventory.All, userData: null);
         subtypeAll.Selected += (_, _) =>
         {
             _selectedSubtype = null;
@@ -130,7 +130,7 @@ public partial class InventoryWindow : Window
     private void UpdateSubtypeOptions()
     {
         _subtypeBox.ClearItems();
-        var all = _subtypeBox.AddItem("All", userData: null);
+        var all = _subtypeBox.AddItem(Strings.Inventory.All, userData: null);
         all.Selected += (_, _) =>
         {
             _selectedSubtype = null;

--- a/Intersect.Client.Core/Localization/Strings.cs
+++ b/Intersect.Client.Core/Localization/Strings.cs
@@ -1788,6 +1788,12 @@ If you are sure you want to hand over your guild enter '\c{{#ff8080}}{02}\c{{}}'
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public static LocalizedString Title = @"Inventory";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Sort = @"Sort";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString All = @"All";
     }
 
     public partial struct EntityContextMenu

--- a/Intersect.Client.Core/Localization/Translations/en-US.json
+++ b/Intersect.Client.Core/Localization/Translations/en-US.json
@@ -1,0 +1,6 @@
+{
+  "Inventory": {
+    "Sort": "Sort",
+    "All": "All"
+  }
+}

--- a/Intersect.Client.Core/Localization/Translations/es-ES.json
+++ b/Intersect.Client.Core/Localization/Translations/es-ES.json
@@ -1,0 +1,6 @@
+{
+  "Inventory": {
+    "Sort": "Ordenar",
+    "All": "Todos"
+  }
+}


### PR DESCRIPTION
## Summary
- replace hardcoded "Sort"/"All" labels with localized strings
- add `Sort` and `All` entries to inventory localization
- provide English and Spanish translations for new keys

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets missing)*
- `dotnet test Intersect.Tests/Intersect.Tests.csproj` *(fails: MsgPack003 requires MessagePackObjectAttribute)*

------
https://chatgpt.com/codex/tasks/task_e_68bb824e54588324a254a66ff787e094