### PR TITLE
feat: display quest reward info in offer window

### DIFF
--- a/Intersect.Client.Core/Interface/Game/QuestOfferWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/QuestOfferWindow.cs
@@ -1,10 +1,13 @@
+using System.Collections.Generic;
 using Intersect.Client.Core;
 using Intersect.Client.Framework.File_Management;
+using Intersect.Client.Framework.Gwen;
 using Intersect.Client.Framework.Gwen.Control;
 using Intersect.Client.Framework.Gwen.Control.EventArguments;
 using Intersect.Client.General;
 using Intersect.Client.Localization;
 using Intersect.Client.Networking;
+using Intersect.Enums;
 using Intersect.GameObjects;
 
 namespace Intersect.Client.Interface.Game;
@@ -31,6 +34,10 @@ public partial class QuestOfferWindow : IQuestWindow
     private Label mQuestTitle;
 
     private readonly ScrollControl _rewardContainer;
+
+    private readonly ScrollControl _rewardItemContainer;
+
+    private readonly ScrollControl _rewardExpContainer;
 
     public QuestOfferWindow(Canvas gameCanvas)
     {
@@ -60,25 +67,55 @@ public partial class QuestOfferWindow : IQuestWindow
         mDeclineButton.Clicked += _declineButton_Clicked;
 
         mQuestOfferWindow.LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
+
+        _rewardItemContainer = new ScrollControl(_rewardContainer)
+        {
+            Dock = Pos.Top,
+        };
+
+        _rewardExpContainer = new ScrollControl(_rewardContainer)
+        {
+            Dock = Pos.Top,
+        };
+
         Interface.InputBlockingComponents.Add(mQuestOfferWindow);
     }
 
     public void AddRewardWidget(Base widget)
     {
-        widget.Parent = _rewardContainer;
+        switch (widget)
+        {
+            case QuestRewardItem:
+                widget.Parent = _rewardItemContainer;
+                break;
+            case QuestRewardExp:
+                widget.Parent = _rewardExpContainer;
+                break;
+            default:
+                widget.Parent = _rewardItemContainer;
+                break;
+        }
     }
 
     public void ClearRewardWidgets()
     {
-        _rewardContainer.DeleteAllChildren();
+        _rewardItemContainer.DeleteAllChildren();
+        _rewardExpContainer.DeleteAllChildren();
     }
 
     private void _declineButton_Clicked(Base sender, MouseButtonState arguments)
     {
         if (Globals.QuestOffers.Count > 0)
         {
-            PacketSender.SendDeclineQuest(Globals.QuestOffers[0]);
+            var questId = Globals.QuestOffers[0];
+            PacketSender.SendDeclineQuest(questId);
             Globals.QuestOffers.RemoveAt(0);
+            Globals.QuestRewards.Remove(questId);
+            Globals.QuestExperience.Remove(questId);
+            Globals.QuestJobExperience.Remove(questId);
+            Globals.QuestGuildExperience.Remove(questId);
+            Globals.QuestFactionHonor.Remove(questId);
+            ClearRewardWidgets();
         }
     }
 
@@ -86,8 +123,15 @@ public partial class QuestOfferWindow : IQuestWindow
     {
         if (Globals.QuestOffers.Count > 0)
         {
-            PacketSender.SendAcceptQuest(Globals.QuestOffers[0]);
+            var questId = Globals.QuestOffers[0];
+            PacketSender.SendAcceptQuest(questId);
             Globals.QuestOffers.RemoveAt(0);
+            Globals.QuestRewards.Remove(questId);
+            Globals.QuestExperience.Remove(questId);
+            Globals.QuestJobExperience.Remove(questId);
+            Globals.QuestGuildExperience.Remove(questId);
+            Globals.QuestFactionHonor.Remove(questId);
+            ClearRewardWidgets();
         }
     }
 
@@ -96,6 +140,7 @@ public partial class QuestOfferWindow : IQuestWindow
         if (quest == null)
         {
             Hide();
+            ClearRewardWidgets();
         }
         else
         {
@@ -109,6 +154,27 @@ public partial class QuestOfferWindow : IQuestWindow
 
                 mQuestPromptLabel.SizeToChildren(false, true);
                 mQuestOfferText = quest.StartDescription;
+
+                ClearRewardWidgets();
+
+                if (Globals.QuestRewards.TryGetValue(quest.Id, out var rewards))
+                {
+                    foreach (var reward in rewards)
+                    {
+                        _ = new QuestRewardItem(this, reward.Key, reward.Value);
+                    }
+                }
+
+                Globals.QuestExperience.TryGetValue(quest.Id, out var playerExp);
+                Globals.QuestJobExperience.TryGetValue(quest.Id, out Dictionary<JobType, long>? jobExp);
+                Globals.QuestGuildExperience.TryGetValue(quest.Id, out var guildExp);
+                Globals.QuestFactionHonor.TryGetValue(quest.Id, out Dictionary<Factions, int>? factionHonor);
+
+                if (playerExp > 0 || (jobExp != null && jobExp.Count > 0) || guildExp > 0 ||
+                    (factionHonor != null && factionHonor.Count > 0))
+                {
+                    _ = new QuestRewardExp(this, playerExp, jobExp, guildExp, factionHonor);
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- add item and experience reward containers nested inside existing quest reward container
- populate quest reward items and experience from global data
- clear quest reward caches when accepting or declining quests

## Testing
- `dotnet build Intersect.Client.Core/Intersect.Client.Core.csproj` *(fails: DeliveryMethod, NetPacketReader, etc. missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c4f6b943c08324917c1cc5d8bcfc5a