### PR TITLE
Sync sell market window with inventory updates

### DIFF
--- a/Intersect.Client.Core/Interface/Game/Market/SellMarketWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Market/SellMarketWindow.cs
@@ -124,8 +124,10 @@ namespace Intersect.Client.Interface.Game.Market
             _selectedType = (ItemType?)_typeBox.SelectedItem?.UserData;
             _selectedSubtype = (string?)_subtypeBox.SelectedItem?.UserData;
             _lastAsc = _sortAscending;
-
        
+            Globals.Me.InventoryUpdated += PlayerOnInventoryUpdated;
+            _window.Disposed += (s, e) => Globals.Me.InventoryUpdated -= PlayerOnInventoryUpdated;
+
             BuildLayout();
             _window.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
 


### PR DESCRIPTION
## Summary
- keep SellMarketWindow slots in sync with player inventory by subscribing to `InventoryUpdated`

## Testing
- `dotnet test` *(fails: project file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4ae33678c8324b2a313e3249e89b6