### PR TITLE
Respetar filtros al ordenar inventario

### DIFF
--- a/Intersect.Client.Core/Interface/Game/Inventory/InventoryWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Inventory/InventoryWindow.cs
@@ -319,11 +319,15 @@ public partial class InventoryWindow : Window
             .Where(i => inventory[i.SlotIndex]?.Descriptor != null)
             .ToList();
 
+        var searchText = _searchBox?.Text ?? string.Empty;
+
         var sortedItems = ItemListHelper.FilterAndSort(
             filledItems,
             getDescriptor: i => inventory[i.SlotIndex]?.Descriptor,
             getQuantity: i => inventory[i.SlotIndex]?.Quantity ?? 0,
-            searchText: "",
+            searchText: searchText,
+            type: _selectedType,
+            subtype: _selectedSubtype,
             criterion: _criterion,
             ascending: _sortAscending
         ).ToList();
@@ -355,7 +359,8 @@ public partial class InventoryWindow : Window
                 }
             }
         }
-        // visual se refresca en Update()
+
+        ApplyFilters();
     }
 
     protected override void EnsureInitialized()

--- a/Intersect.Client.Core/Utilities/ItemListHelper.cs
+++ b/Intersect.Client.Core/Utilities/ItemListHelper.cs
@@ -22,6 +22,8 @@ namespace Intersect.Client.Utilities
             Func<T, ItemDescriptor?> getDescriptor,
             Func<T, int>? getQuantity,
             string? searchText,
+            ItemType? type,
+            string? subtype,
             SortCriterion criterion,
             bool ascending
         )
@@ -33,6 +35,15 @@ namespace Intersect.Client.Utilities
             {
                 var d = getDescriptor(entry);
                 if (d == null) return false;
+
+                // filtros explícitos
+                if (type.HasValue && d.ItemType != type.Value) return false;
+
+                if (!string.IsNullOrEmpty(subtype))
+                {
+                    if (!string.Equals(d.Subtype ?? string.Empty, subtype, StringComparison.OrdinalIgnoreCase))
+                        return false;
+                }
 
                 // texto libre
                 if (!SearchHelper.Matches(tokens.FreeText, d.Name)) return false;
@@ -81,5 +92,14 @@ namespace Intersect.Client.Utilities
 
             return ordered;
         }
+
+        public static IEnumerable<T> FilterAndSort<T>(
+            IEnumerable<T> items,
+            Func<T, ItemDescriptor?> getDescriptor,
+            Func<T, int>? getQuantity,
+            string? searchText,
+            SortCriterion criterion,
+            bool ascending
+        ) => FilterAndSort(items, getDescriptor, getQuantity, searchText, null, null, criterion, ascending);
     }
 }


### PR DESCRIPTION
## Summary
- Filtra y ordena sólo los ítems que coinciden con la búsqueda, tipo y subtipo actuales
- Refresca la vista del inventario tras ordenar
- Expone parámetros de tipo y subtipo en ItemListHelper.FilterAndSort

## Testing
- `dotnet build -c Release Intersect.Client.Core/Intersect.Client.Core.csproj`
- `dotnet test -c Release Intersect.Tests/Intersect.Tests.csproj` *(falla: Items does not exist in namespace Intersect.GameObjects)*

------
https://chatgpt.com/codex/tasks/task_e_68bc6f7db4a08324bc6681fca84058b1