### PR TITLE
Handle null inventory items during entity drawing

### DIFF
--- a/Intersect.Client.Core/Entities/Entity.cs
+++ b/Intersect.Client.Core/Entities/Entity.cs
@@ -841,7 +841,9 @@ public partial class Entity : IEntity
                     items = MyEquipment.TryGetValue(z, out var invList)
                         ? invList
                             .Where(i => i >= 0 && i < Options.Instance.Player.MaxInventory)
-                            .Select(i => Inventory[i].ItemId)
+                            .Select(i => Inventory[i]?.ItemId)
+                            .Where(id => id.HasValue)
+                            .Select(id => id.Value)
                             .ToList()
                         : new List<Guid>();
                 }
@@ -1367,7 +1369,9 @@ public partial class Entity : IEntity
                         {
                             equipList = equippedIndexes
                                 .Where(i => i >= 0 && i < Options.Instance.Player.MaxInventory)
-                                .Select(i => Inventory[i].ItemId)
+                                .Select(i => Inventory[i]?.ItemId)
+                                .Where(id => id.HasValue)
+                                .Select(id => id.Value)
                                 .ToList();
                         }
                     }


### PR DESCRIPTION
## Summary
- avoid NullReference when optional equipment entries missing during entity draw
- guard animation equipment lookup against null inventory items

## Testing
- `dotnet test Intersect.sln` *(fails: project file "vendor/LiteNetLib/LiteNetLib.csproj" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc32e5ef288324997ddecc2140c885