### PR TITLE
Add quest tracking dictionaries and UI refresh flag

### DIFF
--- a/Intersect.Client.Core/General/Globals.cs
+++ b/Intersect.Client.Core/General/Globals.cs
@@ -12,6 +12,7 @@ using Intersect.Client.Maps;
 using Intersect.Client.Plugins.Interfaces;
 using Intersect.Core;
 using Intersect.Enums;
+using Intersect.Config;
 using Intersect.Framework.Core.GameObjects.Crafting;
 using Intersect.GameObjects;
 using Intersect.Network.Packets.Server;
@@ -92,6 +93,18 @@ public static partial class Globals
     public static ShowPicturePacket? Picture;
 
     public static readonly List<Guid> QuestOffers = new();
+
+    public static readonly Dictionary<Guid, Dictionary<Guid, int>> QuestRewards = new();
+
+    public static readonly Dictionary<Guid, long> QuestExperience = new();
+
+    public static readonly Dictionary<Guid, Dictionary<JobType, long>> QuestJobExperience = new();
+
+    public static readonly Dictionary<Guid, long> QuestGuildExperience = new();
+
+    public static readonly Dictionary<Guid, Dictionary<Factions, int>> QuestFactionHonor = new();
+
+    public static bool QuestDirty;
 
     public static readonly Random Random = new();
 

--- a/Intersect.Client.Core/Interface/Game/GameInterface.cs
+++ b/Intersect.Client.Core/Interface/Game/GameInterface.cs
@@ -457,6 +457,12 @@ public partial class GameInterface : MutableInterface
             PlayerBox?.SetEntity(Globals.Me);
         }
 
+        if (Globals.QuestDirty)
+        {
+            mShouldUpdateQuestLog = true;
+            Globals.QuestDirty = false;
+        }
+
         GameMenu?.Update(mShouldUpdateQuestLog);
         mShouldUpdateQuestLog = false;
         Hotbar?.Update();

--- a/Intersect.Client.Core/Networking/PacketHandler.cs
+++ b/Intersect.Client.Core/Networking/PacketHandler.cs
@@ -2099,8 +2099,7 @@ internal sealed partial class PacketHandler
             }
 
             Globals.Me.HiddenQuests = packet.HiddenQuests;
-
-            Interface.Interface.EnqueueInGame(uiInGame => uiInGame.NotifyQuestsUpdated());
+            Globals.QuestDirty = true;
         }
     }
 


### PR DESCRIPTION
## Summary
- add quest reward/experience dictionaries and dirty flag
- trigger quest log refresh when quest data changes
- track guild experience and faction honor rewards

## Testing
- `dotnet test` *(fails: project file "LiteNetLib.csproj" was not found)*
- `dotnet build Intersect.Client.Core/Intersect.Client.Core.csproj` *(fails: NetDataWriter and related types missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c4ee8792248324815fc39eb7a5bb3a