### PR TITLE
Filter market listings by subtype

### DIFF
--- a/Intersect.Server.Core/CustomChanges/PacketHandlerCustom.cs
+++ b/Intersect.Server.Core/CustomChanges/PacketHandlerCustom.cs
@@ -628,6 +628,15 @@ internal sealed partial class PacketHandler
         if (packet.Type.HasValue)
             listings = listings.Where(l => ItemDescriptor.Get(l.ItemId)?.ItemType == packet.Type).ToList();
 
+        if (!string.IsNullOrWhiteSpace(packet.Subtype))
+            listings = listings.Where(
+                l => string.Equals(
+                    ItemDescriptor.Get(l.ItemId)?.Subtype,
+                    packet.Subtype,
+                    StringComparison.OrdinalIgnoreCase
+                )
+            ).ToList();
+
         if (packet.MinPrice.HasValue)
             listings = listings.Where(l => l.Price >= packet.MinPrice.Value).ToList();
 


### PR DESCRIPTION
## Summary
- filter market listings by subtype when provided

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2211324fc8324bbe0f1c8ae0e9435