### PR TITLE
Allow configuring elemental damage multipliers

### DIFF
--- a/Documentation/ElementalAffinity.md
+++ b/Documentation/ElementalAffinity.md
@@ -1,0 +1,19 @@
+# Elemental Affinity Settings
+
+Elemental damage multipliers can be adjusted without recompiling the server. Edit the values under the `Combat` section of `resources/config.json`:
+
+```json
+{
+  "Combat": {
+    "ElementalAdvantage": 1.5,
+    "ElementalNeutral": 1.0,
+    "ElementalDisadvantage": 0.5
+  }
+}
+```
+
+* **ElementalAdvantage** – applied when the attacker's element is strong against the defender.
+* **ElementalNeutral** – used when neither element has an advantage.
+* **ElementalDisadvantage** – applied when the attacker is weak against the defender.
+
+Adjust these numbers to quickly balance elemental combat.

--- a/Framework/Intersect.Framework.Core/Config/CombatOptions.cs
+++ b/Framework/Intersect.Framework.Core/Config/CombatOptions.cs
@@ -24,6 +24,21 @@ public partial class CombatOptions
 
     public bool EnableCombatChatMessages { get; set; } = false; // Enables or disables combat chat messages.
 
+    /// <summary>
+    /// Damage multiplier applied when the attacker has elemental advantage.
+    /// </summary>
+    public float ElementalAdvantage { get; set; } = 1.5f;
+
+    /// <summary>
+    /// Damage multiplier applied when neither element has advantage.
+    /// </summary>
+    public float ElementalNeutral { get; set; } = 1.0f;
+
+    /// <summary>
+    /// Damage multiplier applied when the attacker is at an elemental disadvantage.
+    /// </summary>
+    public float ElementalDisadvantage { get; set; } = 0.5f;
+
     //Spells
 
     /// <summary>

--- a/Intersect (Core)/Combat/ElementalAffinity.cs
+++ b/Intersect (Core)/Combat/ElementalAffinity.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using Intersect.Enums;
+using Intersect;
 
 namespace Intersect.Combat;
 
@@ -8,11 +9,15 @@ namespace Intersect.Combat;
 /// </summary>
 public static class ElementalAffinity
 {
-    public const float Advantage = 1.5f;
-    public const float Neutral = 1.0f;
-    public const float Disadvantage = 0.5f;
+    public static float Advantage { get; private set; } = 1.5f;
 
-    private static readonly Dictionary<ElementType, Dictionary<ElementType, float>> Multipliers = new()
+    public static float Neutral { get; private set; } = 1.0f;
+
+    public static float Disadvantage { get; private set; } = 0.5f;
+
+    private static Dictionary<ElementType, Dictionary<ElementType, float>> Multipliers = BuildMultipliers();
+
+    private static Dictionary<ElementType, Dictionary<ElementType, float>> BuildMultipliers() => new()
     {
         [ElementType.Water] = new()
         {
@@ -46,6 +51,14 @@ public static class ElementalAffinity
             [ElementType.Light] = Advantage,
         },
     };
+
+    public static void LoadFromOptions(Options options)
+    {
+        Advantage = options.Combat.ElementalAdvantage;
+        Neutral = options.Combat.ElementalNeutral;
+        Disadvantage = options.Combat.ElementalDisadvantage;
+        Multipliers = BuildMultipliers();
+    }
 
     /// <summary>
     /// Get the multiplier for an attacker/defender elemental combination.

--- a/Intersect.Server.Core/Core/Bootstrapper.cs
+++ b/Intersect.Server.Core/Core/Bootstrapper.cs
@@ -31,6 +31,7 @@ using Intersect.Threading;
 using Intersect.Utilities;
 using Microsoft.Extensions.Logging;
 using Serilog;
+using Intersect.Combat;
 
 
 namespace Intersect.Server.Core;
@@ -213,6 +214,8 @@ internal static class Bootstrapper
 
             return false;
         }
+
+        ElementalAffinity.LoadFromOptions(Options.Instance);
 
         if (ServerContext.IsDefaultResourceDirectory)
         {

--- a/resources/config.json
+++ b/resources/config.json
@@ -1,0 +1,7 @@
+{
+  "Combat": {
+    "ElementalAdvantage": 1.5,
+    "ElementalNeutral": 1.0,
+    "ElementalDisadvantage": 0.5
+  }
+}


### PR DESCRIPTION
## Summary
- add `ElementalAdvantage`, `ElementalNeutral`, and `ElementalDisadvantage` to combat options and default config
- load configurable multipliers into `ElementalAffinity` and apply on startup
- document new elemental affinity settings for admins

## Testing
- `dotnet test` *(fails: project file vendor/LiteNetLib/LiteNetLib/LiteNetLib.csproj not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5cd0133b48324aff3e19b5303b811