### PR TITLE
Implement elemental damage and logging

### DIFF
--- a/Intersect.Server.Core/Entities/Combat/DamageOverTimeEffect.cs
+++ b/Intersect.Server.Core/Entities/Combat/DamageOverTimeEffect.cs
@@ -164,7 +164,7 @@ public partial class DamageOverTimeEffect
             SpellDescriptor.Combat.GetEffectiveCritChance(properties),
             SpellDescriptor.Combat.GetEffectiveCritMultiplier(properties),
             deadAnimations,
-            aliveAnimations, false, level
+            aliveAnimations, false, level, SpellDescriptor.Combat.Element
         );
 
         var interval = SpellDescriptor.Combat.GetEffectiveHotDotInterval(properties);

--- a/Intersect.Server.Core/Entities/Combat/Status.cs
+++ b/Intersect.Server.Core/Entities/Combat/Status.cs
@@ -118,7 +118,8 @@ public partial class Status
 
                 var shieldAmount = Formulas.CalculateDamage(
                     vitalDiff, (DamageType)spell.Combat.DamageType, (Enums.Stat)spell.Combat.ScalingStat,
-                    spell.Combat.GetEffectiveScaling(properties), 1.0, attacker, en, level
+                    spell.Combat.GetEffectiveScaling(properties), 1.0, attacker, en, level,
+                    spell.Combat.Element
                 );
 
                 Shield[(int)vital] = Math.Abs(shieldAmount);


### PR DESCRIPTION
## Summary
- extend damage formulas with elemental bonuses, resistances, and affinity multipliers
- pass elemental information through attacks, damage over time, and shields
- display element used in combat messages

## Testing
- `dotnet test` *(fails: project file vendor/LiteNetLib/LiteNetLib.csproj not found)*
- `dotnet build Intersect.Server.Core/Intersect.Server.Core.csproj` *(fails: missing LiteNetLib types)*

------
https://chatgpt.com/codex/tasks/task_e_68c5c9c09588832487c7b20f7e1eada8