### PR TITLE
Allow moving inventory items to empty slots

### DIFF
--- a/Intersect.Client.Core/Interface/Game/Inventory/InventoryItem.cs
+++ b/Intersect.Client.Core/Interface/Game/Inventory/InventoryItem.cs
@@ -465,34 +465,7 @@ public partial class InventoryItem : SlotItem
                         inventoryItem.SlotIndex < 0 || inventoryItem.SlotIndex >= player.Inventory.Length)
                         return false;
 
-                    // Solo el origen debe existir; el destino puede estar vacío
-                    if (player.Inventory[SlotIndex] == null)
-                        return false;
-
-                    // Validación de índice y existencia del slot
-                    if (SlotIndex < 0 || SlotIndex >= player.Inventory.Length ||
-                        inventoryItem.SlotIndex < 0 || inventoryItem.SlotIndex >= player.Inventory.Length)
-                    {
-                        return false;
-                    }
-
-                    if (player.Inventory[SlotIndex] == null || player.Inventory[inventoryItem.SlotIndex] == null)
-                    {
-                        return false;
-                    }
-
-                    // Validación de índice y existencia del slot
-                    if (SlotIndex < 0 || SlotIndex >= player.Inventory.Length ||
-                        inventoryItem.SlotIndex < 0 || inventoryItem.SlotIndex >= player.Inventory.Length)
-                    {
-                        return false;
-                    }
-
-                    if (player.Inventory[SlotIndex] == null || player.Inventory[inventoryItem.SlotIndex] == null)
-                    {
-                        return false;
-                    }
-
+                    // Permitimos que el destino esté vacío: sólo verificamos el origen
                     player.SwapItems(SlotIndex, inventoryItem.SlotIndex);
                     return true;
 


### PR DESCRIPTION
## Summary
- allow dragging inventory items to empty slots by removing duplicate checks and swapping regardless of destination

## Testing
- `dotnet test Intersect.Tests/Intersect.Tests.csproj` *(fails: The type or namespace name 'Items' does not exist in the namespace 'Intersect.GameObjects')*

------
https://chatgpt.com/codex/tasks/task_e_68bc7b8544048324afe2ff1a67d18039