### PR TITLE
Add pet editor integration to main form

### DIFF
--- a/Intersect.Editor/Forms/frmMain.cs
+++ b/Intersect.Editor/Forms/frmMain.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Globalization;
 using System.Security.Cryptography;
+using System.Windows.Forms;
 using DarkUI.Controls;
 using DarkUI.Forms;
 using Intersect.Compression;
@@ -1649,6 +1650,7 @@ public partial class FrmMain : Form
                     if (mPetEditor == null || mPetEditor.Visible == false)
                     {
                         mPetEditor = new FrmPet();
+                        mPetEditor.FormClosed += PetEditor_FormClosed;
                         mPetEditor.InitEditor();
                         mPetEditor.Show();
                     }
@@ -1767,6 +1769,12 @@ public partial class FrmMain : Form
 
             Globals.CurrentEditor = (int)type;
         }
+    }
+
+    private void PetEditor_FormClosed(object sender, FormClosedEventArgs e)
+    {
+        Globals.CurrentEditor = -1;
+        mPetEditor = null;
     }
 
     private void frmMain_FormClosing(object sender, FormClosingEventArgs e)


### PR DESCRIPTION
## Summary
- hook the pet editor form into the main editor lifecycle by registering a FormClosed handler
- import the Windows Forms namespace needed for the new handler

## Testing
- dotnet build Intersect.Editor/Intersect.Editor.csproj *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc986d99d0832bbc19597a2b2de109