### PR TITLE
feat: add guild xp and faction honor event commands

### DIFF
--- a/Framework/Intersect.Framework.Core/GameObjects/Events/Commands/GiveFactionHonorCommand.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Events/Commands/GiveFactionHonorCommand.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+using Intersect.Enums;
+using Intersect.Framework.Core.GameObjects.Events;
+
+namespace Intersect.Framework.Core.GameObjects.Events.Commands;
+
+public partial class GiveFactionHonorCommand : EventCommand
+{
+    public override EventCommandType Type { get; } = EventCommandType.GiveFactionHonor;
+
+    public Dictionary<Factions, int> Honor { get; set; } = new();
+
+    public GiveFactionHonorCommand()
+    {
+        foreach (Factions faction in Enum.GetValues(typeof(Factions)))
+        {
+            if (faction != Factions.Neutral)
+            {
+                Honor[faction] = 0;
+            }
+        }
+    }
+}

--- a/Framework/Intersect.Framework.Core/GameObjects/Events/Commands/GiveGuildExperienceCommand.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Events/Commands/GiveGuildExperienceCommand.cs
@@ -1,0 +1,10 @@
+using Intersect.Framework.Core.GameObjects.Events;
+
+namespace Intersect.Framework.Core.GameObjects.Events.Commands;
+
+public partial class GiveGuildExperienceCommand : EventCommand
+{
+    public override EventCommandType Type { get; } = EventCommandType.GiveGuildExperience;
+
+    public long Exp { get; set; }
+}

--- a/Framework/Intersect.Framework.Core/GameObjects/Events/EventCommandType.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Events/EventCommandType.cs
@@ -147,4 +147,6 @@ public enum EventCommandType
     ChangeBestiary = 206,
     OpenMarket = 207,
     OpenMarketSell = 208,
+    GiveGuildExperience = 209,
+    GiveFactionHonor = 210,
 }

--- a/Framework/Intersect.Framework.Core/GameObjects/Quests/QuestDescriptor.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Quests/QuestDescriptor.cs
@@ -270,24 +270,43 @@ public partial class QuestDescriptor : DatabaseObject<QuestDescriptor>, IFoldera
                                 }
                                 else if (typeName == "GiveFactionHonorCommand")
                                 {
-                                    var factionProperty = command.GetType().GetProperty("Faction") ??
-                                                          command.GetType().GetProperty("Factions") ??
-                                                          command.GetType().GetProperty("FactionId");
+                                    var honorProperty = command.GetType().GetProperty("Honor");
 
-                                    var amountProperty = command.GetType().GetProperty("Honor") ??
-                                                        command.GetType().GetProperty("Amount") ??
-                                                        command.GetType().GetProperty("Value");
-
-                                    if (factionProperty?.GetValue(command) is Factions faction &&
-                                        amountProperty?.GetValue(command) is int honorAmount)
+                                    if (honorProperty?.GetValue(command) is Dictionary<Factions, int> honorDict)
                                     {
-                                        if (honor.ContainsKey(faction))
+                                        foreach (var kvp in honorDict)
                                         {
-                                            honor[faction] += honorAmount;
+                                            if (honor.ContainsKey(kvp.Key))
+                                            {
+                                                honor[kvp.Key] += kvp.Value;
+                                            }
+                                            else
+                                            {
+                                                honor[kvp.Key] = kvp.Value;
+                                            }
                                         }
-                                        else
+                                    }
+                                    else
+                                    {
+                                        var factionProperty = command.GetType().GetProperty("Faction") ??
+                                                              command.GetType().GetProperty("Factions") ??
+                                                              command.GetType().GetProperty("FactionId");
+
+                                        var amountProperty = command.GetType().GetProperty("Honor") ??
+                                                            command.GetType().GetProperty("Amount") ??
+                                                            command.GetType().GetProperty("Value");
+
+                                        if (factionProperty?.GetValue(command) is Factions faction &&
+                                            amountProperty?.GetValue(command) is int honorAmount)
                                         {
-                                            honor[faction] = honorAmount;
+                                            if (honor.ContainsKey(faction))
+                                            {
+                                                honor[faction] += honorAmount;
+                                            }
+                                            else
+                                            {
+                                                honor[faction] = honorAmount;
+                                            }
                                         }
                                     }
                                 }

--- a/Intersect.Editor/Forms/Editors/Events/CommandPrinter.cs
+++ b/Intersect.Editor/Forms/Editors/Events/CommandPrinter.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Text;
 using Intersect.Editor.Localization;
 using Intersect.Editor.Maps;
@@ -764,6 +765,35 @@ public static partial class CommandPrinter
         {
             return Strings.EventCommandList.giveexp.ToString(command.Exp);
         }
+    }
+
+    private static string GetCommandText(GiveGuildExperienceCommand command, MapInstance map)
+    {
+        return Strings.EventCommandList.giveguildexp.ToString(command.Exp);
+    }
+
+    private static string GetCommandText(GiveFactionHonorCommand command, MapInstance map)
+    {
+        var parts = new List<string>();
+        foreach (var kvp in command.Honor)
+        {
+            if (kvp.Value == 0)
+            {
+                continue;
+            }
+
+            var name = kvp.Key switch
+            {
+                Factions.Serolf => Strings.EventCommandList.serolf.ToString(),
+                Factions.Nidraj => Strings.EventCommandList.nidraj.ToString(),
+                _ => Strings.EventCommandList.neutral.ToString(),
+            };
+
+            parts.Add($"{name}: {kvp.Value}");
+        }
+
+        var text = string.Join(", ", parts);
+        return Strings.EventCommandList.givefactionhonor.ToString(text);
     }
 
     private static string GetCommandText(ChangeLevelCommand command, MapInstance map)

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_GiveFactionHonor.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_GiveFactionHonor.Designer.cs
@@ -1,0 +1,133 @@
+using DarkUI.Controls;
+
+namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
+{
+    partial class EventCommandGiveFactionHonor
+    {
+        private System.ComponentModel.IContainer components = null;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        private void InitializeComponent()
+        {
+            grpGiveHonor = new DarkGroupBox();
+            lblSerolf = new System.Windows.Forms.Label();
+            lblNidraj = new System.Windows.Forms.Label();
+            nudSerolf = new DarkNumericUpDown();
+            nudNidraj = new DarkNumericUpDown();
+            btnCancel = new DarkButton();
+            btnSave = new DarkButton();
+            grpGiveHonor.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)nudSerolf).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)nudNidraj).BeginInit();
+            SuspendLayout();
+            // 
+            // grpGiveHonor
+            // 
+            grpGiveHonor.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            grpGiveHonor.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            grpGiveHonor.Controls.Add(lblSerolf);
+            grpGiveHonor.Controls.Add(nudSerolf);
+            grpGiveHonor.Controls.Add(lblNidraj);
+            grpGiveHonor.Controls.Add(nudNidraj);
+            grpGiveHonor.Controls.Add(btnCancel);
+            grpGiveHonor.Controls.Add(btnSave);
+            grpGiveHonor.ForeColor = System.Drawing.Color.Gainsboro;
+            grpGiveHonor.Location = new System.Drawing.Point(3, 3);
+            grpGiveHonor.Name = "grpGiveHonor";
+            grpGiveHonor.Size = new System.Drawing.Size(200, 150);
+            grpGiveHonor.TabIndex = 18;
+            grpGiveHonor.TabStop = false;
+            grpGiveHonor.Text = "Give Faction Honor:";
+            // 
+            // lblSerolf
+            // 
+            lblSerolf.AutoSize = true;
+            lblSerolf.Location = new System.Drawing.Point(6, 32);
+            lblSerolf.Name = "lblSerolf";
+            lblSerolf.Size = new System.Drawing.Size(44, 15);
+            lblSerolf.TabIndex = 29;
+            lblSerolf.Text = "Serolf";
+            // 
+            // lblNidraj
+            // 
+            lblNidraj.AutoSize = true;
+            lblNidraj.Location = new System.Drawing.Point(6, 61);
+            lblNidraj.Name = "lblNidraj";
+            lblNidraj.Size = new System.Drawing.Size(45, 15);
+            lblNidraj.TabIndex = 30;
+            lblNidraj.Text = "Nidraj";
+            // 
+            // nudSerolf
+            // 
+            nudSerolf.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            nudSerolf.ForeColor = System.Drawing.Color.Gainsboro;
+            nudSerolf.Location = new System.Drawing.Point(80, 30);
+            nudSerolf.Maximum = new decimal(new int[] { 10000, 0, 0, 0 });
+            nudSerolf.Minimum = new decimal(new int[] { 10000, 0, 0, int.MinValue });
+            nudSerolf.Name = "nudSerolf";
+            nudSerolf.Size = new System.Drawing.Size(114, 23);
+            nudSerolf.TabIndex = 28;
+            nudSerolf.Value = new decimal(new int[] { 0, 0, 0, 0 });
+            // 
+            // nudNidraj
+            // 
+            nudNidraj.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            nudNidraj.ForeColor = System.Drawing.Color.Gainsboro;
+            nudNidraj.Location = new System.Drawing.Point(80, 59);
+            nudNidraj.Maximum = new decimal(new int[] { 10000, 0, 0, 0 });
+            nudNidraj.Minimum = new decimal(new int[] { 10000, 0, 0, int.MinValue });
+            nudNidraj.Name = "nudNidraj";
+            nudNidraj.Size = new System.Drawing.Size(114, 23);
+            nudNidraj.TabIndex = 31;
+            nudNidraj.Value = new decimal(new int[] { 0, 0, 0, 0 });
+            // 
+            // btnCancel
+            // 
+            btnCancel.Location = new System.Drawing.Point(119, 121);
+            btnCancel.Name = "btnCancel";
+            btnCancel.Padding = new System.Windows.Forms.Padding(5);
+            btnCancel.Size = new System.Drawing.Size(75, 23);
+            btnCancel.TabIndex = 27;
+            btnCancel.Text = "Cancel";
+            btnCancel.Click += btnCancel_Click;
+            // 
+            // btnSave
+            // 
+            btnSave.Location = new System.Drawing.Point(6, 121);
+            btnSave.Name = "btnSave";
+            btnSave.Padding = new System.Windows.Forms.Padding(5);
+            btnSave.Size = new System.Drawing.Size(75, 23);
+            btnSave.TabIndex = 26;
+            btnSave.Text = "Ok";
+            btnSave.Click += btnSave_Click;
+            // 
+            // EventCommandGiveFactionHonor
+            // 
+            BackColor = System.Drawing.Color.FromArgb(64, 64, 64);
+            Controls.Add(grpGiveHonor);
+            Name = "EventCommandGiveFactionHonor";
+            Size = new System.Drawing.Size(206, 156);
+            grpGiveHonor.ResumeLayout(false);
+            grpGiveHonor.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)nudSerolf).EndInit();
+            ((System.ComponentModel.ISupportInitialize)nudNidraj).EndInit();
+            ResumeLayout(false);
+        }
+
+        private DarkGroupBox grpGiveHonor;
+        private DarkButton btnCancel;
+        private DarkButton btnSave;
+        private DarkNumericUpDown nudSerolf;
+        private DarkNumericUpDown nudNidraj;
+        private System.Windows.Forms.Label lblSerolf;
+        private System.Windows.Forms.Label lblNidraj;
+    }
+}

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_GiveFactionHonor.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_GiveFactionHonor.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Windows.Forms;
+using Intersect.Enums;
+using Intersect.Editor.Localization;
+using Intersect.Framework.Core.GameObjects.Events.Commands;
+using Intersect.Editor.Forms.Editors.Events;
+
+namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
+{
+    public partial class EventCommandGiveFactionHonor : UserControl
+    {
+        private readonly FrmEvent mEventEditor;
+        private readonly GiveFactionHonorCommand mMyCommand;
+
+        public EventCommandGiveFactionHonor(GiveFactionHonorCommand refCommand, FrmEvent editor)
+        {
+            InitializeComponent();
+            mEventEditor = editor;
+            mMyCommand = refCommand;
+            InitLocalization();
+
+            if (mMyCommand.Honor.TryGetValue(Factions.Serolf, out var serolf))
+            {
+                nudSerolf.Value = serolf;
+            }
+
+            if (mMyCommand.Honor.TryGetValue(Factions.Nidraj, out var nidraj))
+            {
+                nudNidraj.Value = nidraj;
+            }
+        }
+
+        private void InitLocalization()
+        {
+            grpGiveHonor.Text = Strings.EventGiveFactionHonor.Title;
+            lblSerolf.Text = Strings.EventCommandList.serolf;
+            lblNidraj.Text = Strings.EventCommandList.nidraj;
+            btnSave.Text = Strings.General.Okay;
+            btnCancel.Text = Strings.General.Cancel;
+        }
+
+        private void btnSave_Click(object sender, EventArgs e)
+        {
+            mMyCommand.Honor[Factions.Serolf] = (int)nudSerolf.Value;
+            mMyCommand.Honor[Factions.Nidraj] = (int)nudNidraj.Value;
+            mEventEditor.FinishCommandEdit();
+        }
+
+        private void btnCancel_Click(object sender, EventArgs e)
+        {
+            mEventEditor.CancelCommandEdit();
+        }
+    }
+}

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_GiveGuildExperience.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_GiveGuildExperience.Designer.cs
@@ -1,0 +1,103 @@
+using DarkUI.Controls;
+
+namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
+{
+    partial class EventCommandGiveGuildExperience
+    {
+        private System.ComponentModel.IContainer components = null;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        private void InitializeComponent()
+        {
+            grpGiveExperience = new DarkGroupBox();
+            lblExperience = new System.Windows.Forms.Label();
+            nudExperience = new DarkNumericUpDown();
+            btnCancel = new DarkButton();
+            btnSave = new DarkButton();
+            grpGiveExperience.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)nudExperience).BeginInit();
+            SuspendLayout();
+            // 
+            // grpGiveExperience
+            // 
+            grpGiveExperience.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            grpGiveExperience.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            grpGiveExperience.Controls.Add(lblExperience);
+            grpGiveExperience.Controls.Add(nudExperience);
+            grpGiveExperience.Controls.Add(btnCancel);
+            grpGiveExperience.Controls.Add(btnSave);
+            grpGiveExperience.ForeColor = System.Drawing.Color.Gainsboro;
+            grpGiveExperience.Location = new System.Drawing.Point(3, 3);
+            grpGiveExperience.Name = "grpGiveExperience";
+            grpGiveExperience.Size = new System.Drawing.Size(168, 123);
+            grpGiveExperience.TabIndex = 18;
+            grpGiveExperience.TabStop = false;
+            grpGiveExperience.Text = "Give Guild Experience:";
+            // 
+            // lblExperience
+            // 
+            lblExperience.AutoSize = true;
+            lblExperience.Location = new System.Drawing.Point(6, 32);
+            lblExperience.Name = "lblExperience";
+            lblExperience.Size = new System.Drawing.Size(63, 15);
+            lblExperience.TabIndex = 29;
+            lblExperience.Text = "Amount:";
+            // 
+            // nudExperience
+            // 
+            nudExperience.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            nudExperience.ForeColor = System.Drawing.Color.Gainsboro;
+            nudExperience.Location = new System.Drawing.Point(75, 30);
+            nudExperience.Maximum = new decimal(new int[] { 410065408, 2, 0, 0 });
+            nudExperience.Name = "nudExperience";
+            nudExperience.Size = new System.Drawing.Size(87, 23);
+            nudExperience.TabIndex = 28;
+            nudExperience.Value = new decimal(new int[] { 0, 0, 0, 0 });
+            // 
+            // btnCancel
+            // 
+            btnCancel.Location = new System.Drawing.Point(87, 94);
+            btnCancel.Name = "btnCancel";
+            btnCancel.Padding = new System.Windows.Forms.Padding(5);
+            btnCancel.Size = new System.Drawing.Size(75, 23);
+            btnCancel.TabIndex = 27;
+            btnCancel.Text = "Cancel";
+            btnCancel.Click += btnCancel_Click;
+            // 
+            // btnSave
+            // 
+            btnSave.Location = new System.Drawing.Point(6, 94);
+            btnSave.Name = "btnSave";
+            btnSave.Padding = new System.Windows.Forms.Padding(5);
+            btnSave.Size = new System.Drawing.Size(75, 23);
+            btnSave.TabIndex = 26;
+            btnSave.Text = "Ok";
+            btnSave.Click += btnSave_Click;
+            // 
+            // EventCommandGiveGuildExperience
+            // 
+            BackColor = System.Drawing.Color.FromArgb(64, 64, 64);
+            Controls.Add(grpGiveExperience);
+            Name = "EventCommandGiveGuildExperience";
+            Size = new System.Drawing.Size(176, 129);
+            grpGiveExperience.ResumeLayout(false);
+            grpGiveExperience.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)nudExperience).EndInit();
+            ResumeLayout(false);
+        }
+
+        private DarkGroupBox grpGiveExperience;
+        private DarkButton btnCancel;
+        private DarkButton btnSave;
+        private DarkNumericUpDown nudExperience;
+        private System.Windows.Forms.Label lblExperience;
+    }
+}

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_GiveGuildExperience.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_GiveGuildExperience.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Windows.Forms;
+using Intersect.Editor.Localization;
+using Intersect.Framework.Core.GameObjects.Events.Commands;
+using Intersect.Editor.Forms.Editors.Events;
+
+namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
+{
+    public partial class EventCommandGiveGuildExperience : UserControl
+    {
+        private readonly FrmEvent mEventEditor;
+        private readonly GiveGuildExperienceCommand mMyCommand;
+
+        public EventCommandGiveGuildExperience(GiveGuildExperienceCommand refCommand, FrmEvent editor)
+        {
+            InitializeComponent();
+            mMyCommand = refCommand;
+            mEventEditor = editor;
+            InitLocalization();
+            nudExperience.Value = mMyCommand.Exp;
+        }
+
+        private void InitLocalization()
+        {
+            grpGiveExperience.Text = Strings.EventGiveGuildExperience.Title;
+            lblExperience.Text = Strings.EventGiveGuildExperience.Label;
+            btnSave.Text = Strings.General.Okay;
+            btnCancel.Text = Strings.General.Cancel;
+        }
+
+        private void btnSave_Click(object sender, EventArgs e)
+        {
+            mMyCommand.Exp = (long)nudExperience.Value;
+            mEventEditor.FinishCommandEdit();
+        }
+
+        private void btnCancel_Click(object sender, EventArgs e)
+        {
+            mEventEditor.CancelCommandEdit();
+        }
+    }
+}

--- a/Intersect.Editor/Forms/Editors/Events/frmEvent.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/Events/frmEvent.Designer.cs
@@ -59,7 +59,8 @@ namespace Intersect.Editor.Forms.Editors.Events
             var treeNode23 = new TreeNode("Change Face");
             var treeNode24 = new TreeNode("Change Gender");
             var treeNode78 = new TreeNode("Set Alignment");
-            var treeNode79 = new TreeNode("Alignment", new TreeNode[] { treeNode78 });
+            var treeNode84 = new TreeNode("Give Faction Honor");
+            var treeNode79 = new TreeNode("Alignment", new TreeNode[] { treeNode78, treeNode84 });
             var treeNode25 = new TreeNode("Set Access");
             var treeNode26 = new TreeNode("Change Class");
             var treeNode27 = new TreeNode("Equip/Unequip Item");
@@ -103,7 +104,8 @@ namespace Intersect.Editor.Forms.Editors.Events
             var treeNode64 = new TreeNode("Disband Guild");
             var treeNode65 = new TreeNode("Open Guild Bank");
             var treeNode66 = new TreeNode("Set Guild Bank Slots Count");
-            var treeNode67 = new TreeNode("Guilds", new TreeNode[] { treeNode63, treeNode64, treeNode65, treeNode66 });
+            var treeNode83 = new TreeNode("Give Guild Experience");
+            var treeNode67 = new TreeNode("Guilds", new TreeNode[] { treeNode63, treeNode64, treeNode65, treeNode66, treeNode83 });
             var treeNode68 = new TreeNode("Give Job Experience");
             var treeNode69 = new TreeNode("Jobs", new TreeNode[] { treeNode68 });
             var treeNode70 = new TreeNode("Open Enchant Window");
@@ -909,6 +911,8 @@ namespace Intersect.Editor.Forms.Editors.Events
             treeNode24.Text = "Change Gender";
             treeNode78.Name = "setalignment";
             treeNode78.Text = "Set Alignment";
+            treeNode84.Name = "givefactionhonor";
+            treeNode84.Text = "Give Faction Honor";
             treeNode79.Name = "alignment";
             treeNode79.Text = "Alignment";
             treeNode25.Name = "setaccess";
@@ -997,6 +1001,8 @@ namespace Intersect.Editor.Forms.Editors.Events
             treeNode65.Text = "Open Guild Bank";
             treeNode66.Name = "setguildbankslots";
             treeNode66.Text = "Set Guild Bank Slots Count";
+            treeNode83.Name = "giveguildexperience";
+            treeNode83.Text = "Give Guild Experience";
             treeNode67.Name = "guilds";
             treeNode67.Text = "Guilds";
             treeNode68.Name = "givejobexperience";

--- a/Intersect.Editor/Forms/Editors/Events/frmEvent.cs
+++ b/Intersect.Editor/Forms/Editors/Events/frmEvent.cs
@@ -768,6 +768,14 @@ public partial class FrmEvent : Form
                 tmpCommand = new GiveJobExperienceCommand();
 
                 break;
+            case EventCommandType.GiveGuildExperience:
+                tmpCommand = new GiveGuildExperienceCommand();
+
+                break;
+            case EventCommandType.GiveFactionHonor:
+                tmpCommand = new GiveFactionHonorCommand();
+
+                break;
             case EventCommandType.OpenEnchantment:
                 tmpCommand = new OpenEnchantmentWindowCommand();
                 break;
@@ -1462,6 +1470,14 @@ public partial class FrmEvent : Form
              
             case EventCommandType.GiveJobExperience:
                 cmdWindow = new EventCommandGiveJobExperience((GiveJobExperienceCommand)command, this);
+
+                break;
+            case EventCommandType.GiveGuildExperience:
+                cmdWindow = new EventCommandGiveGuildExperience((GiveGuildExperienceCommand)command, this);
+
+                break;
+            case EventCommandType.GiveFactionHonor:
+                cmdWindow = new EventCommandGiveFactionHonor((GiveFactionHonorCommand)command, this);
 
                 break;
             case EventCommandType.OpenEnchantment:

--- a/Intersect.Editor/Intersect.Editor.csproj
+++ b/Intersect.Editor/Intersect.Editor.csproj
@@ -267,6 +267,18 @@
     <Compile Update="Forms\Editors\Events\Event Commands\EventCommand_GiveExperience.Designer.cs">
       <DependentUpon>EventCommand_GiveExperience.cs</DependentUpon>
     </Compile>
+    <Compile Update="Forms\Editors\Events\Event Commands\EventCommand_GiveGuildExperience.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Update="Forms\Editors\Events\Event Commands\EventCommand_GiveGuildExperience.Designer.cs">
+      <DependentUpon>EventCommand_GiveGuildExperience.cs</DependentUpon>
+    </Compile>
+    <Compile Update="Forms\Editors\Events\Event Commands\EventCommand_GiveFactionHonor.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Update="Forms\Editors\Events\Event Commands\EventCommand_GiveFactionHonor.Designer.cs">
+      <DependentUpon>EventCommand_GiveFactionHonor.cs</DependentUpon>
+    </Compile>
     <Compile Update="Forms\Editors\Events\Event Commands\EventCommand_GotoLabel.cs">
       <SubType>UserControl</SubType>
     </Compile>

--- a/Intersect.Editor/Localization/Strings.cs
+++ b/Intersect.Editor/Localization/Strings.cs
@@ -2138,6 +2138,10 @@ Tick timer saved in server config.json.";
 
         public static LocalizedString giveexp = @"Give Player {00} Experience";
 
+        public static LocalizedString giveguildexp = @"Give Guild {00} Experience";
+
+        public static LocalizedString givefactionhonor = @"Give Faction Honor [{00}]";
+
         public static LocalizedString globalswitch = @"Set Global Switch {00} to {01}";
 
         public static LocalizedString globalvariable = @"Set Global Variable {00} ({01})";
@@ -2462,6 +2466,8 @@ Tick timer saved in server config.json.";
             {"exiteventprocess", @"Exit Event Process"},
             {"fadeoutbgm", @"Fadeout BGM"},
             {"giveexperience", @"Give Experience"},
+            {"giveguildexperience", @"Give Guild Experience"},
+            {"givefactionhonor", @"Give Faction Honor"},
             {"gotolabel", @"Go To Label"},
             {"hidepicture", @"Hide Picture"},
             {"holdplayer", @"Hold Player"},
@@ -3156,6 +3162,21 @@ Tick timer saved in server config.json.";
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public static LocalizedString Variable = @"Variable";
+    }
+
+    public partial struct EventGiveGuildExperience
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Title = @"Give Guild Experience";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Label = @"Amount:";
+    }
+
+    public partial struct EventGiveFactionHonor
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Title = @"Give Faction Honor";
     }
 
     public partial struct EventGotoLabel

--- a/Intersect.Server.Core/CustomChanges/Player.Guild.cs
+++ b/Intersect.Server.Core/CustomChanges/Player.Guild.cs
@@ -33,7 +33,7 @@ namespace Intersect.Server.Entities
             Guild?.UpdateMemberList();
         }
 
-        private void DonateGuildExperience(long amount)
+        public void DonateGuildExperience(long amount)
         {
             if (Guild == null || amount <= 0) return;
 

--- a/Intersect.Server.Core/Entities/Events/CommandProcessing.cs
+++ b/Intersect.Server.Core/Entities/Events/CommandProcessing.cs
@@ -2323,6 +2323,36 @@ public static partial class CommandProcessing
         }
     }
 
+    // Give Guild Experience Command
+    private static void ProcessCommand(
+        GiveGuildExperienceCommand command,
+        Player player,
+        Event instance,
+        CommandInstance stackInfo,
+        Stack<CommandInstance> callStack
+    )
+    {
+        if (command.Exp > 0)
+        {
+            player.DonateGuildExperience(command.Exp);
+        }
+    }
+
+    // Give Faction Honor Command
+    private static void ProcessCommand(
+        GiveFactionHonorCommand command,
+        Player player,
+        Event instance,
+        CommandInstance stackInfo,
+        Stack<CommandInstance> callStack
+    )
+    {
+        if (command.Honor.TryGetValue(player.Faction, out var amount) && amount != 0)
+        {
+            HonorService.AdjustHonor(player, amount);
+        }
+    }
+
 
     private static void ProcessCommand(
     OpenEnchantmentWindowCommand command,


### PR DESCRIPTION
## Summary
- add GiveGuildExperienceCommand and GiveFactionHonorCommand with serialization
- extend event command types and processing for guild XP and faction honor
- add editor UI and localization for configuring new rewards

## Testing
- `dotnet build Intersect.sln` *(fails: project file "vendor/LiteNetLib/LiteNetLib/LiteNetLib.csproj" was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4e79648f483248c20979c19239e6c