### PR TITLE
Fix inventory update handler in SellMarketWindow

### DIFF
--- a/Intersect.Client.Core/Interface/Game/Market/SellMarketWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Market/SellMarketWindow.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Intersect;
 using Intersect.Client.Core;
+using Intersect.Client.Entities;
 using Intersect.Client.Framework.GenericClasses;
 using Intersect.Client.Framework.Gwen.Control;
 using Intersect.Client.Framework.Gwen.Control.Layout;
@@ -400,7 +401,7 @@ namespace Intersect.Client.Interface.Game.Market
             PopulateSlotContainer.Populate(_inventoryScroll, visibleItems);
         }
 
-        private void PlayerOnInventoryUpdated(object? sender, EventArgs e)
+        private void PlayerOnInventoryUpdated(Player player, int slotIndex)
         {
             _slotsDirty = true;
             Update();


### PR DESCRIPTION
## Summary
- Subscribe SellMarketWindow to player inventory updates and handle events using the correct `Player, slotIndex` delegate signature.

## Testing
- `~/.dotnet/dotnet build Intersect.Client.Core/Intersect.Client.Core.csproj -c Release` *(fails: Failed to download package Microsoft.NETCore.App.Runtime.win-x64.8.0.20)*

------
https://chatgpt.com/codex/tasks/task_e_68c4a7d513ec8324b449e9009506ffc8