### PR TITLE
Refine market window page requests

### DIFF
--- a/Intersect.Client.Core/Interface/Game/Market/MarketWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Market/MarketWindow.cs
@@ -218,7 +218,13 @@ public partial class MarketWindow : Window
 
     private void RequestPage(int page)
     {
-        PacketSender.SendSearchMarket(page, _pageSize);
+        _page = page;
+
+        var name = _searchBox.Text?.Trim() ?? string.Empty;
+        int? minPrice = int.TryParse(_minPriceBox.Text, out var mn) ? mn : null;
+        int? maxPrice = int.TryParse(_maxPriceBox.Text, out var mx) ? mx : null;
+
+        PacketSender.SendSearchMarket(name, minPrice, maxPrice, _selectedType, _selectedSubtype);
     }
 
     private void ApplyFilters()


### PR DESCRIPTION
## Summary
- Track current page when changing pages in the market window
- Send market searches with existing filters instead of page parameters

## Testing
- `dotnet build Intersect.Client.Core/Intersect.Client.Core.csproj` *(fails: NetLogger types missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c0e3171a0483248f791de3ede15d4b