### PR TITLE
Remove obsolete Quest window back button

### DIFF
--- a/Intersect.Client.Core/Interface/Game/QuestsWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/QuestsWindow.cs
@@ -21,7 +21,6 @@ namespace Intersect.Client.Interface.Game
 {
     public partial class QuestsWindow : IQuestWindow
     {
-        private readonly Button mBackButton;
 
         private readonly ScrollControl mQuestDescArea;
         private readonly RichLabel mQuestDescLabel;
@@ -100,9 +99,6 @@ namespace Intersect.Client.Interface.Game
             _rewardExpContainer = TryGetOrCreate(_rewardContainer, "QuestRewardExpContainer", 10, 10, 380, RewardExpHeight);
             _rewardItemsContainer = TryGetOrCreate(_rewardContainer, "QuestRewardItemContainer", 10, 60, 380, 50);
 
-            mBackButton = new Button(mQuestsWindow, "BackButton");
-            mBackButton.Text = Strings.QuestLog.Back;
-            mBackButton.Clicked += _backButton_Clicked;
 
             mQuitButton = new Button(mQuestsWindow, "AbandonQuestButton");
             mQuitButton.SetText(Strings.QuestLog.Abandon);
@@ -159,12 +155,6 @@ namespace Intersect.Client.Interface.Game
                     }
                 );
             }
-        }
-
-        private void _backButton_Clicked(Base sender, MouseButtonState arguments)
-        {
-            mSelectedQuest = null;
-            UpdateSelectedQuest();
         }
 
         private bool _shouldUpdateList;
@@ -381,7 +371,6 @@ namespace Intersect.Client.Interface.Game
                 mQuestTitle.Hide();
                 mQuestDescArea.Hide();
                 mQuestStatus.Hide();
-                mBackButton.Hide();
                 mQuitButton.Hide();
                 ClearRewardWidgets();
                 return;
@@ -488,7 +477,6 @@ namespace Intersect.Client.Interface.Game
             mQuestDescLabel.Width = mQuestDescArea.Width - mQuestDescArea.VerticalScrollBar.Width;
             mQuestDescLabel.SizeToChildren(false, true);
             mQuestStatus.Show();
-            mBackButton.Show();
             mQuitButton.Show();
 
             // Cargar recompensas de esta quest (ítems + exp) y acomodar

--- a/resources/gui/layouts/game/QuestsWindow.json
+++ b/resources/gui/layouts/game/QuestsWindow.json
@@ -1,0 +1,12 @@
+{
+  "Name": "QuestsWindow",
+  "Children": [
+    { "Name": "QuestList" },
+    { "Name": "QuestTitle" },
+    { "Name": "QuestStatus" },
+    { "Name": "QuestDescription" },
+    { "Name": "QuestTasksContainer" },
+    { "Name": "QuestRewardContainer" },
+    { "Name": "AbandonQuestButton" }
+  ]
+}


### PR DESCRIPTION
## Summary
- drop unused back button from QuestsWindow logic
- provide matching layout without BackButton control

## Testing
- `dotnet build Intersect.Client.Core/Intersect.Client.Core.csproj -c Release`
- `dotnet test Intersect.Tests.Client/Intersect.Tests.Client.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68c5931850ec832486f49acdf9ce0f5a