### PR TITLE
Fix null item handling in inventory filter

### DIFF
--- a/Intersect.Client.Core/Interface/Game/Inventory/InventoryWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Inventory/InventoryWindow.cs
@@ -217,22 +217,35 @@ public partial class InventoryWindow : Window
 
         var matched = Items.Where(i =>
         {
+            if (i is null)
+            {
+                return false;
+            }
+
             var slot = Globals.Me.Inventory[i.SlotIndex];
             var descriptor = slot?.Descriptor;
-            if (descriptor == null) return false;
+            if (descriptor == null)
+            {
+                return false;
+            }
 
-            if (_selectedType.HasValue && descriptor.ItemType != _selectedType) return false;
+            if (_selectedType.HasValue && descriptor.ItemType != _selectedType)
+            {
+                return false;
+            }
 
             if (!string.IsNullOrEmpty(_selectedSubtype) &&
                 !descriptor.Subtype.Equals(_selectedSubtype, StringComparison.OrdinalIgnoreCase))
+            {
                 return false;
+            }
 
             return SearchHelper.Matches(_searchBox.Text, descriptor.Name);
         });
 
         var matchedList = matched.ToList();
         var matchedSet = matchedList.ToHashSet();
-        var nonMatched = Items.Where(i => !matchedSet.Contains(i));
+        var nonMatched = Items.Where(i => i is not null && !matchedSet.Contains(i));
         var arranged = matchedList.Concat(nonMatched).ToList();
 
         var filterActive = !string.IsNullOrWhiteSpace(_searchBox.Text) ||


### PR DESCRIPTION
## Summary
- avoid null references when filtering inventory items by skipping null entries

## Testing
- `dotnet test Intersect.Tests/Intersect.Tests.csproj` *(fails: CS0234 type or namespace name 'Items' does not exist in 'Intersect.GameObjects')*

------
https://chatgpt.com/codex/tasks/task_e_68bc4d8411b48324a1499710dd1f656f