### PR TITLE
feat: allow items and spells to modify combat math

### DIFF
--- a/Framework/Intersect.Framework.Core/GameObjects/Items/ItemProperties.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Items/ItemProperties.cs
@@ -1,7 +1,19 @@
+using System.Collections.Generic;
 using Intersect.Enums;
 using MessagePack;
 
 namespace Intersect.Framework.Core.GameObjects.Items;
+
+// Placeholder interfaces for custom item modifiers such as equipment or runes
+public interface IResistanceModifier
+{
+    IReadOnlyDictionary<ElementType, float> GetResistanceModifiers();
+}
+
+public interface IDamageModifier
+{
+    IReadOnlyDictionary<ElementType, float> GetDamageModifiers();
+}
 
 [MessagePackObject]
 public partial class ItemProperties

--- a/Framework/Intersect.Framework.Core/GameObjects/Spells/SpellProperties.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Spells/SpellProperties.cs
@@ -1,6 +1,20 @@
+using System.Collections.Generic;
+using System.Linq;
 using MessagePack;
+using Intersect.Enums;
 
 namespace Intersect.Framework.Core.GameObjects.Spells;
+
+// Placeholder interfaces for custom spell modifiers such as runes
+public interface IResistanceModifier
+{
+    IReadOnlyDictionary<ElementType, float> GetResistanceModifiers();
+}
+
+public interface IDamageModifier
+{
+    IReadOnlyDictionary<ElementType, float> GetDamageModifiers();
+}
 
 [MessagePackObject]
 public class SpellProperties

--- a/Intersect.Server.Core/Entities/Combat/ResistanceBuff.cs
+++ b/Intersect.Server.Core/Entities/Combat/ResistanceBuff.cs
@@ -1,4 +1,5 @@
 using Intersect.Framework.Core.GameObjects.Spells;
+using Intersect.GameObjects;
 
 namespace Intersect.Server.Entities.Combat;
 

--- a/Intersect.Server.Core/Entities/Entity.cs
+++ b/Intersect.Server.Core/Entities/Entity.cs
@@ -405,14 +405,16 @@ public abstract partial class Entity : IEntity
         var baseVal = Resistances.TryGetValue(element, out var val) ? val : 0f;
         var buffVal = _cachedResistanceBuffs.Sum(b => b.Resistances[(int)element]);
         var equipVal = this is Player player ? player.GetEquipmentResistance(element) : 0f;
-        return baseVal + buffVal + equipVal;
+        var spellVal = this is Player spellPlayer ? spellPlayer.GetSpellResistance(element) : 0f;
+        return baseVal + buffVal + equipVal + spellVal;
     }
 
     public float GetElementDamageBonus(ElementType element)
     {
         var baseVal = ElementDamageBonus.TryGetValue(element, out var val) ? val : 0f;
         var equipVal = this is Player player ? player.GetEquipmentElementDamageBonus(element) : 0f;
-        return baseVal + equipVal;
+        var spellVal = this is Player spellPlayer ? spellPlayer.GetSpellElementDamageBonus(element) : 0f;
+        return baseVal + equipVal + spellVal;
     }
 
     public virtual void Update(long timeMs)


### PR DESCRIPTION
## Summary
- add modifier interfaces for items and spells
- aggregate item and spell modifiers when computing resistances and damage

## Testing
- `dotnet test Intersect.Tests/Intersect.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68c5fc56847c83248ecf7781e1e0a8f8