### PR TITLE
Add pet descriptor networking integration

### DIFF
--- a/Intersect.Editor/Networking/PacketHandler.cs
+++ b/Intersect.Editor/Networking/PacketHandler.cs
@@ -14,6 +14,7 @@ using Intersect.Framework.Core.GameObjects.Maps;
 using Intersect.Framework.Core.GameObjects.Maps.MapList;
 using Intersect.Framework.Core.GameObjects.NPCs;
 using Intersect.Framework.Core.GameObjects.PlayerClass;
+using Intersect.Framework.Core.GameObjects.Pets;
 using Intersect.Framework.Core.GameObjects.Resources;
 using Intersect.Framework.Core.GameObjects.Variables;
 using Intersect.GameObjects;
@@ -525,6 +526,20 @@ internal sealed partial class PacketHandler
                     var npc = new NPCDescriptor(id);
                     npc.Load(json);
                     NPCDescriptor.Lookup.Set(id, npc);
+                }
+
+                break;
+            case GameObjectType.Pet:
+                if (deleted)
+                {
+                    var pet = PetDescriptor.Get(id);
+                    pet.Delete();
+                }
+                else
+                {
+                    var pet = new PetDescriptor(id);
+                    pet.Load(json);
+                    PetDescriptor.Lookup.Set(id, pet);
                 }
 
                 break;

--- a/Intersect.Server.Core/Database/DbInterface.cs
+++ b/Intersect.Server.Core/Database/DbInterface.cs
@@ -19,6 +19,7 @@ using Intersect.Framework.Core.GameObjects.Maps;
 using Intersect.Framework.Core.GameObjects.Maps.MapList;
 using Intersect.Framework.Core.GameObjects.NPCs;
 using Intersect.Framework.Core.GameObjects.PlayerClass;
+using Intersect.Framework.Core.GameObjects.Pets;
 using Intersect.Framework.Core.GameObjects.Resources;
 using Intersect.Framework.Core.GameObjects.Variables;
 using Intersect.Framework.Core.GameObjects;
@@ -729,6 +730,10 @@ public static partial class DbInterface
                 NPCDescriptor.Lookup.Clear();
 
                 break;
+            case GameObjectType.Pet:
+                PetDescriptor.Lookup.Clear();
+
+                break;
             case GameObjectType.Projectile:
                 ProjectileDescriptor.Lookup.Clear();
 
@@ -826,7 +831,7 @@ public static partial class DbInterface
                         }
 
                         break;
-                   
+
                     case GameObjectType.Npc:
                         foreach (var npc in context.Npcs)
                         {
@@ -834,6 +839,15 @@ public static partial class DbInterface
                         }
 
                         break;
+
+                    case GameObjectType.Pet:
+                        foreach (var pet in context.Pets)
+                        {
+                            PetDescriptor.Lookup.Set(pet.Id, pet);
+                        }
+
+                        break;
+
                     case GameObjectType.Projectile:
                         foreach (var proj in context.Projectiles)
                         {
@@ -1130,6 +1144,10 @@ public static partial class DbInterface
                 dbObj = new NPCDescriptor(predefinedid);
 
                 break;
+            case GameObjectType.Pet:
+                dbObj = new PetDescriptor(predefinedid);
+
+                break;
             case GameObjectType.Projectile:
                 dbObj = new ProjectileDescriptor(predefinedid);
 
@@ -1235,6 +1253,12 @@ public static partial class DbInterface
                     case GameObjectType.Npc:
                         context.Npcs.Add((NPCDescriptor)dbObj);
                         NPCDescriptor.Lookup.Set(dbObj.Id, dbObj);
+
+                        break;
+
+                    case GameObjectType.Pet:
+                        context.Pets.Add((PetDescriptor)dbObj);
+                        PetDescriptor.Lookup.Set(dbObj.Id, dbObj);
 
                         break;
 
@@ -1374,6 +1398,11 @@ public static partial class DbInterface
                         break;
                     case GameObjectType.Npc:
                         context.Npcs.Remove((NPCDescriptor)gameObject);
+
+                        break;
+
+                    case GameObjectType.Pet:
+                        context.Pets.Remove((PetDescriptor)gameObject);
 
                         break;
                     case GameObjectType.Projectile:
@@ -1553,6 +1582,11 @@ public static partial class DbInterface
                             npcDescriptor.SyncBestiaryJson();
                             context.Npcs.Update(npcDescriptor);
                         }
+
+                        break;
+
+                    case GameObjectType.Pet:
+                        context.Pets.Update((PetDescriptor)gameObject);
 
                         break;
                     case GameObjectType.Projectile:

--- a/Intersect.Server.Core/Networking/PacketSender.cs
+++ b/Intersect.Server.Core/Networking/PacketSender.cs
@@ -14,6 +14,7 @@ using Intersect.Framework.Core.GameObjects.Mapping.Tilesets;
 using Intersect.Framework.Core.GameObjects.Maps.MapList;
 using Intersect.Framework.Core.GameObjects.NPCs;
 using Intersect.Framework.Core.GameObjects.PlayerClass;
+using Intersect.Framework.Core.GameObjects.Pets;
 using Intersect.Framework.Core.GameObjects.Resources;
 using Intersect.Framework.Core.GameObjects.Variables;
 using Intersect.Framework.Core.Network.Packets.Security;
@@ -1866,6 +1867,13 @@ public static partial class PacketSender
                 break;
             case GameObjectType.Npc:
                 foreach (var obj in NPCDescriptor.Lookup)
+                {
+                    SendGameObject(client, obj.Value, false, false, packetList);
+                }
+
+                break;
+            case GameObjectType.Pet:
+                foreach (var obj in PetDescriptor.Lookup)
                 {
                     SendGameObject(client, obj.Value, false, false, packetList);
                 }

--- a/Intersect.Server/Networking/NetworkedPacketHandler.cs
+++ b/Intersect.Server/Networking/NetworkedPacketHandler.cs
@@ -11,6 +11,7 @@ using Intersect.Framework.Core.GameObjects.Maps;
 using Intersect.Framework.Core.GameObjects.Maps.MapList;
 using Intersect.Framework.Core.GameObjects.NPCs;
 using Intersect.Framework.Core.GameObjects.PlayerClass;
+using Intersect.Framework.Core.GameObjects.Pets;
 using Intersect.Framework.Core.GameObjects.Resources;
 using Intersect.Framework.Core.GameObjects.Variables;
 using Intersect.Framework.Core.Security;
@@ -909,6 +910,10 @@ internal sealed partial class NetworkedPacketHandler
                     obj = NPCDescriptor.Get(id);
 
                     break;
+                case GameObjectType.Pet:
+                    obj = PetDescriptor.Get(id);
+
+                    break;
 
                 case GameObjectType.Projectile:
                     obj = ProjectileDescriptor.Get(id);
@@ -1059,6 +1064,10 @@ internal sealed partial class NetworkedPacketHandler
                     break;
                 case GameObjectType.Npc:
                     obj = NPCDescriptor.Get(id);
+
+                    break;
+                case GameObjectType.Pet:
+                    obj = PetDescriptor.Get(id);
 
                     break;
 


### PR DESCRIPTION
## Summary
- load, update, and delete pet descriptors in the editor's game object packet handler
- ensure the server database layer can load, add, save, and remove pet descriptors alongside other game objects
- include pets in server game object packet broadcasting and in save/delete request handling

## Testing
- `dotnet build Intersect.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cc9ff41d34832bbcf2c546503890b9