### PR TITLE
Use IsVisibleInTree for sell window

### DIFF
--- a/Intersect.Client.Core/CustomChanges/PacketHandlerCustom.cs
+++ b/Intersect.Client.Core/CustomChanges/PacketHandlerCustom.cs
@@ -286,7 +286,7 @@ internal sealed partial class PacketHandler
 
         var sellWindow = Interface.Interface.GameUi.SellMarketWindow;
 
-        if (sellWindow != null && sellWindow.IsVisible())
+        if (sellWindow != null && sellWindow.IsVisibleInTree)
         {
             // Si aún está esperando ese ítem, forzar refresco
             if (sellWindow.GetSelectedItemId() == packet.ItemId || sellWindow._waitingPriceForItemId == packet.ItemId)

--- a/Intersect.Client.Core/Interface/Game/Market/SellMarketWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Market/SellMarketWindow.cs
@@ -353,6 +353,9 @@ namespace Intersect.Client.Interface.Game.Market
             return true;
         }
 
+        /// <summary>
+        /// Wrapper for <see cref="IsVisibleInTree"/> maintained for compatibility.
+        /// </summary>
         public bool IsVisible() => IsVisibleInTree;
 
         public Guid GetSelectedItemId() => _selectedItemId;


### PR DESCRIPTION
## Summary
- use IsVisibleInTree instead of custom wrapper in market price handler
- document SellMarketWindow.IsVisible as a compatibility wrapper

## Testing
- `dotnet test` *(fails: project file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0ed2bcd7483249fb096bd0f1f92b6