### PR TITLE
Make market page size configurable

### DIFF
--- a/Framework/Intersect.Framework.Core/Config/MarketOptions.cs
+++ b/Framework/Intersect.Framework.Core/Config/MarketOptions.cs
@@ -1,0 +1,10 @@
+namespace Intersect.Config;
+
+public partial class MarketOptions
+{
+    /// <summary>
+    /// Number of listings to display per page in market searches.
+    /// </summary>
+    public int PageSize { get; set; } = 10;
+}
+

--- a/Framework/Intersect.Framework.Core/Config/Options.cs
+++ b/Framework/Intersect.Framework.Core/Config/Options.cs
@@ -226,6 +226,8 @@ public partial record Options
 
     public ItemOptions Items { get; set; } = new();
 
+    public MarketOptions Market { get; set; } = new();
+
     public AlignmentOptions Alignment { get; set; } = new();
 
 

--- a/Intersect.Client.Core/Interface/Game/Market/MarketWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Market/MarketWindow.cs
@@ -58,7 +58,7 @@ namespace Intersect.Client.Interface.Game.Market
         private readonly Timer _debounce;
 
         private int _page;
-        private readonly int _pageSize = 10;
+        private readonly int _pageSize;
         private int _total;
 
         private string _lastName = string.Empty;
@@ -74,6 +74,7 @@ namespace Intersect.Client.Interface.Game.Market
         public MarketWindow(Canvas parent)
         {
             Instance = this;
+            _pageSize = Options.Instance.Market.PageSize;
             mMarketWindow = new WindowControl(parent, Strings.Market.windowTitle, false, "MarketWindow");
             mMarketWindow.SetSize(800, 600);
             mMarketWindow.DisableResizing();

--- a/Intersect.Server.Core/CustomChanges/PacketHandlerCustom.cs
+++ b/Intersect.Server.Core/CustomChanges/PacketHandlerCustom.cs
@@ -632,7 +632,7 @@ internal sealed partial class PacketHandler
             listings = listings.Where(l => l.Price <= packet.MaxPrice.Value).ToList();
 
         var total = listings.Count;
-        const int pageSize = 10;
+        var pageSize = Options.Instance.Market.PageSize;
         var maxPage = Math.Max((int)Math.Ceiling(total / (double)pageSize) - 1, 0);
         var page = Math.Clamp(packet.Page, 0, maxPage);
         listings = listings.Skip(page * pageSize).Take(pageSize).ToList();


### PR DESCRIPTION
## Summary
- add `MarketOptions.PageSize` to control market listings per page
- use configured page size in server and client market pagination

## Testing
- ⚠️ `dotnet test -p:EnableWindowsTargeting=true` *(failed: Failed to download package 'Humanizer.Core.pl.2.14.1'...)*

------
https://chatgpt.com/codex/tasks/task_e_68c3802401ec8324857d6470a6001bca