### PR TITLE
Add seller foreign key to market transactions

### DIFF
--- a/Intersect.Server.Core/Database/PlayerData/Market/MarketManager.cs
+++ b/Intersect.Server.Core/Database/PlayerData/Market/MarketManager.cs
@@ -260,6 +260,7 @@ namespace Intersect.Server.Database.PlayerData.Players
             var transaction = new MarketTransaction
             {
                 ListingId = listing.Id,
+                SellerId = listing.Seller.Id,
                 Seller = listing.Seller,
                 BuyerName = buyer.Name,
                 ItemId = listing.ItemId,

--- a/Intersect.Server.Core/Database/PlayerData/Market/MarketTransaction.cs
+++ b/Intersect.Server.Core/Database/PlayerData/Market/MarketTransaction.cs
@@ -21,6 +21,10 @@ namespace Intersect.Server.Database.PlayerData.Market;
         public string BuyerName { get; set; }
 
         [Required]
+        public Guid SellerId { get; set; }
+
+        [Required]
+        [ForeignKey(nameof(SellerId))]
         public virtual Player Seller { get; set; }
 
         [Required]


### PR DESCRIPTION
## Summary
- track seller identifiers in market transactions with new required `SellerId` column
- load seller entity via `Seller` navigation property using that key
- include seller id when recording market sales

## Testing
- `dotnet build Intersect.Server.Core/Intersect.Server.Core.csproj` *(fails: DeliveryMethod/NetDataWriter types missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c0fa5773a083249136f8e8f12918b6