### PR TITLE
Add server/client support for opening market windows

### DIFF
--- a/Framework/Intersect.Framework.Core/Network/Packets/Server/MarketParcket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Server/MarketParcket.cs
@@ -5,14 +5,17 @@ namespace Intersect.Network.Packets.Server
     [MessagePackObject]
     public class MarketWindowPacket : IntersectPacket
     {
-        public MarketWindowPacket(bool openMarket, bool openSell)
+        public MarketWindowPacket(bool openMarket, bool openSell, int slot = -1)
         {
             OpenMarket = openMarket;
             OpenSell = openSell;
+            Slot = slot;
         }
 
         [Key(0)] public bool OpenMarket { get; set; }
 
         [Key(1)] public bool OpenSell { get; set; }
+
+        [Key(2)] public int Slot { get; set; }
     }
 }

--- a/Intersect.Client.Core/CustomChanges/PacketHandlerCustom.cs
+++ b/Intersect.Client.Core/CustomChanges/PacketHandlerCustom.cs
@@ -316,7 +316,7 @@ internal sealed partial class PacketHandler
         else if (packet.OpenSell)
         {
             Interface.Interface.GameUi.CloseMarket();
-            Interface.Interface.GameUi.OpenSellMarket();  // muestra tu inventario para poner objetos a la venta
+            Interface.Interface.GameUi.NotifyOpenSellMarket(packet.Slot);
         }
     }
 

--- a/Intersect.Server.Core/CustomChanges/PacketSenderCustom.cs
+++ b/Intersect.Server.Core/CustomChanges/PacketSenderCustom.cs
@@ -157,6 +157,28 @@ public static partial class PacketSender
         player.SendPacket(new BrokeItemWindowPacket());
     }
 
+    public static void SendOpenMarket(Player player)
+    {
+        if (player == null)
+        {
+            return;
+        }
+
+        player.SendPacket(new MarketWindowPacket(true, false));
+    }
+
+    public static void SendOpenSellMarket(Player player, int slot)
+    {
+        if (player == null)
+        {
+            return;
+        }
+
+        SendInventory(player);
+
+        player.SendPacket(new MarketWindowPacket(false, true, slot));
+    }
+
 
    
     public static void SendRefreshMarket(Player player)


### PR DESCRIPTION
## Summary
- add slot-aware MarketWindowPacket and market open helpers
- allow server to send open market or sell market UI updates
- update client handler to use selected slot for sell window

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Invalid response from proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68c206d913ec8324a63d977d1499a9a0