### PR TITLE
feat: send quest rewards with quest packets

### DIFF
--- a/Framework/Intersect.Framework.Core/Network/Packets/Server/QuestOfferPacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Server/QuestOfferPacket.cs
@@ -1,4 +1,5 @@
-﻿using MessagePack;
+using MessagePack;
+using Intersect.Enums;
 
 namespace Intersect.Network.Packets.Server;
 
@@ -10,12 +11,34 @@ public partial class QuestOfferPacket : IntersectPacket
     {
     }
 
-    public QuestOfferPacket(Guid questId)
+    public QuestOfferPacket(Guid questId, Dictionary<Guid, int> questRewardItems, long questRewardExperience,
+        Dictionary<JobType, long> questRewardJobExperience, long questRewardGuildExperience,
+        Dictionary<Factions, int> questRewardFactionHonor)
     {
         QuestId = questId;
+        QuestRewardItems = questRewardItems;
+        QuestRewardExperience = questRewardExperience;
+        QuestRewardJobExperience = questRewardJobExperience;
+        QuestRewardGuildExperience = questRewardGuildExperience;
+        QuestRewardFactionHonor = questRewardFactionHonor;
     }
 
     [Key(0)]
     public Guid QuestId { get; set; }
 
+    [Key(1)]
+    public Dictionary<Guid, int> QuestRewardItems { get; set; }
+
+    [Key(2)]
+    public long QuestRewardExperience { get; set; }
+
+    [Key(3)]
+    public Dictionary<JobType, long> QuestRewardJobExperience { get; set; }
+
+    [Key(4)]
+    public long QuestRewardGuildExperience { get; set; }
+
+    [Key(5)]
+    public Dictionary<Factions, int> QuestRewardFactionHonor { get; set; }
 }
+

--- a/Framework/Intersect.Framework.Core/Network/Packets/Server/QuestProgressPacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Server/QuestProgressPacket.cs
@@ -1,4 +1,5 @@
-﻿using MessagePack;
+using MessagePack;
+using Intersect.Enums;
 
 namespace Intersect.Network.Packets.Server;
 
@@ -10,10 +11,20 @@ public partial class QuestProgressPacket : IntersectPacket
     {
     }
 
-    public QuestProgressPacket(Dictionary<Guid, string> quests, Guid[] hiddenQuests)
+    public QuestProgressPacket(Dictionary<Guid, string> quests, Guid[] hiddenQuests,
+        Dictionary<Guid, Dictionary<Guid, int>> questRewardItems,
+        Dictionary<Guid, long> questRewardExperience,
+        Dictionary<Guid, Dictionary<JobType, long>> questRewardJobExperience,
+        Dictionary<Guid, long> questRewardGuildExperience,
+        Dictionary<Guid, Dictionary<Factions, int>> questRewardFactionHonor)
     {
         Quests = quests;
         HiddenQuests = hiddenQuests;
+        QuestRewardItems = questRewardItems;
+        QuestRewardExperience = questRewardExperience;
+        QuestRewardJobExperience = questRewardJobExperience;
+        QuestRewardGuildExperience = questRewardGuildExperience;
+        QuestRewardFactionHonor = questRewardFactionHonor;
     }
 
     [Key(0)]
@@ -22,4 +33,19 @@ public partial class QuestProgressPacket : IntersectPacket
     [Key(1)]
     public Guid[] HiddenQuests { get; set; }
 
+    [Key(2)]
+    public Dictionary<Guid, Dictionary<Guid, int>> QuestRewardItems { get; set; }
+
+    [Key(3)]
+    public Dictionary<Guid, long> QuestRewardExperience { get; set; }
+
+    [Key(4)]
+    public Dictionary<Guid, Dictionary<JobType, long>> QuestRewardJobExperience { get; set; }
+
+    [Key(5)]
+    public Dictionary<Guid, long> QuestRewardGuildExperience { get; set; }
+
+    [Key(6)]
+    public Dictionary<Guid, Dictionary<Factions, int>> QuestRewardFactionHonor { get; set; }
 }
+

--- a/Intersect.Client.Core/Networking/PacketHandler.cs
+++ b/Intersect.Client.Core/Networking/PacketHandler.cs
@@ -2069,6 +2069,12 @@ internal sealed partial class PacketHandler
         {
             Globals.QuestOffers.Add(packet.QuestId);
         }
+
+        Globals.QuestRewards[packet.QuestId] = packet.QuestRewardItems;
+        Globals.QuestExperience[packet.QuestId] = packet.QuestRewardExperience;
+        Globals.QuestJobExperience[packet.QuestId] = packet.QuestRewardJobExperience;
+        Globals.QuestGuildExperience[packet.QuestId] = packet.QuestRewardGuildExperience;
+        Globals.QuestFactionHonor[packet.QuestId] = packet.QuestRewardFactionHonor;
     }
 
     //QuestProgressPacket
@@ -2096,6 +2102,31 @@ internal sealed partial class PacketHandler
                         Globals.Me.QuestProgress.Add(quest.Key, new QuestProgress(quest.Value));
                     }
                 }
+            }
+
+            foreach (var reward in packet.QuestRewardItems)
+            {
+                Globals.QuestRewards[reward.Key] = reward.Value;
+            }
+
+            foreach (var exp in packet.QuestRewardExperience)
+            {
+                Globals.QuestExperience[exp.Key] = exp.Value;
+            }
+
+            foreach (var jobExp in packet.QuestRewardJobExperience)
+            {
+                Globals.QuestJobExperience[jobExp.Key] = jobExp.Value;
+            }
+
+            foreach (var guildExp in packet.QuestRewardGuildExperience)
+            {
+                Globals.QuestGuildExperience[guildExp.Key] = guildExp.Value;
+            }
+
+            foreach (var honor in packet.QuestRewardFactionHonor)
+            {
+                Globals.QuestFactionHonor[honor.Key] = honor.Value;
             }
 
             Globals.Me.HiddenQuests = packet.HiddenQuests;


### PR DESCRIPTION
## Summary
- include quest reward items, experience, job exp, guild exp, and faction honor in quest offer and progress packets
- send quest reward info from server and update client packet handler

## Testing
- `dotnet test` *(fails: project file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4f2982fac83248f04e03a049d450a