### PR TITLE
Add market system scaffolding

### DIFF
--- a/Framework/Intersect.Framework.Core/Network/Packets/Client/BuyMarketListingPacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Client/BuyMarketListingPacket.cs
@@ -1,0 +1,25 @@
+using System;
+using MessagePack;
+
+namespace Intersect.Network.Packets.Client;
+
+[MessagePackObject]
+public partial class BuyMarketListingPacket : IntersectPacket
+{
+    // Parameterless constructor for MessagePack
+    public BuyMarketListingPacket()
+    {
+    }
+
+    public BuyMarketListingPacket(Guid listingId, int quantity)
+    {
+        ListingId = listingId;
+        Quantity = quantity;
+    }
+
+    [Key(0)]
+    public Guid ListingId { get; set; }
+
+    [Key(1)]
+    public int Quantity { get; set; }
+}

--- a/Framework/Intersect.Framework.Core/Network/Packets/Client/CreateMarketListingPacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Client/CreateMarketListingPacket.cs
@@ -1,0 +1,29 @@
+using System;
+using MessagePack;
+
+namespace Intersect.Network.Packets.Client;
+
+[MessagePackObject]
+public partial class CreateMarketListingPacket : IntersectPacket
+{
+    // Parameterless constructor for MessagePack
+    public CreateMarketListingPacket()
+    {
+    }
+
+    public CreateMarketListingPacket(int itemSlot, int quantity, long price)
+    {
+        ItemSlot = itemSlot;
+        Quantity = quantity;
+        Price = price;
+    }
+
+    [Key(0)]
+    public int ItemSlot { get; set; }
+
+    [Key(1)]
+    public int Quantity { get; set; }
+
+    [Key(2)]
+    public long Price { get; set; }
+}

--- a/Framework/Intersect.Framework.Core/Network/Packets/Client/SearchMarketPacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Client/SearchMarketPacket.cs
@@ -1,0 +1,20 @@
+using MessagePack;
+
+namespace Intersect.Network.Packets.Client;
+
+[MessagePackObject]
+public partial class SearchMarketPacket : IntersectPacket
+{
+    // Parameterless constructor for MessagePack
+    public SearchMarketPacket()
+    {
+    }
+
+    public SearchMarketPacket(string query)
+    {
+        Query = query;
+    }
+
+    [Key(0)]
+    public string Query { get; set; } = string.Empty;
+}

--- a/Framework/Intersect.Framework.Core/Network/Packets/Server/MarketListingCreatedPacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Server/MarketListingCreatedPacket.cs
@@ -1,0 +1,21 @@
+using System;
+using MessagePack;
+
+namespace Intersect.Network.Packets.Server;
+
+[MessagePackObject]
+public partial class MarketListingCreatedPacket : IntersectPacket
+{
+    // Parameterless constructor for MessagePack
+    public MarketListingCreatedPacket()
+    {
+    }
+
+    public MarketListingCreatedPacket(Guid listingId)
+    {
+        ListingId = listingId;
+    }
+
+    [Key(0)]
+    public Guid ListingId { get; set; }
+}

--- a/Framework/Intersect.Framework.Core/Network/Packets/Server/MarketListingPacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Server/MarketListingPacket.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+using MessagePack;
+
+namespace Intersect.Network.Packets.Server;
+
+[MessagePackObject]
+public partial class MarketListingPacket : IntersectPacket
+{
+    // Parameterless constructor for MessagePack
+    public MarketListingPacket()
+    {
+    }
+
+    public MarketListingPacket(Guid listingId, Guid sellerId, int itemId, int quantity, long price)
+    {
+        ListingId = listingId;
+        SellerId = sellerId;
+        ItemId = itemId;
+        Quantity = quantity;
+        Price = price;
+    }
+
+    [Key(0)]
+    public Guid ListingId { get; set; }
+
+    [Key(1)]
+    public Guid SellerId { get; set; }
+
+    [Key(2)]
+    public int ItemId { get; set; }
+
+    [Key(3)]
+    public int Quantity { get; set; }
+
+    [Key(4)]
+    public long Price { get; set; }
+}
+
+[MessagePackObject]
+public partial class MarketListingsPacket : IntersectPacket
+{
+    // Parameterless constructor for MessagePack
+    public MarketListingsPacket()
+    {
+    }
+
+    public MarketListingsPacket(List<MarketListingPacket> listings)
+    {
+        Listings = listings;
+    }
+
+    [Key(0)]
+    public List<MarketListingPacket> Listings { get; set; } = new();
+}

--- a/Framework/Intersect.Framework.Core/Network/Packets/Server/MarketPurchaseSuccessPacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Server/MarketPurchaseSuccessPacket.cs
@@ -1,0 +1,21 @@
+using System;
+using MessagePack;
+
+namespace Intersect.Network.Packets.Server;
+
+[MessagePackObject]
+public partial class MarketPurchaseSuccessPacket : IntersectPacket
+{
+    // Parameterless constructor for MessagePack
+    public MarketPurchaseSuccessPacket()
+    {
+    }
+
+    public MarketPurchaseSuccessPacket(Guid listingId)
+    {
+        ListingId = listingId;
+    }
+
+    [Key(0)]
+    public Guid ListingId { get; set; }
+}

--- a/Framework/Intersect.Framework.Core/Network/Packets/Server/MarketTransactionsPacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Server/MarketTransactionsPacket.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using MessagePack;
+
+namespace Intersect.Network.Packets.Server;
+
+[MessagePackObject]
+public partial class MarketTransactionsPacket : IntersectPacket
+{
+    // Parameterless constructor for MessagePack
+    public MarketTransactionsPacket()
+    {
+    }
+
+    public MarketTransactionsPacket(List<MarketTransactionInfo> transactions)
+    {
+        Transactions = transactions;
+    }
+
+    [Key(0)]
+    public List<MarketTransactionInfo> Transactions { get; set; } = new();
+}
+
+[MessagePackObject]
+public partial class MarketTransactionInfo
+{
+    // Parameterless constructor for MessagePack
+    public MarketTransactionInfo()
+    {
+    }
+
+    public MarketTransactionInfo(Guid listingId, Guid buyerId, int quantity, long price)
+    {
+        ListingId = listingId;
+        BuyerId = buyerId;
+        Quantity = quantity;
+        Price = price;
+    }
+
+    [Key(0)]
+    public Guid ListingId { get; set; }
+
+    [Key(1)]
+    public Guid BuyerId { get; set; }
+
+    [Key(2)]
+    public int Quantity { get; set; }
+
+    [Key(3)]
+    public long Price { get; set; }
+}

--- a/Intersect.Client.Core/CustomChanges/PacketHandlerCustom.cs
+++ b/Intersect.Client.Core/CustomChanges/PacketHandlerCustom.cs
@@ -240,4 +240,29 @@ internal sealed partial class PacketHandler
         BestiaryController.ApplyPacket(packet);
     }
 
+    public void HandlePacket(IPacketSender packetSender, MarketListingCreatedPacket packet)
+    {
+        // Placeholder for handling market listing creation confirmation
+    }
+
+    public void HandlePacket(IPacketSender packetSender, MarketListingPacket packet)
+    {
+        // Placeholder for handling a single market listing
+    }
+
+    public void HandlePacket(IPacketSender packetSender, MarketListingsPacket packet)
+    {
+        // Placeholder for handling multiple market listings
+    }
+
+    public void HandlePacket(IPacketSender packetSender, MarketPurchaseSuccessPacket packet)
+    {
+        // Placeholder for handling successful market purchases
+    }
+
+    public void HandlePacket(IPacketSender packetSender, MarketTransactionsPacket packet)
+    {
+        // Placeholder for handling market transaction history
+    }
+
 }

--- a/Intersect.Client.Core/CustomChanges/PacketSenderCustom.cs
+++ b/Intersect.Client.Core/CustomChanges/PacketSenderCustom.cs
@@ -1,3 +1,4 @@
+using System;
 using Intersect.Client.Entities.Events;
 using Intersect.Client.Framework.Gwen.Control;
 using Intersect.Client.Framework.Gwen.Control.EventArguments;
@@ -95,6 +96,21 @@ public static partial class PacketSender
         };
 
         Network.SendPacket(packet);
+    }
+
+    public static void SendCreateMarketListing(int itemSlot, int quantity, long price)
+    {
+        Network.SendPacket(new CreateMarketListingPacket(itemSlot, quantity, price));
+    }
+
+    public static void SendSearchMarket(string query)
+    {
+        Network.SendPacket(new SearchMarketPacket(query));
+    }
+
+    public static void SendBuyMarketListing(Guid listingId, int quantity)
+    {
+        Network.SendPacket(new BuyMarketListingPacket(listingId, quantity));
     }
 
 }

--- a/Intersect.Client.Core/Interface/Game/GameInterface.cs
+++ b/Intersect.Client.Core/Interface/Game/GameInterface.cs
@@ -15,6 +15,7 @@ using Intersect.Client.Interface.Game.Hotbar;
 using Intersect.Client.Interface.Game.Inventory;
 using Intersect.Client.Interface.Game.Mail;
 using Intersect.Client.Interface.Game.Shop;
+using Intersect.Client.Interface.Game.Market;
 using Intersect.Client.Interface.Game.Trades;
 using Intersect.Client.Interface.Menu;
 using Intersect.Client.Interface.Shared;
@@ -56,6 +57,8 @@ public partial class GameInterface : MutableInterface
     private QuestOfferWindow mQuestOfferWindow;
 
     private ShopWindow _shopWindow;
+    private MarketWindow? _marketWindow;
+    private SellMarketWindow? _sellMarketWindow;
     public EnchantItemWindow mEnchantItemWindow;
     private RuneEnchantWindow mRuneItemWindow;
     private BreakItemWindow mBreakItemWindow;
@@ -89,6 +92,12 @@ public partial class GameInterface : MutableInterface
     private bool mShouldOpenCraftingTable;
 
     private bool mShouldOpenShop;
+
+    private bool _shouldOpenMarket;
+    private bool _shouldCloseMarket;
+    private bool _shouldOpenSellMarket;
+    private bool _shouldCloseSellMarket;
+    private int _sellMarketSlot;
 
     private bool mShouldOpenTrading;
 
@@ -288,6 +297,40 @@ public partial class GameInterface : MutableInterface
     {
         _shopWindow = new ShopWindow(GameCanvas) { DeleteOnClose = true };
         mShouldOpenShop = false;
+    }
+
+    //Market
+    public void NotifyOpenMarket()
+    {
+        _shouldOpenMarket = true;
+    }
+
+    public void NotifyCloseMarket()
+    {
+        _shouldCloseMarket = true;
+    }
+
+    public void OpenMarket()
+    {
+        _marketWindow = new MarketWindow(GameCanvas) { DeleteOnClose = true };
+        _shouldOpenMarket = false;
+    }
+
+    public void NotifyOpenSellMarket(int slot)
+    {
+        _sellMarketSlot = slot;
+        _shouldOpenSellMarket = true;
+    }
+
+    public void NotifyCloseSellMarket()
+    {
+        _shouldCloseSellMarket = true;
+    }
+
+    public void OpenSellMarket()
+    {
+        _sellMarketWindow = new SellMarketWindow(GameCanvas, _sellMarketSlot) { DeleteOnClose = true };
+        _shouldOpenSellMarket = false;
     }
 
     //Bank
@@ -522,6 +565,32 @@ public partial class GameInterface : MutableInterface
         }
 
         mShouldCloseShop = false;
+
+        //Market Update
+        if (_shouldOpenMarket)
+        {
+            OpenMarket();
+            GameMenu.OpenInventory();
+        }
+
+        if (_marketWindow != null && (!_marketWindow.IsVisibleInTree || _shouldCloseMarket))
+        {
+            _marketWindow.Close();
+            _marketWindow = null;
+            _shouldCloseMarket = false;
+        }
+
+        if (_shouldOpenSellMarket)
+        {
+            OpenSellMarket();
+        }
+
+        if (_sellMarketWindow != null && (!_sellMarketWindow.IsVisibleInTree || _shouldCloseSellMarket))
+        {
+            _sellMarketWindow.Close();
+            _sellMarketWindow = null;
+            _shouldCloseSellMarket = false;
+        }
 
         //Bank Update
         if (mShouldOpenBank)

--- a/Intersect.Client.Core/Interface/Game/Inventory/InventoryItem.cs
+++ b/Intersect.Client.Core/Interface/Game/Inventory/InventoryItem.cs
@@ -37,6 +37,7 @@ public partial class InventoryItem : SlotItem
     private readonly MenuItem _actionItemMenuItem;
     private readonly MenuItem _dropItemMenuItem;
     private readonly MenuItem _showItemMenuItem;
+    private readonly MenuItem _sellItemMenuItem;
 
     public InventoryItem(InventoryWindow inventoryWindow, Base parent, int index, ContextMenu contextMenu)
         : base(parent, nameof(InventoryItem), index, contextMenu)
@@ -96,6 +97,8 @@ public partial class InventoryItem : SlotItem
         _actionItemMenuItem.Clicked += _actionItemContextItem_Clicked;
         _showItemMenuItem = contextMenu.AddItem(Strings.ItemContextMenu.Show);
         _showItemMenuItem.Clicked += _showItemContextItem_Clicked;
+        _sellItemMenuItem = contextMenu.AddItem(Strings.ItemContextMenu.Sell);
+        _sellItemMenuItem.Clicked += _sellItemContextItem_Clicked;
         contextMenu.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
 
         if (Globals.Me is { } player)
@@ -179,6 +182,12 @@ public partial class InventoryItem : SlotItem
             _actionItemMenuItem.SetText(Strings.ItemContextMenu.Sell.ToString(descriptor.Name));
         }
 
+        if (Globals.GameShop == null && descriptor.CanSell)
+        {
+            contextMenu.AddChild(_sellItemMenuItem);
+            _sellItemMenuItem.SetText(Strings.ItemContextMenu.Sell.ToString(descriptor.Name));
+        }
+
         // Can we drop this item? if so show the user!
         if (descriptor.CanDrop)
         {
@@ -230,6 +239,11 @@ public partial class InventoryItem : SlotItem
         }
 
         Interface.GameUi.AppendChatboxItem(descriptor, slot.ItemProperties ?? new ItemProperties());
+    }
+
+    private void _sellItemContextItem_Clicked(Base sender, MouseButtonState arguments)
+    {
+        Interface.Interface.EnqueueInGame(gameInterface => gameInterface.NotifyOpenSellMarket(SlotIndex));
     }
 
     private void _dropItemContextItem_Clicked(Base sender, MouseButtonState arguments)

--- a/Intersect.Client.Core/Interface/Game/Market/MarketItem.cs
+++ b/Intersect.Client.Core/Interface/Game/Market/MarketItem.cs
@@ -1,0 +1,12 @@
+using Intersect.Client.Framework.Gwen.Control;
+using Intersect.Client.Interface.Game;
+
+namespace Intersect.Client.Interface.Game.Market;
+
+public partial class MarketItem : SlotItem
+{
+    public MarketItem(Base parent, int index, ContextMenu contextMenu)
+        : base(parent, nameof(MarketItem), index, contextMenu)
+    {
+    }
+}

--- a/Intersect.Client.Core/Interface/Game/Market/MarketWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Market/MarketWindow.cs
@@ -1,0 +1,16 @@
+using Intersect.Client.Framework.Gwen;
+using Intersect.Client.Framework.Gwen.Control;
+using Intersect.Client.Localization;
+
+namespace Intersect.Client.Interface.Game.Market;
+
+public partial class MarketWindow : Window
+{
+    public MarketWindow(Canvas gameCanvas) : base(gameCanvas, Strings.Market.Title, false, nameof(MarketWindow))
+    {
+        DisableResizing();
+        Alignment = [Alignments.Center];
+        IsResizable = false;
+        IsClosable = true;
+    }
+}

--- a/Intersect.Client.Core/Interface/Game/Market/SellMarketWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Market/SellMarketWindow.cs
@@ -1,0 +1,19 @@
+using Intersect.Client.Framework.Gwen;
+using Intersect.Client.Framework.Gwen.Control;
+using Intersect.Client.Localization;
+
+namespace Intersect.Client.Interface.Game.Market;
+
+public partial class SellMarketWindow : Window
+{
+    private readonly int _slot;
+
+    public SellMarketWindow(Canvas gameCanvas, int slot) : base(gameCanvas, Strings.Market.Title, false, nameof(SellMarketWindow))
+    {
+        _slot = slot;
+        DisableResizing();
+        Alignment = [Alignments.Center];
+        IsResizable = false;
+        IsClosable = true;
+    }
+}

--- a/Intersect.Client.Core/Localization/Strings.cs
+++ b/Intersect.Client.Core/Localization/Strings.cs
@@ -3166,4 +3166,10 @@ If you are sure you want to hand over your guild enter '\c{{#ff8080}}{02}\c{{}}'
         public static LocalizedString EntityNameAndLevel = @"{00} [Lv. {01}]";
     }
 
+    public partial struct Market
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Title = @"Market";
+    }
+
 }

--- a/Intersect.Editor/Localization/Strings.cs
+++ b/Intersect.Editor/Localization/Strings.cs
@@ -5970,4 +5970,10 @@ Negative values for time to flow backwards.";
 
     }
 
+    public partial struct Market
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Title = @"Market";
+    }
+
 }

--- a/Intersect.Server.Core/CustomChanges/PacketHandlerCustom.cs
+++ b/Intersect.Server.Core/CustomChanges/PacketHandlerCustom.cs
@@ -602,5 +602,20 @@ internal sealed partial class PacketHandler
         PacketSender.SendEntityDataToProximity(player);
     }
 
+    public void HandlePacket(Client client, SearchMarketPacket packet)
+    {
+        // Placeholder for market search handling
+    }
+
+    public void HandlePacket(Client client, CreateMarketListingPacket packet)
+    {
+        // Placeholder for creating market listings
+    }
+
+    public void HandlePacket(Client client, BuyMarketListingPacket packet)
+    {
+        // Placeholder for purchasing market listings
+    }
+
 
 }

--- a/Intersect.Server.Core/CustomChanges/PacketSenderCustom.cs
+++ b/Intersect.Server.Core/CustomChanges/PacketSenderCustom.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using Intersect.Config;
 using Intersect.Core;
 using Intersect.Enums;
@@ -213,6 +215,26 @@ public static partial class PacketSender
             .ToDictionary(b => b.NpcId, b => b.Value);
 
         player.SendPacket(new UnlockedBestiaryEntriesPacket(unlocks, killCounts));
+    }
+
+    public static void SendMarketListingCreated(Player player, Guid listingId)
+    {
+        player.SendPacket(new MarketListingCreatedPacket(listingId));
+    }
+
+    public static void SendMarketListings(Player player, List<MarketListingPacket> listings)
+    {
+        player.SendPacket(new MarketListingsPacket(listings));
+    }
+
+    public static void SendMarketPurchaseSuccess(Player player, Guid listingId)
+    {
+        player.SendPacket(new MarketPurchaseSuccessPacket(listingId));
+    }
+
+    public static void SendMarketTransactions(Player player, List<MarketTransactionInfo> transactions)
+    {
+        player.SendPacket(new MarketTransactionsPacket(transactions));
     }
 
 

--- a/Intersect.Server.Core/Database/PlayerData/Market/MarketListing.cs
+++ b/Intersect.Server.Core/Database/PlayerData/Market/MarketListing.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace Intersect.Server.Database.PlayerData.Market;
+
+public partial class MarketListing
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public Guid SellerId { get; set; }
+    public int ItemId { get; set; }
+    public int Quantity { get; set; }
+    public long Price { get; set; }
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/Intersect.Server.Core/Database/PlayerData/Market/MarketManager.cs
+++ b/Intersect.Server.Core/Database/PlayerData/Market/MarketManager.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+
+namespace Intersect.Server.Database.PlayerData.Market;
+
+public partial class MarketManager
+{
+    private readonly List<MarketListing> _listings = new();
+    private readonly List<MarketTransaction> _transactions = new();
+
+    public IReadOnlyList<MarketListing> Listings => _listings;
+    public IReadOnlyList<MarketTransaction> Transactions => _transactions;
+
+    public void AddListing(MarketListing listing) => _listings.Add(listing);
+
+    public void RecordTransaction(MarketTransaction transaction) => _transactions.Add(transaction);
+}

--- a/Intersect.Server.Core/Database/PlayerData/Market/MarketTransaction.cs
+++ b/Intersect.Server.Core/Database/PlayerData/Market/MarketTransaction.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace Intersect.Server.Database.PlayerData.Market;
+
+public partial class MarketTransaction
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public Guid ListingId { get; set; }
+    public Guid BuyerId { get; set; }
+    public int Quantity { get; set; }
+    public long Price { get; set; }
+    public DateTime TransactionTime { get; set; } = DateTime.UtcNow;
+}

--- a/Intersect.Server.Core/Localization/Strings.cs
+++ b/Intersect.Server.Core/Localization/Strings.cs
@@ -1435,6 +1435,12 @@ public static partial class Strings
         public readonly LocalizedString RevokeNotAllowed = @"You can't revoke this item, {00} has already accepted the trade!";
     }
 
+    public sealed partial class MarketNamespace : LocaleNamespace
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString Title = @"Market";
+    }
+
     public sealed partial class UpnpNamespace : LocaleNamespace
     {
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
@@ -1607,6 +1613,8 @@ public static partial class Strings
 
         public readonly ShopsNamespace Shops = new ShopsNamespace();
 
+        public readonly MarketNamespace Market = new MarketNamespace();
+
         public readonly TradingNamespace Trading = new TradingNamespace();
 
         public readonly UpnpNamespace Upnp = new UpnpNamespace();
@@ -1688,6 +1696,8 @@ public static partial class Strings
     public static RegexNamespace Regex => Root.Regex;
 
     public static ShopsNamespace Shops => Root.Shops;
+
+    public static MarketNamespace Market => Root.Market;
 
     public static TradingNamespace Trading => Root.Trading;
 


### PR DESCRIPTION
## Summary
- stub out market network packets for clients and servers
- add initial market UI windows and inventory integration
- introduce basic market data classes and packet helpers

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bd0b6337bc83248cb293439fdf5e54