### PR TITLE
feat: add market listing cancellation

### DIFF
--- a/Framework/Intersect.Framework.Core/Network/Packets/Client/CancelMarketListingPacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Client/CancelMarketListingPacket.cs
@@ -1,0 +1,21 @@
+using System;
+using MessagePack;
+
+namespace Intersect.Network.Packets.Client;
+
+[MessagePackObject]
+public partial class CancelMarketListingPacket : IntersectPacket
+{
+    // Parameterless constructor for MessagePack
+    public CancelMarketListingPacket()
+    {
+    }
+
+    public CancelMarketListingPacket(Guid listingId)
+    {
+        ListingId = listingId;
+    }
+
+    [Key(0)]
+    public Guid ListingId { get; set; }
+}

--- a/Intersect.Client.Core/CustomChanges/PacketSenderCustom.cs
+++ b/Intersect.Client.Core/CustomChanges/PacketSenderCustom.cs
@@ -115,4 +115,9 @@ public static partial class PacketSender
         Network.SendPacket(new BuyMarketListingPacket(listingId, quantity));
     }
 
+    public static void SendCancelMarketListing(Guid listingId)
+    {
+        Network.SendPacket(new CancelMarketListingPacket(listingId));
+    }
+
 }

--- a/Intersect.Client.Core/Interface/Game/Market/MarketWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Market/MarketWindow.cs
@@ -1,6 +1,9 @@
 using System.Collections.Generic;
+using Intersect.Client.Core;
+using Intersect.Client.Framework.File_Management;
 using Intersect.Client.Framework.Gwen;
 using Intersect.Client.Framework.Gwen.Control;
+using Intersect.Client.General;
 using Intersect.Client.Localization;
 using Intersect.Network.Packets.Server;
 
@@ -23,8 +26,13 @@ public partial class MarketWindow : Window
         foreach (var listing in listings)
         {
             var marketItem = new MarketItem(this, _items.Count, new ContextMenu(this));
-            marketItem.Load(listing.ListingId, listing.ItemId, listing.Properties);
+            marketItem.Load(listing.ListingId, listing.SellerId, listing.ItemId, listing.Properties);
             _items.Add(marketItem);
         }
+    }
+
+    protected override void EnsureInitialized()
+    {
+        LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
     }
 }

--- a/Intersect.Client.Core/Interface/Game/Market/SellMarketWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Market/SellMarketWindow.cs
@@ -1,6 +1,8 @@
 using Intersect.Client.Core;
+using Intersect.Client.Framework.File_Management;
 using Intersect.Client.Framework.Gwen;
 using Intersect.Client.Framework.Gwen.Control;
+using Intersect.Client.General;
 using Intersect.Client.Localization;
 using Intersect.Client.Networking;
 using Intersect.Framework.Core.GameObjects.Items;
@@ -28,5 +30,10 @@ public partial class SellMarketWindow : Window
     public void SellItem(int quantity, long price)
     {
         PacketSender.SendCreateMarketListing(_slot, quantity, price);
+    }
+
+    protected override void EnsureInitialized()
+    {
+        LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
     }
 }

--- a/Intersect.Server.Core/CustomChanges/PacketHandlerCustom.cs
+++ b/Intersect.Server.Core/CustomChanges/PacketHandlerCustom.cs
@@ -31,6 +31,7 @@ using Intersect.Framework.Core.Security;
 using Intersect.Network.Packets.Server;
 using Intersect.Server.Core;
 using Microsoft.Extensions.Logging;
+using Intersect.Server.Database.PlayerData.Market;
 using ChatMsgPacket = Intersect.Network.Packets.Client.ChatMsgPacket;
 using LoginPacket = Intersect.Network.Packets.Client.LoginPacket;
 using PartyInvitePacket = Intersect.Network.Packets.Client.PartyInvitePacket;
@@ -43,6 +44,7 @@ namespace Intersect.Server.Networking;
 
 internal sealed partial class PacketHandler
 {
+    private static readonly MarketManager MarketManager = new();
     public void HandlePacket(Client client, GuildExpPercentagePacket packet)
     {
         var player = client?.Entity;
@@ -616,6 +618,17 @@ internal sealed partial class PacketHandler
     public void HandlePacket(Client client, BuyMarketListingPacket packet)
     {
         // Placeholder for purchasing market listings
+    }
+
+    public void HandlePacket(Client client, CancelMarketListingPacket packet)
+    {
+        var player = client.Entity;
+        if (player == null)
+        {
+            return;
+        }
+
+        MarketManager.CancelListing(player, packet.ListingId);
     }
 
 

--- a/Intersect.Server.Core/Database/PlayerData/Market/MarketManager.cs
+++ b/Intersect.Server.Core/Database/PlayerData/Market/MarketManager.cs
@@ -1,4 +1,8 @@
+using System;
 using System.Collections.Generic;
+using System.Linq;
+using Intersect.Framework.Core.GameObjects.Items;
+using Intersect.Server.Entities;
 
 namespace Intersect.Server.Database.PlayerData.Market;
 
@@ -13,4 +17,18 @@ public partial class MarketManager
     public void AddListing(MarketListing listing) => _listings.Add(listing);
 
     public void RecordTransaction(MarketTransaction transaction) => _transactions.Add(transaction);
+
+    public bool CancelListing(Player player, Guid listingId)
+    {
+        var listing = _listings.FirstOrDefault(l => l.Id == listingId && l.SellerId == player.Id);
+        if (listing == null)
+        {
+            return false;
+        }
+
+        var itemGuid = ItemDescriptor.IdFromList(listing.ItemId);
+        player.TryGiveItem(itemGuid, listing.Quantity, listing.Properties);
+        _listings.Remove(listing);
+        return true;
+    }
 }


### PR DESCRIPTION
## Summary
- add cancel listing packet and sender
- show Cancel button on own market listings
- handle cancel requests server side and return items

## Testing
- `dotnet build Intersect.Client.Core/Intersect.Client.Core.csproj` *(fails: Interface.Interface missing)*
- `dotnet build Intersect.Server.Core/Intersect.Server.Core.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68bd9d52e4c48324a2ecea92924ef9ef