### PR TITLE
Direct market purchase without quantity prompt

### DIFF
--- a/Intersect.Client.Core/Interface/Game/Market/MarketItem.cs
+++ b/Intersect.Client.Core/Interface/Game/Market/MarketItem.cs
@@ -153,7 +153,11 @@ public partial class MarketItem : SlotItem
     }
 
     private void BuyButton_Clicked(Base sender, MouseButtonState args)
-        => Icon_Clicked(sender, args);
+    {
+        if (Globals.Me?.Name == _sellerName) return;
+
+        PacketSender.SendBuyMarketListing(_listingId);
+    }
 
     private void CancelButton_Clicked(Base sender, MouseButtonState args)
         => PacketSender.SendCancelMarketListing(_listingId);


### PR DESCRIPTION
## Summary
- Remove quantity prompt from market buy button
- Buy button now sends a direct `SendBuyMarketListing` call

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0ecb987548324b440aca9f9a07b5c