### PR TITLE
Skip zero-value quest reward labels and add tests

### DIFF
--- a/Intersect.Client.Core/Interface/Game/QuestRewardExp.cs
+++ b/Intersect.Client.Core/Interface/Game/QuestRewardExp.cs
@@ -29,7 +29,10 @@ public partial class QuestRewardExp : Base
         {
             foreach (var pair in jobExp)
             {
-                AddLabel($"+{pair.Value} {pair.Key} EXP");
+                if (pair.Value > 0)
+                {
+                    AddLabel($"+{pair.Value} {pair.Key} EXP");
+                }
             }
         }
 
@@ -42,7 +45,10 @@ public partial class QuestRewardExp : Base
         {
             foreach (var pair in factionHonor)
             {
-                AddLabel($"+{pair.Value} {pair.Key} Honor");
+                if (pair.Value > 0)
+                {
+                    AddLabel($"+{pair.Value} {pair.Key} Honor");
+                }
             }
         }
 

--- a/Intersect.Tests/Entities/SetBonusOrderTests.cs
+++ b/Intersect.Tests/Entities/SetBonusOrderTests.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using Intersect.Config;
 using Intersect.Enums;
 using Intersect.GameObjects;
-using Intersect.GameObjects.Items;
+using Intersect.Framework.Core.GameObjects.Items;
 using Intersect.Server.Database;
 using Intersect.Server.Entities;
 using NUnit.Framework;

--- a/Intersect.Tests/Interface/QuestRewardExpTests.cs
+++ b/Intersect.Tests/Interface/QuestRewardExpTests.cs
@@ -1,0 +1,68 @@
+using System.Collections.Generic;
+using System.Linq;
+using Intersect.Client.Framework.Gwen.Control;
+using Intersect.Client.Interface.Game;
+using Intersect.Config;
+using Intersect.Enums;
+using NUnit.Framework;
+
+namespace Intersect.Tests.Interface;
+
+public class QuestRewardExpTests
+{
+    [SetUp]
+    public void Setup()
+    {
+        Options.EnsureCreated();
+    }
+
+    private sealed class TestQuestWindow : IQuestWindow
+    {
+        public readonly List<Base> Widgets = new();
+
+        public void AddRewardWidget(Base widget)
+        {
+            Widgets.Add(widget);
+        }
+
+        public void ClearRewardWidgets()
+        {
+            Widgets.Clear();
+        }
+    }
+
+    [Test]
+    public void JobExpZeroValueIsSkipped()
+    {
+        var window = new TestQuestWindow();
+        Dictionary<JobType, long> jobExp = new()
+        {
+            [JobType.Farming] = 0,
+            [JobType.Fishing] = 25,
+        };
+
+        var reward = new QuestRewardExp(window, 0, jobExp, 0, null);
+
+        var labels = reward.Children.OfType<Label>().Select(l => l.Text).ToArray();
+
+        Assert.That(labels, Is.EquivalentTo(new[] {"+25 Fishing EXP"}));
+    }
+
+    [Test]
+    public void FactionHonorZeroValueIsSkipped()
+    {
+        var window = new TestQuestWindow();
+        Dictionary<Factions, int> factionHonor = new()
+        {
+            [Factions.Neutral] = 0,
+            [Factions.Serolf] = 5,
+        };
+
+        var reward = new QuestRewardExp(window, 0, null, 0, factionHonor);
+
+        var labels = reward.Children.OfType<Label>().Select(l => l.Text).ToArray();
+
+        Assert.That(labels, Is.EquivalentTo(new[] {"+5 Serolf Honor"}));
+    }
+}
+


### PR DESCRIPTION
## Summary
- avoid creating labels for job EXP or faction honor rewards that are zero
- add tests ensuring zero-valued job EXP and faction honor rewards are ignored
- update SetBonusOrderTests namespace to compile

## Testing
- `dotnet test Intersect.Tests/Intersect.Tests.csproj` *(fails: GetBonusesScalesWithPieces)*
- `dotnet test Intersect.Tests/Intersect.Tests.csproj --filter QuestRewardExpTests`

------
https://chatgpt.com/codex/tasks/task_e_68c59856e56c8324986af9a9af7b9d73