### PR TITLE
refactor: use int for market item ids

### DIFF
--- a/Intersect.Server.Core/CustomChanges/PacketHandlerCustom.cs
+++ b/Intersect.Server.Core/CustomChanges/PacketHandlerCustom.cs
@@ -616,8 +616,7 @@ internal sealed partial class PacketHandler
             return;
         }
 
-        var itemGuid = ItemDescriptor.IdFromList(packet.ItemId);
-        var (suggested, min, max) = MarketStatisticsManager.GetStatistics(itemGuid);
+        var (suggested, min, max) = MarketStatisticsManager.GetStatistics(packet.ItemId);
         PacketSender.SendMarketPriceInfo(player, packet.ItemId, suggested, min, max);
     }
 

--- a/Intersect.Server.Core/Database/PlayerData/Market/MarketListing.cs
+++ b/Intersect.Server.Core/Database/PlayerData/Market/MarketListing.cs
@@ -11,7 +11,7 @@ public partial class MarketListing
 public Guid Id { get; set; } = Guid.NewGuid();
 public Guid SellerId { get; set; }
 public virtual Player? Seller { get; set; }
-public Guid ItemId { get; set; }
+public int ItemId { get; set; }
 public int Quantity { get; set; }
 public long Price { get; set; }
 public DateTime ListedAt { get; set; } = DateTime.UtcNow;

--- a/Intersect.Server.Core/Database/PlayerData/Market/MarketManager.cs
+++ b/Intersect.Server.Core/Database/PlayerData/Market/MarketManager.cs
@@ -50,7 +50,7 @@ namespace Intersect.Server.Database.PlayerData.Market
             {
                 result = result.Where(l =>
                 {
-                    var itemDescriptor = ItemDescriptor.Get(l.ItemId);
+                    var itemDescriptor = ItemDescriptor.Get(ItemDescriptor.IdFromList(l.ItemId));
                     return itemDescriptor != null &&
                            itemDescriptor.Name.Contains(name, StringComparison.OrdinalIgnoreCase);
                 }).ToList();
@@ -60,7 +60,7 @@ namespace Intersect.Server.Database.PlayerData.Market
             {
                 result = result.Where(l =>
                 {
-                    var itemDescriptor = ItemDescriptor.Get(l.ItemId);
+                    var itemDescriptor = ItemDescriptor.Get(ItemDescriptor.IdFromList(l.ItemId));
                     return itemDescriptor != null &&
                            itemDescriptor.Type == GameObjectType.Item &&
                            itemDescriptor.ItemType == type.Value;
@@ -116,7 +116,7 @@ namespace Intersect.Server.Database.PlayerData.Market
                 return false;
             }
 
-            var stats = MarketStatisticsManager.GetStatistics(item.ItemId);
+            var stats = MarketStatisticsManager.GetStatistics(ItemDescriptor.ListIndex(item.ItemId));
             var avg = stats.suggested;
             var min = stats.min;
             var max = stats.max;
@@ -167,7 +167,7 @@ namespace Intersect.Server.Database.PlayerData.Market
                     {
                         Seller = seller,
                         SellerId = seller.Id,
-                        ItemId = item.ItemId,
+                        ItemId = ItemDescriptor.ListIndex(item.ItemId),
                         Quantity = size,
                         Price = totalPrice,
                         ItemProperties = itemProperties,
@@ -257,7 +257,7 @@ namespace Intersect.Server.Database.PlayerData.Market
                     return false;
                 }
 
-                itemToGive = new Item(listing.ItemId, listing.Quantity) { Properties = listing.ItemProperties };
+                itemToGive = new Item(ItemDescriptor.IdFromList(listing.ItemId), listing.Quantity) { Properties = listing.ItemProperties };
                 if (!buyer.CanGiveItem(itemToGive.ItemId, itemToGive.Quantity))
                 {
                     PacketSender.SendChatMsg(buyer, Strings.Market.inventoryfull, ChatMessageType.Error, CustomColors.Alerts.Declined);
@@ -332,7 +332,7 @@ namespace Intersect.Server.Database.PlayerData.Market
                     sender: buyer,
                     receiver: listing.Seller,
                     title: Strings.Market.salecompleted,
-                    message: Strings.Market.yoursolditem.ToString(ItemDescriptor.GetName(listing.ItemId)),
+                    message: Strings.Market.yoursolditem.ToString(ItemDescriptor.GetName(ItemDescriptor.IdFromList(listing.ItemId))),
                     attachments: new List<MailAttachment> { goldAttachment }
                 );
 
@@ -391,11 +391,11 @@ namespace Intersect.Server.Database.PlayerData.Market
 
             context.Market_Listings.Remove(listing);
 
-            if (!seller.TryGiveItem(listing.ItemId, listing.Quantity, listing.ItemProperties))
+            if (!seller.TryGiveItem(ItemDescriptor.IdFromList(listing.ItemId), listing.Quantity, listing.ItemProperties))
             {
                 var attachment = new MailAttachment
                 {
-                    ItemId = listing.ItemId,
+                    ItemId = ItemDescriptor.IdFromList(listing.ItemId),
                     Quantity = listing.Quantity,
                     Properties = listing.ItemProperties
                 };
@@ -443,7 +443,7 @@ namespace Intersect.Server.Database.PlayerData.Market
             {
                 var item = new MailAttachment
                 {
-                    ItemId = listing.ItemId,
+                    ItemId = ItemDescriptor.IdFromList(listing.ItemId),
                     Quantity = listing.Quantity,
                     Properties = listing.ItemProperties
                 };

--- a/Intersect.Server.Core/Database/PlayerData/Market/MarketStatisticsManager.cs
+++ b/Intersect.Server.Core/Database/PlayerData/Market/MarketStatisticsManager.cs
@@ -5,9 +5,9 @@ namespace Intersect.Server.Database.PlayerData.Market;
 
 public static class MarketStatisticsManager
 {
-    private static readonly Dictionary<Guid, MarketStatistics> _statistics = new();
+    private static readonly Dictionary<int, MarketStatistics> _statistics = new();
 
-    private static MarketStatistics GetOrCreateStats(Guid itemId)
+    private static MarketStatistics GetOrCreateStats(int itemId)
     {
         if (!_statistics.TryGetValue(itemId, out var stats))
         {
@@ -18,11 +18,11 @@ public static class MarketStatisticsManager
         return stats;
     }
 
-    public static void RecordListing(Guid itemId, long price) => GetOrCreateStats(itemId).Record(price);
+    public static void RecordListing(int itemId, long price) => GetOrCreateStats(itemId).Record(price);
 
-    public static void RecordSale(Guid itemId, long price) => GetOrCreateStats(itemId).Record(price);
+    public static void RecordSale(int itemId, long price) => GetOrCreateStats(itemId).Record(price);
 
-    public static (long suggested, long min, long max) GetStatistics(Guid itemId)
+    public static (long suggested, long min, long max) GetStatistics(int itemId)
     {
         var stats = GetOrCreateStats(itemId);
         return (stats.SuggestedPrice, stats.MinPrice, stats.MaxPrice);

--- a/Intersect.Server.Core/Database/PlayerData/Market/MarketTransaction.cs
+++ b/Intersect.Server.Core/Database/PlayerData/Market/MarketTransaction.cs
@@ -12,7 +12,7 @@ public Guid Id { get; set; } = Guid.NewGuid();
 public Guid ListingId { get; set; }
 public Guid? BuyerId { get; set; }
 public string BuyerName { get; set; } = string.Empty;
-public Guid ItemId { get; set; }
+public int ItemId { get; set; }
 public Guid SellerId { get; set; }
 public virtual Player? Seller { get; set; }
 public int Quantity { get; set; }

--- a/Intersect.Server.Core/Migrations/Sqlite/Player/20250907191203_AddedMarketSystem.Designer.cs
+++ b/Intersect.Server.Core/Migrations/Sqlite/Player/20250907191203_AddedMarketSystem.Designer.cs
@@ -100,8 +100,8 @@ namespace Intersect.Server.Migrations.Sqlite.Player
                     b.Property<bool>("IsSold")
                         .HasColumnType("INTEGER");
 
-                    b.Property<Guid>("ItemId")
-                        .HasColumnType("TEXT");
+                    b.Property<int>("ItemId")
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("ItemPropertiesJson")
                         .HasColumnType("TEXT")
@@ -138,8 +138,8 @@ namespace Intersect.Server.Migrations.Sqlite.Player
                     b.Property<string>("BuyerName")
                         .HasColumnType("TEXT");
 
-                    b.Property<Guid>("ItemId")
-                        .HasColumnType("TEXT");
+                    b.Property<int>("ItemId")
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("ItemPropertiesJson")
                         .HasColumnType("TEXT")

--- a/Intersect.Server.Core/Migrations/Sqlite/Player/20250907191203_AddedMarketSystem.cs
+++ b/Intersect.Server.Core/Migrations/Sqlite/Player/20250907191203_AddedMarketSystem.cs
@@ -17,7 +17,7 @@ namespace Intersect.Server.Migrations.Sqlite.Player
                 {
                     Id = table.Column<Guid>(type: "TEXT", nullable: false),
                     SellerId = table.Column<Guid>(type: "TEXT", nullable: false),
-                    ItemId = table.Column<Guid>(type: "TEXT", nullable: false),
+                    ItemId = table.Column<int>(type: "INTEGER", nullable: false),
                     Quantity = table.Column<int>(type: "INTEGER", nullable: false),
                     Price = table.Column<long>(type: "INTEGER", nullable: false),
                     ListedAt = table.Column<DateTime>(type: "TEXT", nullable: false),
@@ -44,7 +44,7 @@ namespace Intersect.Server.Migrations.Sqlite.Player
                     ListingId = table.Column<Guid>(type: "TEXT", nullable: false),
                     BuyerId = table.Column<Guid>(type: "TEXT", nullable: true),
                     BuyerName = table.Column<string>(type: "TEXT", nullable: true),
-                    ItemId = table.Column<Guid>(type: "TEXT", nullable: false),
+                    ItemId = table.Column<int>(type: "INTEGER", nullable: false),
                     SellerId = table.Column<Guid>(type: "TEXT", nullable: false),
                     Quantity = table.Column<int>(type: "INTEGER", nullable: false),
                     Price = table.Column<long>(type: "INTEGER", nullable: false),

--- a/Intersect.Server.Core/Migrations/Sqlite/Player/SqlitePlayerContextModelSnapshot.cs
+++ b/Intersect.Server.Core/Migrations/Sqlite/Player/SqlitePlayerContextModelSnapshot.cs
@@ -97,8 +97,8 @@ namespace Intersect.Server.Migrations.Sqlite.Player
                     b.Property<bool>("IsSold")
                         .HasColumnType("INTEGER");
 
-                    b.Property<Guid>("ItemId")
-                        .HasColumnType("TEXT");
+                    b.Property<int>("ItemId")
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("ItemPropertiesJson")
                         .HasColumnType("TEXT")
@@ -135,8 +135,8 @@ namespace Intersect.Server.Migrations.Sqlite.Player
                     b.Property<string>("BuyerName")
                         .HasColumnType("TEXT");
 
-                    b.Property<Guid>("ItemId")
-                        .HasColumnType("TEXT");
+                    b.Property<int>("ItemId")
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("ItemPropertiesJson")
                         .HasColumnType("TEXT")


### PR DESCRIPTION
## Summary
- use `int` for item IDs in market listings and transactions
- convert between item descriptor GUIDs and indices when interacting with inventory and packets
- adjust EF Core migrations and request handlers for new item ID type

## Testing
- `dotnet test` *(fails: project file "vendor/LiteNetLib/..." not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bde078366c8324b3360335708b927b