### PR TITLE
Wire up sets editor toolstrip buttons

### DIFF
--- a/Intersect.Editor/Forms/Editors/frmSets.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/frmSets.Designer.cs
@@ -1230,6 +1230,7 @@ partial class frmSets
         toolStripItemNew.Name = "toolStripItemNew";
         toolStripItemNew.Size = new Size(23, 26);
         toolStripItemNew.Text = "New";
+        toolStripItemNew.Click += toolStripItemNew_Click;
         // 
         // toolStripSeparator1
         // 
@@ -1248,6 +1249,7 @@ partial class frmSets
         toolStripItemDelete.Name = "toolStripItemDelete";
         toolStripItemDelete.Size = new Size(23, 26);
         toolStripItemDelete.Text = "Delete";
+        toolStripItemDelete.Click += toolStripItemDelete_Click;
         // 
         // toolStripSeparator2
         // 
@@ -1265,6 +1267,7 @@ partial class frmSets
         btnAlphabetical.Name = "btnAlphabetical";
         btnAlphabetical.Size = new Size(23, 26);
         btnAlphabetical.Text = "Order Chronologically";
+        btnAlphabetical.Click += btnAlphabetical_Click;
         // 
         // toolStripSeparator4
         // 
@@ -1283,6 +1286,7 @@ partial class frmSets
         toolStripItemCopy.Name = "toolStripItemCopy";
         toolStripItemCopy.Size = new Size(23, 26);
         toolStripItemCopy.Text = "Copy";
+        toolStripItemCopy.Click += toolStripItemCopy_Click;
         // 
         // toolStripItemPaste
         // 
@@ -1294,6 +1298,7 @@ partial class frmSets
         toolStripItemPaste.Name = "toolStripItemPaste";
         toolStripItemPaste.Size = new Size(23, 26);
         toolStripItemPaste.Text = "Paste";
+        toolStripItemPaste.Click += toolStripItemPaste_Click;
         // 
         // toolStripSeparator3
         // 
@@ -1312,6 +1317,7 @@ partial class frmSets
         toolStripItemUndo.Name = "toolStripItemUndo";
         toolStripItemUndo.Size = new Size(23, 26);
         toolStripItemUndo.Text = "Undo";
+        toolStripItemUndo.Click += toolStripItemUndo_Click;
         // 
         // frmSets
         // 


### PR DESCRIPTION
## Summary
- connect sets editor toolstrip buttons to their click handlers

## Testing
- `dotnet build Intersect.Editor/Intersect.Editor.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5a33609788324a57dc9aaf00fd54d