### PR TITLE
Handle null item slots when moving bank items

### DIFF
--- a/Intersect.Client.Core/Entities/Player.cs
+++ b/Intersect.Client.Core/Entities/Player.cs
@@ -1019,9 +1019,15 @@ public partial class Player : Entity, IPlayer
         }
 
         slot ??= Inventory[inventorySlotIndex];
+        if (slot is null)
+        {
+            ApplicationContext.Context.Value?.Logger.LogWarning($"Tried to move item from slot {inventorySlotIndex}, but the slot was empty");
+            return false;
+        }
+
         if (!ItemDescriptor.TryGet(slot.ItemId, out var itemDescriptor))
         {
-            ApplicationContext.Context.Value?.Logger.LogWarning($"Tried to move item that does not exist from slot {inventorySlotIndex}: {itemDescriptor.Id}");
+            ApplicationContext.Context.Value?.Logger.LogWarning($"Tried to move item that does not exist from slot {inventorySlotIndex}: {slot.ItemId}");
             return false;
         }
 
@@ -1146,9 +1152,15 @@ public partial class Player : Entity, IPlayer
         }
 
         slot ??= Globals.BankSlots[bankSlotIndex];
+        if (slot is null)
+        {
+            ApplicationContext.Context.Value?.Logger.LogWarning($"Tried to move item from slot {bankSlotIndex}, but the slot was empty");
+            return false;
+        }
+
         if (!ItemDescriptor.TryGet(slot.ItemId, out var itemDescriptor))
         {
-            ApplicationContext.Context.Value?.Logger.LogWarning($"Tried to move item that does not exist from slot {bankSlotIndex}: {itemDescriptor.Id}");
+            ApplicationContext.Context.Value?.Logger.LogWarning($"Tried to move item that does not exist from slot {bankSlotIndex}: {slot.ItemId}");
             return false;
         }
 


### PR DESCRIPTION
## Summary
- Safely handle bank item moves when item descriptor lookup fails
- Guard against null item slots before accessing `ItemId`

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bcf9a084f48324a858bbd3297a82a2