### PR TITLE
Track inventory slot when creating market listings

### DIFF
--- a/Framework/Intersect.Framework.Core/Network/Packets/Client/CreateMarketListingPacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Client/CreateMarketListingPacket.cs
@@ -13,5 +13,6 @@ namespace Intersect.Network.Packets.Client
         [Key(2)] public int Price { get; set; }
         [Key(3)] public ItemProperties Properties { get; set; }
         [Key(4)] public bool AutoSplit { get; set; }
+        [Key(5)] public int SlotIndex { get; set; }
     }
 }

--- a/Intersect.Client.Core/CustomChanges/PacketSenderCustom.cs
+++ b/Intersect.Client.Core/CustomChanges/PacketSenderCustom.cs
@@ -114,7 +114,7 @@ public static partial class PacketSender
         });
     }
 
-    public static void SendCreateMarketListing(Guid itemId, int quantity, int price, ItemProperties props, bool autoSplit = false)
+    public static void SendCreateMarketListing(Guid itemId, int quantity, int price, ItemProperties props, bool autoSplit = false, int slotIndex = -1)
 
     {
         Network.SendPacket(new CreateMarketListingPacket
@@ -123,7 +123,8 @@ public static partial class PacketSender
             Quantity = quantity,
             Price = price,
             Properties = props,
-            AutoSplit = autoSplit
+            AutoSplit = autoSplit,
+            SlotIndex = slotIndex
         });
     }
     public static void SendCancelMarketListing(Guid listingId)

--- a/Intersect.Client.Core/Interface/Game/Market/SellMarketWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Market/SellMarketWindow.cs
@@ -281,12 +281,12 @@ namespace Intersect.Client.Interface.Game.Market
                 }
             }
 
-            // Propiedades del primer slot
-            var first = matching.First();
-            var props = Globals.Me.Inventory[first.idx].ItemProperties ?? new ItemProperties();
+            // Propiedades del slot seleccionado
+            var slot = Globals.Me.Inventory[_selectedSlot];
+            var props = slot.ItemProperties ?? new ItemProperties();
 
-            // Enviar al server (usa GUID + props actuales)
-            PacketSender.SendCreateMarketListing(_selectedItemId, qty, price, props, _autoSplitCheckbox.IsChecked);
+            // Enviar al server con el índice del slot
+            PacketSender.SendCreateMarketListing(_selectedItemId, qty, price, props, _autoSplitCheckbox.IsChecked, _selectedSlot);
 
             ResetSelection();
         }

--- a/Intersect.Server.Core/CustomChanges/PacketHandlerCustom.cs
+++ b/Intersect.Server.Core/CustomChanges/PacketHandlerCustom.cs
@@ -648,7 +648,8 @@ internal sealed partial class PacketHandler
             item: clone,
             quantity: packet.Quantity,
             pricePerUnit: packet.Price,
-            autoSplit: packet.AutoSplit // <-- NUEVO argumento
+            autoSplit: packet.AutoSplit,
+            slotIndex: packet.SlotIndex
         );
 
         if (success)

--- a/Intersect.Server.Core/Database/PlayerData/Market/MarketManager.cs
+++ b/Intersect.Server.Core/Database/PlayerData/Market/MarketManager.cs
@@ -71,7 +71,7 @@ namespace Intersect.Server.Database.PlayerData.Players
             return result;
         }
 
-        public static bool TryListItem(Player seller, Item item, int quantity, int pricePerUnit, bool autoSplit = false)
+        public static bool TryListItem(Player seller, Item item, int quantity, int pricePerUnit, bool autoSplit = false, int slotIndex = -1)
         {
             if (item == null || quantity <= 0 || pricePerUnit <= 0)
             {
@@ -116,6 +116,12 @@ namespace Intersect.Server.Database.PlayerData.Players
             var itemProperties = item.Properties;
             var packageSizes = autoSplit ? new[] { 1000,500, 100,50, 10, 1 } : new[] { quantity };
 
+            if (slotIndex < 0 || slotIndex >= seller.Items.Count)
+            {
+                PacketSender.SendChatMsg(seller, Strings.Market.invalidlisting, ChatMessageType.Error, CustomColors.Alerts.Error);
+                return false;
+            }
+
             int remaining = quantity;
             bool atLeastOneListed = false;
 
@@ -126,7 +132,7 @@ namespace Intersect.Server.Database.PlayerData.Players
                     var tax = CalculateTax(pricePerUnit, size);
                     var totalPrice = pricePerUnit * size;
 
-                    if (!seller.TryTakeItem(item.ItemId, size)) break;
+                    if (!seller.TryTakeItem(seller.Items[slotIndex], size)) break;
                     if (!seller.TryTakeItem(currencyBase.Id, tax))
                     {
                         seller.TryGiveItem(item.ItemId, size);


### PR DESCRIPTION
## Summary
- include slot index in CreateMarketListingPacket
- send selected slot when creating market listings
- remove items from correct inventory slot on server

## Testing
- `dotnet build Intersect.sln` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: package not found)*
- `dotnet --info` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c25b276c78832498c10f3777ef8750