### PR TITLE
Fix divide-by-zero in slot container population

### DIFF
--- a/Intersect.Client.Core/Utilities/PopulateSlotContainer.cs
+++ b/Intersect.Client.Core/Utilities/PopulateSlotContainer.cs
@@ -1,3 +1,4 @@
+using System;
 using Intersect.Client.Framework.Gwen.Control;
 using Intersect.Client.Interface.Game;
 
@@ -19,8 +20,13 @@ public static class PopulateSlotContainer
             }
 
             var outerSize = slot.OuterBounds.Size;
+            var itemWidth = outerSize.X;
+            if (itemWidth <= 0)
+            {
+                continue;
+            }
 
-            var itemsPerRow = (int)(containerInnerWidth / outerSize.X);
+            var itemsPerRow = Math.Max(1, (int)(containerInnerWidth / itemWidth));
 
             var column = visibleIndex % itemsPerRow;
             var row = visibleIndex / itemsPerRow;


### PR DESCRIPTION
## Summary
- guard slot layout against zero-width items to prevent division by zero

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4a42dee0c8324a50b4cbc449f46f4