### PR TITLE
Ensure sell market selections target items when opening

### DIFF
--- a/Intersect.Client.Core/Interface/Game/GameInterface.cs
+++ b/Intersect.Client.Core/Interface/Game/GameInterface.cs
@@ -320,7 +320,15 @@ public partial class GameInterface : MutableInterface
     public void NotifyOpenSellMarket(int slot)
     {
         _sellMarketSlot = slot;
-        _shouldOpenSellMarket = true;
+
+        if (_sellMarketWindow != null && _sellMarketWindow.IsVisibleInTree)
+        {
+            _sellMarketWindow.SelectItem(slot);
+        }
+        else
+        {
+            _shouldOpenSellMarket = true;
+        }
     }
 
     public void NotifyCloseSellMarket()
@@ -332,6 +340,10 @@ public partial class GameInterface : MutableInterface
     {
         _sellMarketWindow = new SellMarketWindow(GameCanvas);
         _sellMarketWindow.Show();
+        if (_sellMarketSlot >= 0)
+        {
+            _sellMarketWindow.SelectItem(_sellMarketSlot);
+        }
         _shouldOpenSellMarket = false;
     }
 
@@ -424,6 +436,8 @@ public partial class GameInterface : MutableInterface
     {
         return _marketWindow;
     }
+
+    public SellMarketWindow? SellMarketWindow => _sellMarketWindow;
 
     public void RefreshBank()
     {

--- a/Intersect.Client.Core/Interface/Game/Inventory/InventoryItem.cs
+++ b/Intersect.Client.Core/Interface/Game/Inventory/InventoryItem.cs
@@ -253,7 +253,18 @@ public partial class InventoryItem : SlotItem
 
     private void _sellItemContextItem_Clicked(Base sender, MouseButtonState arguments)
     {
-        Interface.EnqueueInGame(gameInterface => gameInterface.NotifyOpenSellMarket(SlotIndex));
+        Interface.EnqueueInGame(gameInterface =>
+        {
+            var sellWindow = gameInterface.SellMarketWindow;
+            if (sellWindow != null && sellWindow.IsVisibleInTree)
+            {
+                sellWindow.SelectItem(SlotIndex);
+            }
+            else
+            {
+                gameInterface.NotifyOpenSellMarket(SlotIndex);
+            }
+        });
     }
 
     private void _dropItemContextItem_Clicked(Base sender, MouseButtonState arguments)


### PR DESCRIPTION
## Summary
- Select pending slot when sell market window opens
- Reuse open sell market window and expose it for inventory use
- Allow inventory context menu to select item in already-open sell market window

## Testing
- `dotnet test Intersect.Tests.Client/Intersect.Tests.Client.csproj -v minimal` *(fails: DeliveryMethod could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_68be40f3ce708324a0f146b16303b6e0