### PR TITLE
Add quest reward UI hooks and controls

### DIFF
--- a/Framework/Intersect.Framework.Core/Network/Packets/Server/QuestOfferPacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Server/QuestOfferPacket.cs
@@ -1,4 +1,5 @@
 using MessagePack;
+using Intersect.Config;
 using Intersect.Enums;
 
 namespace Intersect.Network.Packets.Server;

--- a/Framework/Intersect.Framework.Core/Network/Packets/Server/QuestProgressPacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Server/QuestProgressPacket.cs
@@ -1,4 +1,5 @@
 using MessagePack;
+using Intersect.Config;
 using Intersect.Enums;
 
 namespace Intersect.Network.Packets.Server;

--- a/Intersect.Client.Core/Interface/Game/IQuestWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/IQuestWindow.cs
@@ -1,0 +1,10 @@
+using Intersect.Client.Framework.Gwen.Control;
+
+namespace Intersect.Client.Interface.Game;
+
+public interface IQuestWindow
+{
+    void AddRewardWidget(Base widget);
+    void ClearRewardWidgets();
+}
+

--- a/Intersect.Client.Core/Interface/Game/QuestOfferWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/QuestOfferWindow.cs
@@ -10,7 +10,7 @@ using Intersect.GameObjects;
 namespace Intersect.Client.Interface.Game;
 
 
-public partial class QuestOfferWindow
+public partial class QuestOfferWindow : IQuestWindow
 {
 
     private Button mAcceptButton;
@@ -30,6 +30,8 @@ public partial class QuestOfferWindow
 
     private Label mQuestTitle;
 
+    private readonly ScrollControl _rewardContainer;
+
     public QuestOfferWindow(Canvas gameCanvas)
     {
         mQuestOfferWindow = new WindowControl(gameCanvas, Strings.QuestOffer.Title, false, "QuestOfferWindow");
@@ -45,6 +47,8 @@ public partial class QuestOfferWindow
 
         mQuestPromptLabel = new RichLabel(mQuestPromptArea);
 
+        _rewardContainer = new ScrollControl(mQuestOfferWindow, "QuestRewardContainer");
+
         //Accept Button
         mAcceptButton = new Button(mQuestOfferWindow, "AcceptButton");
         mAcceptButton.SetText(Strings.QuestOffer.Accept);
@@ -57,6 +61,16 @@ public partial class QuestOfferWindow
 
         mQuestOfferWindow.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
         Interface.InputBlockingComponents.Add(mQuestOfferWindow);
+    }
+
+    public void AddRewardWidget(Base widget)
+    {
+        widget.Parent = _rewardContainer;
+    }
+
+    public void ClearRewardWidgets()
+    {
+        _rewardContainer.DeleteAllChildren();
     }
 
     private void _declineButton_Clicked(Base sender, MouseButtonState arguments)

--- a/Intersect.Client.Core/Interface/Game/QuestRewardExp.cs
+++ b/Intersect.Client.Core/Interface/Game/QuestRewardExp.cs
@@ -1,0 +1,61 @@
+using System.Collections.Generic;
+using Intersect.Client.Framework.Gwen;
+using Intersect.Client.Framework.Gwen.Control;
+using Intersect.Config;
+using Intersect.Enums;
+
+namespace Intersect.Client.Interface.Game;
+
+public partial class QuestRewardExp : Base
+{
+    public QuestRewardExp(
+        IQuestWindow window,
+        long playerExp,
+        Dictionary<JobType, long>? jobExp,
+        long guildExp,
+        Dictionary<Factions, int>? factionHonor
+    ) : base(null)
+    {
+        window.AddRewardWidget(this);
+
+        Dock = Pos.Top;
+
+        if (playerExp > 0)
+        {
+            AddLabel($"+{playerExp} EXP");
+        }
+
+        if (jobExp != null)
+        {
+            foreach (var pair in jobExp)
+            {
+                AddLabel($"+{pair.Value} {pair.Key} EXP");
+            }
+        }
+
+        if (guildExp > 0)
+        {
+            AddLabel($"+{guildExp} Guild EXP");
+        }
+
+        if (factionHonor != null)
+        {
+            foreach (var pair in factionHonor)
+            {
+                AddLabel($"+{pair.Value} {pair.Key} Honor");
+            }
+        }
+
+        SizeToChildren(false, true);
+    }
+
+    private void AddLabel(string text)
+    {
+        var label = new Label(this)
+        {
+            Text = text,
+            Dock = Pos.Top,
+        };
+    }
+}
+

--- a/Intersect.Client.Core/Interface/Game/QuestRewardItem.cs
+++ b/Intersect.Client.Core/Interface/Game/QuestRewardItem.cs
@@ -1,0 +1,50 @@
+using System;
+using Intersect.Client.Framework.File_Management;
+using Intersect.Client.Framework.Gwen;
+using Intersect.Client.Framework.Gwen.Control;
+using Intersect.Framework.Core.GameObjects.Items;
+using Intersect.GameObjects;
+
+namespace Intersect.Client.Interface.Game;
+
+public partial class QuestRewardItem : Base
+{
+    private readonly ImagePanel _icon;
+    private readonly Label _quantity;
+
+    public QuestRewardItem(IQuestWindow window, Guid itemId, int quantity) : base(null)
+    {
+        window.AddRewardWidget(this);
+
+        MinimumSize = new Point(34, 34);
+        Margin = new Margin(4);
+
+        _icon = new ImagePanel(this)
+        {
+            MinimumSize = new Point(32, 32),
+            Alignment = [Alignments.Center],
+        };
+
+        _quantity = new Label(this)
+        {
+            Alignment = [Alignments.Bottom, Alignments.Right],
+            BackgroundTemplateName = "quantity.png",
+            FontName = "sourcesansproblack",
+            FontSize = 8,
+            Padding = new Padding(2),
+        };
+
+        if (ItemDescriptor.TryGet(itemId, out var descriptor))
+        {
+            var texture = GameContentManager.Current.GetTexture(Framework.Content.TextureType.Item, descriptor.Icon);
+            if (texture != null)
+            {
+                _icon.Texture = texture;
+                _icon.RenderColor = descriptor.Color;
+            }
+        }
+
+        _quantity.Text = quantity.ToString();
+    }
+}
+

--- a/Intersect.Client.Core/Interface/Game/QuestsWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/QuestsWindow.cs
@@ -16,7 +16,7 @@ using Intersect.Utilities;
 namespace Intersect.Client.Interface.Game;
 
 
-public partial class QuestsWindow
+public partial class QuestsWindow : IQuestWindow
 {
 
     private readonly Button mBackButton;
@@ -37,6 +37,8 @@ public partial class QuestsWindow
     private readonly Label mQuestTitle;
 
     private readonly Button mQuitButton;
+
+    private readonly ScrollControl _rewardContainer;
 
     private QuestDescriptor mSelectedQuest;
 
@@ -60,6 +62,8 @@ public partial class QuestsWindow
         mQuestDescTemplateLabel = new Label(mQuestsWindow, "QuestDescriptionTemplate");
 
         mQuestDescLabel = new RichLabel(mQuestDescArea);
+
+        _rewardContainer = new ScrollControl(mQuestsWindow, "QuestRewardContainer");
 
         mBackButton = new Button(mQuestsWindow, "BackButton");
         mBackButton.Text = Strings.QuestLog.Back;
@@ -461,6 +465,16 @@ public partial class QuestsWindow
     {
         mQuestsWindow.IsHidden = true;
         mSelectedQuest = null;
+    }
+
+    public void AddRewardWidget(Base widget)
+    {
+        widget.Parent = _rewardContainer;
+    }
+
+    public void ClearRewardWidgets()
+    {
+        _rewardContainer.DeleteAllChildren();
     }
 
 }


### PR DESCRIPTION
## Summary
- introduce `IQuestWindow` interface for managing quest reward widgets
- implement `QuestRewardItem` and `QuestRewardExp` UI controls
- wire quest offer/log windows to support reward widgets

## Testing
- `dotnet build Intersect.Client.Core/Intersect.Client.Core.csproj` *(fails: NetPacketReader not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4f489b9bc8324a4fb3142d191550e