### PR TITLE
Delegate market listings to window

### DIFF
--- a/Intersect.Client.Core/Interface/Game/GameInterface.cs
+++ b/Intersect.Client.Core/Interface/Game/GameInterface.cs
@@ -914,7 +914,6 @@ public partial class GameInterface : MutableInterface
 
     public void UpdateListings(List<MarketListingPacket> listings)
     {
-        MarketWindow.Instance?.UpdateListings(listings);
-
+        _marketWindow?.UpdateListings(listings);
     }
 }

--- a/Intersect.Client.Core/Interface/Game/Market/MarketWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Market/MarketWindow.cs
@@ -308,14 +308,7 @@ public partial class MarketWindow : Window
 
     public void UpdateListings(List<MarketListingPacket> listings)
     {
-        _allListings = listings ?? [];
-        var maxPage = Math.Max(1, (int)Math.Ceiling(_allListings.Count / (double)_pageSize));
-        if (_page > maxPage)
-        {
-            _page = maxPage;
-        }
-
-        ApplyFilters();
+        LoadListings(listings ?? [], _page, _pageSize, listings?.Count ?? 0);
     }
     public void SendSearch()
     {


### PR DESCRIPTION
## Summary
- load market listings directly through MarketWindow
- delegate listing updates from GameInterface to active MarketWindow instance

## Testing
- `dotnet test` *(fails: project file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0ee4ebea8832481f9e3e0973eb68d