### PR TITLE
Avoid duplicate market search requests on initialization

### DIFF
--- a/Intersect.Client.Core/Interface/Game/Market/MarketWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Market/MarketWindow.cs
@@ -342,7 +342,6 @@ public partial class MarketWindow : Window
     protected override void EnsureInitialized()
     {
         LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
-        PacketSender.SendSearchMarket();
         SendSearch();
         _listingScroll.SetBounds(10, 60, Width - 20, Height - 110);
     }


### PR DESCRIPTION
## Summary
- simplify market window initialization to send only one market search request

## Testing
- `dotnet restore Intersect.Client.Core/Intersect.Client.Core.csproj`
- `dotnet build Intersect.Client.Core/Intersect.Client.Core.csproj` (fails: NetDataWriter missing)
- `dotnet test Intersect.Tests/Intersect.Tests.csproj` (fails: NetPeer/NetDataReader missing)

------
https://chatgpt.com/codex/tasks/task_e_68c2214f5ac88324b542645006700b1f