### PR TITLE
Handle pet blockers during dashes

### DIFF
--- a/Intersect.Server.Core/Entities/Combat/Dash.cs
+++ b/Intersect.Server.Core/Entities/Combat/Dash.cs
@@ -117,6 +117,7 @@ public partial class Dash
                             case EntityType.Player:
                                 return;
 
+                            case EntityType.Pet:
                             case EntityType.GlobalEntity:
                             case EntityType.Projectile:
                                 break;

--- a/Intersect.Server.Core/Entities/Entity.cs
+++ b/Intersect.Server.Core/Entities/Entity.cs
@@ -610,6 +610,11 @@ public abstract partial class Entity : IEntity
                     entityType = EntityType.Player;
                     blockingEntity = mapEntity;
                     return false;
+                case Pet pet when !pet.Passable:
+                    blockerType = MovementBlockerType.Entity;
+                    entityType = EntityType.Pet;
+                    blockingEntity = mapEntity;
+                    return false;
                 case Resource resource when !resource.IsPassable():
                     blockerType = MovementBlockerType.Entity;
                     entityType = EntityType.Resource;


### PR DESCRIPTION
## Summary
- prevent dash calculations from throwing when a pet blocks movement by treating pets like other non-blocking entities
- report pets as `EntityType.Pet` from movement checks so dash handling can differentiate them

## Testing
- `dotnet test Intersect.Tests.Server/Intersect.Tests.Server.csproj` *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc667c2984832b8cefdc5e6e891bfc