### PR TITLE
Add pagination to market listings

### DIFF
--- a/Framework/Intersect.Framework.Core/Network/Packets/Client/SearchMarketPacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Client/SearchMarketPacket.cs
@@ -12,5 +12,6 @@ namespace Intersect.Network.Packets.Client
         [Key(2)] public int? MaxPrice { get; set; }
         [Key(3)] public ItemType? Type { get; set; }
         [Key(4)] public string Subtype {  get; set; }
+        [Key(5)] public int Page { get; set; }
     }
 }

--- a/Framework/Intersect.Framework.Core/Network/Packets/Server/MarketListingPacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Server/MarketListingPacket.cs
@@ -20,10 +20,12 @@ namespace Intersect.Network.Packets.Server
     public class MarketListingsPacket : IntersectPacket
     {
         [Key(0)] public List<MarketListingPacket> Listings { get; set; }
+        [Key(1)] public int Total { get; set; }
 
-        public MarketListingsPacket(List<MarketListingPacket> listings)
+        public MarketListingsPacket(List<MarketListingPacket> listings, int total)
         {
             Listings = listings ?? new List<MarketListingPacket>();
+            Total = total;
         }
     }
 }

--- a/Intersect.Client.Core/CustomChanges/PacketHandlerCustom.cs
+++ b/Intersect.Client.Core/CustomChanges/PacketHandlerCustom.cs
@@ -247,7 +247,7 @@ internal sealed partial class PacketHandler
         // Aquí deberás pasar los listados a la ventana del mercado.
         // Puedes almacenarlos en una variable global temporal o llamar directamente a la ventana.
 
-        Interface.Interface.GameUi.UpdateListings(packet.Listings);
+        Interface.Interface.GameUi.UpdateListings(packet.Listings, packet.Total);
     }
     public void HandlePacket(IPacketSender sender, MarketListingCreatedPacket packet)
     {

--- a/Intersect.Client.Core/CustomChanges/PacketSenderCustom.cs
+++ b/Intersect.Client.Core/CustomChanges/PacketSenderCustom.cs
@@ -102,7 +102,7 @@ public static partial class PacketSender
         Network.SendPacket(new BuyMarketListingPacket(listingId));
     }
 
-    public static void SendSearchMarket(string name = "", int? min = null, int? max = null, ItemType? type = null, string? subType = null)
+    public static void SendSearchMarket(string name = "", int? min = null, int? max = null, ItemType? type = null, string? subType = null, int page = 0)
     {
         Network.SendPacket(new SearchMarketPacket
         {
@@ -110,7 +110,8 @@ public static partial class PacketSender
             MinPrice = min,
             MaxPrice = max,
             Type = type,
-            Subtype = subType
+            Subtype = subType,
+            Page = page
         });
     }
 

--- a/Intersect.Client.Core/Interface/Game/GameInterface.cs
+++ b/Intersect.Client.Core/Interface/Game/GameInterface.cs
@@ -841,9 +841,9 @@ public partial class GameInterface : MutableInterface
     }
 
 
-    public void UpdateListings(List<MarketListingPacket> listings)
+    public void UpdateListings(List<MarketListingPacket> listings, int total)
     {
-        MarketWindow.Instance?.UpdateListings(listings);
+        MarketWindow.Instance?.UpdateListings(listings, total);
 
     }
 }

--- a/Intersect.Server.Core/CustomChanges/PacketHandlerCustom.cs
+++ b/Intersect.Server.Core/CustomChanges/PacketHandlerCustom.cs
@@ -19,6 +19,7 @@ using System.Collections.Generic;
 using System.Collections;
 using System.Diagnostics;
 using System.Text;
+using System.Linq;
 using Intersect.Core;
 using Intersect.Framework.Core;
 using Intersect.Framework.Core.GameObjects.Crafting;
@@ -630,7 +631,13 @@ internal sealed partial class PacketHandler
         if (packet.MaxPrice.HasValue)
             listings = listings.Where(l => l.Price <= packet.MaxPrice.Value).ToList();
 
-        PacketSender.SendMarketListings(player, listings);
+        var total = listings.Count;
+        const int pageSize = 10;
+        var maxPage = Math.Max((int)Math.Ceiling(total / (double)pageSize) - 1, 0);
+        var page = Math.Clamp(packet.Page, 0, maxPage);
+        listings = listings.Skip(page * pageSize).Take(pageSize).ToList();
+
+        PacketSender.SendMarketListings(player, listings, total);
     }
     public void HandlePacket(Client client, CreateMarketListingPacket packet)
     {

--- a/Intersect.Server.Core/CustomChanges/PacketSenderCustom.cs
+++ b/Intersect.Server.Core/CustomChanges/PacketSenderCustom.cs
@@ -216,7 +216,7 @@ public static partial class PacketSender
         player.SendPacket(new UnlockedBestiaryEntriesPacket(unlocks, killCounts));
     }
 
-    public static void SendMarketListings(Player player, List<MarketListing> listings)
+    public static void SendMarketListings(Player player, List<MarketListing> listings, int total)
     {
         var listingPackets = listings.Select(l => new MarketListingPacket
         {
@@ -228,7 +228,7 @@ public static partial class PacketSender
             Properties = l.ItemProperties
         }).ToList();
 
-        player.SendPacket(new MarketListingsPacket(listingPackets));
+        player.SendPacket(new MarketListingsPacket(listingPackets, total));
     }
     public static void SendMarketListingCreated(Player player)
     {
@@ -264,16 +264,16 @@ public static partial class PacketSender
         var listings = MarketManager.SearchMarket();
 
         // Construir el paquete de listado de mercado
-        var packet = new MarketListingsPacket(
-            listings.Select(listing => new MarketListingPacket
-            {
-                ListingId = listing.Id,
-                ItemId = listing.ItemId,
-                Quantity = listing.Quantity,
-                Price = listing.Price,
-                Properties = listing.ItemProperties
-            }).ToList()
-        );
+        var listingPackets = listings.Select(listing => new MarketListingPacket
+        {
+            ListingId = listing.Id,
+            ItemId = listing.ItemId,
+            Quantity = listing.Quantity,
+            Price = listing.Price,
+            Properties = listing.ItemProperties
+        }).ToList();
+
+        var packet = new MarketListingsPacket(listingPackets, listings.Count);
 
         // Enviar al cliente
         player.SendPacket(packet);


### PR DESCRIPTION
## Summary
- add paging state and controls to `MarketWindow`
- page-aware search requests and paged listing responses
- paginate results server-side and report total listings

## Testing
- `dotnet test` *(fails: project file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c3779e47e48324bc7c28a68164c2c1