### PR TITLE
Add tooltips to quest reward experience icons

### DIFF
--- a/Intersect.Client.Core/Localization/Strings.cs
+++ b/Intersect.Client.Core/Localization/Strings.cs
@@ -2751,6 +2751,36 @@ If you are sure you want to hand over your guild enter '\c{{#ff8080}}{02}\c{{}}'
         public static LocalizedString Title = @"Quest Offer";
     }
 
+    public partial struct QuestRewardExp
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString PlayerExpTooltip = @"Player EXP";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString JobExpTooltip = @"{0} EXP";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString JobGenericTooltip = @"Job EXP";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString GuildExpTooltip = @"Guild EXP";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString FactionHonorTooltip = @"{0} Honor";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString FactionHonorGenericTooltip = @"Faction Honor";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString FactionNeutralName = @"Neutral";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString FactionSerolfName = @"Serolf";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString FactionNidrajName = @"Nidraj";
+    }
+
     public partial struct Regex
     {
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]

--- a/Intersect.Client.Core/Localization/Translations/en-US.json
+++ b/Intersect.Client.Core/Localization/Translations/en-US.json
@@ -2,5 +2,16 @@
   "Inventory": {
     "Sort": "Sort",
     "All": "All"
+  },
+  "QuestRewardExp": {
+    "PlayerExpTooltip": "Player EXP",
+    "JobExpTooltip": "{0} EXP",
+    "JobGenericTooltip": "Job EXP",
+    "GuildExpTooltip": "Guild EXP",
+    "FactionHonorTooltip": "{0} Honor",
+    "FactionHonorGenericTooltip": "Faction Honor",
+    "FactionNeutralName": "Neutral",
+    "FactionSerolfName": "Serolf",
+    "FactionNidrajName": "Nidraj"
   }
 }

--- a/Intersect.Client.Core/Localization/Translations/es-ES.json
+++ b/Intersect.Client.Core/Localization/Translations/es-ES.json
@@ -2,5 +2,16 @@
   "Inventory": {
     "Sort": "Ordenar",
     "All": "Todos"
+  },
+  "QuestRewardExp": {
+    "PlayerExpTooltip": "EXP de jugador",
+    "JobExpTooltip": "{0} EXP",
+    "JobGenericTooltip": "EXP de oficio",
+    "GuildExpTooltip": "EXP de gremio",
+    "FactionHonorTooltip": "Honor de {0}",
+    "FactionHonorGenericTooltip": "Honor de facción",
+    "FactionNeutralName": "Neutral",
+    "FactionSerolfName": "Serolf",
+    "FactionNidrajName": "Nidraj"
   }
 }

--- a/Intersect.Tests/Interface/QuestRewardExpTests.cs
+++ b/Intersect.Tests/Interface/QuestRewardExpTests.cs
@@ -64,5 +64,21 @@ public class QuestRewardExpTests
 
         Assert.That(labels, Is.EquivalentTo(new[] {"+5 Serolf Honor"}));
     }
+
+    [Test]
+    public void JobExpIconHasTooltip()
+    {
+        var window = new TestQuestWindow();
+        Dictionary<JobType, long> jobExp = new()
+        {
+            [JobType.Farming] = 25,
+        };
+
+        var reward = new QuestRewardExp(window, 0, jobExp, 0, null);
+
+        var icon = reward.Children.First(control => control.Name == "QuestRewardExpIcon");
+
+        Assert.That(icon.TooltipText, Is.EqualTo("Farming EXP"));
+    }
 }
 


### PR DESCRIPTION
## Summary
- expose the quest reward EXP chip controls so their tooltips can be validated and set localized tooltip text on each chip
- add localized strings (with English and Spanish defaults) describing player, guild, job, and faction reward icons
- cover the new tooltip behaviour with a unit test to ensure the job icon shows its EXP tooltip

## Testing
- `dotnet test Intersect.Tests/Intersect.Tests.csproj` *(fails: `dotnet` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ca1847d76c8324b610fd97e13dee13