### PR TITLE
Add missing market localization entries and fix sell window

### DIFF
--- a/Intersect.Client.Core/Interface/Game/Inventory/InventoryItem.cs
+++ b/Intersect.Client.Core/Interface/Game/Inventory/InventoryItem.cs
@@ -8,6 +8,7 @@ using Intersect.Client.Framework.Gwen.DragDrop;
 using Intersect.Client.Framework.Gwen.Input;
 using Intersect.Client.Framework.Input;
 using Intersect.Client.General;
+using Intersect.Client.Interface;
 using Intersect.Client.Interface.Game.Bag;
 using Intersect.Client.Interface.Game.Bank;
 using Intersect.Client.Interface.Game.Hotbar;
@@ -243,7 +244,7 @@ public partial class InventoryItem : SlotItem
 
     private void _sellItemContextItem_Clicked(Base sender, MouseButtonState arguments)
     {
-        Interface.Interface.EnqueueInGame(gameInterface => gameInterface.NotifyOpenSellMarket(SlotIndex));
+        Interface.EnqueueInGame(gameInterface => gameInterface.NotifyOpenSellMarket(SlotIndex));
     }
 
     private void _dropItemContextItem_Clicked(Base sender, MouseButtonState arguments)

--- a/Intersect.Client.Core/Interface/Game/Market/SellMarketWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Market/SellMarketWindow.cs
@@ -8,6 +8,8 @@ using Intersect.Client.Framework.Gwen.Control;
 using Intersect.Client.Framework.Gwen.Control.Layout;
 using Intersect.Client.Framework.File_Management;
 using Intersect.Client.Interface.Game.Chat;
+using Intersect.Client.Interface.Game;
+using Intersect.Client.General;
 using Intersect.Client.Interface.Game.Inventory;
 using Intersect.Client.Localization;
 using Intersect.Client.Networking;
@@ -34,7 +36,7 @@ public sealed class SellMarketWindow
     private readonly Checkbox _autoSplitCheckbox;
 
     // Render helpers por slot
-    public readonly List<InventoryItem> Items = new();
+    public readonly List<SlotItem> Items = new();
 
     #endregion
 
@@ -107,8 +109,8 @@ public sealed class SellMarketWindow
         _suggestedPriceLabel.SetBounds(startX, startY, 250, labelH); startY += labelH + (padY * 2);
         _suggestedRangeLabel.SetBounds(startX, startY, 250, labelH); startY += labelH + (padY * 2);
         // Cantidad / Precio etiquetas
-        new Label(_window,"QuantityLabel") { Text = Strings.Market.quantity }.SetBounds(startX, startY + 10, 100, labelH);
-        new Label(_window,"Pricelabel") { Text = Strings.Market.price }.SetBounds(startX + 110, startY + 10, 100, labelH);
+        new Label(_window,"QuantityLabel") { Text = Strings.Market.Quantity }.SetBounds(startX, startY + 10, 100, labelH);
+        new Label(_window,"Pricelabel") { Text = Strings.Market.Price }.SetBounds(startX + 110, startY + 10, 100, labelH);
         startY += labelH;
 
         _quantityInput.SetBounds(startX, startY+10, 100, inputH);

--- a/Intersect.Client.Core/Localization/Strings.cs
+++ b/Intersect.Client.Core/Localization/Strings.cs
@@ -3180,6 +3180,36 @@ If you are sure you want to hand over your guild enter '\c{{#ff8080}}{02}\c{{}}'
         public static LocalizedString Sell = @"Sell";
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public static LocalizedString Buy = @"Buy";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString sellwindow = @"Sell Item";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString selectitem = @"Select an item";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString pricehint = @"Suggested price: {00}";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString pricerange = @"Price range: {00} - {01}";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString taxes_0 = @"Taxes: 0";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString splitpackages = @"Split packages";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString publish = @"Publish";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString invalidItem = @"Invalid item.";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString publish_colon = @"Publish:";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString taxes_estimated = @"Taxes: {00}";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString noItemSelected = @"No item selected.";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString invalidQuantity = @"Invalid quantity.";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString invalidPrice = @"Invalid price.";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString quantityExceeds = @"Quantity exceeds available.";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString priceOutOfRange = @"Price must be between {00} and {01}.";
     }
 
 }


### PR DESCRIPTION
## Summary
- add client-side market localization strings for sell window
- use `SlotItem` list and existing quantity/price keys in sell window
- route inventory menu sell action via `Interface.EnqueueInGame`

## Testing
- `dotnet build Intersect.Client.Core/Intersect.Client.Core.csproj` *(fails: Could not find a part of the path 'Intersect.Client.network.handshake.bkey.pub')*

------
https://chatgpt.com/codex/tasks/task_e_68bdd35a5d788324b80c071444ccb386