### PR TITLE
Sync equipment slots with item subtypes

### DIFF
--- a/Framework/Intersect.Framework.Core/Config/ItemOptions.cs
+++ b/Framework/Intersect.Framework.Core/Config/ItemOptions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Diagnostics.CodeAnalysis;
 using Intersect.Framework.Core.GameObjects.Items;
 using Newtonsoft.Json;
@@ -30,7 +31,33 @@ public class ItemOptions
     public Dictionary<ItemType, List<string>> ItemSubtypes { get; set; } = new()
 {
     { ItemType.Consumable, new() { "Drink", "Food", "Potion", "Scroll","spell" } },
-    { ItemType.Equipment, new() { "Axe", "Bow", "Dagger", "Hammer", "Spear", "Staff", "Sword", "Wand" } },
+    {
+        ItemType.Equipment,
+        new()
+        {
+            "Axe",
+            "Bow",
+            "Dagger",
+            "Hammer",
+            "Spear",
+            "Staff",
+            "Sword",
+            "Wand",
+            // Equipment slots
+            "Helmet",
+            "Armor",
+            "Weapon",
+            "Shield",
+            "Boots",
+            "Pants",
+            "Cape",
+            "Belt",
+            "Necklace",
+            "Accessory",
+            "Ring",
+            "Karma",
+        }
+    },
     { ItemType.Resource, new()
         {
             "Blood", "Bone", "Cereal", "Claw", "Craft","Crystal", "Ear", "Essence", "Eye", "Fabric", "Feather", "Fiber", "Fish",
@@ -45,6 +72,23 @@ public class ItemOptions
     {
         rarityName = RarityTiers.Skip(rarityLevel).FirstOrDefault();
         return rarityName != default;
+    }
+
+    public void MergeEquipmentSlots(IEnumerable<string> slots)
+    {
+        if (!ItemSubtypes.TryGetValue(ItemType.Equipment, out var list) || list == null)
+        {
+            list = [];
+            ItemSubtypes[ItemType.Equipment] = list;
+        }
+
+        foreach (var slot in slots)
+        {
+            if (!list.Any(s => s.Equals(slot, StringComparison.OrdinalIgnoreCase)))
+            {
+                list.Add(slot);
+            }
+        }
     }
 
 

--- a/Framework/Intersect.Framework.Core/Config/Options.cs
+++ b/Framework/Intersect.Framework.Core/Config/Options.cs
@@ -3,6 +3,8 @@ using Intersect.Config;
 using Intersect.Config.Guilds;
 using Intersect.Core;
 using Intersect.Framework.Annotations;
+using Intersect.Framework.Core.GameObjects.Items;
+using System.Linq;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 
@@ -249,6 +251,12 @@ public partial record Options
         }
     }
 
+    internal void SyncEquipmentItemSubtypes()
+    {
+        var slots = Equipment?.EquipmentSlots?.Select(es => es.Name) ?? Enumerable.Empty<string>();
+        Items?.MergeEquipmentSlots(slots);
+    }
+
     public static bool LoadFromDisk()
     {
         var instance = EnsureCreated();
@@ -262,6 +270,7 @@ public partial record Options
         {
             var rawJson = File.ReadAllText(pathToServerConfig);
             instance = JsonConvert.DeserializeObject<Options>(rawJson, PrivateSerializerSettings) ?? instance;
+            instance.SyncEquipmentItemSubtypes();
             Instance = instance;
         }
 
@@ -277,6 +286,7 @@ public partial record Options
     internal static Options EnsureCreated()
     {
         Options instance = new();
+        instance.SyncEquipmentItemSubtypes();
         Instance = instance;
         return instance;
     }

--- a/Intersect.Client.Core/Utilities/ItemListHelper.cs
+++ b/Intersect.Client.Core/Utilities/ItemListHelper.cs
@@ -49,18 +49,30 @@ namespace Intersect.Client.Utilities
                 return false;
             }
 
-            if (!subtypes.TryGetValue(d.ItemType, out var list) || list == null)
-            {
-                return false;
-            }
-
             var subtype = d.Subtype;
             if (string.IsNullOrEmpty(subtype))
             {
                 return false;
             }
 
-            return list.Any(s => s.Equals(subtype, StringComparison.OrdinalIgnoreCase));
+            if (subtypes.TryGetValue(d.ItemType, out var list) && list != null)
+            {
+                if (list.Any(s => s.Equals(subtype, StringComparison.OrdinalIgnoreCase)))
+                {
+                    return true;
+                }
+            }
+
+            if (d.ItemType == ItemType.Equipment)
+            {
+                var slots = Options.Instance?.Equipment?.EquipmentSlots?.Select(es => es.Name);
+                if (slots != null && slots.Any(s => s.Equals(subtype, StringComparison.OrdinalIgnoreCase)))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         public static IEnumerable<T> FilterAndSort<T>(

--- a/Intersect.Tests/ItemListHelperTests.cs
+++ b/Intersect.Tests/ItemListHelperTests.cs
@@ -76,5 +76,33 @@ public class ItemListHelperTests
 
         Assert.AreEqual(0, result.Count());
     }
+
+    [Test]
+    public void FilterAndSort_IncludesEquipmentSlot()
+    {
+        var descriptor = new ItemDescriptor(Guid.NewGuid())
+        {
+            Name = "Iron Helmet",
+            Price = 5,
+            ItemType = ItemType.Equipment,
+            Subtype = "Helmet"
+        };
+
+        var items = new[] { (Descriptor: descriptor, Quantity: 1) };
+
+        var result = ItemListHelper.FilterAndSort(
+            items,
+            x => x.Descriptor,
+            x => x.Quantity,
+            null,
+            null,
+            null,
+            SortCriterion.Name,
+            true
+        ).ToList();
+
+        Assert.AreEqual(1, result.Count);
+        Assert.AreSame(descriptor, result[0].Descriptor);
+    }
 }
 


### PR DESCRIPTION
## Summary
- extend ItemSubtypes for equipment with default equipment slot names
- keep equipment slots and item subtypes synchronized when loading options
- validate equipment slot names in ItemListHelper and add tests

## Testing
- `dotnet test Intersect.Tests/Intersect.Tests.csproj` *(fails: LiteNetLib not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bcb3ac5a50832488f7a8519d575699