### PR TITLE
Dispose quest reward widgets

### DIFF
--- a/Intersect.Client.Core/Interface/Game/QuestOfferWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/QuestOfferWindow.cs
@@ -84,9 +84,8 @@ namespace Intersect.Client.Interface.Game
 
         public void ClearRewardWidgets()
         {
-            // Dependiendo de tu versión de Gwen, usa DeleteChildren() o limpia manualmente
-            _rewardItemContainer.ClearChildren();
-            _rewardExpContainer.ClearChildren();
+            _rewardItemContainer.ClearChildren(true);
+            _rewardExpContainer.ClearChildren(true);
         }
 
         private void _declineButton_Clicked(Base sender, MouseButtonState arguments)


### PR DESCRIPTION
## Summary
- Ensure quest reward widgets are disposed when clearing the QuestOfferWindow
- Confirm Gwen's `ClearChildren` supports disposing children

## Testing
- ⚠️ `dotnet test` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5925b69cc83249ca12b3e37a48efe