### PR TITLE
feat: provide market price info packet

### DIFF
--- a/Intersect.Server.Core/CustomChanges/PacketSenderCustom.cs
+++ b/Intersect.Server.Core/CustomChanges/PacketSenderCustom.cs
@@ -282,6 +282,38 @@ public static partial class PacketSender
         player.SendPacket(new MarketTransactionsPacket(packets));
     }
 
+    public static void SendPriceInfo(Player player, Guid itemId)
+    {
+        if (player == null)
+        {
+            return;
+        }
+
+        var stats = MarketStatisticsManager.GetStatistics(itemId);
+
+        var suggested = (int)Math.Round(stats.AveragePricePerUnit > 0
+            ? stats.AveragePricePerUnit
+            : stats.GetFallbackAverage());
+
+        if (suggested <= 0)
+        {
+            suggested = 1;
+        }
+
+        var min = stats.GetMinAllowedPrice();
+        var max = stats.GetMaxAllowedPrice();
+
+        var packet = new MarketPriceInfoPacket
+        {
+            ItemId = itemId,
+            SuggestedPrice = suggested,
+            MinAllowedPrice = min,
+            MaxAllowedPrice = max
+        };
+
+        player.SendPacket(packet);
+    }
+
   
 
 }


### PR DESCRIPTION
## Summary
- implement `SendPriceInfo` to send suggested and allowed price ranges for market items

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0e33426248324863d630a0f6a19ab