### PR TITLE
Handle pets in pathfinder blocking

### DIFF
--- a/Framework/Intersect.Framework.Core/Entities/EntityType.cs
+++ b/Framework/Intersect.Framework.Core/Entities/EntityType.cs
@@ -11,4 +11,6 @@ public enum EntityType
     Projectile = 3,
 
     Event = 4,
+
+    Pet = 5,
 }

--- a/Intersect.Server.Core/Entities/Pathfinding/Pathfinder.cs
+++ b/Intersect.Server.Core/Entities/Pathfinding/Pathfinder.cs
@@ -194,7 +194,7 @@ partial class Pathfinder
                                                 {
                                                     mapGrid[mx + en.X, my + en.Y].BlockType = en.GetEntityType() switch
                                                     {
-                                                        EntityType.GlobalEntity => PathNodeBlockType.Npc,
+                                                        EntityType.GlobalEntity or EntityType.Pet => PathNodeBlockType.Npc,
                                                         EntityType.Player => PathNodeBlockType.Player,
                                                         EntityType.Resource => PathNodeBlockType.Entity,
                                                         EntityType.Projectile => PathNodeBlockType.Entity,


### PR DESCRIPTION
## Summary
- extend the pathfinder entity-type switch to treat pets like NPCs when marking blocking nodes
- add a Pet value to the EntityType enum so pets can be identified separately

## Testing
- dotnet build Intersect.sln *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68cc61e8e88c832ba40568d349584d9b