### PR TITLE
Refresh inventory and bank filters on slot updates

### DIFF
--- a/Intersect.Client.Core/Interface/Game/Bank/BankWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Bank/BankWindow.cs
@@ -30,6 +30,7 @@ public partial class BankWindow : Window
     private bool _sortAscending;
     private ItemType? _selectedType;
     private string? _selectedSubtype;
+    private bool _slotsDirty;
 
     //Init
     public BankWindow(Canvas gameCanvas) : base(
@@ -152,7 +153,7 @@ public partial class BankWindow : Window
         var type = (ItemType?)_typeBox.SelectedItem?.UserData;
         var subtype = (string?)_subtypeBox.SelectedItem?.UserData;
 
-        var changed = false;
+        var changed = _slotsDirty;
 
         if (type != _selectedType)
         {
@@ -183,6 +184,7 @@ public partial class BankWindow : Window
         if (changed)
         {
             ApplyFilters();
+            _slotsDirty = false;
         }
 
         for (var i = 0; i < Items.Count; i++)
@@ -268,7 +270,10 @@ public partial class BankWindow : Window
     }
 
 
-    public void Refresh() => ApplyFilters();
+    public void Refresh()
+    {
+        _slotsDirty = true;
+    }
 
     public override void Hide()
     {

--- a/Intersect.Client.Core/Interface/Game/Inventory/InventoryWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Inventory/InventoryWindow.cs
@@ -8,6 +8,7 @@ using Intersect.Client.Localization;
 using Intersect.Client.Utilities;
 using System.Linq;
 using Intersect.Framework.Core.GameObjects.Items;
+using Intersect.Client.Entities;
 
 
 namespace Intersect.Client.Interface.Game.Inventory;
@@ -30,6 +31,7 @@ public partial class InventoryWindow : Window
 
     private string? _lastQuery;
     private bool _lastAsc;
+    private bool _inventoryDirty;
 
     public InventoryWindow(Canvas gameCanvas) : base(gameCanvas, Strings.Inventory.Title, false, nameof(InventoryWindow))
     {
@@ -113,6 +115,10 @@ public partial class InventoryWindow : Window
         _selectedType = (ItemType?)_typeBox.SelectedItem?.UserData;
         _selectedSubtype = (string?)_subtypeBox.SelectedItem?.UserData;
         _lastAsc = _sortAscending;
+        if (Globals.Me is { } player)
+        {
+            player.InventoryUpdated += PlayerOnInventoryUpdated;
+        }
     }
 
     private void SortButton_Clicked(Base sender, MouseButtonState arguments)
@@ -308,7 +314,7 @@ public partial class InventoryWindow : Window
         var type = (ItemType?)_typeBox.SelectedItem?.UserData;
         var subtype = (string?)_subtypeBox.SelectedItem?.UserData;
 
-        var changed = false;
+        var changed = _inventoryDirty;
 
         if (type != _selectedType)
         {
@@ -339,6 +345,7 @@ public partial class InventoryWindow : Window
         if (changed)
         {
             ApplyFilters();
+            _inventoryDirty = false;
         }
 
         var slotCount = Math.Min(Options.Instance.Player.MaxInventory, Items.Count);
@@ -346,6 +353,11 @@ public partial class InventoryWindow : Window
         {
             Items[slotIndex].Update();
         }
+    }
+
+    private void PlayerOnInventoryUpdated(Player player, int slotIndex)
+    {
+        _inventoryDirty = true;
     }
 
   


### PR DESCRIPTION
## Summary
- Reapply inventory filters when player inventory updates
- Reapply bank filters when bank slot contents change

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc28e968008324ad81d8d6976b073f