### PR TITLE
Implement pet behavior change flow

### DIFF
--- a/Framework/Intersect.Framework.Core/Network/Packets/Client/PetBehaviorChangePacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Client/PetBehaviorChangePacket.cs
@@ -1,0 +1,25 @@
+using System;
+using Intersect.Shared.Pets;
+using MessagePack;
+
+namespace Intersect.Network.Packets.Client;
+
+[MessagePackObject]
+public sealed class PetBehaviorChangePacket : IntersectPacket
+{
+    public PetBehaviorChangePacket()
+    {
+    }
+
+    public PetBehaviorChangePacket(PetBehavior behavior, Guid petId = default)
+    {
+        PetId = petId;
+        Behavior = behavior;
+    }
+
+    [Key(0)]
+    public Guid PetId { get; set; }
+
+    [Key(1)]
+    public PetBehavior Behavior { get; set; }
+}

--- a/Framework/Intersect.Framework.Core/Network/Packets/Server/PetStateUpdatePacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Server/PetStateUpdatePacket.cs
@@ -1,0 +1,30 @@
+using System;
+using Intersect.Enums;
+using Intersect.Shared.Pets;
+using MessagePack;
+
+namespace Intersect.Network.Packets.Server;
+
+[MessagePackObject]
+public sealed class PetStateUpdatePacket : IntersectPacket
+{
+    public PetStateUpdatePacket()
+    {
+    }
+
+    public PetStateUpdatePacket(Guid petId, PetState state, PetBehavior behavior)
+    {
+        PetId = petId;
+        State = state;
+        Behavior = behavior;
+    }
+
+    [Key(0)]
+    public Guid PetId { get; set; }
+
+    [Key(1)]
+    public PetState State { get; set; }
+
+    [Key(2)]
+    public PetBehavior Behavior { get; set; }
+}

--- a/Intersect.Client.Core/Networking/PacketHandler.cs
+++ b/Intersect.Client.Core/Networking/PacketHandler.cs
@@ -468,6 +468,26 @@ internal sealed partial class PacketHandler
         }
     }
 
+    public void HandlePacket(IPacketSender packetSender, PetStateUpdatePacket packet)
+    {
+        if (packet == null)
+        {
+            return;
+        }
+
+        if (!Globals.TryGetEntity(EntityType.Pet, packet.PetId, out var entity))
+        {
+            return;
+        }
+
+        if (entity is not Pet pet)
+        {
+            return;
+        }
+
+        pet.ApplyMetadata(pet.OwnerId, pet.DescriptorId, packet.State, pet.Despawnable, packet.Behavior);
+    }
+
     //ResourceEntityPacket
     public void HandlePacket(IPacketSender packetSender, ResourceEntityPacket packet)
     {

--- a/Intersect.Server.Core/Entities/Pet.cs
+++ b/Intersect.Server.Core/Entities/Pet.cs
@@ -75,10 +75,16 @@ public sealed class Pet : Entity
                 return;
             }
 
+            var previousState = State;
             _behavior = value;
 
             ApplyBehaviorSettings(value);
             MarkMetadataDirty();
+
+            if (State == previousState)
+            {
+                BroadcastState();
+            }
         }
     }
 
@@ -99,6 +105,7 @@ public sealed class Pet : Entity
 
             _state = value;
             MarkMetadataDirty();
+            BroadcastState();
         }
     }
 
@@ -830,6 +837,11 @@ public sealed class Pet : Entity
     private void MarkMetadataDirty()
     {
         _metadataDirty = true;
+    }
+
+    private void BroadcastState()
+    {
+        PacketSender.SendPetStateUpdate(this);
     }
 
     internal bool MetadataDirty => _metadataDirty;

--- a/Intersect.Server.Core/Networking/PacketHandler.cs
+++ b/Intersect.Server.Core/Networking/PacketHandler.cs
@@ -29,6 +29,7 @@ using Intersect.Network.Packets.Server;
 using Intersect.Server.Core;
 using Intersect.Server.Services;
 using Microsoft.Extensions.Logging;
+using Intersect.Shared.Pets;
 using ChatMsgPacket = Intersect.Network.Packets.Client.ChatMsgPacket;
 using LoginPacket = Intersect.Network.Packets.Client.LoginPacket;
 using PartyInvitePacket = Intersect.Network.Packets.Client.PartyInvitePacket;
@@ -3258,6 +3259,33 @@ internal sealed partial class PacketHandler
                 player.Target = entity;
             }
         }
+    }
+
+    public void HandlePacket(Client client, PetBehaviorChangePacket packet)
+    {
+        if (client?.Entity is not Player player || packet == null)
+        {
+            return;
+        }
+
+        var pet = player.FindPet(packet.PetId);
+        if (pet == null || pet.IsDisposed || pet.OwnerId != player.Id)
+        {
+            return;
+        }
+
+        if (pet.Behavior == packet.Behavior)
+        {
+            return;
+        }
+
+        if (!player.TryBeginPetBehaviorChange())
+        {
+            return;
+        }
+
+        pet.SetBehavior(packet.Behavior);
+        player.ActivePetMode = packet.Behavior;
     }
 
     //SetAlignmentRequestPacket

--- a/Intersect.Server.Core/Networking/PacketSender.cs
+++ b/Intersect.Server.Core/Networking/PacketSender.cs
@@ -1031,6 +1031,29 @@ public static partial class PacketSender
         SendDataToProximityOnMapInstance(map.Id, mapInstanceId, new PetEntityUpdatePacket(map.Id, updates.ToArray()));
     }
 
+    public static void SendPetStateUpdate(Pet pet)
+    {
+        if (pet == null)
+        {
+            return;
+        }
+
+        var packet = new PetStateUpdatePacket(pet.Id, pet.State, pet.Behavior);
+
+        var owner = pet.Owner;
+        if (owner != null && !owner.IsDisposed)
+        {
+            owner.SendPacket(packet, TransmissionMode.Any);
+        }
+
+        if (pet.MapId == Guid.Empty || pet.MapInstanceId == Guid.Empty)
+        {
+            return;
+        }
+
+        SendDataToProximityOnMapInstance(pet.MapId, pet.MapInstanceId, packet, owner, TransmissionMode.Any);
+    }
+
     //EntityStatsPacket
     public static void SendEntityStats(Entity en)
     {


### PR DESCRIPTION
## Summary
- add a client packet to request pet behavior changes
- enforce ownership/cooldown when applying pet behavior updates on the server and broadcast state changes
- send a new pet state update packet so clients stay in sync with behavior/state transitions

## Testing
- `dotnet build` *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd7072b9ac832b80e6b501b848b9ba