### PR TITLE
Align bank interface sorting and filtering with inventory

### DIFF
--- a/Intersect.Client.Core/Interface/Game/Bank/BankItem.cs
+++ b/Intersect.Client.Core/Interface/Game/Bank/BankItem.cs
@@ -320,17 +320,5 @@ public partial class BankItem : SlotItem
     public void SetFilterMatch(bool isMatch)
     {
         _filterMatch = isMatch;
-        // Actualizar aspecto inmediatamente
-        if (!_filterMatch)
-        {
-            // Simular slot vacío visualmente
-            _quantityLabel.IsVisibleInParent = false;
-            Icon.IsVisibleInParent = false;
-        }
-        else
-        {
-            // Se restablece en Update() según el estado real del slot
-            // (no hacemos nada aquí para evitar parpadeos)
-        }
     }
 }


### PR DESCRIPTION
## Summary
- Add inventory-style sort cycling and client-side swap operations for bank items
- Rework bank filters to hide unmatched slots like inventory filtering
- Simplify bank slot drag-drop filter flag

## Testing
- `dotnet test` *(fails: project files missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bcf1bc79f08324b9f8ad4a1e4e43a1