### PR TITLE
Expose SellMarketWindow visibility and selected item

### DIFF
--- a/Intersect.Client.Core/Interface/Game/Market/SellMarketWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Market/SellMarketWindow.cs
@@ -353,6 +353,10 @@ namespace Intersect.Client.Interface.Game.Market
             return true;
         }
 
+        public bool IsVisible() => IsVisibleInTree;
+
+        public Guid GetSelectedItemId() => _selectedItemId;
+
         private void ResetSelection()
         {
             _selectedSlot = -1;


### PR DESCRIPTION
## Summary
- add helper methods to expose SellMarketWindow visibility and selected item

## Testing
- `dotnet test` *(fails: project file "vendor/LiteNetLib/LiteNetLib/LiteNetLib.csproj" was not found)*
- `dotnet build Intersect.Client.Core/Intersect.Client.Core.csproj` *(fails: Restore canceled!)*

------
https://chatgpt.com/codex/tasks/task_e_68c0e615eca083248b0a82ad4d4ed5c1