### PR TITLE
fix: prevent divide by zero in slot population

### DIFF
--- a/Intersect.Client.Core/Utilities/PopulateSlotContainer.cs
+++ b/Intersect.Client.Core/Utilities/PopulateSlotContainer.cs
@@ -20,7 +20,9 @@ public static class PopulateSlotContainer
 
             var outerSize = slot.OuterBounds.Size;
 
-            var itemsPerRow = (int)(containerInnerWidth / outerSize.X);
+            var itemsPerRow = outerSize.X > 0
+                ? Math.Max(1, (int)(containerInnerWidth / outerSize.X))
+                : 1;
 
             var column = visibleIndex % itemsPerRow;
             var row = visibleIndex / itemsPerRow;


### PR DESCRIPTION
## Summary
- ensure at least one slot per row when populating item containers to avoid divide-by-zero errors

## Testing
- `dotnet test` *(fails: project file not found for vendor dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68be1d3ace7483249b0f07e47f282390