### PR TITLE
Keep empty inventory slots visible when filters are inactive

### DIFF
--- a/Intersect.Client.Core/Interface/Game/Inventory/InventoryWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Inventory/InventoryWindow.cs
@@ -201,13 +201,25 @@ public partial class InventoryWindow : Window
 
         var arranged = matchedList.Concat(nonMatched).ToList();
 
+        // Determinar si hay algún filtro activo (búsqueda, tipo o subtipo)
+        var filterActive = !string.IsNullOrWhiteSpace(_searchBox.Text) ||
+                          _selectedType.HasValue ||
+                          !string.IsNullOrEmpty(_selectedSubtype);
+
         // Actualizar el estado visual de cada slot (visible o no)
         foreach (var item in Items)
         {
             if (item is InventoryItem inventoryItem)
             {
                 var isMatch = matchedSet.Contains(item);
-                inventoryItem.IsVisibleInParent = isMatch;
+                var slot = Globals.Me.Inventory[inventoryItem.SlotIndex];
+                var hasDescriptor = slot?.Descriptor != null;
+
+                // Mantener visibles los espacios vacíos cuando no hay filtro activo
+                // o cuando el slot no contiene ningún objeto
+                var show = isMatch || !filterActive || !hasDescriptor;
+
+                inventoryItem.IsVisibleInParent = show;
                 inventoryItem.SetFilterMatch(isMatch);
                 inventoryItem.Update(); // 🔁 fuerza el refresco visual
             }


### PR DESCRIPTION
## Summary
- keep empty inventory slots visible when no filter is active or the slot is blank

## Testing
- `dotnet test Intersect.Tests/Intersect.Tests.csproj` *(fails: The type or namespace name 'Items' does not exist in the namespace 'Intersect.GameObjects')*


------
https://chatgpt.com/codex/tasks/task_e_68bc339b30808324bb2312e043df6b88