### PR TITLE
feat: expand market UI and add suggested pricing

### DIFF
--- a/Intersect.Client.Core/Interface/Game/Market/MarketWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Market/MarketWindow.cs
@@ -12,6 +12,7 @@ namespace Intersect.Client.Interface.Game.Market;
 public partial class MarketWindow : Window
 {
     private readonly List<MarketItem> _items = new();
+    private readonly ScrollControl _listingContainer;
 
     public MarketWindow(Canvas gameCanvas) : base(gameCanvas, Strings.Market.Title, false, nameof(MarketWindow))
     {
@@ -19,13 +20,20 @@ public partial class MarketWindow : Window
         Alignment = [Alignments.Center];
         IsResizable = false;
         IsClosable = true;
+        SetSize(420, 360);
+
+        _listingContainer = new ScrollControl(this, nameof(_listingContainer))
+        {
+            OverflowY = OverflowBehavior.Scroll,
+            OverflowX = OverflowBehavior.Hidden,
+        };
     }
 
     public void LoadListings(List<MarketListingPacket> listings)
     {
         foreach (var listing in listings)
         {
-            var marketItem = new MarketItem(this, _items.Count, new ContextMenu(this));
+            var marketItem = new MarketItem(_listingContainer, _items.Count, new ContextMenu(this));
             marketItem.Load(listing.ListingId, listing.SellerId, listing.ItemId, listing.Properties);
             _items.Add(marketItem);
         }
@@ -34,5 +42,7 @@ public partial class MarketWindow : Window
     protected override void EnsureInitialized()
     {
         LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
+        SetSize(420, 360);
+        _listingContainer.SetBounds(8, 32, Width - 16, Height - 40);
     }
 }

--- a/Intersect.Client.Core/Interface/Game/Market/SellMarketWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Market/SellMarketWindow.cs
@@ -2,6 +2,7 @@ using Intersect.Client.Core;
 using Intersect.Client.Framework.File_Management;
 using Intersect.Client.Framework.Gwen;
 using Intersect.Client.Framework.Gwen.Control;
+using Intersect.Client.Framework.Gwen.Control.EventArguments;
 using Intersect.Client.General;
 using Intersect.Client.Localization;
 using Intersect.Client.Networking;
@@ -13,13 +14,89 @@ public partial class SellMarketWindow : Window
 {
     private readonly int _slot;
 
-    public SellMarketWindow(Canvas gameCanvas, int slot) : base(gameCanvas, Strings.Market.Title, false, nameof(SellMarketWindow))
+    private readonly Label _quantityLabel;
+    private readonly TextBoxNumeric _quantityBox;
+    private readonly Label _priceLabel;
+    private readonly TextBoxNumeric _priceBox;
+    private readonly Label _suggestedPriceLabel;
+    private readonly Button _sellButton;
+    private readonly Button _cancelButton;
+
+    private const int PAD = 8;
+    private const int GAP = 8;
+    private const int LABEL_W = 80;
+    private const int INPUT_W = 140;
+    private const int CTRL_H = 24;
+
+    public SellMarketWindow(Canvas gameCanvas, int slot)
+        : base(gameCanvas, Strings.Market.Title, false, nameof(SellMarketWindow))
     {
         _slot = slot;
         DisableResizing();
         Alignment = [Alignments.Center];
         IsResizable = false;
         IsClosable = true;
+        SetSize(360, 180);
+
+        _quantityLabel = new Label(this, nameof(_quantityLabel))
+        {
+            Text = Strings.Market.Quantity,
+        };
+
+        _quantityBox = new TextBoxNumeric(this, nameof(_quantityBox))
+        {
+            Minimum = 1,
+            Value = 1,
+        };
+
+        _priceLabel = new Label(this, nameof(_priceLabel))
+        {
+            Text = Strings.Market.Price,
+        };
+
+        _priceBox = new TextBoxNumeric(this, nameof(_priceBox))
+        {
+            Minimum = 0,
+        };
+
+        _suggestedPriceLabel = new Label(this, nameof(_suggestedPriceLabel));
+
+        _sellButton = new Button(this, nameof(_sellButton))
+        {
+            Text = Strings.Market.Sell,
+        };
+        _sellButton.Clicked += SellButtonOnClicked;
+
+        _cancelButton = new Button(this, nameof(_cancelButton))
+        {
+            Text = Strings.InputBox.Cancel,
+        };
+        _cancelButton.Clicked += (_, _) => Close();
+
+        RecomputeLayout();
+    }
+
+    private void RecomputeLayout()
+    {
+        SetSize(360, 180);
+        _quantityLabel.SetBounds(PAD, PAD, LABEL_W, CTRL_H);
+        _quantityBox.SetBounds(PAD + LABEL_W + GAP, PAD, INPUT_W, CTRL_H);
+
+        _priceLabel.SetBounds(PAD, PAD + CTRL_H + GAP, LABEL_W, CTRL_H);
+        _priceBox.SetBounds(PAD + LABEL_W + GAP, PAD + CTRL_H + GAP, INPUT_W, CTRL_H);
+
+        _suggestedPriceLabel.SetBounds(PAD, PAD + (CTRL_H + GAP) * 2, LABEL_W + INPUT_W + GAP, CTRL_H);
+
+        _sellButton.SetBounds(PAD, Height - CTRL_H - PAD, 100, CTRL_H);
+        _cancelButton.SetBounds(Width - 100 - PAD, Height - CTRL_H - PAD, 100, CTRL_H);
+    }
+
+    private void SellButtonOnClicked(Base sender, MouseButtonState args)
+    {
+        var quantity = (int)_quantityBox.Value;
+        var price = (long)_priceBox.Value;
+        SellItem(quantity, price);
+        Close();
     }
 
     public ItemProperties? GetItemProperties()
@@ -32,8 +109,17 @@ public partial class SellMarketWindow : Window
         PacketSender.SendCreateMarketListing(_slot, quantity, price);
     }
 
+    private void UpdateSuggestedPrice()
+    {
+        var suggested = Globals.Me?.Inventory[_slot]?.Descriptor.Price ?? 0;
+        _suggestedPriceLabel.Text = Strings.Market.SuggestedPrice.ToString(suggested);
+    }
+
     protected override void EnsureInitialized()
     {
         LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
+        RecomputeLayout();
+        UpdateSuggestedPrice();
     }
 }
+

--- a/Intersect.Client.Core/Localization/Strings.cs
+++ b/Intersect.Client.Core/Localization/Strings.cs
@@ -3170,6 +3170,14 @@ If you are sure you want to hand over your guild enter '\c{{#ff8080}}{02}\c{{}}'
     {
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public static LocalizedString Title = @"Market";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Quantity = @"Quantity";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Price = @"Price";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString SuggestedPrice = @"Suggested Price: {00}";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Sell = @"Sell";
     }
 
 }

--- a/Intersect.Client.Core/Localization/Translations/en-US.json
+++ b/Intersect.Client.Core/Localization/Translations/en-US.json
@@ -2,5 +2,12 @@
   "Inventory": {
     "Sort": "Sort",
     "All": "All"
+  },
+  "Market": {
+    "Title": "Market",
+    "Quantity": "Quantity",
+    "Price": "Price",
+    "SuggestedPrice": "Suggested Price: {00}",
+    "Sell": "Sell"
   }
 }

--- a/Intersect.Client.Core/Localization/Translations/es-ES.json
+++ b/Intersect.Client.Core/Localization/Translations/es-ES.json
@@ -2,5 +2,12 @@
   "Inventory": {
     "Sort": "Ordenar",
     "All": "Todos"
+  },
+  "Market": {
+    "Title": "Mercado",
+    "Quantity": "Cantidad",
+    "Price": "Precio",
+    "SuggestedPrice": "Precio sugerido: {00}",
+    "Sell": "Vender"
   }
 }


### PR DESCRIPTION
## Summary
- resize market listing window and add scrollable container
- add quantity, price and suggested price UI to SellMarketWindow
- localize new market labels in English and Spanish

## Testing
- `dotnet test` *(fails: project file ... not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bda4ba2df88324a876582658356e7d