### PR TITLE
Only show sell context menu item when Sell Market open

### DIFF
--- a/Intersect.Client.Core/Interface/Game/Inventory/InventoryItem.cs
+++ b/Intersect.Client.Core/Interface/Game/Inventory/InventoryItem.cs
@@ -192,10 +192,16 @@ public partial class InventoryItem : SlotItem
             _actionItemMenuItem.SetText(Strings.ItemContextMenu.Sell.ToString(descriptor.Name));
         }
 
-        if (Globals.GameShop == null && descriptor.CanSell)
+        var sellMarketOpen = Interface.GameUi?.SellMarketWindow?.IsVisibleInTree == true;
+        if (Globals.GameShop == null && descriptor.CanSell && sellMarketOpen)
         {
             contextMenu.AddChild(_sellItemMenuItem);
             _sellItemMenuItem.SetText(Strings.ItemContextMenu.Sell.ToString(descriptor.Name));
+            _sellItemMenuItem.Show();
+        }
+        else
+        {
+            _sellItemMenuItem.Hide();
         }
 
         // Can we drop this item? if so show the user!


### PR DESCRIPTION
## Summary
- only show Sell menu item when Sell Market window is visible
- hide sell option to avoid empty menu entries when Sell Market closed

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets missing)*
- `dotnet test Intersect.Tests/Intersect.Tests.csproj` *(fails: missing network handshake key resource)*

------
https://chatgpt.com/codex/tasks/task_e_68be428b59e48324bb93ac78df8514e8