### PR TITLE
feat: add search filters to market packet

### DIFF
--- a/Framework/Intersect.Framework.Core/Network/Packets/Client/SearchMarketPacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Client/SearchMarketPacket.cs
@@ -1,5 +1,6 @@
 using System;
 using MessagePack;
+using Intersect.Framework.Core.GameObjects.Items;
 
 namespace Intersect.Network.Packets.Client;
 
@@ -18,7 +19,10 @@ public partial class SearchMarketPacket : IntersectPacket
         int? minPrice,
         int? maxPrice,
         bool? status,
-        Guid? sellerId
+        Guid? sellerId,
+        string itemName = "",
+        ItemType? type = null,
+        string? subtype = null
     )
     {
         Page = page;
@@ -28,6 +32,9 @@ public partial class SearchMarketPacket : IntersectPacket
         MaxPrice = maxPrice;
         Status = status;
         SellerId = sellerId;
+        ItemName = itemName;
+        Type = type;
+        Subtype = subtype;
     }
 
     [Key(0)]
@@ -50,4 +57,13 @@ public partial class SearchMarketPacket : IntersectPacket
 
     [Key(6)]
     public Guid? SellerId { get; set; }
+
+    [Key(7)]
+    public string ItemName { get; set; } = string.Empty;
+
+    [Key(8)]
+    public ItemType? Type { get; set; }
+
+    [Key(9)]
+    public string? Subtype { get; set; }
 }


### PR DESCRIPTION
## Summary
- extend SearchMarketPacket with fields for item name, type, and subtype
- allow constructors to accept these new optional filters

## Testing
- `dotnet build Framework/Intersect.Framework.Core/Intersect.Framework.Core.csproj -c Release`
- `dotnet build Intersect.Client.Core/Intersect.Client.Core.csproj -c Release` *(fails: DisconnectInfo could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_68be5d6ff1c48324bca94f9719028abd