### PR TITLE
Add paginated market search and packets

### DIFF
--- a/Framework/Intersect.Framework.Core/Network/Packets/Client/SearchMarketPacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Client/SearchMarketPacket.cs
@@ -1,3 +1,4 @@
+using System;
 using MessagePack;
 
 namespace Intersect.Network.Packets.Client;
@@ -10,11 +11,43 @@ public partial class SearchMarketPacket : IntersectPacket
     {
     }
 
-    public SearchMarketPacket(string query)
+    public SearchMarketPacket(
+        int page,
+        int pageSize,
+        int? itemId,
+        int? minPrice,
+        int? maxPrice,
+        bool? status,
+        Guid? sellerId
+    )
     {
-        Query = query;
+        Page = page;
+        PageSize = pageSize;
+        ItemId = itemId;
+        MinPrice = minPrice;
+        MaxPrice = maxPrice;
+        Status = status;
+        SellerId = sellerId;
     }
 
     [Key(0)]
-    public string Query { get; set; } = string.Empty;
+    public int Page { get; set; }
+
+    [Key(1)]
+    public int PageSize { get; set; }
+
+    [Key(2)]
+    public int? ItemId { get; set; }
+
+    [Key(3)]
+    public int? MinPrice { get; set; }
+
+    [Key(4)]
+    public int? MaxPrice { get; set; }
+
+    [Key(5)]
+    public bool? Status { get; set; }
+
+    [Key(6)]
+    public Guid? SellerId { get; set; }
 }

--- a/Framework/Intersect.Framework.Core/Network/Packets/Server/MarketListingPacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Server/MarketListingPacket.cs
@@ -50,11 +50,23 @@ public partial class MarketListingsPacket : IntersectPacket
     {
     }
 
-    public MarketListingsPacket(List<MarketListingPacket> listings)
+    public MarketListingsPacket(List<MarketListingPacket> listings, int page, int pageSize, int total)
     {
         Listings = listings;
+        Page = page;
+        PageSize = pageSize;
+        Total = total;
     }
 
     [Key(0)]
     public List<MarketListingPacket> Listings { get; set; } = new();
+
+    [Key(1)]
+    public int Page { get; set; }
+
+    [Key(2)]
+    public int PageSize { get; set; }
+
+    [Key(3)]
+    public int Total { get; set; }
 }

--- a/Framework/Intersect.Framework.Core/Network/Packets/Server/MarketWindowPacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Server/MarketWindowPacket.cs
@@ -5,14 +5,20 @@ namespace Intersect.Network.Packets.Server
     [MessagePackObject]
     public class MarketWindowPacket : IntersectPacket
     {
-        public MarketWindowPacket(MarketWindowPacketType action, int slot = -1)
+        public MarketWindowPacket(MarketWindowPacketType action, int slot = -1, int page = 1, int pageSize = 0, int total = 0)
         {
             Action = action;
             Slot = slot;
+            Page = page;
+            PageSize = pageSize;
+            Total = total;
         }
 
         [Key(0)] public MarketWindowPacketType Action { get; set; }
         [Key(1)] public int Slot { get; set; }
+        [Key(2)] public int Page { get; set; }
+        [Key(3)] public int PageSize { get; set; }
+        [Key(4)] public int Total { get; set; }
     }
 
     public enum MarketWindowPacketType

--- a/Intersect.Client.Core/CustomChanges/PacketHandlerCustom.cs
+++ b/Intersect.Client.Core/CustomChanges/PacketHandlerCustom.cs
@@ -255,11 +255,10 @@ internal sealed partial class PacketHandler
 
     public void HandlePacket(IPacketSender packetSender, MarketListingsPacket packet)
     {
-        // Placeholder for handling multiple market listings
-        foreach (var listing in packet.Listings)
+        Interface.Interface.EnqueueInGame(gameInterface =>
         {
-            var _ = listing.Properties;
-        }
+            gameInterface.GetMarketWindow()?.LoadListings(packet.Listings, packet.Page, packet.PageSize, packet.Total);
+        });
     }
 
     public void HandlePacket(IPacketSender packetSender, MarketPurchaseSuccessPacket packet)

--- a/Intersect.Client.Core/CustomChanges/PacketSenderCustom.cs
+++ b/Intersect.Client.Core/CustomChanges/PacketSenderCustom.cs
@@ -105,9 +105,17 @@ public static partial class PacketSender
         Network.SendPacket(new CreateMarketListingPacket(itemSlot, quantity, price, props, autoSplit));
     }
 
-    public static void SendSearchMarket(string query)
+    public static void SendSearchMarket(
+        int page,
+        int pageSize,
+        int? itemId = null,
+        int? minPrice = null,
+        int? maxPrice = null,
+        bool? status = null,
+        Guid? sellerId = null
+    )
     {
-        Network.SendPacket(new SearchMarketPacket(query));
+        Network.SendPacket(new SearchMarketPacket(page, pageSize, itemId, minPrice, maxPrice, status, sellerId));
     }
 
     public static void SendBuyMarketListing(Guid listingId, int quantity)

--- a/Intersect.Client.Core/Interface/Game/GameInterface.cs
+++ b/Intersect.Client.Core/Interface/Game/GameInterface.cs
@@ -420,6 +420,11 @@ public partial class GameInterface : MutableInterface
         return _bankWindow;
     }
 
+    public MarketWindow? GetMarketWindow()
+    {
+        return _marketWindow;
+    }
+
     public void RefreshBank()
     {
         _bankWindow?.Refresh();

--- a/Intersect.Server.Core/CustomChanges/PacketHandlerCustom.cs
+++ b/Intersect.Server.Core/CustomChanges/PacketHandlerCustom.cs
@@ -19,6 +19,7 @@ using System.Collections.Generic;
 using System.Collections;
 using System.Diagnostics;
 using System.Text;
+using System.Linq;
 using Intersect.Core;
 using Intersect.Framework.Core;
 using Intersect.Framework.Core.GameObjects.Crafting;
@@ -605,7 +606,32 @@ internal sealed partial class PacketHandler
 
     public void HandlePacket(Client client, SearchMarketPacket packet)
     {
-        // Placeholder for market search handling
+        var player = client.Entity;
+        if (player == null)
+        {
+            return;
+        }
+
+        var (listings, total) = MarketManager.SearchMarket(
+            packet.Page,
+            packet.PageSize,
+            packet.ItemId,
+            packet.MinPrice,
+            packet.MaxPrice,
+            packet.Status,
+            packet.SellerId
+        );
+
+        var packets = listings.Select(l => new MarketListingPacket(
+            l.Id,
+            l.SellerId,
+            l.ItemId,
+            l.Quantity,
+            l.Price,
+            l.ItemProperties
+        )).ToList();
+
+        PacketSender.SendMarketListings(player, packets, packet.Page, packet.PageSize, total);
     }
 
     public void HandlePacket(Client client, RequestMarketPricePacket packet)

--- a/Intersect.Server.Core/CustomChanges/PacketSenderCustom.cs
+++ b/Intersect.Server.Core/CustomChanges/PacketSenderCustom.cs
@@ -248,9 +248,9 @@ public static partial class PacketSender
         player.SendPacket(new MarketListingCreatedPacket(listingId));
     }
 
-    public static void SendMarketListings(Player player, List<MarketListingPacket> listings)
+    public static void SendMarketListings(Player player, List<MarketListingPacket> listings, int page, int pageSize, int total)
     {
-        player.SendPacket(new MarketListingsPacket(listings));
+        player.SendPacket(new MarketListingsPacket(listings, page, pageSize, total));
     }
 
     public static void SendMarketPurchaseSuccess(Player player, Guid listingId)


### PR DESCRIPTION
## Summary
- add paging and filtering support to market search
- include page, pageSize and total metadata in market packets
- allow client UI to request and navigate market pages

## Testing
- `dotnet build` *(fails: project files not found)*
- `dotnet test` *(fails: project files not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bde2c118bc8324a5315cc640525283