### PR TITLE
Add retry handling for market searches

### DIFF
--- a/Intersect.Client.Core/CustomChanges/PacketHandlerCustom.cs
+++ b/Intersect.Client.Core/CustomChanges/PacketHandlerCustom.cs
@@ -242,10 +242,10 @@ internal sealed partial class PacketHandler
     public void HandlePacket(IPacketSender sender, MarketListingsPacket packet)
     {
         if (packet?.Listings == null)
+        {
+            Interface.Interface.GameUi.mMarketWindow?.SearchFailed("Invalid response");
             return;
-
-        // Aquí deberás pasar los listados a la ventana del mercado.
-        // Puedes almacenarlos en una variable global temporal o llamar directamente a la ventana.
+        }
 
         Interface.Interface.GameUi.UpdateListings(packet.Listings, packet.Total);
     }

--- a/Intersect.Client.Core/Localization/Strings.cs
+++ b/Intersect.Client.Core/Localization/Strings.cs
@@ -387,6 +387,9 @@ public static partial class Strings
         public static LocalizedString sellButton = @"Sell";
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString retryButton = @"Retry";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public static LocalizedString headerItemName = @"Item Name";
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]

--- a/Intersect.Client.Core/Networking/PacketHandler.cs
+++ b/Intersect.Client.Core/Networking/PacketHandler.cs
@@ -1253,8 +1253,15 @@ internal sealed partial class PacketHandler
     {
         Fade.FadeIn(ClientConfiguration.Instance.FadeDurationMs);
         Globals.WaitingOnServer = false;
-        Interface.Interface.ShowAlert(packet.Error, packet.Header, alertType: AlertType.Error);
-        Interface.Interface.MenuUi?.Reset();
+        if (Interface.Interface.GameUi?.mMarketWindow != null && Interface.Interface.GameUi.mMarketWindow.IsWaitingSearch)
+        {
+            Interface.Interface.GameUi.mMarketWindow.SearchFailed(packet.Error);
+        }
+        else
+        {
+            Interface.Interface.ShowAlert(packet.Error, packet.Header, alertType: AlertType.Error);
+            Interface.Interface.MenuUi?.Reset();
+        }
     }
 
     //MapItemsPacket


### PR DESCRIPTION
## Summary
- add error display and retry button to market window
- show retry info on failed market search packets
- resend previous search query on retry

## Testing
- `dotnet build` *(fails: MSB3202 project file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c37a413c808324a381560864632199