### PR TITLE
Handle market event commands in editor switch

### DIFF
--- a/Intersect.Editor/Forms/Editors/Events/frmEvent.cs
+++ b/Intersect.Editor/Forms/Editors/Events/frmEvent.cs
@@ -1473,6 +1473,10 @@ public partial class FrmEvent : Form
                 break;
             case EventCommandType.OpenMailBox:
                 break;
+            case EventCommandType.OpenMarket:
+                break;
+            case EventCommandType.OpenSellMarket:
+                break;
             default:
                 throw new ArgumentOutOfRangeException();
         }


### PR DESCRIPTION
## Summary
- handle OpenMarket and OpenSellMarket commands in event editor to avoid crash

## Testing
- `dotnet build Intersect.Editor/Intersect.Editor.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc61b7e888324acb57b94a9615ed0