### PR TITLE
Enforce configurable market price range with persistence

### DIFF
--- a/Framework/Intersect.Framework.Core/Config/MarketOptions.cs
+++ b/Framework/Intersect.Framework.Core/Config/MarketOptions.cs
@@ -1,0 +1,12 @@
+namespace Intersect.Config;
+
+/// <summary>
+/// Configurable options for the player market system.
+/// </summary>
+public partial class MarketOptions
+{
+    /// <summary>
+    /// Allowed variance from the baseline price when listing items.
+    /// </summary>
+    public float AllowedPriceVariance { get; set; } = 0.3f;
+}

--- a/Framework/Intersect.Framework.Core/Config/Options.cs
+++ b/Framework/Intersect.Framework.Core/Config/Options.cs
@@ -210,6 +210,8 @@ public partial record Options
 
     public LootOptions Loot { get; set; } = new();
 
+    public MarketOptions Market { get; set; } = new();
+
     public ProcessingOptions Processing { get; set; } = new();
 
     public SpriteOptions Sprites { get; set; } = new();

--- a/Intersect.Server.Core/Database/PlayerData/Market/MarketManager.cs
+++ b/Intersect.Server.Core/Database/PlayerData/Market/MarketManager.cs
@@ -140,7 +140,7 @@ namespace Intersect.Server.Database.PlayerData.Market
             var min = stats.min;
             var max = stats.max;
 
-            if (min > 0 && max > 0 && (pricePerUnit < min || pricePerUnit > max))
+            if (pricePerUnit < min || pricePerUnit > max)
             {
                 PacketSender.SendChatMsg(
                     seller,

--- a/Intersect.Server.Core/Database/PlayerData/Market/MarketStatistics.cs
+++ b/Intersect.Server.Core/Database/PlayerData/Market/MarketStatistics.cs
@@ -1,19 +1,22 @@
 using System.Collections.Generic;
 using System.Linq;
+using Newtonsoft.Json;
 
 namespace Intersect.Server.Database.PlayerData.Market;
 
 public class MarketStatistics
 {
     private const int MaxSamples = 20;
-    private readonly Queue<long> _prices = new();
+
+    [JsonProperty]
+    private readonly List<long> _prices = new();
 
     public void Record(long price)
     {
-        _prices.Enqueue(price);
+        _prices.Add(price);
         if (_prices.Count > MaxSamples)
         {
-            _prices.Dequeue();
+            _prices.RemoveAt(0);
         }
     }
 

--- a/Intersect.Server.Core/Database/PlayerData/Market/MarketStatisticsManager.cs
+++ b/Intersect.Server.Core/Database/PlayerData/Market/MarketStatisticsManager.cs
@@ -1,11 +1,57 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
+using Intersect.Framework.Core.GameObjects.Items;
+using Newtonsoft.Json;
+using Intersect;
 
 namespace Intersect.Server.Database.PlayerData.Market;
 
 public static class MarketStatisticsManager
 {
-    private static readonly Dictionary<int, MarketStatistics> _statistics = new();
+    private static Dictionary<int, MarketStatistics> _statistics = new();
+
+    private static readonly string StatsFilePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "market_stats.json");
+
+    static MarketStatisticsManager()
+    {
+        Load();
+    }
+
+    private static void Load()
+    {
+        if (!File.Exists(StatsFilePath))
+        {
+            return;
+        }
+
+        try
+        {
+            var json = File.ReadAllText(StatsFilePath);
+            var data = JsonConvert.DeserializeObject<Dictionary<int, MarketStatistics>>(json);
+            if (data != null)
+            {
+                _statistics = data;
+            }
+        }
+        catch
+        {
+            // ignore load errors
+        }
+    }
+
+    private static void Save()
+    {
+        try
+        {
+            var json = JsonConvert.SerializeObject(_statistics, Formatting.Indented);
+            File.WriteAllText(StatsFilePath, json);
+        }
+        catch
+        {
+            // ignore save errors
+        }
+    }
 
     private static MarketStatistics GetOrCreateStats(int itemId)
     {
@@ -18,14 +64,42 @@ public static class MarketStatisticsManager
         return stats;
     }
 
-    public static void RecordListing(int itemId, long price) => GetOrCreateStats(itemId).Record(price);
+    public static void RecordListing(int itemId, long price)
+    {
+        GetOrCreateStats(itemId).Record(price);
+        Save();
+    }
 
-    public static void RecordSale(int itemId, long price) => GetOrCreateStats(itemId).Record(price);
+    public static void RecordSale(int itemId, long price)
+    {
+        GetOrCreateStats(itemId).Record(price);
+        Save();
+    }
 
     public static (long suggested, long min, long max) GetStatistics(int itemId)
     {
         var stats = GetOrCreateStats(itemId);
-        return (stats.SuggestedPrice, stats.MinPrice, stats.MaxPrice);
+        var average = stats.SuggestedPrice;
+
+        long basePrice = average;
+        if (basePrice <= 0)
+        {
+            var descriptor = ItemDescriptor.Get(ItemDescriptor.IdFromList(itemId));
+            basePrice = descriptor?.Price ?? 0;
+        }
+
+        if (basePrice <= 0)
+        {
+            return (0, 0, long.MaxValue);
+        }
+
+        var variance = Options.Instance.Market.AllowedPriceVariance;
+        var min = (long)Math.Floor(basePrice * (1 - variance));
+        var max = (long)Math.Ceiling(basePrice * (1 + variance));
+
+        var suggested = average > 0 ? average : basePrice;
+
+        return (suggested, min, max);
     }
 
     public static void UpdateStatistics(MarketTransaction transaction)


### PR DESCRIPTION
## Summary
- persist market statistics to disk and calculate allowed price range based on historical averages or base item price
- integrate price variance tuning into main `Options` config via new `MarketOptions`
- validate listings against computed price bounds and reject out-of-range prices with explicit limits

## Testing
- ❌ `dotnet test` (dotnet SDK not installed; `apt-get install -y dotnet-sdk-7.0` couldn't locate package)


------
https://chatgpt.com/codex/tasks/task_e_68be135d0ef08324a5cb00a4dad81566