### PR TITLE
Add item descriptor validation and tests

### DIFF
--- a/Intersect.Tests/Intersect.Tests.csproj
+++ b/Intersect.Tests/Intersect.Tests.csproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Intersect (Core)\Intersect.Core.csproj" />
     <ProjectReference Include="..\Intersect.Server.Core\Intersect.Server.Core.csproj" />
+    <ProjectReference Include="..\Intersect.Client.Core\Intersect.Client.Core.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Intersect.Tests/ItemListHelperTests.cs
+++ b/Intersect.Tests/ItemListHelperTests.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Linq;
+using Intersect.Client.Utilities;
+using Intersect.Enums;
+using Intersect.Framework.Core.GameObjects.Items;
+using NUnit.Framework;
+using Assert = Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
+using Intersect;
+
+namespace Intersect.Tests;
+
+[TestFixture]
+public class ItemListHelperTests
+{
+    [SetUp]
+    public void Setup()
+    {
+        Options.EnsureCreated();
+    }
+
+    [Test]
+    public void FilterAndSort_IncludesValidItem()
+    {
+        var descriptor = new ItemDescriptor(Guid.NewGuid())
+        {
+            Name = "Sword",
+            Price = 10,
+            ItemType = ItemType.Equipment,
+            Subtype = "Sword"
+        };
+
+        var items = new[] { (Descriptor: descriptor, Quantity: 1) };
+
+        var result = ItemListHelper.FilterAndSort(
+            items,
+            x => x.Descriptor,
+            x => x.Quantity,
+            null,
+            null,
+            null,
+            SortCriterion.Name,
+            true
+        ).ToList();
+
+        Assert.AreEqual(1, result.Count);
+        Assert.AreSame(descriptor, result[0].Descriptor);
+    }
+
+    [TestCase("", 10, ItemType.Equipment, "Sword", 1, TestName = "EmptyName")]
+    [TestCase("Sword", -1, ItemType.Equipment, "Sword", 1, TestName = "NegativePrice")]
+    [TestCase("Sword", 10, ItemType.Equipment, "Sword", -1, TestName = "NegativeQuantity")]
+    [TestCase("Sword", 10, (ItemType)999, "Sword", 1, TestName = "InvalidItemType")]
+    [TestCase("Sword", 10, ItemType.Equipment, "UnknownSubtype", 1, TestName = "UnknownSubtype")]
+    public void FilterAndSort_ExcludesInvalidItems(string name, int price, ItemType type, string subtype, int quantity)
+    {
+        var descriptor = new ItemDescriptor(Guid.NewGuid())
+        {
+            Name = name,
+            Price = price,
+            ItemType = type,
+            Subtype = subtype
+        };
+
+        var items = new[] { (Descriptor: descriptor, Quantity: quantity) };
+
+        var result = ItemListHelper.FilterAndSort(
+            items,
+            x => x.Descriptor,
+            x => x.Quantity,
+            null,
+            null,
+            null,
+            SortCriterion.Name,
+            true
+        );
+
+        Assert.AreEqual(0, result.Count());
+    }
+}
+


### PR DESCRIPTION
## Summary
- add IsValid helper to validate item descriptors and quantities
- filter invalid items in item list helper
- add unit tests for ItemListHelper

## Testing
- `dotnet test Intersect.Tests/Intersect.Tests.csproj --filter ItemListHelper` *(fails: The type or namespace name 'LiteNetLib' could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_68bca5b7bd5c8324b3a9cc908a5e6e89