### PR TITLE
Add pet editor form and menu integration

### DIFF
--- a/Intersect.Editor/Forms/Editors/frmPet.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/frmPet.Designer.cs
@@ -1,0 +1,1074 @@
+using DarkUI.Controls;
+
+namespace Intersect.Editor.Forms.Editors
+{
+    partial class FrmPet
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            components = new System.ComponentModel.Container();
+            var resources = new System.ComponentModel.ComponentResourceManager(typeof(FrmPet));
+            toolStrip = new DarkToolStrip();
+            toolStripItemNew = new System.Windows.Forms.ToolStripButton();
+            toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
+            toolStripItemDelete = new System.Windows.Forms.ToolStripButton();
+            toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
+            btnAlphabetical = new System.Windows.Forms.ToolStripButton();
+            toolStripSeparator4 = new System.Windows.Forms.ToolStripSeparator();
+            toolStripItemCopy = new System.Windows.Forms.ToolStripButton();
+            toolStripItemPaste = new System.Windows.Forms.ToolStripButton();
+            toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
+            toolStripItemUndo = new System.Windows.Forms.ToolStripButton();
+            grpPets = new DarkGroupBox();
+            btnClearSearch = new DarkButton();
+            txtSearch = new DarkTextBox();
+            lstGameObjects = new Intersect.Editor.Forms.Controls.GameObjectList();
+            pnlContainer = new System.Windows.Forms.Panel();
+            grpImmunities = new DarkGroupBox();
+            flpImmunities = new System.Windows.Forms.FlowLayoutPanel();
+            lblTenacity = new System.Windows.Forms.Label();
+            nudTenacity = new DarkNumericUpDown();
+            grpSpells = new DarkGroupBox();
+            cmbSpell = new DarkComboBox();
+            btnRemoveSpell = new DarkButton();
+            btnAddSpell = new DarkButton();
+            lstSpells = new System.Windows.Forms.ListBox();
+            grpCombat = new DarkGroupBox();
+            nudAttackSpeedValue = new DarkNumericUpDown();
+            lblAttackSpeedValue = new System.Windows.Forms.Label();
+            cmbAttackSpeedModifier = new DarkComboBox();
+            lblAttackSpeedModifier = new System.Windows.Forms.Label();
+            lblCritMultiplier = new System.Windows.Forms.Label();
+            nudCritMultiplier = new DarkNumericUpDown();
+            lblCritChance = new System.Windows.Forms.Label();
+            nudCritChance = new DarkNumericUpDown();
+            lblDamage = new System.Windows.Forms.Label();
+            nudDamage = new DarkNumericUpDown();
+            lblScaling = new System.Windows.Forms.Label();
+            nudScaling = new DarkNumericUpDown();
+            lblScalingStat = new System.Windows.Forms.Label();
+            cmbScalingStat = new DarkComboBox();
+            lblDamageType = new System.Windows.Forms.Label();
+            cmbDamageType = new DarkComboBox();
+            lblAttackAnimation = new System.Windows.Forms.Label();
+            cmbAttackAnimation = new DarkComboBox();
+            lblDeathAnimation = new System.Windows.Forms.Label();
+            cmbDeathAnimation = new DarkComboBox();
+            lblIdleAnimation = new System.Windows.Forms.Label();
+            cmbIdleAnimation = new DarkComboBox();
+            grpVitals = new DarkGroupBox();
+            flpVitals = new System.Windows.Forms.FlowLayoutPanel();
+            flpVitalRegen = new System.Windows.Forms.FlowLayoutPanel();
+            lblVitals = new System.Windows.Forms.Label();
+            lblVitalRegen = new System.Windows.Forms.Label();
+            grpStats = new DarkGroupBox();
+            flpStats = new System.Windows.Forms.FlowLayoutPanel();
+            grpGeneral = new DarkGroupBox();
+            lblExperience = new System.Windows.Forms.Label();
+            nudExperience = new DarkNumericUpDown();
+            lblLevel = new System.Windows.Forms.Label();
+            nudLevel = new DarkNumericUpDown();
+            lblIdleSprite = new System.Windows.Forms.Label();
+            cmbSprite = new DarkComboBox();
+            btnAddFolder = new DarkButton();
+            lblFolder = new System.Windows.Forms.Label();
+            cmbFolder = new DarkComboBox();
+            lblName = new System.Windows.Forms.Label();
+            txtName = new DarkTextBox();
+            btnSave = new DarkButton();
+            btnCancel = new DarkButton();
+            toolStrip.SuspendLayout();
+            grpPets.SuspendLayout();
+            pnlContainer.SuspendLayout();
+            grpImmunities.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)nudTenacity).BeginInit();
+            grpSpells.SuspendLayout();
+            grpCombat.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)nudAttackSpeedValue).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)nudCritMultiplier).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)nudCritChance).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)nudDamage).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)nudScaling).BeginInit();
+            grpVitals.SuspendLayout();
+            grpStats.SuspendLayout();
+            grpGeneral.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)nudExperience).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)nudLevel).BeginInit();
+            SuspendLayout();
+            // 
+            // toolStrip
+            // 
+            toolStrip.AutoSize = false;
+            toolStrip.BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
+            toolStrip.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { toolStripItemNew, toolStripSeparator1, toolStripItemDelete, toolStripSeparator2, btnAlphabetical, toolStripSeparator4, toolStripItemCopy, toolStripItemPaste, toolStripSeparator3, toolStripItemUndo });
+            toolStrip.Location = new System.Drawing.Point(0, 0);
+            toolStrip.Name = "toolStrip";
+            toolStrip.Padding = new System.Windows.Forms.Padding(6, 0, 1, 0);
+            toolStrip.Size = new System.Drawing.Size(1244, 29);
+            toolStrip.TabIndex = 0;
+            toolStrip.Text = "toolStrip1";
+            // 
+            // toolStripItemNew
+            // 
+            toolStripItemNew.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            toolStripItemNew.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripItemNew.Image = (System.Drawing.Image)resources.GetObject("toolStripItemNew.Image");
+            toolStripItemNew.ImageTransparentColor = System.Drawing.Color.Magenta;
+            toolStripItemNew.Name = "toolStripItemNew";
+            toolStripItemNew.Size = new System.Drawing.Size(23, 26);
+            toolStripItemNew.Text = "New";
+            toolStripItemNew.Click += toolStripItemNew_Click;
+            // 
+            // toolStripSeparator1
+            // 
+            toolStripSeparator1.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripSeparator1.Margin = new System.Windows.Forms.Padding(0, 0, 2, 0);
+            toolStripSeparator1.Name = "toolStripSeparator1";
+            toolStripSeparator1.Size = new System.Drawing.Size(6, 29);
+            // 
+            // toolStripItemDelete
+            // 
+            toolStripItemDelete.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            toolStripItemDelete.Enabled = false;
+            toolStripItemDelete.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripItemDelete.Image = (System.Drawing.Image)resources.GetObject("toolStripItemDelete.Image");
+            toolStripItemDelete.ImageTransparentColor = System.Drawing.Color.Magenta;
+            toolStripItemDelete.Name = "toolStripItemDelete";
+            toolStripItemDelete.Size = new System.Drawing.Size(23, 26);
+            toolStripItemDelete.Text = "Delete";
+            toolStripItemDelete.Click += toolStripItemDelete_Click;
+            // 
+            // toolStripSeparator2
+            // 
+            toolStripSeparator2.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripSeparator2.Margin = new System.Windows.Forms.Padding(0, 0, 2, 0);
+            toolStripSeparator2.Name = "toolStripSeparator2";
+            toolStripSeparator2.Size = new System.Drawing.Size(6, 29);
+            // 
+            // btnAlphabetical
+            // 
+            btnAlphabetical.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            btnAlphabetical.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            btnAlphabetical.Image = (System.Drawing.Image)resources.GetObject("btnAlphabetical.Image");
+            btnAlphabetical.ImageTransparentColor = System.Drawing.Color.Magenta;
+            btnAlphabetical.Name = "btnAlphabetical";
+            btnAlphabetical.Size = new System.Drawing.Size(23, 26);
+            btnAlphabetical.Text = "Order Alphabetically";
+            btnAlphabetical.Click += btnAlphabetical_Click;
+            // 
+            // toolStripSeparator4
+            // 
+            toolStripSeparator4.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripSeparator4.Margin = new System.Windows.Forms.Padding(0, 0, 2, 0);
+            toolStripSeparator4.Name = "toolStripSeparator4";
+            toolStripSeparator4.Size = new System.Drawing.Size(6, 29);
+            // 
+            // toolStripItemCopy
+            // 
+            toolStripItemCopy.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            toolStripItemCopy.Enabled = false;
+            toolStripItemCopy.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripItemCopy.Image = (System.Drawing.Image)resources.GetObject("toolStripItemCopy.Image");
+            toolStripItemCopy.ImageTransparentColor = System.Drawing.Color.Magenta;
+            toolStripItemCopy.Name = "toolStripItemCopy";
+            toolStripItemCopy.Size = new System.Drawing.Size(23, 26);
+            toolStripItemCopy.Text = "Copy";
+            toolStripItemCopy.Click += toolStripItemCopy_Click;
+            // 
+            // toolStripItemPaste
+            // 
+            toolStripItemPaste.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            toolStripItemPaste.Enabled = false;
+            toolStripItemPaste.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripItemPaste.Image = (System.Drawing.Image)resources.GetObject("toolStripItemPaste.Image");
+            toolStripItemPaste.ImageTransparentColor = System.Drawing.Color.Magenta;
+            toolStripItemPaste.Name = "toolStripItemPaste";
+            toolStripItemPaste.Size = new System.Drawing.Size(23, 26);
+            toolStripItemPaste.Text = "Paste";
+            toolStripItemPaste.Click += toolStripItemPaste_Click;
+            // 
+            // toolStripSeparator3
+            // 
+            toolStripSeparator3.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripSeparator3.Margin = new System.Windows.Forms.Padding(0, 0, 2, 0);
+            toolStripSeparator3.Name = "toolStripSeparator3";
+            toolStripSeparator3.Size = new System.Drawing.Size(6, 29);
+            // 
+            // toolStripItemUndo
+            // 
+            toolStripItemUndo.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            toolStripItemUndo.Enabled = false;
+            toolStripItemUndo.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripItemUndo.Image = (System.Drawing.Image)resources.GetObject("toolStripItemUndo.Image");
+            toolStripItemUndo.ImageTransparentColor = System.Drawing.Color.Magenta;
+            toolStripItemUndo.Name = "toolStripItemUndo";
+            toolStripItemUndo.Size = new System.Drawing.Size(23, 26);
+            toolStripItemUndo.Text = "Undo";
+            toolStripItemUndo.Click += toolStripItemUndo_Click;
+            // 
+            // grpPets
+            // 
+            grpPets.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left)));
+            grpPets.BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
+            grpPets.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            grpPets.Controls.Add(btnClearSearch);
+            grpPets.Controls.Add(txtSearch);
+            grpPets.Controls.Add(lstGameObjects);
+            grpPets.ForeColor = System.Drawing.Color.Gainsboro;
+            grpPets.Location = new System.Drawing.Point(12, 44);
+            grpPets.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            grpPets.Name = "grpPets";
+            grpPets.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            grpPets.Size = new System.Drawing.Size(300, 653);
+            grpPets.TabIndex = 1;
+            grpPets.TabStop = false;
+            grpPets.Text = "Pets";
+            // 
+            // btnClearSearch
+            // 
+            btnClearSearch.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            btnClearSearch.Location = new System.Drawing.Point(236, 22);
+            btnClearSearch.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            btnClearSearch.Name = "btnClearSearch";
+            btnClearSearch.Padding = new System.Windows.Forms.Padding(6);
+            btnClearSearch.Size = new System.Drawing.Size(60, 27);
+            btnClearSearch.TabIndex = 2;
+            btnClearSearch.Text = "X";
+            btnClearSearch.Click += btnClearSearch_Click;
+            // 
+            // txtSearch
+            // 
+            txtSearch.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            txtSearch.Location = new System.Drawing.Point(9, 24);
+            txtSearch.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            txtSearch.Name = "txtSearch";
+            txtSearch.Size = new System.Drawing.Size(219, 23);
+            txtSearch.TabIndex = 1;
+            txtSearch.TextChanged += txtSearch_TextChanged;
+            txtSearch.Enter += txtSearch_Enter;
+            txtSearch.Leave += txtSearch_Leave;
+            // 
+            // lstGameObjects
+            // 
+            lstGameObjects.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            lstGameObjects.Location = new System.Drawing.Point(9, 58);
+            lstGameObjects.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            lstGameObjects.Name = "lstGameObjects";
+            lstGameObjects.Size = new System.Drawing.Size(279, 582);
+            lstGameObjects.TabIndex = 0;
+            // 
+            // pnlContainer
+            // 
+            pnlContainer.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            pnlContainer.Controls.Add(grpImmunities);
+            pnlContainer.Controls.Add(grpSpells);
+            pnlContainer.Controls.Add(grpCombat);
+            pnlContainer.Controls.Add(grpVitals);
+            pnlContainer.Controls.Add(grpStats);
+            pnlContainer.Controls.Add(grpGeneral);
+            pnlContainer.Location = new System.Drawing.Point(320, 44);
+            pnlContainer.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            pnlContainer.Name = "pnlContainer";
+            pnlContainer.Size = new System.Drawing.Size(912, 592);
+            pnlContainer.TabIndex = 2;
+            // 
+            // grpImmunities
+            // 
+            grpImmunities.BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
+            grpImmunities.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            grpImmunities.Controls.Add(flpImmunities);
+            grpImmunities.Controls.Add(lblTenacity);
+            grpImmunities.Controls.Add(nudTenacity);
+            grpImmunities.ForeColor = System.Drawing.Color.Gainsboro;
+            grpImmunities.Location = new System.Drawing.Point(458, 302);
+            grpImmunities.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            grpImmunities.Name = "grpImmunities";
+            grpImmunities.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            grpImmunities.Size = new System.Drawing.Size(440, 179);
+            grpImmunities.TabIndex = 5;
+            grpImmunities.TabStop = false;
+            grpImmunities.Text = "Immunities";
+            // 
+            // flpImmunities
+            // 
+            flpImmunities.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            flpImmunities.AutoScroll = true;
+            flpImmunities.Location = new System.Drawing.Point(10, 22);
+            flpImmunities.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            flpImmunities.Name = "flpImmunities";
+            flpImmunities.Size = new System.Drawing.Size(422, 108);
+            flpImmunities.TabIndex = 1;
+            // 
+            // lblTenacity
+            // 
+            lblTenacity.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            lblTenacity.AutoSize = true;
+            lblTenacity.Location = new System.Drawing.Point(7, 139);
+            lblTenacity.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            lblTenacity.Name = "lblTenacity";
+            lblTenacity.Size = new System.Drawing.Size(59, 15);
+            lblTenacity.TabIndex = 2;
+            lblTenacity.Text = "Tenacity";
+            // 
+            // nudTenacity
+            // 
+            nudTenacity.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            nudTenacity.DecimalPlaces = 2;
+            nudTenacity.Location = new System.Drawing.Point(10, 157);
+            nudTenacity.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            nudTenacity.Maximum = new decimal(new int[] { 100, 0, 0, 0 });
+            nudTenacity.Name = "nudTenacity";
+            nudTenacity.Size = new System.Drawing.Size(154, 23);
+            nudTenacity.TabIndex = 0;
+            nudTenacity.ValueChanged += nudTenacity_ValueChanged;
+            // 
+            // grpSpells
+            // 
+            grpSpells.BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
+            grpSpells.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            grpSpells.Controls.Add(cmbSpell);
+            grpSpells.Controls.Add(btnRemoveSpell);
+            grpSpells.Controls.Add(btnAddSpell);
+            grpSpells.Controls.Add(lstSpells);
+            grpSpells.ForeColor = System.Drawing.Color.Gainsboro;
+            grpSpells.Location = new System.Drawing.Point(458, 16);
+            grpSpells.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            grpSpells.Name = "grpSpells";
+            grpSpells.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            grpSpells.Size = new System.Drawing.Size(440, 272);
+            grpSpells.TabIndex = 4;
+            grpSpells.TabStop = false;
+            grpSpells.Text = "Spells";
+            // 
+            // cmbSpell
+            // 
+            cmbSpell.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            cmbSpell.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
+            cmbSpell.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            cmbSpell.FormattingEnabled = true;
+            cmbSpell.Location = new System.Drawing.Point(10, 209);
+            cmbSpell.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            cmbSpell.Name = "cmbSpell";
+            cmbSpell.Size = new System.Drawing.Size(420, 24);
+            cmbSpell.TabIndex = 3;
+            cmbSpell.SelectedIndexChanged += cmbSpell_SelectedIndexChanged;
+            // 
+            // btnRemoveSpell
+            // 
+            btnRemoveSpell.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            btnRemoveSpell.Location = new System.Drawing.Point(340, 237);
+            btnRemoveSpell.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            btnRemoveSpell.Name = "btnRemoveSpell";
+            btnRemoveSpell.Padding = new System.Windows.Forms.Padding(6);
+            btnRemoveSpell.Size = new System.Drawing.Size(90, 27);
+            btnRemoveSpell.TabIndex = 2;
+            btnRemoveSpell.Text = "Remove";
+            btnRemoveSpell.Click += btnRemoveSpell_Click;
+            // 
+            // btnAddSpell
+            // 
+            btnAddSpell.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            btnAddSpell.Location = new System.Drawing.Point(10, 237);
+            btnAddSpell.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            btnAddSpell.Name = "btnAddSpell";
+            btnAddSpell.Padding = new System.Windows.Forms.Padding(6);
+            btnAddSpell.Size = new System.Drawing.Size(90, 27);
+            btnAddSpell.TabIndex = 1;
+            btnAddSpell.Text = "Add";
+            btnAddSpell.Click += btnAddSpell_Click;
+            // 
+            // lstSpells
+            // 
+            lstSpells.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            lstSpells.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            lstSpells.FormattingEnabled = true;
+            lstSpells.ItemHeight = 15;
+            lstSpells.Location = new System.Drawing.Point(10, 22);
+            lstSpells.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            lstSpells.Name = "lstSpells";
+            lstSpells.Size = new System.Drawing.Size(420, 182);
+            lstSpells.TabIndex = 0;
+            lstSpells.SelectedIndexChanged += lstSpells_SelectedIndexChanged;
+            // 
+            // grpCombat
+            // 
+            grpCombat.BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
+            grpCombat.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            grpCombat.Controls.Add(nudAttackSpeedValue);
+            grpCombat.Controls.Add(lblAttackSpeedValue);
+            grpCombat.Controls.Add(cmbAttackSpeedModifier);
+            grpCombat.Controls.Add(lblAttackSpeedModifier);
+            grpCombat.Controls.Add(lblCritMultiplier);
+            grpCombat.Controls.Add(nudCritMultiplier);
+            grpCombat.Controls.Add(lblCritChance);
+            grpCombat.Controls.Add(nudCritChance);
+            grpCombat.Controls.Add(lblDamage);
+            grpCombat.Controls.Add(nudDamage);
+            grpCombat.Controls.Add(lblScaling);
+            grpCombat.Controls.Add(nudScaling);
+            grpCombat.Controls.Add(lblScalingStat);
+            grpCombat.Controls.Add(cmbScalingStat);
+            grpCombat.Controls.Add(lblDamageType);
+            grpCombat.Controls.Add(cmbDamageType);
+            grpCombat.Controls.Add(lblAttackAnimation);
+            grpCombat.Controls.Add(cmbAttackAnimation);
+            grpCombat.Controls.Add(lblDeathAnimation);
+            grpCombat.Controls.Add(cmbDeathAnimation);
+            grpCombat.Controls.Add(lblIdleAnimation);
+            grpCombat.Controls.Add(cmbIdleAnimation);
+            grpCombat.ForeColor = System.Drawing.Color.Gainsboro;
+            grpCombat.Location = new System.Drawing.Point(10, 330);
+            grpCombat.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            grpCombat.Name = "grpCombat";
+            grpCombat.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            grpCombat.Size = new System.Drawing.Size(440, 260);
+            grpCombat.TabIndex = 3;
+            grpCombat.TabStop = false;
+            grpCombat.Text = "Combat";
+            // 
+            // nudAttackSpeedValue
+            // 
+            nudAttackSpeedValue.Location = new System.Drawing.Point(221, 234);
+            nudAttackSpeedValue.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            nudAttackSpeedValue.Maximum = new decimal(new int[] { 100000, 0, 0, 0 });
+            nudAttackSpeedValue.Name = "nudAttackSpeedValue";
+            nudAttackSpeedValue.Size = new System.Drawing.Size(203, 23);
+            nudAttackSpeedValue.TabIndex = 21;
+            nudAttackSpeedValue.ValueChanged += nudAttackSpeedValue_ValueChanged;
+            // 
+            // lblAttackSpeedValue
+            // 
+            lblAttackSpeedValue.AutoSize = true;
+            lblAttackSpeedValue.Location = new System.Drawing.Point(218, 216);
+            lblAttackSpeedValue.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            lblAttackSpeedValue.Name = "lblAttackSpeedValue";
+            lblAttackSpeedValue.Size = new System.Drawing.Size(36, 15);
+            lblAttackSpeedValue.TabIndex = 20;
+            lblAttackSpeedValue.Text = "Value";
+            // 
+            // cmbAttackSpeedModifier
+            // 
+            cmbAttackSpeedModifier.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
+            cmbAttackSpeedModifier.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            cmbAttackSpeedModifier.FormattingEnabled = true;
+            cmbAttackSpeedModifier.Location = new System.Drawing.Point(10, 234);
+            cmbAttackSpeedModifier.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            cmbAttackSpeedModifier.Name = "cmbAttackSpeedModifier";
+            cmbAttackSpeedModifier.Size = new System.Drawing.Size(203, 24);
+            cmbAttackSpeedModifier.TabIndex = 19;
+            cmbAttackSpeedModifier.SelectedIndexChanged += cmbAttackSpeedModifier_SelectedIndexChanged;
+            // 
+            // lblAttackSpeedModifier
+            // 
+            lblAttackSpeedModifier.AutoSize = true;
+            lblAttackSpeedModifier.Location = new System.Drawing.Point(7, 216);
+            lblAttackSpeedModifier.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            lblAttackSpeedModifier.Name = "lblAttackSpeedModifier";
+            lblAttackSpeedModifier.Size = new System.Drawing.Size(57, 15);
+            lblAttackSpeedModifier.TabIndex = 18;
+            lblAttackSpeedModifier.Text = "Modifier";
+            // 
+            // lblCritMultiplier
+            // 
+            lblCritMultiplier.AutoSize = true;
+            lblCritMultiplier.Location = new System.Drawing.Point(218, 165);
+            lblCritMultiplier.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            lblCritMultiplier.Name = "lblCritMultiplier";
+            lblCritMultiplier.Size = new System.Drawing.Size(83, 15);
+            lblCritMultiplier.TabIndex = 17;
+            lblCritMultiplier.Text = "Crit Multiplier";
+            // 
+            // nudCritMultiplier
+            // 
+            nudCritMultiplier.DecimalPlaces = 2;
+            nudCritMultiplier.Location = new System.Drawing.Point(221, 183);
+            nudCritMultiplier.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            nudCritMultiplier.Maximum = new decimal(new int[] { 100, 0, 0, 0 });
+            nudCritMultiplier.Minimum = new decimal(new int[] { 1, 0, 0, 65536 });
+            nudCritMultiplier.Name = "nudCritMultiplier";
+            nudCritMultiplier.Size = new System.Drawing.Size(203, 23);
+            nudCritMultiplier.TabIndex = 16;
+            nudCritMultiplier.Value = new decimal(new int[] { 15, 0, 0, 65536 });
+            nudCritMultiplier.ValueChanged += nudCritMultiplier_ValueChanged;
+            // 
+            // lblCritChance
+            // 
+            lblCritChance.AutoSize = true;
+            lblCritChance.Location = new System.Drawing.Point(7, 165);
+            lblCritChance.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            lblCritChance.Name = "lblCritChance";
+            lblCritChance.Size = new System.Drawing.Size(68, 15);
+            lblCritChance.TabIndex = 15;
+            lblCritChance.Text = "Crit Chance";
+            // 
+            // nudCritChance
+            // 
+            nudCritChance.Location = new System.Drawing.Point(10, 183);
+            nudCritChance.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            nudCritChance.Maximum = new decimal(new int[] { 100, 0, 0, 0 });
+            nudCritChance.Name = "nudCritChance";
+            nudCritChance.Size = new System.Drawing.Size(203, 23);
+            nudCritChance.TabIndex = 14;
+            nudCritChance.ValueChanged += nudCritChance_ValueChanged;
+            // 
+            // lblDamage
+            // 
+            lblDamage.AutoSize = true;
+            lblDamage.Location = new System.Drawing.Point(218, 118);
+            lblDamage.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            lblDamage.Name = "lblDamage";
+            lblDamage.Size = new System.Drawing.Size(51, 15);
+            lblDamage.TabIndex = 13;
+            lblDamage.Text = "Damage";
+            // 
+            // nudDamage
+            // 
+            nudDamage.Location = new System.Drawing.Point(221, 136);
+            nudDamage.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            nudDamage.Maximum = new decimal(new int[] { 100000, 0, 0, 0 });
+            nudDamage.Name = "nudDamage";
+            nudDamage.Size = new System.Drawing.Size(203, 23);
+            nudDamage.TabIndex = 12;
+            nudDamage.ValueChanged += nudDamage_ValueChanged;
+            // 
+            // lblScaling
+            // 
+            lblScaling.AutoSize = true;
+            lblScaling.Location = new System.Drawing.Point(7, 118);
+            lblScaling.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            lblScaling.Name = "lblScaling";
+            lblScaling.Size = new System.Drawing.Size(45, 15);
+            lblScaling.TabIndex = 11;
+            lblScaling.Text = "Scaling";
+            // 
+            // nudScaling
+            // 
+            nudScaling.Location = new System.Drawing.Point(10, 136);
+            nudScaling.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            nudScaling.Maximum = new decimal(new int[] { 1000, 0, 0, 0 });
+            nudScaling.Minimum = new decimal(new int[] { 1, 0, 0, 0 });
+            nudScaling.Name = "nudScaling";
+            nudScaling.Size = new System.Drawing.Size(203, 23);
+            nudScaling.TabIndex = 10;
+            nudScaling.Value = new decimal(new int[] { 100, 0, 0, 0 });
+            nudScaling.ValueChanged += nudScaling_ValueChanged;
+            // 
+            // lblScalingStat
+            // 
+            lblScalingStat.AutoSize = true;
+            lblScalingStat.Location = new System.Drawing.Point(218, 70);
+            lblScalingStat.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            lblScalingStat.Name = "lblScalingStat";
+            lblScalingStat.Size = new System.Drawing.Size(70, 15);
+            lblScalingStat.TabIndex = 9;
+            lblScalingStat.Text = "Scaling Stat";
+            // 
+            // cmbScalingStat
+            // 
+            cmbScalingStat.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
+            cmbScalingStat.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            cmbScalingStat.FormattingEnabled = true;
+            cmbScalingStat.Location = new System.Drawing.Point(221, 88);
+            cmbScalingStat.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            cmbScalingStat.Name = "cmbScalingStat";
+            cmbScalingStat.Size = new System.Drawing.Size(203, 24);
+            cmbScalingStat.TabIndex = 8;
+            cmbScalingStat.SelectedIndexChanged += cmbScalingStat_SelectedIndexChanged;
+            // 
+            // lblDamageType
+            // 
+            lblDamageType.AutoSize = true;
+            lblDamageType.Location = new System.Drawing.Point(7, 70);
+            lblDamageType.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            lblDamageType.Name = "lblDamageType";
+            lblDamageType.Size = new System.Drawing.Size(74, 15);
+            lblDamageType.TabIndex = 7;
+            lblDamageType.Text = "Damage Type";
+            // 
+            // cmbDamageType
+            // 
+            cmbDamageType.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
+            cmbDamageType.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            cmbDamageType.FormattingEnabled = true;
+            cmbDamageType.Location = new System.Drawing.Point(10, 88);
+            cmbDamageType.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            cmbDamageType.Name = "cmbDamageType";
+            cmbDamageType.Size = new System.Drawing.Size(203, 24);
+            cmbDamageType.TabIndex = 6;
+            cmbDamageType.SelectedIndexChanged += cmbDamageType_SelectedIndexChanged;
+            // 
+            // lblAttackAnimation
+            // 
+            lblAttackAnimation.AutoSize = true;
+            lblAttackAnimation.Location = new System.Drawing.Point(7, 22);
+            lblAttackAnimation.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            lblAttackAnimation.Name = "lblAttackAnimation";
+            lblAttackAnimation.Size = new System.Drawing.Size(99, 15);
+            lblAttackAnimation.TabIndex = 0;
+            lblAttackAnimation.Text = "Attack Animation";
+            // 
+            // cmbAttackAnimation
+            // 
+            cmbAttackAnimation.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
+            cmbAttackAnimation.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            cmbAttackAnimation.FormattingEnabled = true;
+            cmbAttackAnimation.Location = new System.Drawing.Point(10, 40);
+            cmbAttackAnimation.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            cmbAttackAnimation.Name = "cmbAttackAnimation";
+            cmbAttackAnimation.Size = new System.Drawing.Size(203, 24);
+            cmbAttackAnimation.TabIndex = 1;
+            cmbAttackAnimation.SelectedIndexChanged += cmbAttackAnimation_SelectedIndexChanged;
+            // 
+            // lblDeathAnimation
+            // 
+            lblDeathAnimation.AutoSize = true;
+            lblDeathAnimation.Location = new System.Drawing.Point(218, 22);
+            lblDeathAnimation.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            lblDeathAnimation.Name = "lblDeathAnimation";
+            lblDeathAnimation.Size = new System.Drawing.Size(95, 15);
+            lblDeathAnimation.TabIndex = 2;
+            lblDeathAnimation.Text = "Death Animation";
+            // 
+            // cmbDeathAnimation
+            // 
+            cmbDeathAnimation.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
+            cmbDeathAnimation.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            cmbDeathAnimation.FormattingEnabled = true;
+            cmbDeathAnimation.Location = new System.Drawing.Point(221, 40);
+            cmbDeathAnimation.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            cmbDeathAnimation.Name = "cmbDeathAnimation";
+            cmbDeathAnimation.Size = new System.Drawing.Size(203, 24);
+            cmbDeathAnimation.TabIndex = 3;
+            cmbDeathAnimation.SelectedIndexChanged += cmbDeathAnimation_SelectedIndexChanged;
+            // 
+            // lblIdleAnimation
+            // 
+            lblIdleAnimation.AutoSize = true;
+            lblIdleAnimation.Location = new System.Drawing.Point(7, 118);
+            lblIdleAnimation.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            lblIdleAnimation.Name = "lblIdleAnimation";
+            lblIdleAnimation.Size = new System.Drawing.Size(81, 15);
+            lblIdleAnimation.TabIndex = 4;
+            lblIdleAnimation.Text = "Idle Animation";
+            // 
+            // cmbIdleAnimation
+            // 
+            cmbIdleAnimation.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
+            cmbIdleAnimation.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            cmbIdleAnimation.FormattingEnabled = true;
+            cmbIdleAnimation.Location = new System.Drawing.Point(10, 136);
+            cmbIdleAnimation.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            cmbIdleAnimation.Name = "cmbIdleAnimation";
+            cmbIdleAnimation.Size = new System.Drawing.Size(203, 24);
+            cmbIdleAnimation.TabIndex = 5;
+            cmbIdleAnimation.SelectedIndexChanged += cmbIdleAnimation_SelectedIndexChanged;
+            // 
+            // grpVitals
+            // 
+            grpVitals.BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
+            grpVitals.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            grpVitals.Controls.Add(flpVitals);
+            grpVitals.Controls.Add(flpVitalRegen);
+            grpVitals.Controls.Add(lblVitals);
+            grpVitals.Controls.Add(lblVitalRegen);
+            grpVitals.ForeColor = System.Drawing.Color.Gainsboro;
+            grpVitals.Location = new System.Drawing.Point(10, 214);
+            grpVitals.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            grpVitals.Name = "grpVitals";
+            grpVitals.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            grpVitals.Size = new System.Drawing.Size(440, 148);
+            grpVitals.TabIndex = 2;
+            grpVitals.TabStop = false;
+            grpVitals.Text = "Vitals";
+            // 
+            // flpVitals
+            // 
+            flpVitals.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            flpVitals.AutoScroll = true;
+            flpVitals.Location = new System.Drawing.Point(10, 40);
+            flpVitals.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            flpVitals.Name = "flpVitals";
+            flpVitals.Size = new System.Drawing.Size(420, 46);
+            flpVitals.TabIndex = 0;
+            // 
+            // flpVitalRegen
+            // 
+            flpVitalRegen.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            flpVitalRegen.AutoScroll = true;
+            flpVitalRegen.Location = new System.Drawing.Point(10, 106);
+            flpVitalRegen.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            flpVitalRegen.Name = "flpVitalRegen";
+            flpVitalRegen.Size = new System.Drawing.Size(420, 33);
+            flpVitalRegen.TabIndex = 1;
+            // 
+            // lblVitals
+            // 
+            lblVitals.AutoSize = true;
+            lblVitals.Location = new System.Drawing.Point(7, 22);
+            lblVitals.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            lblVitals.Name = "lblVitals";
+            lblVitals.Size = new System.Drawing.Size(36, 15);
+            lblVitals.TabIndex = 2;
+            lblVitals.Text = "Max";
+            // 
+            // lblVitalRegen
+            // 
+            lblVitalRegen.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            lblVitalRegen.AutoSize = true;
+            lblVitalRegen.Location = new System.Drawing.Point(7, 88);
+            lblVitalRegen.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            lblVitalRegen.Name = "lblVitalRegen";
+            lblVitalRegen.Size = new System.Drawing.Size(66, 15);
+            lblVitalRegen.TabIndex = 3;
+            lblVitalRegen.Text = "Regeneration";
+            // 
+            // grpStats
+            // 
+            grpStats.BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
+            grpStats.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            grpStats.Controls.Add(flpStats);
+            grpStats.ForeColor = System.Drawing.Color.Gainsboro;
+            grpStats.Location = new System.Drawing.Point(10, 148);
+            grpStats.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            grpStats.Name = "grpStats";
+            grpStats.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            grpStats.Size = new System.Drawing.Size(440, 60);
+            grpStats.TabIndex = 1;
+            grpStats.TabStop = false;
+            grpStats.Text = "Stats";
+            // 
+            // flpStats
+            // 
+            flpStats.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            flpStats.AutoScroll = true;
+            flpStats.Location = new System.Drawing.Point(10, 22);
+            flpStats.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            flpStats.Name = "flpStats";
+            flpStats.Size = new System.Drawing.Size(420, 28);
+            flpStats.TabIndex = 0;
+            // 
+            // grpGeneral
+            // 
+            grpGeneral.BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
+            grpGeneral.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            grpGeneral.Controls.Add(lblExperience);
+            grpGeneral.Controls.Add(nudExperience);
+            grpGeneral.Controls.Add(lblLevel);
+            grpGeneral.Controls.Add(nudLevel);
+            grpGeneral.Controls.Add(lblIdleSprite);
+            grpGeneral.Controls.Add(cmbSprite);
+            grpGeneral.Controls.Add(btnAddFolder);
+            grpGeneral.Controls.Add(lblFolder);
+            grpGeneral.Controls.Add(cmbFolder);
+            grpGeneral.Controls.Add(lblName);
+            grpGeneral.Controls.Add(txtName);
+            grpGeneral.ForeColor = System.Drawing.Color.Gainsboro;
+            grpGeneral.Location = new System.Drawing.Point(10, 16);
+            grpGeneral.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            grpGeneral.Name = "grpGeneral";
+            grpGeneral.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            grpGeneral.Size = new System.Drawing.Size(440, 126);
+            grpGeneral.TabIndex = 0;
+            grpGeneral.TabStop = false;
+            grpGeneral.Text = "General";
+            // 
+            // lblExperience
+            // 
+            lblExperience.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            lblExperience.AutoSize = true;
+            lblExperience.Location = new System.Drawing.Point(216, 79);
+            lblExperience.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            lblExperience.Name = "lblExperience";
+            lblExperience.Size = new System.Drawing.Size(63, 15);
+            lblExperience.TabIndex = 10;
+            lblExperience.Text = "Experience";
+            // 
+            // nudExperience
+            // 
+            nudExperience.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            nudExperience.Location = new System.Drawing.Point(219, 97);
+            nudExperience.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            nudExperience.Maximum = new decimal(new int[] { 100000000, 0, 0, 0 });
+            nudExperience.Name = "nudExperience";
+            nudExperience.Size = new System.Drawing.Size(203, 23);
+            nudExperience.TabIndex = 9;
+            nudExperience.ValueChanged += nudExperience_ValueChanged;
+            // 
+            // lblLevel
+            // 
+            lblLevel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            lblLevel.AutoSize = true;
+            lblLevel.Location = new System.Drawing.Point(216, 31);
+            lblLevel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            lblLevel.Name = "lblLevel";
+            lblLevel.Size = new System.Drawing.Size(36, 15);
+            lblLevel.TabIndex = 6;
+            lblLevel.Text = "Level";
+            // 
+            // nudLevel
+            // 
+            nudLevel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            nudLevel.Location = new System.Drawing.Point(219, 49);
+            nudLevel.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            nudLevel.Maximum = new decimal(new int[] { 1000, 0, 0, 0 });
+            nudLevel.Minimum = new decimal(new int[] { 1, 0, 0, 0 });
+            nudLevel.Name = "nudLevel";
+            nudLevel.Size = new System.Drawing.Size(203, 23);
+            nudLevel.TabIndex = 5;
+            nudLevel.Value = new decimal(new int[] { 1, 0, 0, 0 });
+            nudLevel.ValueChanged += nudLevel_ValueChanged;
+            // 
+            // lblIdleSprite
+            // 
+            lblIdleSprite.AutoSize = true;
+            lblIdleSprite.Location = new System.Drawing.Point(7, 79);
+            lblIdleSprite.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            lblIdleSprite.Name = "lblIdleSprite";
+            lblIdleSprite.Size = new System.Drawing.Size(38, 15);
+            lblIdleSprite.TabIndex = 4;
+            lblIdleSprite.Text = "Sprite";
+            // 
+            // cmbSprite
+            // 
+            cmbSprite.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
+            cmbSprite.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            cmbSprite.FormattingEnabled = true;
+            cmbSprite.Location = new System.Drawing.Point(10, 97);
+            cmbSprite.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            cmbSprite.Name = "cmbSprite";
+            cmbSprite.Size = new System.Drawing.Size(203, 24);
+            cmbSprite.TabIndex = 3;
+            cmbSprite.SelectedIndexChanged += cmbSprite_SelectedIndexChanged;
+            // 
+            // btnAddFolder
+            // 
+            btnAddFolder.Location = new System.Drawing.Point(373, 23);
+            btnAddFolder.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            btnAddFolder.Name = "btnAddFolder";
+            btnAddFolder.Padding = new System.Windows.Forms.Padding(6);
+            btnAddFolder.Size = new System.Drawing.Size(49, 27);
+            btnAddFolder.TabIndex = 2;
+            btnAddFolder.Text = "+";
+            btnAddFolder.Click += btnAddFolder_Click;
+            // 
+            // lblFolder
+            // 
+            lblFolder.AutoSize = true;
+            lblFolder.Location = new System.Drawing.Point(216, 9);
+            lblFolder.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            lblFolder.Name = "lblFolder";
+            lblFolder.Size = new System.Drawing.Size(41, 15);
+            lblFolder.TabIndex = 7;
+            lblFolder.Text = "Folder";
+            // 
+            // cmbFolder
+            // 
+            cmbFolder.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
+            cmbFolder.FormattingEnabled = true;
+            cmbFolder.Location = new System.Drawing.Point(219, 27);
+            cmbFolder.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            cmbFolder.Name = "cmbFolder";
+            cmbFolder.Size = new System.Drawing.Size(146, 24);
+            cmbFolder.TabIndex = 1;
+            cmbFolder.SelectedIndexChanged += cmbFolder_SelectedIndexChanged;
+            // 
+            // lblName
+            // 
+            lblName.AutoSize = true;
+            lblName.Location = new System.Drawing.Point(7, 9);
+            lblName.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            lblName.Name = "lblName";
+            lblName.Size = new System.Drawing.Size(39, 15);
+            lblName.TabIndex = 0;
+            lblName.Text = "Name";
+            // 
+            // txtName
+            // 
+            txtName.Location = new System.Drawing.Point(10, 27);
+            txtName.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            txtName.Name = "txtName";
+            txtName.Size = new System.Drawing.Size(203, 23);
+            txtName.TabIndex = 0;
+            txtName.TextChanged += txtName_TextChanged;
+            // 
+            // btnSave
+            // 
+            btnSave.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            btnSave.Location = new System.Drawing.Point(1062, 642);
+            btnSave.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            btnSave.Name = "btnSave";
+            btnSave.Padding = new System.Windows.Forms.Padding(6);
+            btnSave.Size = new System.Drawing.Size(88, 27);
+            btnSave.TabIndex = 3;
+            btnSave.Text = "Save";
+            btnSave.Click += btnSave_Click;
+            // 
+            // btnCancel
+            // 
+            btnCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            btnCancel.Location = new System.Drawing.Point(964, 642);
+            btnCancel.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            btnCancel.Name = "btnCancel";
+            btnCancel.Padding = new System.Windows.Forms.Padding(6);
+            btnCancel.Size = new System.Drawing.Size(88, 27);
+            btnCancel.TabIndex = 4;
+            btnCancel.Text = "Cancel";
+            btnCancel.Click += btnCancel_Click;
+            // 
+            // FrmPet
+            // 
+            AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+            AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            ClientSize = new System.Drawing.Size(1244, 709);
+            Controls.Add(btnCancel);
+            Controls.Add(btnSave);
+            Controls.Add(pnlContainer);
+            Controls.Add(grpPets);
+            Controls.Add(toolStrip);
+            KeyPreview = true;
+            Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            Name = "FrmPet";
+            StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            Text = "Pet Editor";
+            Load += frmPet_Load;
+            FormClosed += frmPet_FormClosed;
+            KeyDown += form_KeyDown;
+            toolStrip.ResumeLayout(false);
+            toolStrip.PerformLayout();
+            grpPets.ResumeLayout(false);
+            grpPets.PerformLayout();
+            pnlContainer.ResumeLayout(false);
+            grpImmunities.ResumeLayout(false);
+            grpImmunities.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)nudTenacity).EndInit();
+            grpSpells.ResumeLayout(false);
+            grpCombat.ResumeLayout(false);
+            grpCombat.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)nudAttackSpeedValue).EndInit();
+            ((System.ComponentModel.ISupportInitialize)nudCritMultiplier).EndInit();
+            ((System.ComponentModel.ISupportInitialize)nudCritChance).EndInit();
+            ((System.ComponentModel.ISupportInitialize)nudDamage).EndInit();
+            ((System.ComponentModel.ISupportInitialize)nudScaling).EndInit();
+            grpVitals.ResumeLayout(false);
+            grpVitals.PerformLayout();
+            grpStats.ResumeLayout(false);
+            grpGeneral.ResumeLayout(false);
+            grpGeneral.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)nudExperience).EndInit();
+            ((System.ComponentModel.ISupportInitialize)nudLevel).EndInit();
+            ResumeLayout(false);
+        }
+
+        #endregion
+
+        private DarkToolStrip toolStrip;
+        private System.Windows.Forms.ToolStripButton toolStripItemNew;
+        private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
+        private System.Windows.Forms.ToolStripButton toolStripItemDelete;
+        private System.Windows.Forms.ToolStripSeparator toolStripSeparator2;
+        private System.Windows.Forms.ToolStripButton btnAlphabetical;
+        private System.Windows.Forms.ToolStripSeparator toolStripSeparator4;
+        private System.Windows.Forms.ToolStripButton toolStripItemCopy;
+        private System.Windows.Forms.ToolStripButton toolStripItemPaste;
+        private System.Windows.Forms.ToolStripSeparator toolStripSeparator3;
+        private System.Windows.Forms.ToolStripButton toolStripItemUndo;
+        private DarkGroupBox grpPets;
+        private DarkButton btnClearSearch;
+        private DarkTextBox txtSearch;
+        private Intersect.Editor.Forms.Controls.GameObjectList lstGameObjects;
+        private System.Windows.Forms.Panel pnlContainer;
+        private DarkGroupBox grpGeneral;
+        private DarkGroupBox grpStats;
+        private System.Windows.Forms.FlowLayoutPanel flpStats;
+        private DarkGroupBox grpVitals;
+        private System.Windows.Forms.FlowLayoutPanel flpVitals;
+        private System.Windows.Forms.FlowLayoutPanel flpVitalRegen;
+        private System.Windows.Forms.Label lblVitals;
+        private System.Windows.Forms.Label lblVitalRegen;
+        private DarkGroupBox grpCombat;
+        private System.Windows.Forms.Label lblAttackAnimation;
+        private DarkComboBox cmbAttackAnimation;
+        private System.Windows.Forms.Label lblDeathAnimation;
+        private DarkComboBox cmbDeathAnimation;
+        private System.Windows.Forms.Label lblIdleAnimation;
+        private DarkComboBox cmbIdleAnimation;
+        private System.Windows.Forms.Label lblDamageType;
+        private DarkComboBox cmbDamageType;
+        private System.Windows.Forms.Label lblScalingStat;
+        private DarkComboBox cmbScalingStat;
+        private System.Windows.Forms.Label lblScaling;
+        private DarkNumericUpDown nudScaling;
+        private System.Windows.Forms.Label lblDamage;
+        private DarkNumericUpDown nudDamage;
+        private System.Windows.Forms.Label lblCritChance;
+        private DarkNumericUpDown nudCritChance;
+        private System.Windows.Forms.Label lblCritMultiplier;
+        private DarkNumericUpDown nudCritMultiplier;
+        private System.Windows.Forms.Label lblAttackSpeedModifier;
+        private DarkComboBox cmbAttackSpeedModifier;
+        private System.Windows.Forms.Label lblAttackSpeedValue;
+        private DarkNumericUpDown nudAttackSpeedValue;
+        private DarkGroupBox grpSpells;
+        private DarkComboBox cmbSpell;
+        private DarkButton btnRemoveSpell;
+        private DarkButton btnAddSpell;
+        private System.Windows.Forms.ListBox lstSpells;
+        private DarkGroupBox grpImmunities;
+        private System.Windows.Forms.FlowLayoutPanel flpImmunities;
+        private System.Windows.Forms.Label lblTenacity;
+        private DarkNumericUpDown nudTenacity;
+        private DarkButton btnSave;
+        private DarkButton btnCancel;
+        private System.Windows.Forms.Label lblName;
+        private DarkTextBox txtName;
+        private System.Windows.Forms.Label lblFolder;
+        private DarkComboBox cmbFolder;
+        private DarkButton btnAddFolder;
+        private System.Windows.Forms.Label lblIdleSprite;
+        private DarkComboBox cmbSprite;
+        private System.Windows.Forms.Label lblLevel;
+        private DarkNumericUpDown nudLevel;
+        private System.Windows.Forms.Label lblExperience;
+        private DarkNumericUpDown nudExperience;
+    }
+}

--- a/Intersect.Editor/Forms/Editors/frmPet.cs
+++ b/Intersect.Editor/Forms/Editors/frmPet.cs
@@ -1,0 +1,942 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Windows.Forms;
+using DarkUI.Controls;
+using DarkUI.Forms;
+using Intersect.Editor.Content;
+using Intersect.Editor.Core;
+using Intersect.Editor.General;
+using Intersect.Editor.Localization;
+using Intersect.Editor.Networking;
+using Intersect.Enums;
+using Intersect.Framework.Core.GameObjects.Animations;
+using Intersect.Framework.Core.GameObjects.Pets;
+using Intersect.Framework.Core.GameObjects.Spells;
+using Intersect.GameObjects;
+using Intersect.Utilities;
+
+namespace Intersect.Editor.Forms.Editors;
+
+public partial class FrmPet : EditorForm
+{
+    private readonly BindingList<string> _spellNames = new();
+    private readonly Dictionary<SpellEffect, DarkCheckBox> _immunityCheckboxes = new();
+    private readonly Dictionary<Stat, DarkNumericUpDown> _statControls = new();
+    private readonly Dictionary<Vital, DarkNumericUpDown> _vitalControls = new();
+    private readonly Dictionary<Vital, DarkNumericUpDown> _vitalRegenControls = new();
+
+    private readonly List<PetDescriptor> _changed = new();
+    private readonly List<string> _knownFolders = new();
+
+    private string? _copiedItem;
+    private PetDescriptor? _editorItem;
+    private bool _isClosing;
+
+    public FrmPet()
+    {
+        ApplyHooks();
+        InitializeComponent();
+        Icon = Program.Icon;
+        _btnSave = btnSave;
+        _btnCancel = btnCancel;
+
+        lstGameObjects.Init(
+            UpdateToolStripItems,
+            AssignEditorItem,
+            toolStripItemNew_Click,
+            toolStripItemCopy_Click,
+            toolStripItemUndo_Click,
+            toolStripItemPaste_Click,
+            toolStripItemDelete_Click
+        );
+
+        InitStatControls();
+        InitVitalControls();
+        InitImmunityControls();
+
+        lstSpells.DataSource = _spellNames;
+        pnlContainer.Hide();
+        UpdateToolStripItems();
+        UpdateEditorButtons(false);
+    }
+
+    private void frmPet_Load(object sender, EventArgs e)
+    {
+        cmbSprite.Items.Clear();
+        cmbSprite.Items.Add(Strings.General.None);
+        cmbSprite.Items.AddRange(
+            GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Entity)
+        );
+
+        cmbAttackAnimation.Items.Clear();
+        cmbAttackAnimation.Items.Add(Strings.General.None);
+        cmbAttackAnimation.Items.AddRange(AnimationDescriptor.Names);
+
+        cmbDeathAnimation.Items.Clear();
+        cmbDeathAnimation.Items.Add(Strings.General.None);
+        cmbDeathAnimation.Items.AddRange(AnimationDescriptor.Names);
+
+        cmbIdleAnimation.Items.Clear();
+        cmbIdleAnimation.Items.Add(Strings.General.None);
+        cmbIdleAnimation.Items.AddRange(AnimationDescriptor.Names);
+
+        cmbSpell.Items.Clear();
+        cmbSpell.Items.AddRange(SpellDescriptor.Names);
+        if (cmbSpell.Items.Count > 0)
+        {
+            cmbSpell.SelectedIndex = 0;
+        }
+
+        cmbDamageType.Items.Clear();
+        for (var i = 0; i < Strings.Combat.damagetypes.Count; i++)
+        {
+            cmbDamageType.Items.Add(Strings.Combat.damagetypes[i]);
+        }
+        if (cmbDamageType.Items.Count > 0)
+        {
+            cmbDamageType.SelectedIndex = 0;
+        }
+
+        cmbAttackSpeedModifier.Items.Clear();
+        foreach (var modifier in Strings.NpcEditor.attackspeedmodifiers)
+        {
+            cmbAttackSpeedModifier.Items.Add(modifier.Value.ToString());
+        }
+        if (cmbAttackSpeedModifier.Items.Count > 0)
+        {
+            cmbAttackSpeedModifier.SelectedIndex = 0;
+        }
+
+        cmbScalingStat.Items.Clear();
+        for (var i = 0; i < Enum.GetValues<Stat>().Length; i++)
+        {
+            cmbScalingStat.Items.Add(Globals.GetStatName(i));
+        }
+        if (cmbScalingStat.Items.Count > 0)
+        {
+            cmbScalingStat.SelectedIndex = 0;
+        }
+
+        toolStripItemNew.ToolTipText = Strings.NpcEditor.New;
+        toolStripItemDelete.ToolTipText = Strings.NpcEditor.delete;
+        toolStripItemCopy.ToolTipText = Strings.NpcEditor.copy;
+        toolStripItemPaste.ToolTipText = Strings.NpcEditor.paste;
+        toolStripItemUndo.ToolTipText = Strings.NpcEditor.undo;
+        btnAlphabetical.ToolTipText = Strings.NpcEditor.sortalphabetically;
+
+        nudDamage.Maximum = Options.Instance.Player.MaxStat;
+        nudScaling.Maximum = 1000;
+        nudCritChance.Maximum = 100;
+        nudAttackSpeedValue.Maximum = 100000;
+
+        InitLocalization();
+        InitEditor();
+    }
+
+    private void InitLocalization()
+    {
+        Text = Strings.Pets.title;
+        grpPets.Text = Strings.Pets.petlist;
+        btnClearSearch.Text = Strings.Pets.clearsearch;
+        txtSearch.Text = Strings.Pets.searchplaceholder;
+        grpGeneral.Text = Strings.Pets.general;
+        lblName.Text = Strings.Pets.name;
+        lblFolder.Text = Strings.Pets.folderlabel;
+        btnAddFolder.Text = Strings.Pets.addfolder;
+        lblIdleSprite.Text = Strings.Pets.sprite;
+        lblLevel.Text = Strings.Pets.level;
+        lblExperience.Text = Strings.Pets.experience;
+        grpStats.Text = Strings.Pets.stats;
+        grpVitals.Text = Strings.Pets.vitals;
+        lblVitals.Text = Strings.Pets.maxvitals;
+        lblVitalRegen.Text = Strings.Pets.vitalregen;
+        grpCombat.Text = Strings.Pets.combat;
+        lblAttackAnimation.Text = Strings.Pets.attackanimation;
+        lblDeathAnimation.Text = Strings.Pets.deathanimation;
+        lblIdleAnimation.Text = Strings.Pets.idleanimation;
+        lblDamageType.Text = Strings.Pets.damagetype;
+        lblScalingStat.Text = Strings.Pets.scalingstat;
+        lblScaling.Text = Strings.Pets.scalingamount;
+        lblDamage.Text = Strings.Pets.damage;
+        lblCritChance.Text = Strings.Pets.critchance;
+        lblCritMultiplier.Text = Strings.Pets.critmultiplier;
+        lblAttackSpeedModifier.Text = Strings.Pets.attackspeedmodifier;
+        lblAttackSpeedValue.Text = Strings.Pets.attackspeedvalue;
+        grpSpells.Text = Strings.Pets.spells;
+        btnAddSpell.Text = Strings.Pets.addspell;
+        btnRemoveSpell.Text = Strings.Pets.removespell;
+        grpImmunities.Text = Strings.Pets.immunities;
+        lblTenacity.Text = Strings.Pets.tenacity;
+        btnSave.Text = Strings.Pets.save;
+        btnCancel.Text = Strings.Pets.cancel;
+    }
+
+    private void InitStatControls()
+    {
+        flpStats.Controls.Clear();
+        _statControls.Clear();
+
+        foreach (var stat in Enum.GetValues<Stat>())
+        {
+            var panel = new Panel
+            {
+                Width = 120,
+                Height = 50,
+                Margin = new Padding(4)
+            };
+
+            var label = new Label
+            {
+                Text = Globals.GetStatName((int)stat),
+                AutoSize = true,
+                Location = new System.Drawing.Point(0, 0)
+            };
+
+            var numeric = new DarkNumericUpDown
+            {
+                Minimum = 0,
+                Maximum = Options.Instance.Player.MaxStat,
+                Location = new System.Drawing.Point(0, 20),
+                Width = 100
+            };
+
+            numeric.ValueChanged += (_, _) =>
+            {
+                if (_editorItem == null)
+                {
+                    return;
+                }
+
+                _editorItem.Stats[(int)stat] = (int)numeric.Value;
+            };
+
+            panel.Controls.Add(label);
+            panel.Controls.Add(numeric);
+            flpStats.Controls.Add(panel);
+            _statControls.Add(stat, numeric);
+        }
+    }
+
+    private void InitVitalControls()
+    {
+        flpVitals.Controls.Clear();
+        flpVitalRegen.Controls.Clear();
+        _vitalControls.Clear();
+        _vitalRegenControls.Clear();
+
+        foreach (var vital in Enum.GetValues<Vital>())
+        {
+            var maxPanel = new Panel
+            {
+                Width = 200,
+                Height = 45,
+                Margin = new Padding(4)
+            };
+
+            var maxLabel = new Label
+            {
+                Text = vital.ToString(),
+                AutoSize = true,
+                Location = new System.Drawing.Point(0, 0)
+            };
+
+            var maxNumeric = new DarkNumericUpDown
+            {
+                Minimum = 0,
+                Maximum = int.MaxValue,
+                Location = new System.Drawing.Point(0, 18),
+                Width = 180
+            };
+
+            maxNumeric.ValueChanged += (_, _) =>
+            {
+                if (_editorItem == null)
+                {
+                    return;
+                }
+
+                _editorItem.MaxVitals[(int)vital] = (long)maxNumeric.Value;
+            };
+
+            maxPanel.Controls.Add(maxLabel);
+            maxPanel.Controls.Add(maxNumeric);
+            flpVitals.Controls.Add(maxPanel);
+            _vitalControls.Add(vital, maxNumeric);
+
+            var regenPanel = new Panel
+            {
+                Width = 200,
+                Height = 45,
+                Margin = new Padding(4)
+            };
+
+            var regenLabel = new Label
+            {
+                Text = vital + " Regen",
+                AutoSize = true,
+                Location = new System.Drawing.Point(0, 0)
+            };
+
+            var regenNumeric = new DarkNumericUpDown
+            {
+                Minimum = 0,
+                Maximum = int.MaxValue,
+                Location = new System.Drawing.Point(0, 18),
+                Width = 180
+            };
+
+            regenNumeric.ValueChanged += (_, _) =>
+            {
+                if (_editorItem == null)
+                {
+                    return;
+                }
+
+                _editorItem.VitalRegen[(int)vital] = (long)regenNumeric.Value;
+            };
+
+            regenPanel.Controls.Add(regenLabel);
+            regenPanel.Controls.Add(regenNumeric);
+            flpVitalRegen.Controls.Add(regenPanel);
+            _vitalRegenControls.Add(vital, regenNumeric);
+        }
+    }
+
+    private void InitImmunityControls()
+    {
+        flpImmunities.Controls.Clear();
+        _immunityCheckboxes.Clear();
+
+        foreach (var effect in Enum.GetValues<SpellEffect>())
+        {
+            if (effect == SpellEffect.None)
+            {
+                continue;
+            }
+
+            var checkbox = new DarkCheckBox
+            {
+                Text = Strings.NpcEditor.Immunities.ContainsKey(effect)
+                    ? Strings.NpcEditor.Immunities[effect]
+                    : effect.ToString(),
+                AutoSize = true
+            };
+
+            checkbox.CheckedChanged += (_, _) =>
+            {
+                if (_editorItem == null)
+                {
+                    return;
+                }
+
+                if (checkbox.Checked)
+                {
+                    if (!_editorItem.Immunities.Contains(effect))
+                    {
+                        _editorItem.Immunities.Add(effect);
+                    }
+                }
+                else
+                {
+                    _editorItem.Immunities.Remove(effect);
+                }
+            };
+
+            flpImmunities.Controls.Add(checkbox);
+            _immunityCheckboxes.Add(effect, checkbox);
+        }
+    }
+
+    private void AssignEditorItem(Guid id)
+    {
+        _editorItem = PetDescriptor.Get(id);
+        UpdateEditor();
+    }
+
+    protected override void GameObjectUpdatedDelegate(GameObjectType type)
+    {
+        if (type == GameObjectType.Pet)
+        {
+            InitEditor();
+            if (_editorItem != null && !PetDescriptor.Lookup.Values.Contains(_editorItem))
+            {
+                _editorItem = null;
+                UpdateEditor();
+            }
+        }
+    }
+
+    private void btnSave_Click(object sender, EventArgs e)
+    {
+        if (_isClosing)
+        {
+            return;
+        }
+
+        _isClosing = true;
+        foreach (var item in _changed)
+        {
+            item.Immunities.Sort();
+            PacketSender.SendSaveObject(item);
+            item.DeleteBackup();
+        }
+
+        Hide();
+        Globals.CurrentEditor = -1;
+        Dispose();
+    }
+
+    private void btnCancel_Click(object sender, EventArgs e)
+    {
+        if (_isClosing)
+        {
+            return;
+        }
+
+        _isClosing = true;
+        foreach (var item in _changed)
+        {
+            item.RestoreBackup();
+            item.DeleteBackup();
+        }
+
+        Hide();
+        Globals.CurrentEditor = -1;
+        Dispose();
+    }
+
+    private void frmPet_FormClosed(object sender, FormClosedEventArgs e)
+    {
+        btnCancel_Click(null, EventArgs.Empty);
+    }
+
+    private void UpdateEditor()
+    {
+        if (_editorItem != null)
+        {
+            pnlContainer.Show();
+            txtName.Text = _editorItem.Name;
+            cmbFolder.Text = _editorItem.Folder;
+            var spriteIndex = cmbSprite.FindString(TextUtils.NullToNone(_editorItem.Sprite));
+            if (spriteIndex >= 0)
+            {
+                cmbSprite.SelectedIndex = spriteIndex;
+            }
+            else if (cmbSprite.Items.Count > 0)
+            {
+                cmbSprite.SelectedIndex = 0;
+            }
+            nudLevel.Value = Math.Max(nudLevel.Minimum, Math.Min(nudLevel.Maximum, _editorItem.Level));
+            nudExperience.Value = Math.Max(nudExperience.Minimum, Math.Min(nudExperience.Maximum, _editorItem.Experience));
+            SetComboIndex(cmbAttackAnimation, AnimationDescriptor.ListIndex(_editorItem.AttackAnimationId) + 1, 0);
+            SetComboIndex(cmbDeathAnimation, AnimationDescriptor.ListIndex(_editorItem.DeathAnimationId) + 1, 0);
+            SetComboIndex(cmbIdleAnimation, AnimationDescriptor.ListIndex(_editorItem.IdleAnimationId) + 1, 0);
+            SetComboIndex(cmbDamageType, _editorItem.DamageType);
+            SetComboIndex(cmbScalingStat, _editorItem.ScalingStat);
+            nudScaling.Value = Math.Max(nudScaling.Minimum, Math.Min(nudScaling.Maximum, _editorItem.Scaling));
+            nudDamage.Value = Math.Max(nudDamage.Minimum, Math.Min(nudDamage.Maximum, _editorItem.Damage));
+            nudCritChance.Value = Math.Max(nudCritChance.Minimum, Math.Min(nudCritChance.Maximum, _editorItem.CritChance));
+            nudCritMultiplier.Value = Math.Max(nudCritMultiplier.Minimum, Math.Min(nudCritMultiplier.Maximum, (decimal)_editorItem.CritMultiplier));
+            SetComboIndex(cmbAttackSpeedModifier, _editorItem.AttackSpeedModifier);
+            nudAttackSpeedValue.Value = Math.Max(nudAttackSpeedValue.Minimum, Math.Min(nudAttackSpeedValue.Maximum, _editorItem.AttackSpeedValue));
+            nudTenacity.Value = (decimal)_editorItem.Tenacity;
+
+            foreach (var (stat, control) in _statControls)
+            {
+                control.Value = Math.Max(control.Minimum, Math.Min(control.Maximum, _editorItem.Stats[(int)stat]));
+            }
+
+            foreach (var (vital, control) in _vitalControls)
+            {
+                control.Value = Math.Max(control.Minimum, Math.Min(control.Maximum, _editorItem.MaxVitals[(int)vital]));
+            }
+
+            foreach (var (vital, control) in _vitalRegenControls)
+            {
+                control.Value = Math.Max(control.Minimum, Math.Min(control.Maximum, _editorItem.VitalRegen[(int)vital]));
+            }
+
+            foreach (var (effect, checkbox) in _immunityCheckboxes)
+            {
+                checkbox.Checked = _editorItem.Immunities.Contains(effect);
+            }
+
+            _spellNames.RaiseListChangedEvents = false;
+            _spellNames.Clear();
+            foreach (var spellId in _editorItem.Spells)
+            {
+                _spellNames.Add(spellId != Guid.Empty ? SpellDescriptor.GetName(spellId) : Strings.General.None);
+            }
+
+            _spellNames.RaiseListChangedEvents = true;
+            _spellNames.ResetBindings();
+
+            if (_editorItem.Spells.Count > 0)
+            {
+                lstSpells.SelectedIndex = 0;
+                cmbSpell.SelectedIndex = SpellDescriptor.ListIndex(_editorItem.Spells[0]);
+            }
+            else if (cmbSpell.Items.Count > 0)
+            {
+                cmbSpell.SelectedIndex = 0;
+            }
+
+            if (!_changed.Contains(_editorItem))
+            {
+                _changed.Add(_editorItem);
+                _editorItem.MakeBackup();
+            }
+        }
+        else
+        {
+            pnlContainer.Hide();
+        }
+
+        var hasItem = _editorItem != null;
+        UpdateEditorButtons(hasItem);
+        UpdateToolStripItems();
+    }
+
+    private void txtName_TextChanged(object sender, EventArgs e)
+    {
+        if (_editorItem == null)
+        {
+            return;
+        }
+
+        _editorItem.Name = txtName.Text;
+        lstGameObjects.UpdateText(txtName.Text);
+    }
+
+    private void cmbSprite_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        if (_editorItem == null)
+        {
+            return;
+        }
+
+        _editorItem.Sprite = TextUtils.SanitizeNone(cmbSprite.Text);
+    }
+
+    private void nudLevel_ValueChanged(object sender, EventArgs e)
+    {
+        if (_editorItem == null)
+        {
+            return;
+        }
+
+        _editorItem.Level = (int)nudLevel.Value;
+    }
+
+    private void nudExperience_ValueChanged(object sender, EventArgs e)
+    {
+        if (_editorItem == null)
+        {
+            return;
+        }
+
+        _editorItem.Experience = (long)nudExperience.Value;
+    }
+
+    private void cmbAttackAnimation_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        if (_editorItem == null)
+        {
+            return;
+        }
+
+        _editorItem.AttackAnimation = AnimationDescriptor.Get(AnimationDescriptor.IdFromList(cmbAttackAnimation.SelectedIndex - 1));
+    }
+
+    private void cmbDeathAnimation_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        if (_editorItem == null)
+        {
+            return;
+        }
+
+        _editorItem.DeathAnimation = AnimationDescriptor.Get(AnimationDescriptor.IdFromList(cmbDeathAnimation.SelectedIndex - 1));
+    }
+
+    private void cmbIdleAnimation_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        if (_editorItem == null)
+        {
+            return;
+        }
+
+        _editorItem.IdleAnimation = AnimationDescriptor.Get(AnimationDescriptor.IdFromList(cmbIdleAnimation.SelectedIndex - 1));
+    }
+
+    private void cmbDamageType_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        if (_editorItem == null)
+        {
+            return;
+        }
+
+        _editorItem.DamageType = cmbDamageType.SelectedIndex;
+    }
+
+    private void cmbScalingStat_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        if (_editorItem == null)
+        {
+            return;
+        }
+
+        _editorItem.ScalingStat = cmbScalingStat.SelectedIndex;
+    }
+
+    private void nudScaling_ValueChanged(object sender, EventArgs e)
+    {
+        if (_editorItem == null)
+        {
+            return;
+        }
+
+        _editorItem.Scaling = (int)nudScaling.Value;
+    }
+
+    private void nudDamage_ValueChanged(object sender, EventArgs e)
+    {
+        if (_editorItem == null)
+        {
+            return;
+        }
+
+        _editorItem.Damage = (int)nudDamage.Value;
+    }
+
+    private void nudCritChance_ValueChanged(object sender, EventArgs e)
+    {
+        if (_editorItem == null)
+        {
+            return;
+        }
+
+        _editorItem.CritChance = (int)nudCritChance.Value;
+    }
+
+    private void nudCritMultiplier_ValueChanged(object sender, EventArgs e)
+    {
+        if (_editorItem == null)
+        {
+            return;
+        }
+
+        _editorItem.CritMultiplier = (double)nudCritMultiplier.Value;
+    }
+
+    private void cmbAttackSpeedModifier_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        if (_editorItem == null)
+        {
+            return;
+        }
+
+        _editorItem.AttackSpeedModifier = cmbAttackSpeedModifier.SelectedIndex;
+    }
+
+    private void nudAttackSpeedValue_ValueChanged(object sender, EventArgs e)
+    {
+        if (_editorItem == null)
+        {
+            return;
+        }
+
+        _editorItem.AttackSpeedValue = (int)nudAttackSpeedValue.Value;
+    }
+
+    private void nudTenacity_ValueChanged(object sender, EventArgs e)
+    {
+        if (_editorItem == null)
+        {
+            return;
+        }
+
+        _editorItem.Tenacity = (double)nudTenacity.Value;
+    }
+
+    private void cmbSpell_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        if (_editorItem == null || lstSpells.SelectedIndex < 0)
+        {
+            return;
+        }
+
+        if (lstSpells.SelectedIndex >= _editorItem.Spells.Count)
+        {
+            return;
+        }
+
+        var selectedSpell = SpellDescriptor.IdFromList(cmbSpell.SelectedIndex);
+        _editorItem.Spells[lstSpells.SelectedIndex] = selectedSpell;
+        var displayName = selectedSpell != Guid.Empty ? SpellDescriptor.GetName(selectedSpell) : Strings.General.None;
+        _spellNames[lstSpells.SelectedIndex] = displayName;
+        _spellNames.ResetItem(lstSpells.SelectedIndex);
+    }
+
+    private void lstSpells_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        if (_editorItem == null)
+        {
+            return;
+        }
+
+        if (lstSpells.SelectedIndex < 0 || lstSpells.SelectedIndex >= _editorItem.Spells.Count)
+        {
+            return;
+        }
+
+        cmbSpell.SelectedIndex = SpellDescriptor.ListIndex(_editorItem.Spells[lstSpells.SelectedIndex]);
+    }
+
+    private void btnAddSpell_Click(object sender, EventArgs e)
+    {
+        if (_editorItem == null)
+        {
+            return;
+        }
+
+        if (cmbSpell.SelectedIndex < 0)
+        {
+            return;
+        }
+
+        var spellId = SpellDescriptor.IdFromList(cmbSpell.SelectedIndex);
+        _editorItem.Spells.Add(spellId);
+        _spellNames.Add(spellId != Guid.Empty ? SpellDescriptor.GetName(spellId) : Strings.General.None);
+    }
+
+    private void btnRemoveSpell_Click(object sender, EventArgs e)
+    {
+        if (_editorItem == null)
+        {
+            return;
+        }
+
+        if (lstSpells.SelectedIndex < 0 || lstSpells.SelectedIndex >= _editorItem.Spells.Count)
+        {
+            return;
+        }
+
+        var index = lstSpells.SelectedIndex;
+        _editorItem.Spells.RemoveAt(index);
+        _spellNames.RemoveAt(index);
+    }
+
+    private void cmbFolder_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        if (_editorItem == null)
+        {
+            return;
+        }
+
+        _editorItem.Folder = cmbFolder.Text;
+        InitEditor();
+    }
+
+    private void btnAddFolder_Click(object sender, EventArgs e)
+    {
+        if (_editorItem == null)
+        {
+            return;
+        }
+
+        var folderName = string.Empty;
+        var result = DarkInputBox.ShowInformation(
+            Strings.Pets.folderprompt,
+            Strings.Pets.foldertitle,
+            ref folderName,
+            DarkDialogButton.OkCancel
+        );
+
+        if (result == DialogResult.OK && !string.IsNullOrWhiteSpace(folderName))
+        {
+            if (!cmbFolder.Items.Contains(folderName))
+            {
+                _editorItem.Folder = folderName;
+                lstGameObjects.UpdateText(folderName);
+                InitEditor();
+                cmbFolder.Text = folderName;
+            }
+        }
+    }
+
+    private void btnAlphabetical_Click(object sender, EventArgs e)
+    {
+        btnAlphabetical.Checked = !btnAlphabetical.Checked;
+        InitEditor();
+    }
+
+    private void txtSearch_TextChanged(object sender, EventArgs e)
+    {
+        InitEditor();
+    }
+
+    private void txtSearch_Leave(object sender, EventArgs e)
+    {
+        if (string.IsNullOrWhiteSpace(txtSearch.Text))
+        {
+            txtSearch.Text = Strings.Pets.searchplaceholder;
+        }
+    }
+
+    private void txtSearch_Enter(object sender, EventArgs e)
+    {
+        txtSearch.SelectAll();
+    }
+
+    private void btnClearSearch_Click(object sender, EventArgs e)
+    {
+        txtSearch.Text = Strings.Pets.searchplaceholder;
+        InitEditor();
+    }
+
+    private bool CustomSearch()
+    {
+        return !string.IsNullOrWhiteSpace(txtSearch.Text) && txtSearch.Text != Strings.Pets.searchplaceholder;
+    }
+
+    public void InitEditor()
+    {
+        var folders = new List<string>();
+        foreach (var descriptor in PetDescriptor.Lookup)
+        {
+            if (descriptor.Value is not PetDescriptor pet)
+            {
+                continue;
+            }
+
+            if (!string.IsNullOrEmpty(pet.Folder) && !folders.Contains(pet.Folder))
+            {
+                folders.Add(pet.Folder);
+                if (!_knownFolders.Contains(pet.Folder))
+                {
+                    _knownFolders.Add(pet.Folder);
+                }
+            }
+        }
+
+        folders.Sort();
+        _knownFolders.Sort();
+
+        cmbFolder.Items.Clear();
+        cmbFolder.Items.Add(string.Empty);
+        cmbFolder.Items.AddRange(_knownFolders.Cast<object>().ToArray());
+
+        var items = PetDescriptor.Lookup
+            .OrderBy(p => p.Value?.Name)
+            .Select(
+                pair => new KeyValuePair<Guid, KeyValuePair<string, string>>(
+                    pair.Key,
+                    new KeyValuePair<string, string>(
+                        ((PetDescriptor)pair.Value)?.Name ?? Models.DatabaseObject<PetDescriptor>.Deleted,
+                        ((PetDescriptor)pair.Value)?.Folder ?? string.Empty
+                    )
+                )
+            )
+            .ToArray();
+
+        lstGameObjects.Repopulate(items, folders, btnAlphabetical.Checked, CustomSearch(), txtSearch.Text);
+    }
+
+    private void toolStripItemNew_Click(object sender, EventArgs e)
+    {
+        PacketSender.SendCreateObject(GameObjectType.Pet);
+    }
+
+    private void toolStripItemDelete_Click(object sender, EventArgs e)
+    {
+        if (_editorItem == null || !lstGameObjects.Focused)
+        {
+            return;
+        }
+
+        if (DarkMessageBox.ShowWarning(
+                Strings.Pets.deleteprompt,
+                Strings.Pets.deletetitle,
+                DarkDialogButton.YesNo,
+                Icon
+            ) == DialogResult.Yes)
+        {
+            PacketSender.SendDeleteObject(_editorItem);
+        }
+    }
+
+    private void toolStripItemCopy_Click(object sender, EventArgs e)
+    {
+        if (_editorItem == null || !lstGameObjects.Focused)
+        {
+            return;
+        }
+
+        _copiedItem = _editorItem.JsonData;
+        toolStripItemPaste.Enabled = true;
+    }
+
+    private void toolStripItemPaste_Click(object sender, EventArgs e)
+    {
+        if (_editorItem == null || _copiedItem == null || !lstGameObjects.Focused)
+        {
+            return;
+        }
+
+        _editorItem.Load(_copiedItem, true);
+        UpdateEditor();
+    }
+
+    private void toolStripItemUndo_Click(object sender, EventArgs e)
+    {
+        if (_editorItem == null || !_changed.Contains(_editorItem))
+        {
+            return;
+        }
+
+        if (DarkMessageBox.ShowWarning(
+                Strings.Pets.undoprompt,
+                Strings.Pets.undotitle,
+                DarkDialogButton.YesNo,
+                Icon
+            ) == DialogResult.Yes)
+        {
+            _editorItem.RestoreBackup();
+            UpdateEditor();
+        }
+    }
+
+    private void UpdateToolStripItems()
+    {
+        toolStripItemCopy.Enabled = _editorItem != null && lstGameObjects.Focused;
+        toolStripItemPaste.Enabled = _editorItem != null && _copiedItem != null && lstGameObjects.Focused;
+        toolStripItemDelete.Enabled = _editorItem != null && lstGameObjects.Focused;
+        toolStripItemUndo.Enabled = _editorItem != null && lstGameObjects.Focused;
+    }
+
+    private void form_KeyDown(object sender, KeyEventArgs e)
+    {
+        if (e.Control && e.KeyCode == Keys.N)
+        {
+            toolStripItemNew_Click(sender, e);
+        }
+    }
+
+    private static void SetComboIndex(DarkComboBox combo, int index, int fallbackIndex = 0)
+    {
+        if (combo.Items.Count == 0)
+        {
+            combo.SelectedIndex = -1;
+            return;
+        }
+
+        if (index < 0 || index >= combo.Items.Count)
+        {
+            index = Math.Min(Math.Max(fallbackIndex, 0), combo.Items.Count - 1);
+        }
+
+        combo.SelectedIndex = index;
+    }
+}

--- a/Intersect.Editor/Forms/Editors/frmPet.resx
+++ b/Intersect.Editor/Forms/Editors/frmPet.resx
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!--
+    Microsoft ResX Schema
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+  -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="toolStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="toolStripItemNew.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAACMSURBVDhP7Y3BCYAwFEM7h1M4Q/fy2rUEp3AFT1UovSrR
+        /22orQpeDTxqNS8aToxxVeTVu7A4dM35DKRyHxbzUyr1oASmsd8lBXf9JtVyUGCxdCd8CKEV9QgXaqK1
+        dsc5h3t5RKX8nP1yUh1BUcn/ng/wiOgpLKLIMoNv6Ih2zT+QBu54HHiD1L/EmA2wn/hWQ4oVCwAAAABJ
+        RU5ErkJggg==
+</value>
+  </data>
+  <data name="toolStripItemDelete.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAFbSURBVDhPrZK9SgNBFIV9AcEHSJHKwkpIZZfOSkhtZeED
+        BPQBVh9A7S2CjaYQJI2VEEyRQoTFRhEEkUCCWExk/8rxfpOZxVlmY+OBC8Pcc879mVn5NxRF0cyyLJLo
+        KqXW7LUH7iXfkxgSotkzCTm0vz9n+un8zESSJO9VExF05rOpejw51h+jO53neVxycEV4sb5qYnx0AOGG
+        HCQ5n07jB33d3tCDnS2NUZqmm0YMqgYEVeQ+opvnfk9fthomMKIbK13AjYC7M4DMHd1UTLtW5oOFhEzc
+        mS7o1NLDCJkQ94f7/tLqsMxAqg8tLQw2/fX2+tcI4fmZje3+FmBEN7y7M4PjPR+oE/PWkuswO9W55x/M
+        JxP/k/E0TkhgRGWeljxkisAjd7u7XX4yA9eiE9MNy7TpEsxPji7QlBznvEzsQFeMxogvg6vFd0YgLSlC
+        qkSWWwvhN9mLhIySxz9ZBc31XkEs1QAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="btnAlphabetical.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAABrSURBVDhPnc9BCoAwDETR3rM37omyU1KcMFGJGQf+JtCH
+        Dp+ZHdw+KvNHc87dHfsqAI8BgFUl0O0V2EdlANB17s8f8X8pBeAxALAqATioJSCpylj8DfAXKAWw1koA
+        wKoS6BbAQ1XGogaMcQIneCosACuo6QAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="toolStripItemCopy.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAABVSURBVDhP7YxBCgAgCAR9m///S3XxWghGUWJLdGxhkHId
+        8iIiFcHqe3TJzCGQIKfi8l6gD4RQoJ8RkKAXVr5gHOjsXAlW7BwXWH3PM0HEUYBg9SlEDZN0dAOhJqHd
+        AAAAAElFTkSuQmCC
+</value>
+  </data>
+  <data name="toolStripItemPaste.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAACKSURBVDhP7Y3LDYAgEEQpwVKsgSoojl4swSbUCwc0Aa7q
+        4BJN+IjGo5O8ZJndGVhKxpjWWts551aih0fre+0BLaVchRAezPB2NXSSV/gVwXGYPJiVUt6ns1ghCDjn
+        UQG86w3FToVgDcWCWS9Fvi/Ao0RVAcwUjwpyhzmf4n8BFApS5HZRwRuONGMbrIJ1JIN8O2QAAAAASUVO
+        RK5CYII=
+</value>
+  </data>
+  <data name="toolStripItemUndo.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAEfSURBVDhPjVK7DgFBFN0/4A/4AvEJfkAi0ZLoNArR6hUq
+        tUgkElGJ1jYaDYVsI9Fq2EYyin2Ua864d9g1u/YkJ5nHOfcxcy2G53nVIAiEZBSGYdn3/TnviQJnuCPL
+        BzDf3aeoDNZaPFweo0J7EVnNmSLWOMMd9GR9AyaYIXQfT702kZKIWCUIwIJSd6XX9dE2sk9XRaz5HJWg
+        HbLHAzCn9pnbURklHQ6CdnBGdnMAsDXZKSF6lhkbqITvlIdhCvBthuZvAAO1WQhRlPv0FrKAIBCjIs7+
+        84hpkF9VS5qN32iCFHSSM4FAGLifQUpCltc3mZE5j3l+uNxiYzzeODA7f8um1xa96V6baaAc3JEsG/zq
+        PMaoKLeZQa+f46ss6wVeddKu0bn3NAAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>54</value>
+  </metadata>
+</root>

--- a/Intersect.Editor/Forms/frmMain.Designer.cs
+++ b/Intersect.Editor/Forms/frmMain.Designer.cs
@@ -109,6 +109,7 @@ namespace Intersect.Editor.Forms
             this.craftingTableEditorToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.itemEditorToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.npcEditorToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.petEditorToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.projectileEditorToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.questEditorToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.resourceEditorToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -812,6 +813,7 @@ namespace Intersect.Editor.Forms
             this.craftingTableEditorToolStripMenuItem,
             this.itemEditorToolStripMenuItem,
             this.npcEditorToolStripMenuItem,
+            this.petEditorToolStripMenuItem,
             this.projectileEditorToolStripMenuItem,
             this.questEditorToolStripMenuItem,
             this.resourceEditorToolStripMenuItem,
@@ -880,6 +882,14 @@ namespace Intersect.Editor.Forms
             this.npcEditorToolStripMenuItem.Size = new System.Drawing.Size(191, 22);
             this.npcEditorToolStripMenuItem.Text = "Npc Editor";
             this.npcEditorToolStripMenuItem.Click += new System.EventHandler(this.npcEditorToolStripMenuItem_Click);
+            //
+            // petEditorToolStripMenuItem
+            //
+            this.petEditorToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
+            this.petEditorToolStripMenuItem.Name = "petEditorToolStripMenuItem";
+            this.petEditorToolStripMenuItem.Size = new System.Drawing.Size(191, 22);
+            this.petEditorToolStripMenuItem.Text = "Pet Editor";
+            this.petEditorToolStripMenuItem.Click += new System.EventHandler(this.petEditorToolStripMenuItem_Click);
             // 
             // projectileEditorToolStripMenuItem
             // 
@@ -1112,7 +1122,8 @@ namespace Intersect.Editor.Forms
 		private ToolStripMenuItem commonEventEditorToolStripMenuItem;
 		private ToolStripMenuItem craftingTableEditorToolStripMenuItem;
 		private ToolStripMenuItem itemEditorToolStripMenuItem;
-		private ToolStripMenuItem npcEditorToolStripMenuItem;
+        private ToolStripMenuItem npcEditorToolStripMenuItem;
+        private ToolStripMenuItem petEditorToolStripMenuItem;
 		private ToolStripMenuItem projectileEditorToolStripMenuItem;
 		private ToolStripMenuItem questEditorToolStripMenuItem;
 		private ToolStripMenuItem resourceEditorToolStripMenuItem;

--- a/Intersect.Editor/Forms/frmMain.cs
+++ b/Intersect.Editor/Forms/frmMain.cs
@@ -57,6 +57,8 @@ public partial class FrmMain : Form
 
     private FrmNpc mNpcEditor;
 
+    private FrmPet mPetEditor;
+
     private FrmProjectile mProjectileEditor;
 
     private FrmQuest mQuestEditor;
@@ -187,6 +189,7 @@ public partial class FrmMain : Form
         craftsEditorToolStripMenuItem.Text = Strings.MainForm.craftingeditor;
         itemEditorToolStripMenuItem.Text = Strings.MainForm.itemeditor;
         npcEditorToolStripMenuItem.Text = Strings.MainForm.npceditor;
+        petEditorToolStripMenuItem.Text = Strings.MainForm.peteditor;
         projectileEditorToolStripMenuItem.Text = Strings.MainForm.projectileeditor;
         questEditorToolStripMenuItem.Text = Strings.MainForm.questeditor;
         resourceEditorToolStripMenuItem.Text = Strings.MainForm.resourceeditor;
@@ -1243,6 +1246,11 @@ public partial class FrmMain : Form
         PacketSender.SendOpenEditor(GameObjectType.Npc);
     }
 
+    private void petEditorToolStripMenuItem_Click(object sender, EventArgs e)
+    {
+        PacketSender.SendOpenEditor(GameObjectType.Pet);
+    }
+
     private void spellEditorToolStripMenuItem_Click(object sender, EventArgs e)
     {
         PacketSender.SendOpenEditor(GameObjectType.Spell);
@@ -1634,6 +1642,15 @@ public partial class FrmMain : Form
                         mNpcEditor = new FrmNpc();
                         mNpcEditor.InitEditor();
                         mNpcEditor.Show();
+                    }
+
+                    break;
+                case GameObjectType.Pet:
+                    if (mPetEditor == null || mPetEditor.Visible == false)
+                    {
+                        mPetEditor = new FrmPet();
+                        mPetEditor.InitEditor();
+                        mPetEditor.Show();
                     }
 
                     break;

--- a/Intersect.Editor/Localization/Strings.cs
+++ b/Intersect.Editor/Localization/Strings.cs
@@ -4344,6 +4344,8 @@ Tick timer saved in server config.json.";
 
         public static LocalizedString npceditor = @"Npc Editor";
 
+        public static LocalizedString peteditor = @"Pet Editor";
+
         public static LocalizedString options = @"Options";
 
         public static LocalizedString overlay = @"Overlay";
@@ -4904,6 +4906,93 @@ Tick timer saved in server config.json.";
             {SpellEffect.Sleep, @"Sleep"},
             {SpellEffect.Taunt, @"Taunt"},
         };
+
+    }
+
+    public partial struct Pets
+    {
+
+        public static LocalizedString title = @"Pet Editor";
+
+        public static LocalizedString petlist = @"Pets";
+
+        public static LocalizedString searchplaceholder = @"Search...";
+
+        public static LocalizedString clearsearch = @"Clear";
+
+        public static LocalizedString general = @"General";
+
+        public static LocalizedString name = @"Name:";
+
+        public static LocalizedString folderlabel = @"Folder:";
+
+        public static LocalizedString addfolder = @"Add";
+
+        public static LocalizedString folderprompt = @"Enter a folder name:";
+
+        public static LocalizedString foldertitle = @"New Folder";
+
+        public static LocalizedString sprite = @"Sprite";
+
+        public static LocalizedString level = @"Level:";
+
+        public static LocalizedString experience = @"Experience:";
+
+        public static LocalizedString stats = @"Stats";
+
+        public static LocalizedString vitals = @"Vitals";
+
+        public static LocalizedString maxvitals = @"Max";
+
+        public static LocalizedString vitalregen = @"Regeneration";
+
+        public static LocalizedString combat = @"Combat";
+
+        public static LocalizedString attackanimation = @"Attack Animation:";
+
+        public static LocalizedString deathanimation = @"Death Animation:";
+
+        public static LocalizedString idleanimation = @"Idle Animation:";
+
+        public static LocalizedString damagetype = @"Damage Type:";
+
+        public static LocalizedString scalingstat = @"Scaling Stat:";
+
+        public static LocalizedString scalingamount = @"Scaling Amount (%):";
+
+        public static LocalizedString damage = @"Base Damage:";
+
+        public static LocalizedString critchance = @"Crit Chance (%):";
+
+        public static LocalizedString critmultiplier = @"Crit Multiplier:";
+
+        public static LocalizedString attackspeedmodifier = @"Attack Speed Modifier:";
+
+        public static LocalizedString attackspeedvalue = @"Attack Speed Value:";
+
+        public static LocalizedString spells = @"Spells";
+
+        public static LocalizedString addspell = @"Add";
+
+        public static LocalizedString removespell = @"Remove";
+
+        public static LocalizedString immunities = @"Immunities";
+
+        public static LocalizedString tenacity = @"Tenacity (%):";
+
+        public static LocalizedString save = @"Save";
+
+        public static LocalizedString cancel = @"Cancel";
+
+        public static LocalizedString deleteprompt =
+            @"Are you sure you want to delete this pet? This action cannot be reverted!";
+
+        public static LocalizedString deletetitle = @"Delete Pet";
+
+        public static LocalizedString undoprompt =
+            @"Are you sure you want to undo changes made to this pet? This action cannot be reverted!";
+
+        public static LocalizedString undotitle = @"Undo Changes";
 
     }
 


### PR DESCRIPTION
## Summary
- add a dedicated pet editor form covering stats, vitals, spells, immunities, search and folder management
- add localization strings and resource assets required for the pet editor UI
- integrate the pet editor with the main menu and editor-opening workflow

## Testing
- dotnet build Intersect.Editor/Intersect.Editor.csproj *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc8ee59704832bb9024c70ec32374d