### PR TITLE
Add SpawnPet event command type

### DIFF
--- a/Framework/Intersect.Framework.Core/GameObjects/Events/Commands/SpawnPetCommand.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Events/Commands/SpawnPetCommand.cs
@@ -4,19 +4,19 @@ namespace Intersect.Framework.Core.GameObjects.Events.Commands;
 
 public partial class SpawnPetCommand : EventCommand
 {
-    public override EventCommandType Type { get; } = EventCommandType.Null;
+    public override EventCommandType Type { get; } = EventCommandType.SpawnPet;
 
     public Guid PetId { get; set; }
 
     public Direction Dir { get; set; }
 
-    //Tile Spawn Variables  (Will spawn on map tile if mapid is not empty)
+    // Pet tile spawn variables (spawns on the specified map tile when MapId is set)
     public Guid MapId { get; set; }
 
-    //Entity Spawn Variables (Will spawn on/around entity if entityId is not empty)
+    // Pet entity spawn variables (spawns relative to the specified entity when EntityId is set)
     public Guid EntityId { get; set; }
 
-    //Map Coords or Coords Centered around player to spawn at
+    // Map coordinates or offsets relative to the pet spawn target
     public sbyte X { get; set; }
 
     public sbyte Y { get; set; }

--- a/Framework/Intersect.Framework.Core/GameObjects/Events/EventCommandType.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Events/EventCommandType.cs
@@ -63,6 +63,7 @@ public enum EventCommandType
     ReleasePlayer,
 
     SpawnNpc,
+    SpawnPet,
 
     //Special Effects
     PlayAnimation,


### PR DESCRIPTION
## Summary
- set the SpawnPet event command to use its own command type and clarify that the spawn parameters are pet specific
- add the SpawnPet entry next to SpawnNpc in the shared EventCommandType enumeration so values stay contiguous

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68cc39991200832b9bd63e3219e6a812