### PR TITLE
Hide filtered inventory items

### DIFF
--- a/Intersect.Client.Core/Interface/Game/Inventory/InventoryWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Inventory/InventoryWindow.cs
@@ -200,7 +200,9 @@ public partial class InventoryWindow : Window
         {
             if (item is InventoryItem inventoryItem)
             {
-                inventoryItem.SetFilterMatch(matchedSet.Contains(item));
+                var isMatch = matchedSet.Contains(item);
+                inventoryItem.IsVisibleInParent = isMatch;
+                inventoryItem.SetFilterMatch(isMatch);
                 inventoryItem.Update(); // 🔁 fuerza el refresco visual
             }
         }

--- a/Intersect.Client.Core/Utilities/PopulateSlotContainer.cs
+++ b/Intersect.Client.Core/Utilities/PopulateSlotContainer.cs
@@ -9,20 +9,27 @@ public static class PopulateSlotContainer
     public static void Populate(ScrollControl slotContainer, List<SlotItem> items)
     {
         float containerInnerWidth = slotContainer.InnerPanel.InnerWidth;
+        var visibleIndex = 0;
         for (var slotIndex = 0; slotIndex < items.Count; slotIndex++)
         {
             var slot = items[slotIndex];
+            if (!slot.IsVisibleInParent)
+            {
+                continue;
+            }
+
             var outerSize = slot.OuterBounds.Size;
 
             var itemsPerRow = (int)(containerInnerWidth / outerSize.X);
 
-            var column = slotIndex % itemsPerRow;
-            var row = slotIndex / itemsPerRow;
+            var column = visibleIndex % itemsPerRow;
+            var row = visibleIndex / itemsPerRow;
 
             var xPosition = column * outerSize.X + slot.Margin.Left;
             var yPosition = row * outerSize.Y + slot.Margin.Top;
 
             slot.SetPosition(xPosition, yPosition);
+            visibleIndex++;
         }
     }
 


### PR DESCRIPTION
## Summary
- track filter matches by toggling `IsVisibleInParent` on inventory slots
- skip hidden items when laying out slot containers

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*
- `dotnet format --verify-no-changes` *(fails: multiple whitespace/import errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bc250e68948324827b583d99260309