### PR TITLE
Add elemental type support for items and spells

### DIFF
--- a/Framework/Intersect.Framework.Core/GameObjects/Items/ItemDescriptor.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Items/ItemDescriptor.cs
@@ -127,6 +127,9 @@ public partial class ItemDescriptor : DatabaseObject<ItemDescriptor>, IFolderabl
 
     public int DamageType { get; set; }
 
+    [Column("Element")]
+    public ElementType Element { get; set; } = ElementType.Neutral;
+
     public int AttackSpeedModifier { get; set; }
 
     public int AttackSpeedValue { get; set; }

--- a/Framework/Intersect.Framework.Core/GameObjects/Spells/SpellCombatDescriptor.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Spells/SpellCombatDescriptor.cs
@@ -19,6 +19,9 @@ public partial class SpellCombatDescriptor
 
     public int DamageType { get; set; } = 1;
 
+    [Column("Element")]
+    public ElementType Element { get; set; } = ElementType.Neutral;
+
     public int HitRadius { get; set; }
 
     public bool Friendly { get; set; }

--- a/Intersect.Editor/Forms/Editors/frmItem.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/frmItem.Designer.cs
@@ -96,7 +96,9 @@ namespace Intersect.Editor.Forms.Editors
             btnAddFolder = new DarkButton();
             lblFolder = new Label();
             cmbFolder = new DarkComboBox();
+            cmbElement = new DarkComboBox();
             cmbRarity = new DarkComboBox();
+            lblElement = new Label();
             lblRarity = new Label();
             nudPrice = new DarkNumericUpDown();
             chkCanDrop = new DarkCheckBox();
@@ -449,6 +451,8 @@ namespace Intersect.Editor.Forms.Editors
             grpGeneral.Controls.Add(btnAddFolder);
             grpGeneral.Controls.Add(lblFolder);
             grpGeneral.Controls.Add(cmbFolder);
+            grpGeneral.Controls.Add(cmbElement);
+            grpGeneral.Controls.Add(lblElement);
             grpGeneral.Controls.Add(cmbRarity);
             grpGeneral.Controls.Add(lblRarity);
             grpGeneral.Controls.Add(nudPrice);
@@ -1193,9 +1197,41 @@ namespace Intersect.Editor.Forms.Editors
             cmbFolder.Text = null;
             cmbFolder.TextPadding = new Padding(2);
             cmbFolder.SelectedIndexChanged += cmbFolder_SelectedIndexChanged;
-            // 
+            //
+            // cmbElement
+            //
+            cmbElement.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            cmbElement.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            cmbElement.BorderStyle = ButtonBorderStyle.Solid;
+            cmbElement.ButtonColor = System.Drawing.Color.FromArgb(43, 43, 43);
+            cmbElement.DrawDropdownHoverOutline = false;
+            cmbElement.DrawFocusRectangle = false;
+            cmbElement.DrawMode = DrawMode.OwnerDrawFixed;
+            cmbElement.DropDownStyle = ComboBoxStyle.DropDownList;
+            cmbElement.FlatStyle = FlatStyle.Flat;
+            cmbElement.ForeColor = System.Drawing.Color.Gainsboro;
+            cmbElement.FormattingEnabled = true;
+            cmbElement.Location = new System.Drawing.Point(62, 197);
+            cmbElement.Margin = new Padding(4, 3, 4, 3);
+            cmbElement.Name = "cmbElement";
+            cmbElement.Size = new Size(221, 24);
+            cmbElement.TabIndex = 48;
+            cmbElement.Text = null;
+            cmbElement.TextPadding = new Padding(2);
+            cmbElement.SelectedIndexChanged += cmbElement_SelectedIndexChanged;
+            //
+            // lblElement
+            //
+            lblElement.AutoSize = true;
+            lblElement.Location = new System.Drawing.Point(9, 200);
+            lblElement.Margin = new Padding(4, 0, 4, 0);
+            lblElement.Name = "lblElement";
+            lblElement.Size = new Size(53, 15);
+            lblElement.TabIndex = 48;
+            lblElement.Text = "Element:";
+            //
             // cmbRarity
-            // 
+            //
             cmbRarity.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
             cmbRarity.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
             cmbRarity.BorderStyle = ButtonBorderStyle.Solid;
@@ -3592,7 +3628,9 @@ namespace Intersect.Editor.Forms.Editors
         private DarkCheckBox chkSingleUseSpell;
         private DarkCheckBox chkSingleUseEvent;
         private DarkCheckBox chkQuickCast;
+        private DarkComboBox cmbElement;
         private DarkComboBox cmbRarity;
+        private Label lblElement;
         private Label lblRarity;
         private DarkButton btnClearSearch;
         private DarkTextBox txtSearch;

--- a/Intersect.Editor/Forms/Editors/frmItem.cs
+++ b/Intersect.Editor/Forms/Editors/frmItem.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Drawing.Imaging;
 using DarkUI.Forms;
 using Intersect.Editor.Content;
@@ -228,6 +229,10 @@ public partial class FrmItem : EditorForm
             cmbRarity.Items.Add(Strings.ItemEditor.rarity.GetValueOrDefault(rarityName, $"{rarity}:{rarityName}"));
         }
 
+        lblElement.Text = "Element";
+        cmbElement.Items.Clear();
+        cmbElement.Items.AddRange(Enum.GetNames<ElementType>());
+
         grpEvents.Text = Strings.ItemEditor.EventGroup;
         lblEventForTrigger.Text = Strings.ItemEditor.EventGroupLabel;
 
@@ -366,6 +371,11 @@ public partial class FrmItem : EditorForm
             else if (cmbRarity.Items.Count > 0)
             {
                 cmbRarity.SelectedIndex = 0;
+            }
+
+            if (cmbElement.Items.Count > 0)
+            {
+                cmbElement.SelectedIndex = (int)mEditorItem.Element;
             }
 
             // Stats fijos
@@ -1184,6 +1194,11 @@ public partial class FrmItem : EditorForm
     private void cmbRarity_SelectedIndexChanged(object sender, EventArgs e)
     {
         mEditorItem.Rarity = cmbRarity.SelectedIndex;
+    }
+
+    private void cmbElement_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Element = (ElementType)cmbElement.SelectedIndex;
     }
 
     private void cmbCooldownGroup_SelectedIndexChanged(object sender, EventArgs e)

--- a/Intersect.Editor/Forms/Editors/frmSpell.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/frmSpell.Designer.cs
@@ -162,7 +162,9 @@ namespace Intersect.Editor.Forms.Editors
             lblCritChance = new Label();
             lblScaling = new Label();
             cmbDamageType = new DarkComboBox();
+            cmbElement = new DarkComboBox();
             lblDamageType = new Label();
+            lblElement = new Label();
             lblHPDamage = new Label();
             lblManaDamage = new Label();
             grpEvent = new DarkGroupBox();
@@ -1871,6 +1873,8 @@ namespace Intersect.Editor.Forms.Editors
             grpDamage.Controls.Add(lblScaling);
             grpDamage.Controls.Add(cmbDamageType);
             grpDamage.Controls.Add(lblDamageType);
+            grpDamage.Controls.Add(lblElement);
+            grpDamage.Controls.Add(cmbElement);
             grpDamage.Controls.Add(lblHPDamage);
             grpDamage.Controls.Add(lblManaDamage);
             grpDamage.ForeColor = System.Drawing.Color.Gainsboro;
@@ -1878,7 +1882,7 @@ namespace Intersect.Editor.Forms.Editors
             grpDamage.Margin = new Padding(4, 3, 4, 3);
             grpDamage.Name = "grpDamage";
             grpDamage.Padding = new Padding(4, 3, 4, 3);
-            grpDamage.Size = new Size(246, 426);
+            grpDamage.Size = new Size(246, 464);
             grpDamage.TabIndex = 49;
             grpDamage.TabStop = false;
             grpDamage.Text = "Damage";
@@ -2056,9 +2060,41 @@ namespace Intersect.Editor.Forms.Editors
             lblDamageType.Size = new Size(81, 15);
             lblDamageType.TabIndex = 49;
             lblDamageType.Text = "Damage Type:";
-            // 
+            //
+            // lblElement
+            //
+            lblElement.AutoSize = true;
+            lblElement.Location = new System.Drawing.Point(7, 428);
+            lblElement.Margin = new Padding(4, 0, 4, 0);
+            lblElement.Name = "lblElement";
+            lblElement.Size = new Size(53, 15);
+            lblElement.TabIndex = 64;
+            lblElement.Text = "Element:";
+            //
+            // cmbElement
+            //
+            cmbElement.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            cmbElement.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            cmbElement.BorderStyle = ButtonBorderStyle.Solid;
+            cmbElement.ButtonColor = System.Drawing.Color.FromArgb(43, 43, 43);
+            cmbElement.DrawDropdownHoverOutline = false;
+            cmbElement.DrawFocusRectangle = false;
+            cmbElement.DrawMode = DrawMode.OwnerDrawFixed;
+            cmbElement.DropDownStyle = ComboBoxStyle.DropDownList;
+            cmbElement.FlatStyle = FlatStyle.Flat;
+            cmbElement.ForeColor = System.Drawing.Color.Gainsboro;
+            cmbElement.FormattingEnabled = true;
+            cmbElement.Location = new System.Drawing.Point(10, 447);
+            cmbElement.Margin = new Padding(4, 3, 4, 3);
+            cmbElement.Name = "cmbElement";
+            cmbElement.Size = new Size(221, 24);
+            cmbElement.TabIndex = 65;
+            cmbElement.Text = null;
+            cmbElement.TextPadding = new Padding(2);
+            cmbElement.SelectedIndexChanged += cmbElement_SelectedIndexChanged;
+            //
             // lblHPDamage
-            // 
+            //
             lblHPDamage.AutoSize = true;
             lblHPDamage.Location = new System.Drawing.Point(7, 53);
             lblHPDamage.Margin = new Padding(4, 0, 4, 0);
@@ -2850,6 +2886,8 @@ namespace Intersect.Editor.Forms.Editors
         private System.Windows.Forms.Label lblScaling;
         private DarkComboBox cmbDamageType;
         private System.Windows.Forms.Label lblDamageType;
+        private DarkComboBox cmbElement;
+        private System.Windows.Forms.Label lblElement;
         private System.Windows.Forms.Label lblHPDamage;
         private System.Windows.Forms.Label lblManaDamage;
         private System.Windows.Forms.Label lblTickAnimation;

--- a/Intersect.Editor/Forms/Editors/frmSpell.cs
+++ b/Intersect.Editor/Forms/Editors/frmSpell.cs
@@ -17,6 +17,7 @@ using Intersect.Utilities;
 using System.Drawing;
 using System.Windows.Forms;
 using System.Collections.Generic;
+using System;
 using Graphics = System.Drawing.Graphics;
 
 namespace Intersect.Editor.Forms.Editors;
@@ -281,6 +282,10 @@ public partial class FrmSpell : EditorForm
             cmbDamageType.Items.Add(Strings.Combat.damagetypes[i]);
         }
 
+        lblElement.Text = "Element";
+        cmbElement.Items.Clear();
+        cmbElement.Items.AddRange(Enum.GetNames<ElementType>());
+
         lblScalingStat.Text = Strings.SpellEditor.scalingstat;
         lblScaling.Text = Strings.SpellEditor.scalingamount;
 
@@ -531,9 +536,10 @@ public partial class FrmSpell : EditorForm
             nudDmgPercentage.Value = mEditorItem.Combat.PercentageStatDiff[(int)Stat.Damages];
             nudCurPercentage.Value = mEditorItem.Combat.PercentageStatDiff[(int)Stat.Cures];
 
-            chkFriendly.Checked = Convert.ToBoolean(mEditorItem.Combat.Friendly);
-            cmbDamageType.SelectedIndex = mEditorItem.Combat.DamageType;
-            cmbScalingStat.SelectedIndex = mEditorItem.Combat.ScalingStat;
+        chkFriendly.Checked = Convert.ToBoolean(mEditorItem.Combat.Friendly);
+        cmbDamageType.SelectedIndex = mEditorItem.Combat.DamageType;
+        cmbElement.SelectedIndex = (int)mEditorItem.Combat.Element;
+        cmbScalingStat.SelectedIndex = mEditorItem.Combat.ScalingStat;
             nudScaling.Value = mEditorItem.Combat.Scaling;
             nudCritChance.Value = mEditorItem.Combat.CritChance;
             nudCritMultiplier.Value = (decimal)mEditorItem.Combat.CritMultiplier;
@@ -884,6 +890,11 @@ public partial class FrmSpell : EditorForm
     private void cmbDamageType_SelectedIndexChanged(object sender, EventArgs e)
     {
         mEditorItem.Combat.DamageType = cmbDamageType.SelectedIndex;
+    }
+
+    private void cmbElement_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        mEditorItem.Combat.Element = (ElementType)cmbElement.SelectedIndex;
     }
 
     private void cmbScalingStat_SelectedIndexChanged(object sender, EventArgs e)


### PR DESCRIPTION
## Summary
- add Element field with database mapping to items and spell combat data
- expose element selection in item and spell editors

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package dotnet-sdk-7.0)*

------
https://chatgpt.com/codex/tasks/task_e_68c5c3e709108324988c84e5882a9618