### PR TITLE
Fix market listings initialization

### DIFF
--- a/Intersect.Client.Core/Interface/Game/Market/MarketWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Market/MarketWindow.cs
@@ -564,7 +564,6 @@ namespace Intersect.Client.Interface.Game.Market
                 }
 
                 mListingScroll.VerticalScrollBar.BarMoved += OnScroll;
-                ApplyFilters();
             }
             else
             {
@@ -624,9 +623,11 @@ namespace Intersect.Client.Interface.Game.Market
 
                     mListingOrder.Add(listing.ListingId);
                 }
-
-                ApplyFilters();
             }
+
+            ApplyFilters();
+
+            mListingScroll.UpdateScrollBars();
 
             if ((_useVirtualization ? _filteredListings.Count : mListingOrder.Count) == 0)
             {


### PR DESCRIPTION
## Summary
- ensure market filters are applied after listing data is populated
- refresh scroll bars so market icons appear immediately

## Testing
- `dotnet test -p:EnableWindowsTargeting=true` *(failed: Failed to download package 'Humanizer.Core.nl.2.14.1' from nuget, 503 Service Unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68c4ac3d7f98832499b64fffc7b515a6