### PR TITLE
Fix market listings filtering

### DIFF
--- a/Intersect.Client.Core/Interface/Game/Market/MarketWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Market/MarketWindow.cs
@@ -308,7 +308,8 @@ public partial class MarketWindow : Window
 
     public void UpdateListings(List<MarketListingPacket> listings)
     {
-        LoadListings(listings ?? [], _page, _pageSize, listings?.Count ?? 0);
+        _allListings = listings ?? [];
+        ApplyFilters();
     }
     public void SendSearch()
     {


### PR DESCRIPTION
## Summary
- assign incoming listings to `_allListings` and apply filters to update market results

## Testing
- `dotnet build Intersect.Client.Core/Intersect.Client.Core.csproj` *(fails: CS0246 types from LiteNetLib missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c21e25aba083249093edfd0375f824