### PR TITLE
Ensure faction honor command respects non-neutral factions

### DIFF
--- a/Framework/Intersect.Framework.Core/GameObjects/Events/Commands/GiveFactionHonorCommand.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Events/Commands/GiveFactionHonorCommand.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using Intersect.Enums;
 using Intersect.Framework.Core.GameObjects.Events;
@@ -9,16 +8,35 @@ public partial class GiveFactionHonorCommand : EventCommand
 {
     public override EventCommandType Type { get; } = EventCommandType.GiveFactionHonor;
 
-    public Dictionary<Factions, int> Honor { get; set; } = new();
+    private Dictionary<Factions, int> mHonor = new();
+
+    public Dictionary<Factions, int> Honor
+    {
+        get => mHonor;
+        set
+        {
+            mHonor = value ?? new Dictionary<Factions, int>();
+            EnsureFactionEntries();
+        }
+    }
 
     public GiveFactionHonorCommand()
     {
-        foreach (Factions faction in Enum.GetValues(typeof(Factions)))
+        EnsureFactionEntries();
+    }
+
+    private void EnsureFactionEntries()
+    {
+        mHonor.Remove(Factions.Neutral);
+
+        if (!mHonor.ContainsKey(Factions.Serolf))
         {
-            if (faction != Factions.Neutral)
-            {
-                Honor[faction] = 0;
-            }
+            mHonor[Factions.Serolf] = 0;
+        }
+
+        if (!mHonor.ContainsKey(Factions.Nidraj))
+        {
+            mHonor[Factions.Nidraj] = 0;
         }
     }
 }

--- a/Intersect.Server.Core/Entities/Events/CommandProcessing.cs
+++ b/Intersect.Server.Core/Entities/Events/CommandProcessing.cs
@@ -2348,7 +2348,33 @@ public static partial class CommandProcessing
         Stack<CommandInstance> callStack
     )
     {
-        if (command.Honor.TryGetValue(player.Faction, out var amount) && amount != 0)
+        if (player.Faction == Factions.Neutral)
+        {
+            return;
+        }
+
+        if (command.Honor == null)
+        {
+            return;
+        }
+
+        var amount = 0;
+        switch (player.Faction)
+        {
+            case Factions.Serolf:
+                command.Honor.TryGetValue(Factions.Serolf, out amount);
+                break;
+
+            case Factions.Nidraj:
+                command.Honor.TryGetValue(Factions.Nidraj, out amount);
+                break;
+
+            default:
+                command.Honor.TryGetValue(player.Faction, out amount);
+                break;
+        }
+
+        if (amount != 0)
         {
             HonorService.AdjustHonor(player, amount);
         }


### PR DESCRIPTION
## Summary
- ensure the faction honor event command always provides entries for the two non-neutral factions and drops any neutral value
- guard the server-side give faction honor command so only non-neutral players receive the configured honor for their faction

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68c8df77b09c83249652e464f837145d