### PR TITLE
Add shared pet behavior support across client and server

### DIFF
--- a/Framework/Intersect.Framework.Core/GameObjects/Pets/PetBehavior.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Pets/PetBehavior.cs
@@ -1,0 +1,9 @@
+namespace Intersect.Shared.Pets;
+
+public enum PetBehavior : byte
+{
+    Follow = 0,
+    Stay = 1,
+    Defend = 2,
+    Passive = 3,
+}

--- a/Framework/Intersect.Framework.Core/Network/Packets/Server/PetEntityPacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Server/PetEntityPacket.cs
@@ -1,6 +1,7 @@
 
 using System;
 using Intersect.Enums;
+using Intersect.Shared.Pets;
 using MessagePack;
 
 namespace Intersect.Network.Packets.Server;
@@ -20,9 +21,11 @@ public sealed class PetEntityPacket : EntityPacket
     public Guid DescriptorId { get; set; }
 
     [Key(26)]
-
     public PetState State { get; set; }
 
     [Key(27)]
     public bool Despawnable { get; set; }
+
+    [Key(28)]
+    public PetBehavior Behavior { get; set; }
 }

--- a/Framework/Intersect.Framework.Core/Network/Packets/Server/PetEntityUpdatePacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Server/PetEntityUpdatePacket.cs
@@ -1,5 +1,6 @@
 using System;
 using Intersect.Enums;
+using Intersect.Shared.Pets;
 using MessagePack;
 
 namespace Intersect.Network.Packets.Server;
@@ -42,4 +43,7 @@ public sealed class PetEntityUpdate
 
     [Key(4)]
     public bool Despawnable { get; set; }
+
+    [Key(5)]
+    public PetBehavior Behavior { get; set; }
 }

--- a/Intersect.Client.Core/Entities/Pet.cs
+++ b/Intersect.Client.Core/Entities/Pet.cs
@@ -4,6 +4,7 @@ using Intersect.Enums;
 using Intersect.Framework.Core;
 using Intersect.Framework.Core.GameObjects.Pets;
 using Intersect.Network.Packets.Server;
+using Intersect.Shared.Pets;
 
 namespace Intersect.Client.Entities;
 
@@ -36,6 +37,11 @@ public sealed class Pet : Entity
     ///     Gets the current state reported by the server for the pet.
     /// </summary>
     public PetState State { get; private set; } = PetState.Idle;
+
+    /// <summary>
+    ///     Gets the behaviour currently reported by the server for the pet.
+    /// </summary>
+    public PetBehavior Behavior { get; private set; } = PetBehavior.Follow;
 
     /// <summary>
     ///     Gets the descriptor identifier used to spawn this pet.
@@ -96,19 +102,22 @@ public sealed class Pet : Entity
     /// <param name="descriptorId">Identifier of the descriptor that spawned the pet.</param>
     /// <param name="state">Current state reported by the server.</param>
     /// <param name="despawnable">Indicates whether the pet can despawn automatically.</param>
-    public void ApplyMetadata(Guid ownerId, Guid descriptorId, PetState state, bool despawnable)
+    /// <param name="behavior">Behaviour reported by the server.</param>
+    public void ApplyMetadata(Guid ownerId, Guid descriptorId, PetState state, bool despawnable, PetBehavior behavior)
     {
         var ownerChanged = OwnerId != ownerId;
         var descriptorChanged = DescriptorId != descriptorId;
         var stateChanged = State != state;
         var despawnableChanged = Despawnable != despawnable;
+        var behaviorChanged = Behavior != behavior;
 
         OwnerId = ownerId;
         DescriptorId = descriptorId;
         State = state;
         Despawnable = despawnable;
+        Behavior = behavior;
 
-        if (ownerChanged || descriptorChanged || stateChanged || despawnableChanged)
+        if (ownerChanged || descriptorChanged || stateChanged || despawnableChanged || behaviorChanged)
         {
             Globals.NotifyPetMetadataApplied(this);
         }
@@ -124,6 +133,7 @@ public sealed class Pet : Entity
         DescriptorId = Guid.Empty;
         State = PetState.Idle;
         Despawnable = false;
+        Behavior = PetBehavior.Follow;
     }
 
     /// <inheritdoc />
@@ -136,6 +146,12 @@ public sealed class Pet : Entity
             return;
         }
 
-        ApplyMetadata(petPacket.OwnerId, petPacket.DescriptorId, petPacket.State, petPacket.Despawnable);
+        ApplyMetadata(
+            petPacket.OwnerId,
+            petPacket.DescriptorId,
+            petPacket.State,
+            petPacket.Despawnable,
+            petPacket.Behavior
+        );
     }
 }

--- a/Intersect.Client.Core/Networking/PacketHandler.cs
+++ b/Intersect.Client.Core/Networking/PacketHandler.cs
@@ -458,7 +458,13 @@ internal sealed partial class PacketHandler
                 continue;
             }
 
-            pet.ApplyMetadata(update.OwnerId, update.DescriptorId, update.State, update.Despawnable);
+            pet.ApplyMetadata(
+                update.OwnerId,
+                update.DescriptorId,
+                update.State,
+                update.Despawnable,
+                update.Behavior
+            );
         }
     }
 

--- a/Intersect.Server.Core/Entities/Player.cs
+++ b/Intersect.Server.Core/Entities/Player.cs
@@ -46,6 +46,7 @@ using Stat = Intersect.Enums.Stat;
 using Intersect.Framework.Core.GameObjects.Guild;
 using System.Linq;
 using Intersect.Server.Services;
+using Intersect.Shared.Pets;
 
 namespace Intersect.Server.Entities;
 
@@ -81,7 +82,7 @@ public partial class Player : Entity
 
     [JsonIgnore][NotMapped] public Pet? CurrentPet { get; private set; }
 
-    [JsonIgnore][NotMapped] public PetBehaviorMode ActivePetMode { get; set; } = PetBehaviorMode.Defend;
+    [JsonIgnore][NotMapped] public PetBehavior ActivePetMode { get; set; } = PetBehavior.Defend;
 
     #endregion
 

--- a/Intersect.Server.Core/Networking/PacketSender.cs
+++ b/Intersect.Server.Core/Networking/PacketSender.cs
@@ -1015,16 +1015,17 @@ public static partial class PacketSender
         var updates = new List<PetEntityUpdate>(pets.Count);
         foreach (var pet in pets)
         {
-            updates.Add(
-                new PetEntityUpdate
-                {
-                    EntityId = pet.Id,
-                    OwnerId = pet.OwnerId,
-                    DescriptorId = pet.Descriptor?.Id ?? Guid.Empty,
-                    State = pet.State,
-                    Despawnable = pet.Despawnable,
-                }
-            );
+                    updates.Add(
+                        new PetEntityUpdate
+                        {
+                            EntityId = pet.Id,
+                            OwnerId = pet.OwnerId,
+                            DescriptorId = pet.Descriptor?.Id ?? Guid.Empty,
+                            State = pet.State,
+                            Despawnable = pet.Despawnable,
+                            Behavior = pet.Behavior,
+                        }
+                    );
         }
 
         SendDataToProximityOnMapInstance(map.Id, mapInstanceId, new PetEntityUpdatePacket(map.Id, updates.ToArray()));


### PR DESCRIPTION
## Summary
- add a shared PetBehavior enum so client and server agree on pet modes
- expose the pet behavior through server entities, packets, and updates
- mirror the new behavior field on the client so metadata and UI stay in sync

## Testing
- `dotnet build Intersect.sln` *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd6b1a3bc0832bab9ecfb6db447ae4