### PR TITLE
Stop debounce timer when market window closes

### DIFF
--- a/Intersect.Client.Core/Interface/Game/Market/MarketWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Market/MarketWindow.cs
@@ -69,6 +69,7 @@ namespace Intersect.Client.Interface.Game.Market
         private int _lastPage;
 
         private bool _waiting;
+        private bool _closed;
 
         // Virtualization fields
         private const int ItemHeight = 44;
@@ -136,6 +137,8 @@ namespace Intersect.Client.Interface.Game.Market
                 AutoReset = false,
             };
             _debounce.Elapsed += DebounceElapsed;
+            mMarketWindow.Closed += OnWindowClosed;
+            mMarketWindow.Disposed += OnWindowClosed;
 
             mMinLabel = new Label(mMarketWindow, "MarketMinLabel");
             mMinLabel.Text = Strings.Market.minPriceLabel;
@@ -277,7 +280,18 @@ namespace Intersect.Client.Interface.Game.Market
 
         private void DebounceElapsed(object? sender, ElapsedEventArgs e)
         {
+            if (_closed)
+            {
+                return;
+            }
             mMarketWindow?.RunOnMainThread(SendSearch);
+        }
+
+        private void OnWindowClosed(Base sender, EventArgs args)
+        {
+            _closed = true;
+            _debounce.Stop();
+            _debounce.Dispose();
         }
 
         public void QueueSearch()


### PR DESCRIPTION
## Summary
- stop and dispose debounce timer when the Market window closes or is disposed
- guard debounce callback against running after the window has closed

## Testing
- `dotnet test` *(fails: project file "vendor/LiteNetLib/LiteNetLib/LiteNetLib.csproj" was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c3810c42d08324bce6b5650dfb0ac8