### PR TITLE
Track active pet behavior mode on players

### DIFF
--- a/Framework/Intersect.Framework.Core/GameObjects/Pets/PetBehaviorMode.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Pets/PetBehaviorMode.cs
@@ -1,0 +1,7 @@
+namespace Intersect.Enums;
+
+public enum PetBehaviorMode
+{
+    None = 0,
+    Defend = 1,
+}

--- a/Intersect.Server.Core/Entities/Pet.cs
+++ b/Intersect.Server.Core/Entities/Pet.cs
@@ -314,6 +314,16 @@ public sealed class Pet : Entity
             return;
         }
 
+        if (owner.ActivePetMode != PetBehaviorMode.Defend)
+        {
+            return;
+        }
+
+        if (IsRestrained())
+        {
+            return;
+        }
+
         var aggressor = attacker;
         if (aggressor == null || !IsValidAggressor(aggressor, owner))
         {
@@ -411,6 +421,11 @@ public sealed class Pet : Entity
         }
 
         State = PetState.Idle;
+    }
+
+    private bool IsRestrained()
+    {
+        return HasStatusEffect(SpellEffect.Stun) || HasStatusEffect(SpellEffect.Sleep);
     }
 
     private bool IsValidAggressor(Entity? attacker, Player owner)

--- a/Intersect.Server.Core/Entities/Player.cs
+++ b/Intersect.Server.Core/Entities/Player.cs
@@ -81,6 +81,8 @@ public partial class Player : Entity
 
     [JsonIgnore][NotMapped] public Pet? CurrentPet { get; private set; }
 
+    [JsonIgnore][NotMapped] public PetBehaviorMode ActivePetMode { get; set; } = PetBehaviorMode.Defend;
+
     #endregion
 
     private Entity? _pendingPetAttacker;


### PR DESCRIPTION
## Summary
- add a shared `PetBehaviorMode` enum for clients and the server
- expose the active pet behavior mode on `Player` instances
- gate defensive pet targeting on the owner's mode and the pet not being crowd controlled

## Testing
- `dotnet build Intersect.sln` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ccd116ea34832b80e5c4f8f848a1f8