### PR TITLE
Add market window event commands and remove emoji text

### DIFF
--- a/Framework/Intersect.Framework.Core/GameObjects/Events/Commands/OpenMarketSellWindowCommand.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Events/Commands/OpenMarketSellWindowCommand.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Intersect.Framework.Core.GameObjects.Events.Commands;
+public class OpenMarketSellWindowCommand : EventCommand
+{
+    public override EventCommandType Type { get; } = EventCommandType.OpenSellMarket;
+
+    public int Slot { get; set; }
+}

--- a/Framework/Intersect.Framework.Core/GameObjects/Events/Commands/OpenMarketWindowCommand.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Events/Commands/OpenMarketWindowCommand.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Intersect.Framework.Core.GameObjects.Events.Commands;
+public class OpenMarketWindowCommand : EventCommand
+{
+    public override EventCommandType Type { get; } = EventCommandType.OpenMarket;
+}

--- a/Framework/Intersect.Framework.Core/GameObjects/Events/EventCommandType.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Events/EventCommandType.cs
@@ -145,4 +145,6 @@ public enum EventCommandType
     OpenMailBox = 204,
     SendMail = 205,
     ChangeBestiary = 206,
+    OpenMarket = 207,
+    OpenSellMarket = 208,
 }

--- a/Framework/Intersect.Framework.Core/Network/Packets/Server/MarketWindowPacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Server/MarketWindowPacket.cs
@@ -1,0 +1,25 @@
+using MessagePack;
+
+namespace Intersect.Network.Packets.Server
+{
+    [MessagePackObject]
+    public class MarketWindowPacket : IntersectPacket
+    {
+        public MarketWindowPacket(MarketWindowPacketType action, int slot = -1)
+        {
+            Action = action;
+            Slot = slot;
+        }
+
+        [Key(0)] public MarketWindowPacketType Action { get; set; }
+        [Key(1)] public int Slot { get; set; }
+    }
+
+    public enum MarketWindowPacketType
+    {
+        OpenMarket,
+        CloseMarket,
+        OpenSell,
+        CloseSell,
+    }
+}

--- a/Intersect (Core)/CustomColors.cs
+++ b/Intersect (Core)/CustomColors.cs
@@ -84,7 +84,7 @@ public static partial class CustomColors
             {"Hostile", new LabelColor(new Color(255, 255, 81, 0), Color.Black, new Color(180, 0, 0, 0))},
             {"Moderator", new LabelColor(new Color(255, 0, 255, 255), Color.Black, new Color(180, 0, 0, 0))},
             {"Admin", new LabelColor(new Color(255, 255, 255, 0), Color.Black, new Color(180, 0, 0, 0))},
-            { "Market",     new LabelColor(new Color(255, 255, 191, 0),   Color.Black, new Color(180, 0, 0, 0)) } // 🔶 Canal de comercio
+            { "Market",     new LabelColor(new Color(255, 255, 191, 0),   Color.Black, new Color(180, 0, 0, 0)) } // Canal de comercio
         };
 
     }

--- a/Intersect.Client.Core/CustomChanges/PacketHandlerCustom.cs
+++ b/Intersect.Client.Core/CustomChanges/PacketHandlerCustom.cs
@@ -276,4 +276,26 @@ internal sealed partial class PacketHandler
         SellMarketWindow.Instance?.SetMarketInfo(packet.SuggestedPrice, packet.MinPrice, packet.MaxPrice);
     }
 
+    public void HandlePacket(IPacketSender packetSender, MarketWindowPacket packet)
+    {
+        Interface.Interface.EnqueueInGame(gameInterface =>
+        {
+            switch (packet.Action)
+            {
+                case MarketWindowPacketType.OpenMarket:
+                    gameInterface.NotifyOpenMarket();
+                    break;
+                case MarketWindowPacketType.CloseMarket:
+                    gameInterface.NotifyCloseMarket();
+                    break;
+                case MarketWindowPacketType.OpenSell:
+                    gameInterface.NotifyOpenSellMarket(packet.Slot);
+                    break;
+                case MarketWindowPacketType.CloseSell:
+                    gameInterface.NotifyCloseSellMarket();
+                    break;
+            }
+        });
+    }
+
 }

--- a/Intersect.Client.Core/Interface/Game/Bestiary/BestiaryWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Bestiary/BestiaryWindow.cs
@@ -205,8 +205,8 @@ public sealed class BestiaryWindow : Window
             var killsReq = desc.BestiaryRequirements.TryGetValue(unlock, out var req) ? req : 0;
             var currentKills = BestiaryController.GetKillCount(npcId);
             var lockedText = killsReq > 0
-                ? $"🔒 Derrota {currentKills}/{killsReq} veces para desbloquear."
-                : "🔒 Información bloqueada.";
+                ? $"Derrota {currentKills}/{killsReq} veces para desbloquear."
+                : "Información bloqueada.";
 
             var label = new Label(_detailsContent, $"{unlock}LockedLabel")
             {

--- a/Intersect.Client.Core/Interface/Game/Character/CharacterWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Character/CharacterWindow.cs
@@ -117,7 +117,7 @@ public partial class CharacterWindow:Window
 
       IsResizable = false;
 
-        // 📌 Nombre, Nivel y Clase
+        // Nombre, Nivel y Clase
         mCharacterName = new Label(this, "CharacterNameLabel");
         mCharacterName.SetTextColor(Color.White, ComponentState.Normal);
         mCharacterName.SetPosition(16, 16);
@@ -133,7 +133,7 @@ public partial class CharacterWindow:Window
         mFactionButton.SetToolTipText("Faction");
         mFactionButton.Clicked += (s, e) => Interface.GameUi.GameMenu?.ToggleFactionWindow();
 
-        // 🖼️ Contenedor y retrato
+        // Contenedor y retrato
         mCharacterContainer = new ImagePanel(this, "CharacterContainer");
         mCharacterContainer.SetSize(96, 96);
         mCharacterContainer.SetPosition(16, 70);
@@ -142,7 +142,7 @@ public partial class CharacterWindow:Window
         mCharacterPortrait.SetSize(64, 64);
         mCharacterPortrait.SetPosition(16, 16);
 
-        // 🧩 Slots visuales Paperdoll
+        // Slots visuales Paperdoll
         PaperdollPanels = new ImagePanel[Options.Instance.Equipment.Slots.Count + 1];
         PaperdollTextures = new string[Options.Instance.Equipment.Slots.Count + 1];
         for (var i = 0; i <= Options.Instance.Equipment.Slots.Count; i++)
@@ -152,7 +152,7 @@ public partial class CharacterWindow:Window
             PaperdollPanels[i].Hide();
         }
 
-        // 🧱 Equipamiento en grilla modular (4x4)
+        // Equipamiento en grilla modular (4x4)
         var startX = 300;
         var startY = 40;
         var slotW = 32;
@@ -189,7 +189,7 @@ public partial class CharacterWindow:Window
                     multiSlotTracker[slotName]++;
                 }
 
-                // 📐 Ubicación provisional
+                // Ubicación provisional
                 int row = itemIndex / 4;
                 int col = itemIndex % 4;
 
@@ -202,7 +202,7 @@ public partial class CharacterWindow:Window
         }
 
 
-        // 📊 Etiquetas y botones de stats
+        // Etiquetas y botones de stats
         int statsX = 16;
         int statsY = 180;
         int statSpacing = 22;

--- a/Intersect.Client.Core/Interface/Game/DescriptionWindows/ItemDescriptionWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/DescriptionWindows/ItemDescriptionWindow.cs
@@ -369,12 +369,12 @@ public partial class ItemDescriptionWindow() : DescriptionWindowBase(Interface.G
 
             if (_itemDescriptor.EquipmentSlot == Options.Instance.Equipment.WeaponSlot && !string.IsNullOrWhiteSpace(_itemDescriptor.Subtype))
             {
-                // 🔥 Mostrar solo el subtipo si es arma
+                // Mostrar solo el subtipo si es arma
                 header.SetSubtitle($"{_itemDescriptor.Subtype}", Color.White);
             }
             else
             {
-                // 🔥 Mostrar info extra si no tiene subtipo o no es arma
+                // Mostrar info extra si no tiene subtipo o no es arma
                 var extraInfo = _itemDescriptor.EquipmentSlot == Options.Instance.Equipment.WeaponSlot && _itemDescriptor.TwoHanded
                     ? $"{Strings.ItemDescription.TwoHand} {equipSlot}"
                     : equipSlot;
@@ -384,7 +384,7 @@ public partial class ItemDescriptionWindow() : DescriptionWindowBase(Interface.G
         }
         else
         {
-            // 🔥 Mostrar subtipo si lo tiene, si no solo el tipo
+            // Mostrar subtipo si lo tiene, si no solo el tipo
             var subtypeInfo = !string.IsNullOrWhiteSpace(_itemDescriptor.Subtype)
        ? _itemDescriptor.Subtype
        : typeDesc?.ToString() ?? "";

--- a/Intersect.Client.Core/Interface/Game/GameInterface.cs
+++ b/Intersect.Client.Core/Interface/Game/GameInterface.cs
@@ -312,7 +312,8 @@ public partial class GameInterface : MutableInterface
 
     public void OpenMarket()
     {
-        _marketWindow = new MarketWindow(GameCanvas) { DeleteOnClose = true };
+        _marketWindow ??= new MarketWindow(GameCanvas) { DeleteOnClose = true };
+        _marketWindow.Show();
         _shouldOpenMarket = false;
     }
 
@@ -330,6 +331,7 @@ public partial class GameInterface : MutableInterface
     public void OpenSellMarket()
     {
         _sellMarketWindow = new SellMarketWindow(GameCanvas, _sellMarketSlot) { DeleteOnClose = true };
+        _sellMarketWindow.Show();
         _shouldOpenSellMarket = false;
     }
 

--- a/Intersect.Client.Core/Interface/Game/Job/JobsWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Job/JobsWindow.cs
@@ -205,7 +205,7 @@ namespace Intersect.Client.Interface.Game.Job
         private void LoadRecipes(JobType jobType)
         {  // Record current scroll position before clearing to preserve it
             var currentScroll = mRecipePanel.VerticalScrollBar.ScrollAmount;
-            // 🔄 Limpiar visual y lógicamente las recetas anteriores
+            // Limpiar visual y lógicamente las recetas anteriores
             foreach (var craftedItem in mItems)
             {
                 if (craftedItem.Container is { } container)

--- a/Intersect.Client.Core/Interface/Game/Mail/MailBoxWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Mail/MailBoxWindow.cs
@@ -44,7 +44,7 @@ public partial class MailBoxWindow : Window
         const int fontSize = 12;
         var textColor = Color.White;
 
-        // 📩 Panel Izquierdo: Lista de Correos
+        // Panel Izquierdo: Lista de Correos
         mMailLabel = new Label(this, "Mail")
         {
             Text = Strings.MailBox.mails,
@@ -65,7 +65,7 @@ public partial class MailBoxWindow : Window
         mMailListBox.RowSelected += Selected_MailListBox;
         mMailListBox.AllowMultiSelect = false;
 
-        // 📨 Panel Derecho: Detalles del Correo
+        // Panel Derecho: Detalles del Correo
         mSender = new Label(this, "Sender")
         {
             FontName = defaultFont,
@@ -244,7 +244,7 @@ public partial class MailBoxWindow : Window
 
         public void UpdateMail()
         {
-            // 🔍 Validar inicialización
+            // Validar inicialización
             if (mMailListBox == null || mAttachmentSlots == null)
             {
                 ApplicationContext.CurrentContext.Logger.LogWarning(
@@ -252,7 +252,7 @@ public partial class MailBoxWindow : Window
                 return;
             }
 
-            // 🔄 Limpiar lista de correos y contenedor de adjuntos
+            // Limpiar lista de correos y contenedor de adjuntos
             mMailListBox.RemoveAllRows();
             mMailListBox.ScrollToTop();
 
@@ -262,7 +262,7 @@ public partial class MailBoxWindow : Window
                 slot.IsHidden = true;
             }
 
-            // 🔍 Validar y actualizar correos
+            // Validar y actualizar correos
             if (Globals.Mails == null || Globals.Mails.Count == 0)
             {
                 mSender?.Hide();
@@ -282,7 +282,7 @@ public partial class MailBoxWindow : Window
                     continue;
                 }
 
-                // 📩 Verificar datos antes de agregar a la lista
+                // Verificar datos antes de agregar a la lista
                 ApplicationContext.CurrentContext.Logger.LogDebug(
                     "Mail received - ID: {MailId}, Sender: {SenderName}, Title: {MailTitle}",
                     mail.MailID,
@@ -291,14 +291,14 @@ public partial class MailBoxWindow : Window
 
                 string senderName = !string.IsNullOrWhiteSpace(mail.SenderName) ? mail.SenderName : "Unknown Sender";
                 string mailTitle = !string.IsNullOrWhiteSpace(mail.Name) ? mail.Name.Trim() : "No Subject";
-                string displayText = $"📩 {senderName}: {mailTitle}";
+                string displayText = $"{senderName}: {mailTitle}";
 
                 var row = mMailListBox.AddRow(displayText, "", mail);
                 row.SetTextColor(Color.White);
             }
 
 
-            // 🔹 Seleccionar el primer correo automáticamente
+            // Seleccionar el primer correo automáticamente
             mMailListBox.SelectByUserData(Globals.Mails[0]);
         }
 

--- a/Intersect.Client.Core/Interface/Game/Mail/SendMailBoxWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Mail/SendMailBoxWindow.cs
@@ -81,7 +81,7 @@ namespace Intersect.Client.Interface.Game.Mail
             // **Title**
             _titleLabel = new Label(this, "TitleLabel")
             {
-                Text = "🏷 Title:",
+                Text = "Title:",
                 FontName = defaultFont,
                 FontSize = fontSize
             };
@@ -100,7 +100,7 @@ namespace Intersect.Client.Interface.Game.Mail
             // **Message**
             _messageLabel = new Label(this, "MessageLabel")
             {
-                Text = "📝 Message:",
+                Text = "Message:",
                 FontName = defaultFont,
                 FontSize = fontSize
             };

--- a/Intersect.Editor/Forms/Editors/Events/CommandPrinter.cs
+++ b/Intersect.Editor/Forms/Editors/Events/CommandPrinter.cs
@@ -1713,6 +1713,14 @@ public static partial class CommandPrinter
     {
         return Strings.EventCommandList.openmailbox;
     }
+    private static string GetCommandText(OpenMarketWindowCommand command, MapInstance map)
+    {
+        return Strings.EventCommandList.openmarket;
+    }
+    private static string GetCommandText(OpenMarketSellWindowCommand command, MapInstance map)
+    {
+        return Strings.EventCommandList.opensellmarket;
+    }
     private static string GetCommandText(SendMailBoxCommand command, MapInstance map)
     {
         return Strings.EventCommandList.sendmail;

--- a/Intersect.Editor/Forms/Editors/Events/frmEvent.cs
+++ b/Intersect.Editor/Forms/Editors/Events/frmEvent.cs
@@ -784,6 +784,12 @@ public partial class FrmEvent : Form
             case EventCommandType.OpenMailBox:
                 tmpCommand = new OpenMailBoxCommand();
                 break;
+            case EventCommandType.OpenMarket:
+                tmpCommand = new OpenMarketWindowCommand();
+                break;
+            case EventCommandType.OpenSellMarket:
+                tmpCommand = new OpenMarketSellWindowCommand();
+                break;
             default:
                 throw new ArgumentOutOfRangeException();
         }

--- a/Intersect.Editor/Forms/Editors/frmItem.cs
+++ b/Intersect.Editor/Forms/Editors/frmItem.cs
@@ -714,7 +714,7 @@ public partial class FrmItem : EditorForm
             }
         }
 
-        // 🔥 Asignar subtipo actual o el primero por defecto
+        // Asignar subtipo actual o el primero por defecto
         if (cmbSubType.Items.Count > 0)
         {
             cmbSubType.SelectedItem = mEditorItem.Subtype ?? cmbSubType.Items[0];

--- a/Intersect.Editor/Localization/Strings.cs
+++ b/Intersect.Editor/Localization/Strings.cs
@@ -2406,6 +2406,10 @@ Tick timer saved in server config.json.";
         public static LocalizedString sendmail = @"Send Mail";
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public static LocalizedString openmailbox = @"Open Mail Box";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString openmarket = @"Open Market Window";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString opensellmarket = @"Open Sell Market Window";
     }
 
     public partial struct EventChangePlayerColor
@@ -2517,6 +2521,8 @@ Tick timer saved in server config.json.";
             {"mailbox", @"Mail Box"},
             {"sendmail", @"Send Mail"},
             {"openmailbox", @"Open Mail Box"},
+            {"openmarket", @"Open Market Window"},
+            {"opensellmarket", @"Open Sell Market Window"},
         };
 
     }
@@ -4051,7 +4057,7 @@ Tick timer saved in server config.json.";
         {
             SubtypesDynamic.Clear();
 
-            // 🔥 Corrected: Accessing ItemOptions through Intersect.Options.Instance
+            // Corrected: Accessing ItemOptions through Intersect.Options.Instance
             if (Intersect.Options.Instance?.Items?.ItemSubtypes != null)
             {
                 foreach (var kvp in Intersect.Options.Instance.Items.ItemSubtypes)

--- a/Intersect.Server.Core/CustomChanges/PacketSenderCustom.cs
+++ b/Intersect.Server.Core/CustomChanges/PacketSenderCustom.cs
@@ -156,6 +156,26 @@ public static partial class PacketSender
         player.SendPacket(new BrokeItemWindowPacket());
     }
 
+    public static void SendOpenMarket(Player player)
+    {
+        player.SendPacket(new MarketWindowPacket(MarketWindowPacketType.OpenMarket));
+    }
+
+    public static void SendCloseMarket(Player player)
+    {
+        player.SendPacket(new MarketWindowPacket(MarketWindowPacketType.CloseMarket));
+    }
+
+    public static void SendOpenSellMarket(Player player, int slot)
+    {
+        player.SendPacket(new MarketWindowPacket(MarketWindowPacketType.OpenSell, slot));
+    }
+
+    public static void SendCloseSellMarket(Player player)
+    {
+        player.SendPacket(new MarketWindowPacket(MarketWindowPacketType.CloseSell));
+    }
+
     public static void SendOpenMailBox(Player player)
     {
         var mails = new List<MailBoxUpdatePacket>();

--- a/Intersect.Server.Core/CustomChanges/PlayerCustom.cs
+++ b/Intersect.Server.Core/CustomChanges/PlayerCustom.cs
@@ -260,6 +260,15 @@ namespace Intersect.Server.Entities
         {
             PacketSender.SendOpenBrokeItemWindow(this);
         }
+        public void OpenMarket()
+        {
+            PacketSender.SendOpenMarket(this);
+        }
+
+        public void OpenSellMarket(int slot)
+        {
+            PacketSender.SendOpenSellMarket(this, slot);
+        }
         [NotMapped] public bool InMailBox;
         [JsonIgnore]
         public virtual List<MailBox> MailBoxs { get; set; } = new List<MailBox>();

--- a/Intersect.Server.Core/Database/Item.cs
+++ b/Intersect.Server.Core/Database/Item.cs
@@ -606,7 +606,7 @@ public class Item : IItem
             success = true;
             var name = (isStat ? targetStat : (object)targetVit).ToString();
             resultMessage = isCritical
-                ? $"🔥 ¡Éxito Crítico! {name} +{amount}."
+                ? $"¡Éxito Crítico! {name} +{amount}."
                 : $"¡Éxito! {name} +{amount}.";
         }
         else

--- a/Intersect.Server.Core/Entities/Events/CommandProcessing.cs
+++ b/Intersect.Server.Core/Entities/Events/CommandProcessing.cs
@@ -2366,6 +2366,28 @@ public static partial class CommandProcessing
     {
         player.OpenMailBox();
     }
+
+    private static void ProcessCommand(
+      OpenMarketWindowCommand command,
+      Player player,
+      Event instance,
+      CommandInstance stackInfo,
+      Stack<CommandInstance> callStack
+  )
+    {
+        player.OpenMarket();
+    }
+
+    private static void ProcessCommand(
+      OpenMarketSellWindowCommand command,
+      Player player,
+      Event instance,
+      CommandInstance stackInfo,
+      Stack<CommandInstance> callStack
+  )
+    {
+        player.OpenSellMarket(command.Slot);
+    }
     private static void ProcessCommand(
         SendMailBoxCommand command,
         Player player,

--- a/Intersect.Server.Core/Entities/Player.cs
+++ b/Intersect.Server.Core/Entities/Player.cs
@@ -1523,7 +1523,7 @@ public partial class Player : Entity
 
         // Aplicar bonificación de equipo a la experiencia ganada  
         long totalExp = (long)Math.Round(amount + (amount * (GetEquipmentBonusEffect(ItemEffect.EXP) / 100f)));
-        // 💡 Bonus adicional por mejoras del gremio  
+        // Bonus adicional por mejoras del gremio
         if (IsInGuild && Guild.HasUpgrade(GuildUpgradeType.BonusXp))
         {
             float guildBonus = Guild.GetXpBonusMultiplier(); // ej: 1.15  
@@ -6235,7 +6235,7 @@ public partial class Player : Entity
         var slotConfig = Options.Instance.Equipment.EquipmentSlots[equipmentSlot];
         var maxAllowed = slotConfig.MaxItems;
 
-        // 🔍 Si está lleno, reemplazamos el primero (lógica de auto-reemplazo)
+        // Si está lleno, reemplazamos el primero (lógica de auto-reemplazo)
         if (Equipment[equipmentSlot].Count >= maxAllowed)
         {
             var toReplace = Equipment[equipmentSlot][0];


### PR DESCRIPTION
## Summary
- add OpenMarket and OpenSellMarket event types
- notify clients about market windows with MarketWindowPacket
- lazy-load market UI and strip emoji text

## Testing
- `dotnet build Intersect.sln` *(fails: project files vendor/LiteNetLib and dockpanelsuite missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bdad06c5e88324aad97f72f99ee510