### PR TITLE
fix: avoid null ref when equipment inventory empty

### DIFF
--- a/Intersect.Client.Core/Interface/Game/EntityPanel/EntityBox.cs
+++ b/Intersect.Client.Core/Interface/Game/EntityPanel/EntityBox.cs
@@ -806,7 +806,12 @@ public partial class EntityBox
                     {
                         if (invIndex >= 0 && invIndex < Options.Instance.Player.MaxInventory)
                         {
-                            equipment[slotIndex].Add(player.Inventory[invIndex].ItemId);
+                            var inventoryItem = player.Inventory[invIndex];
+
+                            if (inventoryItem != null)
+                            {
+                                equipment[slotIndex].Add(inventoryItem.ItemId);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- guard against null inventory slots when syncing equipment for entity panel

## Testing
- `dotnet test Intersect.Tests/Intersect.Tests.csproj` *(fails: CS0234: The type or namespace name 'Items' does not exist in the namespace 'Intersect.GameObjects')*

------
https://chatgpt.com/codex/tasks/task_e_68bc506a84a88324974754c1337027b0