### PR TITLE
Allow swapping with empty inventory slots

### DIFF
--- a/Intersect.Client.Core/Entities/Player.cs
+++ b/Intersect.Client.Core/Entities/Player.cs
@@ -476,28 +476,24 @@ public partial class Player : Entity, IPlayer
         }
 
         var fromSlot = Inventory[fromSlotIndex];
-        if (fromSlot == null || fromSlot.ItemId == Guid.Empty)
-        {
-            ApplicationContext.Context.Value?.Logger.LogWarning($"Tried to swap item from slot {fromSlotIndex}, but the slot was empty");
-            return;
-        }
-
         var toSlot = Inventory[toSlotIndex];
-        if (toSlot == null || toSlot.ItemId == Guid.Empty)
+
+        var fromEmpty = fromSlot == null || fromSlot.ItemId == Guid.Empty;
+        var toEmpty = toSlot == null || toSlot.ItemId == Guid.Empty;
+
+        if (fromEmpty && toEmpty)
         {
-            ApplicationContext.Context.Value?.Logger.LogWarning($"Tried to swap item with slot {toSlotIndex}, but the slot was empty");
             return;
         }
 
         PacketSender.SendSwapInvItems(fromSlotIndex, toSlotIndex);
 
-        if (
+        if (!fromEmpty && !toEmpty &&
             fromSlot.ItemId == toSlot.ItemId &&
             ItemDescriptor.TryGet(toSlot.ItemId, out var itemInSlot) &&
             itemInSlot.IsStackable &&
             fromSlot.Quantity < itemInSlot.MaxInventoryStack &&
-            toSlot.Quantity < itemInSlot.MaxInventoryStack
-        )
+            toSlot.Quantity < itemInSlot.MaxInventoryStack)
         {
             var combinedQuantity = fromSlot.Quantity + toSlot.Quantity;
             var toQuantity = Math.Min(itemInSlot.MaxInventoryStack, combinedQuantity);


### PR DESCRIPTION
## Summary
- permit swapping when one inventory slot is empty so sorting can move empty slots to the end

## Testing
- `dotnet test` *(fails: project file vendor/LiteNetLib/LiteNetLib/LiteNetLib.csproj not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2608e72c083248e229412820819d7