### PR TITLE
Fix SellMarket inventory loading

### DIFF
--- a/Intersect.Client.Core/Interface/Game/Inventory/InventoryItem.cs
+++ b/Intersect.Client.Core/Interface/Game/Inventory/InventoryItem.cs
@@ -111,11 +111,74 @@ public partial class InventoryItem : SlotItem
 
 
 
-    public InventoryItem(SellMarketWindow sellMarketWindow, Base parent, int i, ContextMenu contextMenu)
-        : base(parent, nameof(InventoryItem), i, contextMenu) // Fix: Pass the required "parent" argument to the base constructor
+    public InventoryItem(
+        SellMarketWindow sellMarketWindow,
+        Base parent,
+        int index,
+        ContextMenu? contextMenu = null
+    ) : base(parent, nameof(InventoryItem), index, contextMenu ?? new ContextMenu(parent))
     {
+        // We don't have an InventoryWindow in this context.
+        _inventoryWindow = null!;
         this.sellMarketWindow = sellMarketWindow;
-        this.i = i;
+
+        TextureFilename = "inventoryitem.png";
+
+        _equipImageBackground = new ImagePanel(this, "EquippedIcon")
+        {
+            Texture = Graphics.Renderer.WhitePixel,
+        };
+
+        _equipLabel = new Label(this, "EquippedLabel")
+        {
+            IsVisibleInParent = false,
+            Text = Strings.Inventory.EquippedSymbol,
+            FontName = "sourcesansproblack",
+            FontSize = 8,
+            TextColor = new Color(0, 255, 255, 255),
+            Alignment = [Alignments.Right, Alignments.Top],
+            BackgroundTemplateName = "equipped.png",
+            Padding = new Padding(2),
+        };
+
+        _cooldownLabel = new Label(this, "CooldownLabel")
+        {
+            IsVisibleInParent = false,
+            FontName = "sourcesansproblack",
+            FontSize = 8,
+            TextColor = new Color(0, 255, 255, 255),
+            Alignment = [Alignments.Center],
+            BackgroundTemplateName = "quantity.png",
+            Padding = new Padding(2),
+        };
+
+        _quantityLabel = new Label(this, "Quantity")
+        {
+            Alignment = [Alignments.Bottom, Alignments.Right],
+            BackgroundTemplateName = "quantity.png",
+            FontName = "sourcesansproblack",
+            FontSize = 8,
+            Padding = new Padding(2),
+        };
+
+        LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
+
+        // Create dummy context menu items to satisfy readonly fields.
+        _contextMenu!.ClearChildren();
+        _useItemMenuItem = _contextMenu.AddItem(Strings.ItemContextMenu.Use);
+        _actionItemMenuItem = _contextMenu.AddItem(Strings.ItemContextMenu.Bank);
+        _dropItemMenuItem = _contextMenu.AddItem(Strings.ItemContextMenu.Drop);
+        _showItemMenuItem = _contextMenu.AddItem(Strings.ItemContextMenu.Show);
+        _sellItemMenuItem = _contextMenu.AddItem(Strings.ItemContextMenu.Sell);
+        _contextMenu.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
+
+        Icon.Clicked += (_, args) =>
+        {
+            if (args.MouseButton == MouseButton.Left)
+            {
+                sellMarketWindow.SelectItem(this, SlotIndex);
+            }
+        };
     }
 
     #region Context Menu
@@ -665,9 +728,6 @@ public partial class InventoryItem : SlotItem
     // Campo nuevo:
     private bool _filterMatch = true;
     private SellMarketWindow sellMarketWindow;
-    private ScrollControl mInventoryScroll;
-    private int i;
-    private object value;
 
     // Método nuevo (llámalo desde la ventana):
     public void SetFilterMatch(bool match)

--- a/Intersect.Client.Core/Interface/Game/Market/SellMarketWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Market/SellMarketWindow.cs
@@ -165,6 +165,9 @@ public sealed class SellMarketWindow
 
     private void InitItemContainer()
     {
+        Items.Clear();
+        mInventoryScroll.DeleteAll();
+
         for (int i = 0; i < Options.Instance.Player.MaxInventory; i++)
         {
             var item = new InventoryItem(this, mInventoryScroll, i, null);


### PR DESCRIPTION
## Summary
- initialize inventory item UI for Sell Market and select item on left click
- refresh sell market inventory grid before repopulating to avoid stale entries

## Testing
- `dotnet build Intersect.Client.Core/Intersect.Client.Core.csproj` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf53e0d948324be6f8c8b57531e99