### PR TITLE
Add pet state enum and initial spawn pet command

### DIFF
--- a/Framework/Intersect.Framework.Core/GameObjects/Events/Commands/SpawnPetCommand.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Events/Commands/SpawnPetCommand.cs
@@ -1,0 +1,23 @@
+using Intersect.Enums;
+
+namespace Intersect.Framework.Core.GameObjects.Events.Commands;
+
+public partial class SpawnPetCommand : EventCommand
+{
+    public override EventCommandType Type { get; } = EventCommandType.Null;
+
+    public Guid PetId { get; set; }
+
+    public Direction Dir { get; set; }
+
+    //Tile Spawn Variables  (Will spawn on map tile if mapid is not empty)
+    public Guid MapId { get; set; }
+
+    //Entity Spawn Variables (Will spawn on/around entity if entityId is not empty)
+    public Guid EntityId { get; set; }
+
+    //Map Coords or Coords Centered around player to spawn at
+    public sbyte X { get; set; }
+
+    public sbyte Y { get; set; }
+}

--- a/Intersect (Core)/Enums/PetState.cs
+++ b/Intersect (Core)/Enums/PetState.cs
@@ -1,0 +1,8 @@
+namespace Intersect.Enums;
+
+public enum PetState
+{
+    Idle,
+    Follow,
+    Attack,
+}


### PR DESCRIPTION
## Summary
- introduce a PetState enum alongside the other shared enums so pets can track idle, follow, and attack states
- scaffold a SpawnPetCommand event command patterned after the existing SpawnNpcCommand to carry pet descriptor references and spawn positioning data

## Testing
- `dotnet build Intersect.sln` *(fails: `dotnet` command not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb816a65b8832b8b1262b7f33a89fd