### PR TITLE
Improve market listing updates

### DIFF
--- a/Intersect.Client.Core/Interface/Game/Market/MarketItem.cs
+++ b/Intersect.Client.Core/Interface/Game/Market/MarketItem.cs
@@ -28,6 +28,7 @@ public partial class MarketItem : SlotItem
     private readonly Label _priceLabel;
     private readonly Button _buyButton;
 
+    public Guid ListingId => _listingId;
     public int ItemId => _itemId;
     public long Price => _price;
     public ItemType ItemType { get; private set; }
@@ -71,6 +72,11 @@ public partial class MarketItem : SlotItem
     }
 
     public void Load(Guid listingId, Guid sellerId, int itemId, int quantity, long price, ItemProperties properties)
+    {
+        Update(listingId, sellerId, itemId, quantity, price, properties);
+    }
+
+    public void Update(Guid listingId, Guid sellerId, int itemId, int quantity, long price, ItemProperties properties)
     {
         _listingId = listingId;
         _sellerId = sellerId;


### PR DESCRIPTION
## Summary
- add MarketItem.Update to refresh item state in place
- preserve scroll and focus when loading market listings
- diff listings to update, add, or remove items instead of rebuilding

## Testing
- `dotnet test` *(fails: missing resource 'network.handshake.bkey.pub')*
- `dotnet build Intersect.Client.Core/Intersect.Client.Core.csproj -c Debug`


------
https://chatgpt.com/codex/tasks/task_e_68be1820c2208324879eda01c1d77618