### PR TITLE
feat: clean up quest reward data on state changes

### DIFF
--- a/Intersect.Client.Core/General/Globals.cs
+++ b/Intersect.Client.Core/General/Globals.cs
@@ -106,6 +106,15 @@ public static partial class Globals
 
     public static bool QuestDirty;
 
+    public static void RemoveQuestRewards(Guid questId)
+    {
+        QuestRewards.Remove(questId);
+        QuestExperience.Remove(questId);
+        QuestJobExperience.Remove(questId);
+        QuestGuildExperience.Remove(questId);
+        QuestFactionHonor.Remove(questId);
+    }
+
     public static readonly Random Random = new();
 
     public static GameSystem System;

--- a/Intersect.Client.Core/Interface/Game/QuestOfferWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/QuestOfferWindow.cs
@@ -97,11 +97,7 @@ public partial class QuestOfferWindow : IQuestWindow
             var questId = Globals.QuestOffers[0];
             PacketSender.SendDeclineQuest(questId);
             Globals.QuestOffers.RemoveAt(0);
-            Globals.QuestRewards.Remove(questId);
-            Globals.QuestExperience.Remove(questId);
-            Globals.QuestJobExperience.Remove(questId);
-            Globals.QuestGuildExperience.Remove(questId);
-            Globals.QuestFactionHonor.Remove(questId);
+            Globals.RemoveQuestRewards(questId);
             ClearRewardWidgets();
         }
     }
@@ -113,11 +109,7 @@ public partial class QuestOfferWindow : IQuestWindow
             var questId = Globals.QuestOffers[0];
             PacketSender.SendAcceptQuest(questId);
             Globals.QuestOffers.RemoveAt(0);
-            Globals.QuestRewards.Remove(questId);
-            Globals.QuestExperience.Remove(questId);
-            Globals.QuestJobExperience.Remove(questId);
-            Globals.QuestGuildExperience.Remove(questId);
-            Globals.QuestFactionHonor.Remove(questId);
+            Globals.RemoveQuestRewards(questId);
             ClearRewardWidgets();
         }
     }

--- a/Intersect.Client.Core/Interface/Game/QuestsWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/QuestsWindow.cs
@@ -94,6 +94,7 @@ public partial class QuestsWindow : IQuestWindow
                     if (s is InputBox inputBox && inputBox.UserData is Guid questId)
                     {
                         PacketSender.SendAbandonQuest(questId);
+                        Globals.RemoveQuestRewards(questId);
                     }
                 }
             );
@@ -102,7 +103,9 @@ public partial class QuestsWindow : IQuestWindow
 
     void AbandonQuest(object sender, EventArgs e)
     {
-        PacketSender.SendAbandonQuest((Guid) ((InputBox) sender).UserData);
+        var questId = (Guid) ((InputBox) sender).UserData;
+        PacketSender.SendAbandonQuest(questId);
+        Globals.RemoveQuestRewards(questId);
     }
 
     private void _backButton_Clicked(Base sender, MouseButtonState arguments)

--- a/Intersect.Client.Core/Networking/PacketHandler.cs
+++ b/Intersect.Client.Core/Networking/PacketHandler.cs
@@ -2090,16 +2090,24 @@ internal sealed partial class PacketHandler
                     {
                         Globals.Me.QuestProgress.Remove(quest.Key);
                     }
+
+                    Globals.RemoveQuestRewards(quest.Key);
                 }
                 else
                 {
+                    var progress = new QuestProgress(quest.Value);
                     if (Globals.Me.QuestProgress.ContainsKey(quest.Key))
                     {
-                        Globals.Me.QuestProgress[quest.Key] = new QuestProgress(quest.Value);
+                        Globals.Me.QuestProgress[quest.Key] = progress;
                     }
                     else
                     {
-                        Globals.Me.QuestProgress.Add(quest.Key, new QuestProgress(quest.Value));
+                        Globals.Me.QuestProgress.Add(quest.Key, progress);
+                    }
+
+                    if (progress.Completed)
+                    {
+                        Globals.RemoveQuestRewards(quest.Key);
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- centralize quest reward removal logic
- clear reward data when quests are accepted, declined, completed, or abandoned

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package dotnet-sdk-7.0)*

------
https://chatgpt.com/codex/tasks/task_e_68c4fa95412c8324be04d37f7374fb94