### PR TITLE
Manage player pet lifecycle

### DIFF
--- a/Intersect.Server.Core/Entities/Player.cs
+++ b/Intersect.Server.Core/Entities/Player.cs
@@ -75,6 +75,17 @@ public partial class Player : Entity
 
     #endregion
 
+    #region Pets
+
+    [JsonIgnore][NotMapped] public List<Pet> SpawnedPets { get; } = new();
+
+    [JsonIgnore][NotMapped] public Pet? CurrentPet { get; private set; }
+
+    #endregion
+
+    [JsonIgnore, NotMapped]
+    private readonly object _spawnedPetsLock = new();
+
     [JsonIgnore, NotMapped]
     public long[] MaxVitals => GetMaxVitals();
 
@@ -555,6 +566,8 @@ public partial class Player : Entity
             return;
         }
 
+        ClearPets(true);
+
         Guild?.NotifyPlayerDisposed(this);
 
         base.Dispose();
@@ -641,6 +654,8 @@ public partial class Player : Entity
         }
 
         SpawnedNpcs.Clear();
+
+        ClearPets(true);
 
         lock (mEventLock)
         {
@@ -804,6 +819,8 @@ public partial class Player : Entity
             Monitor.TryEnter(EntityLock, ref lockObtained);
             if (lockObtained)
             {
+                UpdatePetState(timeMs);
+
                 if (Client == null) //Client logged out
                 {
                     if (CombatTimer < Timing.Global.Milliseconds)
@@ -1090,6 +1107,143 @@ public partial class Player : Entity
             {
                 Monitor.Exit(EntityLock);
             }
+        }
+    }
+
+    private void UpdatePetState(long timeMs)
+    {
+        _ = timeMs;
+
+        CleanupSpawnedPetsList();
+
+        var activePet = ActivePet;
+        var descriptor = activePet?.Descriptor;
+        var currentPet = CurrentPet;
+
+        if (currentPet != null && currentPet.IsDisposed)
+        {
+            DespawnPet(currentPet);
+            currentPet = null;
+        }
+
+        if (descriptor == null)
+        {
+            if (currentPet != null)
+            {
+                DespawnPet(currentPet, false);
+            }
+
+            return;
+        }
+
+        if (currentPet != null && currentPet.Descriptor.Id != descriptor.Id)
+        {
+            DespawnPet(currentPet);
+            currentPet = null;
+        }
+
+        if (currentPet == null)
+        {
+            var newPet = new Pet(descriptor, this);
+            CurrentPet = newPet;
+
+            lock (_spawnedPetsLock)
+            {
+                SpawnedPets.Add(newPet);
+            }
+
+            return;
+        }
+
+        lock (_spawnedPetsLock)
+        {
+            if (!SpawnedPets.Contains(currentPet))
+            {
+                SpawnedPets.Add(currentPet);
+            }
+        }
+    }
+
+    private void DespawnPet(Pet? pet, bool killIfDespawnable = true)
+    {
+        if (pet == null)
+        {
+            return;
+        }
+
+        pet.Despawn(killIfDespawnable);
+
+        lock (_spawnedPetsLock)
+        {
+            SpawnedPets.Remove(pet);
+        }
+
+        if (ReferenceEquals(CurrentPet, pet))
+        {
+            CurrentPet = null;
+        }
+    }
+
+    private Pet[] GetActivePetsSnapshot()
+    {
+        var pets = new List<Pet>();
+
+        lock (_spawnedPetsLock)
+        {
+            foreach (var pet in SpawnedPets)
+            {
+                if (pet != null && !pet.IsDisposed)
+                {
+                    pets.Add(pet);
+                }
+            }
+        }
+
+        var currentPet = CurrentPet;
+        if (currentPet != null && !currentPet.IsDisposed && !pets.Contains(currentPet))
+        {
+            pets.Add(currentPet);
+        }
+
+        return pets.ToArray();
+    }
+
+    private void CleanupSpawnedPetsList()
+    {
+        lock (_spawnedPetsLock)
+        {
+            for (var index = SpawnedPets.Count - 1; index >= 0; index--)
+            {
+                var pet = SpawnedPets[index];
+                if (pet == null || pet.IsDisposed)
+                {
+                    SpawnedPets.RemoveAt(index);
+                }
+            }
+        }
+    }
+
+    private void ClearPets(bool killDespawnable)
+    {
+        var pets = GetActivePetsSnapshot();
+        foreach (var pet in pets)
+        {
+            DespawnPet(pet, killDespawnable);
+        }
+
+        lock (_spawnedPetsLock)
+        {
+            SpawnedPets.Clear();
+        }
+
+        CurrentPet = null;
+    }
+
+    private void NotifyPetsOfOwnerDamage()
+    {
+        foreach (var pet in GetActivePetsSnapshot())
+        {
+            pet.NotifyOwnerDamaged();
         }
     }
 
@@ -1823,6 +1977,8 @@ public partial class Player : Entity
             {
                 EnqueueStartCommonEvent(trigger);
             }
+
+            NotifyPetsOfOwnerDamage();
         }
 
         base.ReactToDamage(vital);


### PR DESCRIPTION
## Summary
- add transient pet tracking and locking to `Player`
- coordinate active pet spawning and cleanup during player updates, logout, and dispose
- extend `Pet` with despawn helpers and owner-damage notifications

## Testing
- `dotnet test Intersect.Tests.Server --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cc3f86d18c832b92f468383753c3a4