### PR TITLE
Add market listing creation localization

### DIFF
--- a/Intersect.Client.Core/Localization/Translations/en-US.json
+++ b/Intersect.Client.Core/Localization/Translations/en-US.json
@@ -8,6 +8,7 @@
     "Quantity": "Quantity",
     "Price": "Price",
     "SuggestedPrice": "Suggested Price: {00}",
-    "Sell": "Sell"
+    "Sell": "Sell",
+    "ListingCreated": "Listing created."
   }
 }

--- a/Intersect.Client.Core/Localization/Translations/es-ES.json
+++ b/Intersect.Client.Core/Localization/Translations/es-ES.json
@@ -8,6 +8,7 @@
     "Quantity": "Cantidad",
     "Price": "Precio",
     "SuggestedPrice": "Precio sugerido: {00}",
-    "Sell": "Vender"
+    "Sell": "Vender",
+    "ListingCreated": "Anuncio creado."
   }
 }

--- a/Intersect.Server.Core/Localization/Strings.cs
+++ b/Intersect.Server.Core/Localization/Strings.cs
@@ -1474,6 +1474,9 @@ public static partial class Strings
         public readonly LocalizedString transactionfailed = @"Transaction failed.";
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString listingcreated = @"Listing created.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public readonly LocalizedString salecompleted = @"Sale completed.";
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]


### PR DESCRIPTION
## Summary
- add `listingcreated` string to market server localization
- translate new market listing string into en-US and es-ES client translations

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*
- `dotnet test Intersect.Tests.Server/Intersect.Tests.Server.csproj` *(fails: MarketListing missing ReturnPending, SellerId)*

------
https://chatgpt.com/codex/tasks/task_e_68c0e5ff35b083248e3b732c22017ab7