### PR TITLE
Add elemental damage bonus stats

### DIFF
--- a/Framework/Intersect.Framework.Core/GameObjects/Items/ItemDescriptor.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Items/ItemDescriptor.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using Intersect.Enums;
 using Intersect.Framework.Core.GameObjects.Animations;
 using Intersect.Framework.Core.GameObjects.Conditions;
@@ -333,6 +334,9 @@ public partial class ItemDescriptor : DatabaseObject<ItemDescriptor>, IFolderabl
     private static Dictionary<ElementType, float> CreateResistanceDictionary() =>
         Enum.GetValues<ElementType>().ToDictionary(type => type, _ => 0f);
 
+    private static Dictionary<ElementType, float> CreateElementDamageBonusDictionary() =>
+        Enum.GetValues<ElementType>().ToDictionary(type => type, _ => 0f);
+
     [Column("Resistances")]
     [JsonIgnore]
     public string ResistancesJson
@@ -345,6 +349,20 @@ public partial class ItemDescriptor : DatabaseObject<ItemDescriptor>, IFolderabl
 
     [NotMapped]
     public Dictionary<ElementType, float> Resistances { get; set; } = CreateResistanceDictionary();
+
+    [Column("ElementDamageBonus")]
+    [JsonIgnore]
+    public string ElementDamageBonusJson
+    {
+        get => JsonConvert.SerializeObject(ElementDamageBonus);
+        set => ElementDamageBonus = string.IsNullOrEmpty(value)
+            ? CreateElementDamageBonusDictionary()
+            : JsonConvert.DeserializeObject<Dictionary<ElementType, float>>(value)
+              ?? CreateElementDamageBonusDictionary();
+    }
+
+    [NotMapped]
+    public Dictionary<ElementType, float> ElementDamageBonus { get; set; } = CreateElementDamageBonusDictionary();
 
     [Column("UsageRequirements")]
     [JsonIgnore]
@@ -520,6 +538,7 @@ public partial class ItemDescriptor : DatabaseObject<ItemDescriptor>, IFolderabl
         VitalsRegen = new long[Enum.GetValues<Vital>().Length];
         PercentageVitalsGiven = new int[Enum.GetValues<Vital>().Length];
         Resistances = CreateResistanceDictionary();
+        ElementDamageBonus = CreateElementDamageBonusDictionary();
         Consumable = new ConsumableData();
         Effects = [];
         Color = new Color(255, 255, 255, 255);

--- a/Framework/Intersect.Framework.Core/Network/Packets/Server/EntityStatsPacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Server/EntityStatsPacket.cs
@@ -11,13 +11,21 @@ public partial class EntityStatsPacket : IntersectPacket
     {
     }
 
-    public EntityStatsPacket(Guid id, EntityType type, Guid mapId, int[] stats, float[] resistances)
+    public EntityStatsPacket(
+        Guid id,
+        EntityType type,
+        Guid mapId,
+        int[] stats,
+        float[] resistances,
+        float[] elementDamageBonuses
+    )
     {
         Id = id;
         Type = type;
         MapId = mapId;
         Stats = stats;
         Resistances = resistances;
+        ElementDamageBonuses = elementDamageBonuses;
     }
 
     [Key(0)]
@@ -34,4 +42,7 @@ public partial class EntityStatsPacket : IntersectPacket
 
     [Key(4)]
     public float[] Resistances { get; set; }
+
+    [Key(5)]
+    public float[] ElementDamageBonuses { get; set; }
 }

--- a/Intersect.Client.Core/Entities/Entity.cs
+++ b/Intersect.Client.Core/Entities/Entity.cs
@@ -202,6 +202,11 @@ public partial class Entity : IEntity
     IReadOnlyDictionary<ElementType, float> IEntity.Resistances =>
         Enum.GetValues<ElementType>().ToDictionary(elem => elem, elem => Resistances[(int)elem]);
 
+    public float[] ElementDamageBonuses { get; set; } = new float[Enum.GetValues<ElementType>().Length];
+
+    IReadOnlyDictionary<ElementType, float> IEntity.ElementDamageBonuses =>
+        Enum.GetValues<ElementType>().ToDictionary(elem => elem, elem => ElementDamageBonuses[(int)elem]);
+
     public IGameTexture? Texture { get; set; }
 
     #region "Animation Textures and Timing"

--- a/Intersect.Client.Core/Interface/Game/Character/CharacterWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Character/CharacterWindow.cs
@@ -64,6 +64,7 @@ public partial class CharacterWindow:Window
     Label mAgilityLabel;
     Label mDamageLabel;
     Label mCureLabel;
+    Label mElementBonusLabel;
     public ImagePanel[] PaperdollPanels;
 
     public string[] PaperdollTextures;
@@ -249,34 +250,37 @@ public partial class CharacterWindow:Window
         mPointsLabel = new Label(this, "PointsLabel");
         mPointsLabel.SetPosition(statsX, statsY + statSpacing * 8);
 
+        mElementBonusLabel = new Label(this, "ElementBonusLabel");
+        mElementBonusLabel.SetPosition(statsX, statsY + statSpacing * 9);
+
         var extraBuffsLabel = new Label(this, "ExtraBuffsLabel");
         extraBuffsLabel.SetText(Strings.Character.ExtraBuffs);
-        extraBuffsLabel.SetPosition(statsX, statsY + statSpacing * 9);
+        extraBuffsLabel.SetPosition(statsX, statsY + statSpacing * 10);
 
         mHpRegen = new Label(this, "HpRegen");
-        mHpRegen.SetPosition(statsX, statsY + statSpacing * 10);
+        mHpRegen.SetPosition(statsX, statsY + statSpacing * 11);
         mManaRegen = new Label(this, "ManaRegen");
-        mManaRegen.SetPosition(statsX, statsY + statSpacing * 11);
+        mManaRegen.SetPosition(statsX, statsY + statSpacing * 12);
         mLifeSteal = new Label(this, "Lifesteal");
-        mLifeSteal.SetPosition(statsX, statsY + statSpacing * 12);
+        mLifeSteal.SetPosition(statsX, statsY + statSpacing * 13);
         mAttackSpeed = new Label(this, "AttackSpeed");
-        mAttackSpeed.SetPosition(statsX, statsY + statSpacing * 13);
+        mAttackSpeed.SetPosition(statsX, statsY + statSpacing * 14);
         mSpeedBuff = new Label(this, "SpeedBuff");
-        mSpeedBuff.SetPosition(statsX, statsY + statSpacing * 14);
+        mSpeedBuff.SetPosition(statsX, statsY + statSpacing * 15);
         mDamageBuff = new Label(this, "DamageBuff");
-        mDamageBuff.SetPosition(statsX, statsY + statSpacing * 15);
+        mDamageBuff.SetPosition(statsX, statsY + statSpacing * 16);
         mCureBuff = new Label(this, "CureBuff");
-        mCureBuff.SetPosition(statsX, statsY + statSpacing * 16);
+        mCureBuff.SetPosition(statsX, statsY + statSpacing * 17);
         mExtraExp = new Label(this, "ExtraExp");
-        mExtraExp.SetPosition(statsX, statsY + statSpacing * 17);
+        mExtraExp.SetPosition(statsX, statsY + statSpacing * 18);
         mLuck = new Label(this, "Luck");
-        mLuck.SetPosition(statsX, statsY + statSpacing * 18);
+        mLuck.SetPosition(statsX, statsY + statSpacing * 19);
         mTenacity = new Label(this, "Tenacity");
-        mTenacity.SetPosition(statsX, statsY + statSpacing * 19);
+        mTenacity.SetPosition(statsX, statsY + statSpacing * 20);
         mCooldownReduction = new Label(this, "CooldownReduction");
-        mCooldownReduction.SetPosition(statsX, statsY + statSpacing * 20);
+        mCooldownReduction.SetPosition(statsX, statsY + statSpacing * 21);
         mManaSteal = new Label(this, "Manasteal");
-        mManaSteal.SetPosition(statsX, statsY + statSpacing * 21);
+        mManaSteal.SetPosition(statsX, statsY + statSpacing * 22);
 
         UpdateExtraBuffs();
 
@@ -476,6 +480,19 @@ public partial class CharacterWindow:Window
             )
         );
         mPointsLabel.SetText(Strings.Character.Points.ToString(player.StatPoints));
+
+        var bonusStrings = new List<string>();
+        for (var i = 0; i < Enum.GetValues<ElementType>().Length; i++)
+        {
+            var val = player.ElementDamageBonuses[i];
+            if (Math.Abs(val) > float.Epsilon)
+            {
+                bonusStrings.Add($"{((ElementType)i)} {val:P0}");
+            }
+        }
+
+        var bonusText = bonusStrings.Count > 0 ? string.Join(", ", bonusStrings) : Strings.Character.None;
+        mElementBonusLabel.SetText(Strings.Character.ElementDamageBonus.ToString(bonusText));
         mAddAbilityPwrBtn.IsHidden = player.StatPoints == 0 ||
                                      player.Stat[(int) Stat.Intelligence] == Options.Instance.Player.MaxStat;
 

--- a/Intersect.Client.Core/Localization/Strings.cs
+++ b/Intersect.Client.Core/Localization/Strings.cs
@@ -1007,6 +1007,9 @@ public static partial class Strings
         public static LocalizedString Points = @"Points: {00}";
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString ElementDamageBonus = @"Element Bonus: {00}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public static LocalizedString StatLabelValue = @"{00}: {01}";
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]

--- a/Intersect.Client.Core/Networking/PacketHandler.cs
+++ b/Intersect.Client.Core/Networking/PacketHandler.cs
@@ -1079,6 +1079,7 @@ internal sealed partial class PacketHandler
 
         en.Stat = packet.Stats;
         en.Resistances = packet.Resistances;
+        en.ElementDamageBonuses = packet.ElementDamageBonuses;
     }
 
     //EntityDirectionPacket

--- a/Intersect.Client.Framework/Entities/IEntity.cs
+++ b/Intersect.Client.Framework/Entities/IEntity.cs
@@ -43,6 +43,7 @@ public interface IEntity : IDisposable
     int Level { get; }
     IReadOnlyDictionary<Stat, int> Stats { get; }
     IReadOnlyDictionary<ElementType, float> Resistances { get; }
+    IReadOnlyDictionary<ElementType, float> ElementDamageBonuses { get; }
     IReadOnlyDictionary<Vital, long> Vitals { get; }
     IReadOnlyDictionary<Vital, long> MaxVitals { get; }
     IReadOnlyList<IItem> Items { get; }

--- a/Intersect.Server.Core/General/Formulas.cs
+++ b/Intersect.Server.Core/General/Formulas.cs
@@ -138,7 +138,7 @@ public partial class Formulas
                 result = -result;
             }
 
-            var attackerElementBonus = attacker.GetResistance(attackerElement);
+            var attackerElementBonus = attacker.GetElementDamageBonus(attackerElement);
             var defenderResistance = victim.GetResistance(attackerElement);
 
             var defenderElement = ElementType.Neutral;

--- a/Intersect.Server.Core/Networking/PacketSender.cs
+++ b/Intersect.Server.Core/Networking/PacketSender.cs
@@ -1036,12 +1036,14 @@ public static partial class PacketSender
         }
 
         var resistances = new float[Enum.GetValues<ElementType>().Length];
+        var elementBonuses = new float[Enum.GetValues<ElementType>().Length];
         for (var i = 0; i < Enum.GetValues<ElementType>().Length; i++)
         {
             resistances[i] = en.GetResistance((ElementType)i);
+            elementBonuses[i] = en.GetElementDamageBonus((ElementType)i);
         }
 
-        return new EntityStatsPacket(en.Id, en.GetEntityType(), en.MapId, stats, resistances);
+        return new EntityStatsPacket(en.Id, en.GetEntityType(), en.MapId, stats, resistances, elementBonuses);
     }
 
     //EntityStatsPacket


### PR DESCRIPTION
## Summary
- track elemental damage bonuses on items
- incorporate equipment element bonuses into player stats and damage calculations
- show elemental bonuses in character window

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package dotnet-sdk-7.0)*

------
https://chatgpt.com/codex/tasks/task_e_68c5cfe0cb888324934280fd0f27024c