### PR TITLE
Improve pet editor localization and toolstrip interactions

### DIFF
--- a/Intersect.Editor/Forms/Editors/frmPet.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/frmPet.Designer.cs
@@ -1091,6 +1091,7 @@ namespace Intersect.Editor.Forms.Editors
             toolStripItemNew.Name = "toolStripItemNew";
             toolStripItemNew.Size = new Size(23, 26);
             toolStripItemNew.Text = "New";
+            toolStripItemNew.Click += toolStripItemNew_Click;
             // 
             // toolStripSeparator1
             // 
@@ -1109,6 +1110,7 @@ namespace Intersect.Editor.Forms.Editors
             toolStripItemDelete.Name = "toolStripItemDelete";
             toolStripItemDelete.Size = new Size(23, 26);
             toolStripItemDelete.Text = "Delete";
+            toolStripItemDelete.Click += toolStripItemDelete_Click;
             // 
             // toolStripSeparator2
             // 
@@ -1126,6 +1128,7 @@ namespace Intersect.Editor.Forms.Editors
             btnAlphabetical.Name = "btnAlphabetical";
             btnAlphabetical.Size = new Size(23, 26);
             btnAlphabetical.Text = "Order Chronologically";
+            btnAlphabetical.Click += btnAlphabetical_Click;
             // 
             // toolStripSeparator4
             // 
@@ -1144,6 +1147,7 @@ namespace Intersect.Editor.Forms.Editors
             toolStripItemCopy.Name = "toolStripItemCopy";
             toolStripItemCopy.Size = new Size(23, 26);
             toolStripItemCopy.Text = "Copy";
+            toolStripItemCopy.Click += toolStripItemCopy_Click;
             // 
             // toolStripItemPaste
             // 
@@ -1155,6 +1159,7 @@ namespace Intersect.Editor.Forms.Editors
             toolStripItemPaste.Name = "toolStripItemPaste";
             toolStripItemPaste.Size = new Size(23, 26);
             toolStripItemPaste.Text = "Paste";
+            toolStripItemPaste.Click += toolStripItemPaste_Click;
             // 
             // toolStripSeparator3
             // 
@@ -1173,6 +1178,7 @@ namespace Intersect.Editor.Forms.Editors
             toolStripItemUndo.Name = "toolStripItemUndo";
             toolStripItemUndo.Size = new Size(23, 26);
             toolStripItemUndo.Text = "Undo";
+            toolStripItemUndo.Click += toolStripItemUndo_Click;
             // 
             // FrmPet
             // 

--- a/Intersect.Editor/Forms/Editors/frmPet.cs
+++ b/Intersect.Editor/Forms/Editors/frmPet.cs
@@ -364,7 +364,17 @@ public partial class FrmPet : EditorForm
         lblLevel.Text = Strings.Pets.level;
         lblExp.Text = Strings.Pets.experience;
         grpStats.Text = Strings.Pets.stats;
+        lblHP.Text = Strings.NpcEditor.hp;
+        lblMana.Text = Strings.NpcEditor.mana;
+        lblStr.Text = Strings.NpcEditor.attack;
+        lblDef.Text = Strings.NpcEditor.defense;
+        lblMag.Text = Strings.NpcEditor.abilitypower;
+        lblMR.Text = Strings.NpcEditor.magicresist;
+        lblSpd.Text = Strings.NpcEditor.speed;
+        label1.Text = $"{Globals.GetStatName((int)Stat.Agility)}:";
         grpRegen.Text = Strings.Pets.vitalregen;
+        lblHpRegen.Text = Strings.NpcEditor.hpregen;
+        lblManaRegen.Text = Strings.NpcEditor.mpregen;
         grpCombat.Text = Strings.Pets.combat;
         lblAttackAnimation.Text = Strings.Pets.attackanimation;
         lblDeathAnimation.Text = Strings.Pets.deathanimation;
@@ -378,6 +388,13 @@ public partial class FrmPet : EditorForm
         lblAttackSpeedValue.Text = Strings.Pets.attackspeedvalue;
         grpImmunities.Text = Strings.Pets.immunities;
         lblTenacity.Text = Strings.Pets.tenacity;
+        foreach (var (effect, checkbox) in _immunityCheckboxes)
+        {
+            if (Strings.NpcEditor.Immunities.TryGetValue(effect, out var text))
+            {
+                checkbox.Text = text;
+            }
+        }
         grpSpells.Text = Strings.Pets.spells;
         btnAdd.Text = Strings.Pets.addspell;
         btnRemove.Text = Strings.Pets.removespell;


### PR DESCRIPTION
## Summary
- wire the pet editor tool strip buttons to their click handlers so the shortcuts work from the toolbar
- update pet editor localization to reuse the NPC strings for stat, regen, and immunity labels
- populate immunity checkbox captions from the shared NPC dictionary so they stay in sync

## Testing
- `dotnet build Intersect.sln` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68ccbbe5d4c4832bbfcd8924029bc5ea