### PR TITLE
feat(editor): add market commands

### DIFF
--- a/Intersect.Editor/Forms/Editors/Events/CommandPrinter.cs
+++ b/Intersect.Editor/Forms/Editors/Events/CommandPrinter.cs
@@ -1717,4 +1717,12 @@ public static partial class CommandPrinter
     {
         return Strings.EventCommandList.sendmail;
     }
+    private static string GetCommandText(OpenMarketWindowCommand command, MapInstance map)
+    {
+        return Strings.EventCommandList.openmarket;
+    }
+    private static string GetCommandText(OpenMarketSellWindowCommand command, MapInstance map)
+    {
+        return Strings.EventCommandList.opensellmarket;
+    }
 }

--- a/Intersect.Editor/Forms/Editors/Events/frmEvent.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/Events/frmEvent.Designer.cs
@@ -113,6 +113,9 @@ namespace Intersect.Editor.Forms.Editors.Events
             var treeNode74 = new TreeNode("Send Mail");
             var treeNode75 = new TreeNode("Open Mail Box");
             var treeNode76 = new TreeNode("Mail Box", new TreeNode[] { treeNode74, treeNode75 });
+            var treeNode77 = new TreeNode("Open Market");
+            var treeNode78 = new TreeNode("Open Sell Market");
+            var treeNode79 = new TreeNode("Market", new TreeNode[] { treeNode77, treeNode78 });
             lblName = new Label();
             txtEventname = new DarkTextBox();
             grpEntityOptions = new DarkGroupBox();
@@ -1014,7 +1017,13 @@ namespace Intersect.Editor.Forms.Editors.Events
             treeNode75.Text = "Open Mail Box";
             treeNode76.Name = "mailbox";
             treeNode76.Text = "Mail Box";
-            lstCommands.Nodes.AddRange(new TreeNode[] { treeNode5, treeNode13, treeNode33, treeNode43, treeNode52, treeNode56, treeNode58, treeNode62, treeNode67, treeNode69, treeNode73, treeNode76 });
+            treeNode77.Name = "openmarket";
+            treeNode77.Text = "Open Market";
+            treeNode78.Name = "opensellmarket";
+            treeNode78.Text = "Open Sell Market";
+            treeNode79.Name = "market";
+            treeNode79.Text = "Market";
+            lstCommands.Nodes.AddRange(new TreeNode[] { treeNode5, treeNode13, treeNode33, treeNode43, treeNode52, treeNode56, treeNode58, treeNode62, treeNode67, treeNode69, treeNode73, treeNode76, treeNode79 });
             lstCommands.Size = new Size(500, 536);
             lstCommands.TabIndex = 2;
             lstCommands.NodeMouseDoubleClick += lstCommands_NodeMouseDoubleClick;

--- a/Intersect.Editor/Localization/Strings.cs
+++ b/Intersect.Editor/Localization/Strings.cs
@@ -2406,6 +2406,10 @@ Tick timer saved in server config.json.";
         public static LocalizedString sendmail = @"Send Mail";
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public static LocalizedString openmailbox = @"Open Mail Box";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString openmarket = @"Open Market";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString opensellmarket = @"Open Sell Market";
     }
 
     public partial struct EventChangePlayerColor


### PR DESCRIPTION
## Summary
- add localization strings for market commands
- show market command text in event command printer
- expose open market and sell market commands in event editor

## Testing
- `dotnet build Intersect.Editor/Intersect.Editor.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c24829f6608324892259b1405132f0