### PR TITLE
Add event command for spawning pets

### DIFF
--- a/Intersect.Editor/Forms/Editors/Events/CommandPrinter.cs
+++ b/Intersect.Editor/Forms/Editors/Events/CommandPrinter.cs
@@ -10,6 +10,7 @@ using Intersect.Framework.Core.GameObjects.Events.Commands;
 using Intersect.Framework.Core.GameObjects.Items;
 using Intersect.Framework.Core.GameObjects.Maps.MapList;
 using Intersect.Framework.Core.GameObjects.NPCs;
+using Intersect.Framework.Core.GameObjects.Pets;
 using Intersect.Framework.Core.GameObjects.PlayerClass;
 using Intersect.Framework.Core.GameObjects.Variables;
 using Intersect.GameObjects;
@@ -1066,6 +1067,72 @@ public static partial class CommandPrinter
 
         return Strings.EventCommandList.spawnnpc.ToString(
             NPCDescriptor.GetName(command.NpcId),
+            Strings.EventCommandList.spawnonevent.ToString(
+                Strings.EventCommandList.deletedevent, command.X, command.Y, retain
+            )
+        );
+    }
+
+    private static string GetCommandText(SpawnPetCommand command, MapInstance map)
+    {
+        if (command == null)
+        {
+            return null;
+        }
+
+        if (command.MapId != Guid.Empty)
+        {
+            foreach (var orderedMap in MapList.OrderedMaps)
+            {
+                if (orderedMap == null)
+                {
+                    continue;
+                }
+
+                if (orderedMap.MapId == command.MapId)
+                {
+                    return Strings.EventCommandList.spawnpet.ToString(
+                        PetDescriptor.GetName(command.PetId),
+                        Strings.EventCommandList.spawnonmap.ToString(
+                            orderedMap.Name, command.X, command.Y, Strings.Direction.dir?[command.Dir]
+                        )
+                    );
+                }
+            }
+
+            return Strings.EventCommandList.spawnpet.ToString(
+                PetDescriptor.GetName(command.PetId),
+                Strings.EventCommandList.spawnonmap.ToString(
+                    Strings.EventCommandList.mapnotfound, command.X, command.Y, Strings.Direction.dir[command.Dir]
+                )
+            );
+        }
+
+        var retain = Strings.EventCommandList.False;
+
+        if (Convert.ToBoolean(command.Dir))
+        {
+            retain = Strings.EventCommandList.True;
+        }
+
+        if (command.EntityId == Guid.Empty)
+        {
+            return Strings.EventCommandList.spawnpet.ToString(
+                PetDescriptor.GetName(command.PetId),
+                Strings.EventCommandList.spawnonplayer.ToString(command.X, command.Y, retain)
+            );
+        }
+
+        if (map.LocalEvents.TryGetValue(command.EntityId, out var localEvent))
+        {
+            return Strings.EventCommandList.spawnpet.ToString(
+                PetDescriptor.GetName(command.PetId),
+                Strings.EventCommandList.spawnonevent.ToString(localEvent.Name, command.X, command.Y, retain)
+            );
+        }
+
+        return Strings.EventCommandList.spawnpet.ToString(
+            PetDescriptor.GetName(command.PetId),
             Strings.EventCommandList.spawnonevent.ToString(
                 Strings.EventCommandList.deletedevent, command.X, command.Y, retain
             )

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_SpawnPet.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_SpawnPet.Designer.cs
@@ -1,0 +1,396 @@
+﻿using DarkUI.Controls;
+
+namespace Intersect.Editor.Forms.Editors.Events.Event_Commands
+{
+    partial class EventCommandSpawnPet
+    {
+        /// <summary> 
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary> 
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary> 
+        /// Required method for Designer support - do not modify 
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.grpSpawnPet = new DarkUI.Controls.DarkGroupBox();
+            this.cmbPet = new DarkUI.Controls.DarkComboBox();
+            this.lblPet = new System.Windows.Forms.Label();
+            this.cmbConditionType = new DarkUI.Controls.DarkComboBox();
+            this.lblSpawnType = new System.Windows.Forms.Label();
+            this.btnCancel = new DarkUI.Controls.DarkButton();
+            this.btnSave = new DarkUI.Controls.DarkButton();
+            this.grpTileSpawn = new DarkUI.Controls.DarkGroupBox();
+            this.btnVisual = new DarkUI.Controls.DarkButton();
+            this.cmbMap = new DarkUI.Controls.DarkComboBox();
+            this.cmbDirection = new DarkUI.Controls.DarkComboBox();
+            this.lblDir = new System.Windows.Forms.Label();
+            this.lblY = new System.Windows.Forms.Label();
+            this.lblMap = new System.Windows.Forms.Label();
+            this.lblX = new System.Windows.Forms.Label();
+            this.grpEntitySpawn = new DarkUI.Controls.DarkGroupBox();
+            this.chkDirRelative = new DarkUI.Controls.DarkCheckBox();
+            this.pnlSpawnLoc = new System.Windows.Forms.Panel();
+            this.lblRelativeLocation = new System.Windows.Forms.Label();
+            this.cmbEntities = new DarkUI.Controls.DarkComboBox();
+            this.lblEntity = new System.Windows.Forms.Label();
+            this.nudWarpY = new DarkUI.Controls.DarkNumericUpDown();
+            this.nudWarpX = new DarkUI.Controls.DarkNumericUpDown();
+            this.grpSpawnPet.SuspendLayout();
+            this.grpTileSpawn.SuspendLayout();
+            this.grpEntitySpawn.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.nudWarpY)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.nudWarpX)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // grpSpawnPet
+            // 
+            this.grpSpawnPet.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
+            this.grpSpawnPet.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
+            this.grpSpawnPet.Controls.Add(this.cmbPet);
+            this.grpSpawnPet.Controls.Add(this.lblPet);
+            this.grpSpawnPet.Controls.Add(this.cmbConditionType);
+            this.grpSpawnPet.Controls.Add(this.lblSpawnType);
+            this.grpSpawnPet.Controls.Add(this.btnCancel);
+            this.grpSpawnPet.Controls.Add(this.btnSave);
+            this.grpSpawnPet.Controls.Add(this.grpTileSpawn);
+            this.grpSpawnPet.Controls.Add(this.grpEntitySpawn);
+            this.grpSpawnPet.ForeColor = System.Drawing.Color.Gainsboro;
+            this.grpSpawnPet.Location = new System.Drawing.Point(3, 3);
+            this.grpSpawnPet.Name = "grpSpawnPet";
+            this.grpSpawnPet.Size = new System.Drawing.Size(256, 388);
+            this.grpSpawnPet.TabIndex = 17;
+            this.grpSpawnPet.TabStop = false;
+            this.grpSpawnPet.Text = "Spawn Pet";
+            // 
+            // cmbPet
+            // 
+            this.cmbPet.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
+            this.cmbPet.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
+            this.cmbPet.BorderStyle = System.Windows.Forms.ButtonBorderStyle.Solid;
+            this.cmbPet.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
+            this.cmbPet.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmbPet.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.cmbPet.ForeColor = System.Drawing.Color.Gainsboro;
+            this.cmbPet.FormattingEnabled = true;
+            this.cmbPet.Location = new System.Drawing.Point(88, 15);
+            this.cmbPet.Name = "cmbPet";
+            this.cmbPet.Size = new System.Drawing.Size(157, 21);
+            this.cmbPet.TabIndex = 26;
+            // 
+            // lblPet
+            // 
+            this.lblPet.AutoSize = true;
+            this.lblPet.Location = new System.Drawing.Point(6, 18);
+            this.lblPet.Name = "lblPet";
+            this.lblPet.Size = new System.Drawing.Size(30, 13);
+            this.lblPet.TabIndex = 25;
+            this.lblPet.Text = "Pet:";
+            // 
+            // cmbConditionType
+            // 
+            this.cmbConditionType.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
+            this.cmbConditionType.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
+            this.cmbConditionType.BorderStyle = System.Windows.Forms.ButtonBorderStyle.Solid;
+            this.cmbConditionType.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
+            this.cmbConditionType.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmbConditionType.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.cmbConditionType.ForeColor = System.Drawing.Color.Gainsboro;
+            this.cmbConditionType.FormattingEnabled = true;
+            this.cmbConditionType.Items.AddRange(new object[] {
+            "Specific Tile",
+            "On/Around Entity"});
+            this.cmbConditionType.Location = new System.Drawing.Point(88, 44);
+            this.cmbConditionType.Name = "cmbConditionType";
+            this.cmbConditionType.Size = new System.Drawing.Size(157, 21);
+            this.cmbConditionType.TabIndex = 22;
+            this.cmbConditionType.SelectedIndexChanged += new System.EventHandler(this.cmbConditionType_SelectedIndexChanged);
+            // 
+            // lblSpawnType
+            // 
+            this.lblSpawnType.AutoSize = true;
+            this.lblSpawnType.Location = new System.Drawing.Point(6, 47);
+            this.lblSpawnType.Name = "lblSpawnType";
+            this.lblSpawnType.Size = new System.Drawing.Size(70, 13);
+            this.lblSpawnType.TabIndex = 21;
+            this.lblSpawnType.Text = "Spawn Type:";
+            // 
+            // btnCancel
+            // 
+            this.btnCancel.Location = new System.Drawing.Point(90, 359);
+            this.btnCancel.Name = "btnCancel";
+            this.btnCancel.Padding = new System.Windows.Forms.Padding(5);
+            this.btnCancel.Size = new System.Drawing.Size(75, 23);
+            this.btnCancel.TabIndex = 20;
+            this.btnCancel.Text = "Cancel";
+            this.btnCancel.Click += new System.EventHandler(this.btnCancel_Click);
+            // 
+            // btnSave
+            // 
+            this.btnSave.Location = new System.Drawing.Point(9, 359);
+            this.btnSave.Name = "btnSave";
+            this.btnSave.Padding = new System.Windows.Forms.Padding(5);
+            this.btnSave.Size = new System.Drawing.Size(75, 23);
+            this.btnSave.TabIndex = 19;
+            this.btnSave.Text = "Ok";
+            this.btnSave.Click += new System.EventHandler(this.btnSave_Click);
+            // 
+            // grpTileSpawn
+            // 
+            this.grpTileSpawn.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
+            this.grpTileSpawn.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
+            this.grpTileSpawn.Controls.Add(this.nudWarpY);
+            this.grpTileSpawn.Controls.Add(this.nudWarpX);
+            this.grpTileSpawn.Controls.Add(this.btnVisual);
+            this.grpTileSpawn.Controls.Add(this.cmbMap);
+            this.grpTileSpawn.Controls.Add(this.cmbDirection);
+            this.grpTileSpawn.Controls.Add(this.lblDir);
+            this.grpTileSpawn.Controls.Add(this.lblY);
+            this.grpTileSpawn.Controls.Add(this.lblMap);
+            this.grpTileSpawn.Controls.Add(this.lblX);
+            this.grpTileSpawn.ForeColor = System.Drawing.Color.Gainsboro;
+            this.grpTileSpawn.Location = new System.Drawing.Point(9, 82);
+            this.grpTileSpawn.Name = "grpTileSpawn";
+            this.grpTileSpawn.Size = new System.Drawing.Size(236, 168);
+            this.grpTileSpawn.TabIndex = 23;
+            this.grpTileSpawn.TabStop = false;
+            this.grpTileSpawn.Text = "Specific Tile";
+            // 
+            // btnVisual
+            // 
+            this.btnVisual.Location = new System.Drawing.Point(40, 133);
+            this.btnVisual.Name = "btnVisual";
+            this.btnVisual.Padding = new System.Windows.Forms.Padding(5);
+            this.btnVisual.Size = new System.Drawing.Size(155, 23);
+            this.btnVisual.TabIndex = 30;
+            this.btnVisual.Text = "Open Visual Interface";
+            this.btnVisual.Click += new System.EventHandler(this.btnVisual_Click);
+            // 
+            // cmbMap
+            // 
+            this.cmbMap.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
+            this.cmbMap.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
+            this.cmbMap.BorderStyle = System.Windows.Forms.ButtonBorderStyle.Solid;
+            this.cmbMap.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
+            this.cmbMap.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmbMap.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.cmbMap.ForeColor = System.Drawing.Color.Gainsboro;
+            this.cmbMap.FormattingEnabled = true;
+            this.cmbMap.Items.AddRange(new object[] {
+            "Retain Direction",
+            "Up",
+            "Down",
+            "Left",
+            "Right"});
+            this.cmbMap.Location = new System.Drawing.Point(74, 19);
+            this.cmbMap.Name = "cmbMap";
+            this.cmbMap.Size = new System.Drawing.Size(121, 21);
+            this.cmbMap.TabIndex = 27;
+            // 
+            // cmbDirection
+            // 
+            this.cmbDirection.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
+            this.cmbDirection.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
+            this.cmbDirection.BorderStyle = System.Windows.Forms.ButtonBorderStyle.Solid;
+            this.cmbDirection.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
+            this.cmbDirection.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmbDirection.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.cmbDirection.ForeColor = System.Drawing.Color.Gainsboro;
+            this.cmbDirection.FormattingEnabled = true;
+            this.cmbDirection.Location = new System.Drawing.Point(74, 100);
+            this.cmbDirection.Name = "cmbDirection";
+            this.cmbDirection.Size = new System.Drawing.Size(121, 21);
+            this.cmbDirection.TabIndex = 26;
+            // 
+            // lblDir
+            // 
+            this.lblDir.AutoSize = true;
+            this.lblDir.Location = new System.Drawing.Point(37, 103);
+            this.lblDir.Name = "lblDir";
+            this.lblDir.Size = new System.Drawing.Size(23, 13);
+            this.lblDir.TabIndex = 25;
+            this.lblDir.Text = "Dir:";
+            // 
+            // lblY
+            // 
+            this.lblY.AutoSize = true;
+            this.lblY.Location = new System.Drawing.Point(37, 76);
+            this.lblY.Name = "lblY";
+            this.lblY.Size = new System.Drawing.Size(17, 13);
+            this.lblY.TabIndex = 24;
+            this.lblY.Text = "Y:";
+            // 
+            // lblMap
+            // 
+            this.lblMap.AutoSize = true;
+            this.lblMap.Location = new System.Drawing.Point(37, 22);
+            this.lblMap.Name = "lblMap";
+            this.lblMap.Size = new System.Drawing.Size(31, 13);
+            this.lblMap.TabIndex = 22;
+            this.lblMap.Text = "Map:";
+            // 
+            // lblX
+            // 
+            this.lblX.AutoSize = true;
+            this.lblX.Location = new System.Drawing.Point(37, 49);
+            this.lblX.Name = "lblX";
+            this.lblX.Size = new System.Drawing.Size(17, 13);
+            this.lblX.TabIndex = 23;
+            this.lblX.Text = "X:";
+            // 
+            // grpEntitySpawn
+            // 
+            this.grpEntitySpawn.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(63)))), ((int)(((byte)(65)))));
+            this.grpEntitySpawn.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
+            this.grpEntitySpawn.Controls.Add(this.chkDirRelative);
+            this.grpEntitySpawn.Controls.Add(this.pnlSpawnLoc);
+            this.grpEntitySpawn.Controls.Add(this.lblRelativeLocation);
+            this.grpEntitySpawn.Controls.Add(this.cmbEntities);
+            this.grpEntitySpawn.Controls.Add(this.lblEntity);
+            this.grpEntitySpawn.ForeColor = System.Drawing.Color.Gainsboro;
+            this.grpEntitySpawn.Location = new System.Drawing.Point(9, 81);
+            this.grpEntitySpawn.Name = "grpEntitySpawn";
+            this.grpEntitySpawn.Size = new System.Drawing.Size(236, 264);
+            this.grpEntitySpawn.TabIndex = 24;
+            this.grpEntitySpawn.TabStop = false;
+            this.grpEntitySpawn.Text = "On/Around Entity";
+            // 
+            // chkDirRelative
+            // 
+            this.chkDirRelative.AutoSize = true;
+            this.chkDirRelative.Location = new System.Drawing.Point(38, 236);
+            this.chkDirRelative.Name = "chkDirRelative";
+            this.chkDirRelative.Size = new System.Drawing.Size(151, 17);
+            this.chkDirRelative.TabIndex = 30;
+            this.chkDirRelative.Text = "Relative to Entity Direction";
+            // 
+            // pnlSpawnLoc
+            // 
+            this.pnlSpawnLoc.Location = new System.Drawing.Point(38, 69);
+            this.pnlSpawnLoc.Name = "pnlSpawnLoc";
+            this.pnlSpawnLoc.Size = new System.Drawing.Size(160, 160);
+            this.pnlSpawnLoc.TabIndex = 29;
+            this.pnlSpawnLoc.MouseDown += new System.Windows.Forms.MouseEventHandler(this.pnlSpawnLoc_MouseDown);
+            // 
+            // lblRelativeLocation
+            // 
+            this.lblRelativeLocation.AutoSize = true;
+            this.lblRelativeLocation.Location = new System.Drawing.Point(37, 49);
+            this.lblRelativeLocation.Name = "lblRelativeLocation";
+            this.lblRelativeLocation.Size = new System.Drawing.Size(93, 13);
+            this.lblRelativeLocation.TabIndex = 28;
+            this.lblRelativeLocation.Text = "Relative Location:";
+            // 
+            // cmbEntities
+            // 
+            this.cmbEntities.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
+            this.cmbEntities.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
+            this.cmbEntities.BorderStyle = System.Windows.Forms.ButtonBorderStyle.Solid;
+            this.cmbEntities.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
+            this.cmbEntities.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmbEntities.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.cmbEntities.ForeColor = System.Drawing.Color.Gainsboro;
+            this.cmbEntities.FormattingEnabled = true;
+            this.cmbEntities.Items.AddRange(new object[] {
+            "Retain Direction",
+            "Up",
+            "Down",
+            "Left",
+            "Right"});
+            this.cmbEntities.Location = new System.Drawing.Point(74, 19);
+            this.cmbEntities.Name = "cmbEntities";
+            this.cmbEntities.Size = new System.Drawing.Size(121, 21);
+            this.cmbEntities.TabIndex = 27;
+            // 
+            // lblEntity
+            // 
+            this.lblEntity.AutoSize = true;
+            this.lblEntity.Location = new System.Drawing.Point(37, 22);
+            this.lblEntity.Name = "lblEntity";
+            this.lblEntity.Size = new System.Drawing.Size(36, 13);
+            this.lblEntity.TabIndex = 22;
+            this.lblEntity.Text = "Entity:";
+            // 
+            // nudWarpY
+            // 
+            this.nudWarpY.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
+            this.nudWarpY.ForeColor = System.Drawing.Color.Gainsboro;
+            this.nudWarpY.Location = new System.Drawing.Point(74, 73);
+            this.nudWarpY.Name = "nudWarpY";
+            this.nudWarpY.Size = new System.Drawing.Size(120, 20);
+            this.nudWarpY.TabIndex = 34;
+            // 
+            // nudWarpX
+            // 
+            this.nudWarpX.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
+            this.nudWarpX.ForeColor = System.Drawing.Color.Gainsboro;
+            this.nudWarpX.Location = new System.Drawing.Point(74, 46);
+            this.nudWarpX.Name = "nudWarpX";
+            this.nudWarpX.Size = new System.Drawing.Size(121, 20);
+            this.nudWarpX.TabIndex = 33;
+            // 
+            // EventCommand_SpawnPet
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoSize = true;
+            this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(45)))), ((int)(((byte)(48)))));
+            this.Controls.Add(this.grpSpawnPet);
+            this.Name = "EventCommandSpawnPet";
+            this.Size = new System.Drawing.Size(267, 394);
+            this.grpSpawnPet.ResumeLayout(false);
+            this.grpSpawnPet.PerformLayout();
+            this.grpTileSpawn.ResumeLayout(false);
+            this.grpTileSpawn.PerformLayout();
+            this.grpEntitySpawn.ResumeLayout(false);
+            this.grpEntitySpawn.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.nudWarpY)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.nudWarpX)).EndInit();
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+        private DarkGroupBox grpSpawnPet;
+        private DarkButton btnCancel;
+        private DarkButton btnSave;
+        private DarkGroupBox grpTileSpawn;
+        private DarkComboBox cmbConditionType;
+        private System.Windows.Forms.Label lblSpawnType;
+        private DarkButton btnVisual;
+        private DarkComboBox cmbMap;
+        private DarkComboBox cmbDirection;
+        private System.Windows.Forms.Label lblDir;
+        private System.Windows.Forms.Label lblY;
+        private System.Windows.Forms.Label lblMap;
+        private System.Windows.Forms.Label lblX;
+        private DarkGroupBox grpEntitySpawn;
+        private DarkCheckBox chkDirRelative;
+        private System.Windows.Forms.Panel pnlSpawnLoc;
+        private DarkComboBox cmbEntities;
+        private System.Windows.Forms.Label lblEntity;
+        private System.Windows.Forms.Label lblRelativeLocation;
+        private DarkComboBox cmbPet;
+        private System.Windows.Forms.Label lblPet;
+        private DarkNumericUpDown nudWarpY;
+        private DarkNumericUpDown nudWarpX;
+    }
+}

--- a/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_SpawnPet.cs
+++ b/Intersect.Editor/Forms/Editors/Events/Event Commands/EventCommand_SpawnPet.cs
@@ -1,0 +1,267 @@
+using Intersect.Editor.Forms.Helpers;
+using Intersect.Editor.Localization;
+using Intersect.Enums;
+using Intersect.Framework.Core.GameObjects.Events;
+using Intersect.Framework.Core.GameObjects.Events.Commands;
+using Intersect.Framework.Core.GameObjects.Maps;
+using Intersect.Framework.Core.GameObjects.Maps.MapList;
+using Intersect.Framework.Core.GameObjects.Pets;
+using Intersect.GameObjects;
+
+namespace Intersect.Editor.Forms.Editors.Events.Event_Commands;
+
+
+public partial class EventCommandSpawnPet : UserControl
+{
+
+    private readonly FrmEvent mEventEditor;
+
+    private MapDescriptor mCurrentMap;
+
+    private EventDescriptor mEditingEvent;
+
+    private SpawnPetCommand mMyCommand;
+
+    private int mSpawnX;
+
+    private int mSpawnY;
+
+    private Grid? mGrid;
+
+    public EventCommandSpawnPet(
+        FrmEvent eventEditor,
+        MapDescriptor currentMap,
+        EventDescriptor currentEvent,
+        SpawnPetCommand editingCommand
+    )
+    {
+        InitializeComponent();
+        mMyCommand = editingCommand;
+        mEventEditor = eventEditor;
+        mEditingEvent = currentEvent;
+        mCurrentMap = currentMap;
+        InitLocalization();
+        cmbPet.Items.Clear();
+        cmbPet.Items.AddRange(PetDescriptor.Names);
+        cmbPet.SelectedIndex = PetDescriptor.ListIndex(mMyCommand.PetId);
+        if (mMyCommand.MapId != Guid.Empty)
+        {
+            cmbConditionType.SelectedIndex = 0;
+        }
+        else
+        {
+            cmbConditionType.SelectedIndex = 1;
+        }
+
+        nudWarpX.Maximum = Options.Instance.Map.MapWidth;
+        nudWarpY.Maximum = Options.Instance.Map.MapHeight;
+        UpdateFormElements();
+        switch (cmbConditionType.SelectedIndex)
+        {
+            case 0: //Tile spawn
+                //Fill in the map cmb
+                nudWarpX.Value = mMyCommand.X;
+                nudWarpY.Value = mMyCommand.Y;
+                cmbDirection.SelectedIndex = (int)mMyCommand.Dir;
+
+                break;
+            case 1: //On/Around Entity Spawn
+                mSpawnX = mMyCommand.X;
+                mSpawnY = mMyCommand.Y;
+                chkDirRelative.Checked = Convert.ToBoolean(mMyCommand.Dir);
+                UpdateSpawnPreview();
+
+                break;
+        }
+    }
+
+    private void InitLocalization()
+    {
+        grpSpawnPet.Text = Strings.EventSpawnPet.title;
+        lblPet.Text = Strings.EventSpawnPet.pet;
+        lblSpawnType.Text = Strings.EventSpawnPet.spawntype;
+        cmbConditionType.Items.Clear();
+        cmbConditionType.Items.Add(Strings.EventSpawnPet.spawntype0);
+        cmbConditionType.Items.Add(Strings.EventSpawnPet.spawntype1);
+
+        grpTileSpawn.Text = Strings.EventSpawnPet.spawntype0;
+        grpEntitySpawn.Text = Strings.EventSpawnPet.spawntype1;
+
+        lblMap.Text = Strings.Warping.map.ToString("");
+        lblX.Text = Strings.Warping.x.ToString("");
+        lblY.Text = Strings.Warping.y.ToString("");
+        lblMap.Text = Strings.Warping.direction.ToString("");
+        cmbDirection.Items.Clear();
+        for (var i = 0; i < 4; i++)
+        {
+            cmbDirection.Items.Add(Strings.Direction.dir[(Direction)i]);
+        }
+
+        cmbDirection.SelectedIndex = 0;
+        btnVisual.Text = Strings.Warping.visual;
+
+        lblEntity.Text = Strings.EventSpawnPet.entity;
+        lblRelativeLocation.Text = Strings.EventSpawnPet.relativelocation;
+        chkDirRelative.Text = Strings.EventSpawnPet.spawnrelative;
+
+        btnSave.Text = Strings.EventSpawnPet.okay;
+        btnCancel.Text = Strings.EventSpawnPet.cancel;
+    }
+
+    private void UpdateFormElements()
+    {
+        grpTileSpawn.Hide();
+        grpEntitySpawn.Hide();
+        switch (cmbConditionType.SelectedIndex)
+        {
+            case 0: //Tile Spawn
+                grpTileSpawn.Show();
+                cmbMap.Items.Clear();
+                for (var i = 0; i < MapList.OrderedMaps.Count; i++)
+                {
+                    cmbMap.Items.Add(MapList.OrderedMaps[i].Name);
+                    if (MapList.OrderedMaps[i].MapId == mMyCommand.MapId)
+                    {
+                        cmbMap.SelectedIndex = i;
+                    }
+                }
+
+                if (cmbMap.SelectedIndex == -1)
+                {
+                    cmbMap.SelectedIndex = 0;
+                }
+
+                break;
+            case 1: //On/Around Entity Spawn
+                grpEntitySpawn.Show();
+                cmbEntities.Items.Clear();
+                cmbEntities.Items.Add(Strings.EventSpawnPet.player);
+                cmbEntities.SelectedIndex = 0;
+
+                if (!mEditingEvent.CommonEvent)
+                {
+                    foreach (var evt in mCurrentMap.LocalEvents)
+                    {
+                        cmbEntities.Items.Add(
+                            evt.Key == mEditingEvent.Id ? Strings.EventSpawnPet.This + " " : "" + evt.Value.Name
+                        );
+
+                        if (mMyCommand.EntityId == evt.Key)
+                        {
+                            cmbEntities.SelectedIndex = cmbEntities.Items.Count - 1;
+                        }
+                    }
+                }
+
+                UpdateSpawnPreview();
+
+                break;
+        }
+    }
+
+    private void UpdateSpawnPreview()
+    {
+        if (mGrid == null)
+        {
+            mGrid = new Grid
+            {
+                DisplayWidth = pnlSpawnLoc.Width,
+                DisplayHeight = pnlSpawnLoc.Height,
+                Columns = 5,
+                Rows = 5,
+                Cells = new[] { new GridCell(2, 2, null, "E") }
+            };
+        }
+
+        pnlSpawnLoc.BackgroundImage = GridHelper.DrawGrid(
+            mGrid.Value.WithAdditionalCells(
+                new GridCell(mSpawnX + 2, mSpawnY + 2, System.Drawing.Color.Red)
+            )
+        );
+    }
+
+    private void btnSave_Click(object sender, EventArgs e)
+    {
+        mMyCommand.PetId = PetDescriptor.IdFromList(cmbPet.SelectedIndex);
+        switch (cmbConditionType.SelectedIndex)
+        {
+            case 0: //Tile Spawn
+                mMyCommand.EntityId = Guid.Empty;
+                mMyCommand.MapId = MapList.OrderedMaps[cmbMap.SelectedIndex].MapId;
+                mMyCommand.X = (sbyte)nudWarpX.Value;
+                mMyCommand.Y = (sbyte)nudWarpY.Value;
+                mMyCommand.Dir = (Direction)cmbDirection.SelectedIndex;
+
+                break;
+            case 1: //On/Around Entity Spawn
+                mMyCommand.MapId = Guid.Empty;
+                if (cmbEntities.SelectedIndex == 0 || cmbEntities.SelectedIndex == -1)
+                {
+                    mMyCommand.EntityId = Guid.Empty;
+                }
+                else
+                {
+                    mMyCommand.EntityId = mCurrentMap.LocalEvents.Keys.ToList()[cmbEntities.SelectedIndex - 1];
+                }
+
+                mMyCommand.X = (sbyte)mSpawnX;
+                mMyCommand.Y = (sbyte)mSpawnY;
+                mMyCommand.Dir = (Direction)Convert.ToInt32(chkDirRelative.Checked);
+
+                break;
+        }
+
+        mEventEditor.FinishCommandEdit();
+    }
+
+    private void btnCancel_Click(object sender, EventArgs e)
+    {
+        mEventEditor.CancelCommandEdit();
+    }
+
+    private void cmbConditionType_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        UpdateFormElements();
+    }
+
+    private void btnVisual_Click(object sender, EventArgs e)
+    {
+        var frmWarpSelection = new FrmWarpSelection();
+        frmWarpSelection.SelectTile(
+            MapList.OrderedMaps[cmbMap.SelectedIndex].MapId, (int)nudWarpX.Value, (int)nudWarpY.Value
+        );
+
+        frmWarpSelection.ShowDialog();
+        if (frmWarpSelection.GetResult())
+        {
+            for (var i = 0; i < MapList.OrderedMaps.Count; i++)
+            {
+                if (MapList.OrderedMaps[i].MapId == frmWarpSelection.GetMap())
+                {
+                    cmbMap.SelectedIndex = i;
+
+                    break;
+                }
+            }
+
+            nudWarpX.Value = frmWarpSelection.GetX();
+            nudWarpY.Value = frmWarpSelection.GetY();
+        }
+    }
+
+    private void pnlSpawnLoc_MouseDown(object sender, MouseEventArgs e)
+    {
+        if (mGrid == null)
+        {
+            return;
+        }
+
+        var cell = GridHelper.CellFromPoint(mGrid.Value, e.X, e.Y);
+        if (cell != null)
+        {
+            (mSpawnX, mSpawnY) = cell.Value;
+            UpdateSpawnPreview();
+        }
+    }
+
+}

--- a/Intersect.Editor/Forms/Editors/Events/frmEvent.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/Events/frmEvent.Designer.cs
@@ -77,10 +77,11 @@ namespace Intersect.Editor.Forms.Editors.Events
             var treeNode37 = new TreeNode("Hold Player");
             var treeNode38 = new TreeNode("Release Player");
             var treeNode39 = new TreeNode("Spawn NPC");
+            var treeNode85 = new TreeNode("Spawn Pet");
             var treeNode40 = new TreeNode("Despawn NPC");
             var treeNode41 = new TreeNode("Hide Player");
             var treeNode42 = new TreeNode("Show Player");
-            var treeNode43 = new TreeNode("Movement", new TreeNode[] { treeNode34, treeNode35, treeNode36, treeNode37, treeNode38, treeNode39, treeNode40, treeNode41, treeNode42 });
+            var treeNode43 = new TreeNode("Movement", new TreeNode[] { treeNode34, treeNode35, treeNode36, treeNode37, treeNode38, treeNode39, treeNode85, treeNode40, treeNode41, treeNode42 });
             var treeNode44 = new TreeNode("Play Animation");
             var treeNode45 = new TreeNode("Play BGM");
             var treeNode46 = new TreeNode("Fadeout BGM");
@@ -947,6 +948,8 @@ namespace Intersect.Editor.Forms.Editors.Events
             treeNode38.Text = "Release Player";
             treeNode39.Name = "spawnnpc";
             treeNode39.Text = "Spawn NPC";
+            treeNode85.Name = "spawnpet";
+            treeNode85.Text = "Spawn Pet";
             treeNode40.Name = "despawnnpc";
             treeNode40.Text = "Despawn NPC";
             treeNode41.Name = "hideplayer";

--- a/Intersect.Editor/Forms/Editors/Events/frmEvent.cs
+++ b/Intersect.Editor/Forms/Editors/Events/frmEvent.cs
@@ -651,6 +651,10 @@ public partial class FrmEvent : Form
                 tmpCommand = new SpawnNpcCommand();
 
                 break;
+            case EventCommandType.SpawnPet:
+                tmpCommand = new SpawnPetCommand();
+
+                break;
             case EventCommandType.PlayAnimation:
                 tmpCommand = new PlayAnimationCommand();
 
@@ -1376,6 +1380,10 @@ public partial class FrmEvent : Form
                 break;
             case EventCommandType.SpawnNpc:
                 cmdWindow = new EventCommandSpawnNpc(this, mCurrentMap, MyEvent, (SpawnNpcCommand)command);
+
+                break;
+            case EventCommandType.SpawnPet:
+                cmdWindow = new EventCommandSpawnPet(this, mCurrentMap, MyEvent, (SpawnPetCommand)command);
 
                 break;
             case EventCommandType.DespawnNpc:

--- a/Intersect.Editor/Intersect.Editor.csproj
+++ b/Intersect.Editor/Intersect.Editor.csproj
@@ -363,6 +363,12 @@
     <Compile Update="Forms\Editors\Events\Event Commands\EventCommand_SpawnNpc.Designer.cs">
       <DependentUpon>EventCommand_SpawnNpc.cs</DependentUpon>
     </Compile>
+    <Compile Update="Forms\Editors\Events\Event Commands\EventCommand_SpawnPet.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Update="Forms\Editors\Events\Event Commands\EventCommand_SpawnPet.Designer.cs">
+      <DependentUpon>EventCommand_SpawnPet.cs</DependentUpon>
+    </Compile>
     <Compile Update="Forms\Editors\Events\Event Commands\EventCommand_StartCommonEvent.cs">
       <SubType>UserControl</SubType>
     </Compile>

--- a/Intersect.Editor/Localization/Strings.cs
+++ b/Intersect.Editor/Localization/Strings.cs
@@ -2295,6 +2295,8 @@ Tick timer saved in server config.json.";
 
         public static LocalizedString spawnnpc = @"Spawn Npc {00} {01}";
 
+        public static LocalizedString spawnpet = @"Spawn Pet {00} {01}";
+
         public static LocalizedString spawnonevent = @"On Event #{00} [X Offset: {01} Y Offset: {02} Dir: {03}]";
 
         public static LocalizedString spawnonmap = @"[On Map {00} X: {01} Y: {02} Dir: {03}]";
@@ -2495,6 +2497,7 @@ Tick timer saved in server config.json.";
             {"showpicture", @"Show Picture"},
             {"showtext", @"Show Text"},
             {"spawnnpc", @"Spawn NPC"},
+            {"spawnpet", @"Spawn Pet"},
             {"specialeffects", @"Special Effects"},
             {"startcommonevent", @"Start Common Event"},
             {"startquest", @"Start Quest"},
@@ -3699,6 +3702,35 @@ Tick timer saved in server config.json.";
         public static LocalizedString This = @"[THIS EVENT]";
 
         public static LocalizedString title = @"Spawn Npc";
+
+    }
+
+    public partial struct EventSpawnPet
+    {
+
+        public static LocalizedString cancel = @"Cancel";
+
+        public static LocalizedString entity = @"Entity:";
+
+        public static LocalizedString pet = @"Pet:";
+
+        public static LocalizedString okay = @"Ok";
+
+        public static LocalizedString player = @"Player";
+
+        public static LocalizedString relativelocation = @"Relative Location:";
+
+        public static LocalizedString spawnrelative = @"Relative to Entity Direction";
+
+        public static LocalizedString spawntype = @"Spawn Type:";
+
+        public static LocalizedString spawntype0 = @"Specific Tile";
+
+        public static LocalizedString spawntype1 = @"On/Around Entity";
+
+        public static LocalizedString This = @"[THIS EVENT]";
+
+        public static LocalizedString title = @"Spawn Pet";
 
     }
 


### PR DESCRIPTION
## Summary
- add handling for the Spawn Pet event command, including command creation, editor routing, and command tree integration
- implement a Spawn Pet command editor that mirrors NPC spawning while sourcing pet descriptors
- extend command printing and localization so Spawn Pet commands display the correct text in the editor

## Testing
- `dotnet build Intersect.Editor/Intersect.Editor.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cc3c04cbd4832b91f860954fb60168