### PR TITLE
Fix null handling in market search filters

### DIFF
--- a/Intersect.Client.Core/Interface/Game/Market/MarketWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Market/MarketWindow.cs
@@ -286,19 +286,14 @@ public partial class MarketWindow : Window
         {
             maxPrice = maxVal;
         }
+
         ItemType? type = null;
-        if (_typeBox.SelectedItem?.UserData?.ToString() != "all")
+        if (_typeBox.SelectedItem?.UserData is ItemType parsedType)
         {
-            if (Enum.TryParse<ItemType>(_typeBox.SelectedItem.UserData.ToString(), out var parsed))
-            {
-                type = parsed;
-            }
+            type = parsedType;
         }
-        string subType = null;
-        if (_subtypeBox.SelectedItem?.UserData?.ToString() != "all")
-        {
-            subType = _subtypeBox.SelectedItem.UserData.ToString();
-        }
+
+        string? subType = _subtypeBox.SelectedItem?.UserData as string;
 
         // Enviar con subtipo adicional
         PacketSender.SendSearchMarket(name, minPrice, maxPrice, type, subType);


### PR DESCRIPTION
## Summary
- prevent null reference when building market search parameters

## Testing
- `dotnet test` *(fails: project file "vendor/.../LiteNetLib.csproj" was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be607c7f248324a08a3ff36d9b41de