### PR TITLE
Disable market buy button while purchasing

### DIFF
--- a/Intersect.Client.Core/Interface/Game/Market/MarketWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Market/MarketWindow.cs
@@ -379,6 +379,11 @@ namespace Intersect.Client.Interface.Game.Market
 
         public void RefreshAfterPurchase()
         {
+            foreach (var item in mCurrentItems.Values)
+            {
+                item.ResetBuying();
+            }
+
             SendSearch();
         }
 


### PR DESCRIPTION
## Summary
- prevent multiple market purchases by disabling buy button until transaction completes
- re-enable buy buttons when server confirms purchase or after timeout

## Testing
- `dotnet test` *(fails: project file vendor/LiteNetLib/LiteNetLib.csproj not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c374295808832490a39c9650a135aa