### PR TITLE
Fix market buy button state management

### DIFF
--- a/Intersect.Client.Core/Interface/Game/Market/MarketItem.cs
+++ b/Intersect.Client.Core/Interface/Game/Market/MarketItem.cs
@@ -101,7 +101,7 @@ namespace Intersect.Client.Interface.Game.Market
         public void Update(MarketListingPacket newListing)
         {
             _listing = newListing;
-            ResetBuying();
+            SetBuying(false);
 
             UpdateActionButton();
 
@@ -218,6 +218,15 @@ namespace Intersect.Client.Interface.Game.Market
             Interface.GameUi.ItemDescriptionWindow?.Hide();
         }
 
+        public void SetBuying(bool on)
+        {
+            _buying = on;
+            if (_buyButton != null)
+            {
+                _buyButton.IsDisabled = on;
+            }
+        }
+
         private async void AttemptPurchase()
         {
             if (_buying)
@@ -225,21 +234,14 @@ namespace Intersect.Client.Interface.Game.Market
                 return;
             }
 
-            _buying = true;
-            _buyButton?.Disable();
+            SetBuying(true);
             PacketSender.SendBuyMarketListing(_listing.ListingId);
 
             await Task.Delay(5000);
             if (_buying)
             {
-                ResetBuying();
+                SetBuying(false);
             }
-        }
-
-        public void ResetBuying()
-        {
-            _buying = false;
-            _buyButton?.Enable();
         }
     }
 }

--- a/Intersect.Client.Core/Interface/Game/Market/MarketWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Market/MarketWindow.cs
@@ -357,6 +357,21 @@ namespace Intersect.Client.Interface.Game.Market
         public void SearchFailed(string message)
         {
             _waiting = false;
+            if (_useVirtualization)
+            {
+                foreach (var item in _virtualRows)
+                {
+                    item.SetBuying(false);
+                }
+            }
+            else
+            {
+                foreach (var item in mCurrentItems.Values)
+                {
+                    item.SetBuying(false);
+                }
+            }
+
             mErrorLabel.SetText(message);
             mErrorLabel.Show();
             mRetryButton.Show();
@@ -927,14 +942,14 @@ namespace Intersect.Client.Interface.Game.Market
             {
                 foreach (var item in _virtualRows)
                 {
-                    item.ResetBuying();
+                    item.SetBuying(false);
                 }
             }
             else
             {
                 foreach (var item in mCurrentItems.Values)
                 {
-                    item.ResetBuying();
+                    item.SetBuying(false);
                 }
             }
 


### PR DESCRIPTION
## Summary
- Add `SetBuying` to manage market item buy state and button disable
- Use `SetBuying` in purchase flow and UI refresh/error paths

## Testing
- `dotnet build Intersect.Client.Core/Intersect.Client.Core.csproj` *(fails: DeliveryMethod not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c4c4605ff48324af0cd5ec6cca798d