### PR TITLE
Handle pets outside global entity lookups

### DIFF
--- a/Intersect.Client.Core/Networking/PacketHandler.cs
+++ b/Intersect.Client.Core/Networking/PacketHandler.cs
@@ -43,21 +43,6 @@ namespace Intersect.Client.Networking;
 
 internal sealed partial class PacketHandler
 {
-    private const string PetEntityTypeName = "Pet";
-
-    private static readonly bool PetEntityTypeDefined;
-
-    private static readonly EntityType PetEntityType;
-
-    static PacketHandler()
-    {
-        if (Enum.TryParse(PetEntityTypeName, ignoreCase: false, out EntityType petEntityType))
-        {
-            PetEntityTypeDefined = true;
-            PetEntityType = petEntityType;
-        }
-    }
-
     private sealed partial class VirtualPacketSender : IPacketSender
     {
         public IApplicationContext ApplicationContext { get; }
@@ -101,8 +86,7 @@ internal sealed partial class PacketHandler
         return type == EntityType.GlobalEntity ||
                type == EntityType.Player ||
                type == EntityType.Resource ||
-               type == EntityType.Projectile ||
-               (PetEntityTypeDefined && type == PetEntityType);
+               type == EntityType.Projectile;
     }
 
     public PacketHandler(IClientContext context, PacketHandlerRegistry packetHandlerRegistry)
@@ -624,28 +608,38 @@ internal sealed partial class PacketHandler
         var type = packet.Type;
         var mapId = packet.MapId;
         Entity en;
-        if (type != EntityType.Event)
+        if (type == EntityType.Pet)
         {
-            if (!Globals.Entities.ContainsKey(id))
+            if (!Globals.TryGetEntity(EntityType.Pet, id, out var entity))
             {
                 return;
             }
 
-            en = Globals.Entities[id];
+            en = entity;
+        }
+        else if (IsGlobalEntityType(type))
+        {
+            if (!Globals.Entities.TryGetValue(id, out var entity))
+            {
+                return;
+            }
+
+            en = entity;
         }
         else
         {
-            if (MapInstance.Get(mapId) == null)
+            var mapInstance = MapInstance.Get(mapId);
+            if (mapInstance == null)
             {
                 return;
             }
 
-            if (!MapInstance.Get(mapId).LocalEntities.ContainsKey(id))
+            if (!mapInstance.LocalEntities.TryGetValue(id, out var entity))
             {
                 return;
             }
 
-            en = MapInstance.Get(mapId).LocalEntities[id];
+            en = entity;
         }
 
         if (en == Globals.Me)
@@ -798,14 +792,23 @@ internal sealed partial class PacketHandler
         var type = packet.Type;
         var mapId = packet.MapId;
         Entity en;
-        if (IsGlobalEntityType(type))
+        if (type == EntityType.Pet)
         {
-            if (!Globals.Entities.ContainsKey(id))
+            if (!Globals.TryGetEntity(EntityType.Pet, id, out var entity))
             {
                 return;
             }
 
-            en = Globals.Entities[id];
+            en = entity;
+        }
+        else if (IsGlobalEntityType(type))
+        {
+            if (!Globals.Entities.TryGetValue(id, out var entity))
+            {
+                return;
+            }
+
+            en = entity;
         }
         else
         {
@@ -815,17 +818,12 @@ internal sealed partial class PacketHandler
                 return;
             }
 
-            if (!gameMap.LocalEntities.ContainsKey(id))
+            if (!gameMap.LocalEntities.TryGetValue(id, out var entity))
             {
                 return;
             }
 
-            en = gameMap.LocalEntities[id];
-        }
-
-        if (en == null)
-        {
-            return;
+            en = entity;
         }
 
         var entityMap = MapInstance.Get(en.MapId);
@@ -1056,15 +1054,24 @@ internal sealed partial class PacketHandler
         var id = packet.Id;
         var type = packet.Type;
         var mapId = packet.MapId;
-        Entity en = null;
-        if (IsGlobalEntityType(type))
+        Entity en;
+        if (type == EntityType.Pet)
         {
-            if (!Globals.Entities.ContainsKey(id))
+            if (!Globals.TryGetEntity(EntityType.Pet, id, out var entity))
             {
                 return;
             }
 
-            en = Globals.Entities[id];
+            en = entity;
+        }
+        else if (IsGlobalEntityType(type))
+        {
+            if (!Globals.Entities.TryGetValue(id, out var entity))
+            {
+                return;
+            }
+
+            en = entity;
         }
         else
         {
@@ -1074,17 +1081,12 @@ internal sealed partial class PacketHandler
                 return;
             }
 
-            if (!entityMap.LocalEntities.ContainsKey(id))
+            if (!entityMap.LocalEntities.TryGetValue(id, out var entity))
             {
                 return;
             }
 
-            en = entityMap.LocalEntities[id];
-        }
-
-        if (en == null)
-        {
-            return;
+            en = entity;
         }
 
         en.Vital = packet.Vitals;
@@ -1142,15 +1144,24 @@ internal sealed partial class PacketHandler
         var id = packet.Id;
         var type = packet.Type;
         var mapId = packet.MapId;
-        Entity en = null;
-        if (IsGlobalEntityType(type))
+        Entity en;
+        if (type == EntityType.Pet)
         {
-            if (!Globals.Entities.ContainsKey(id))
+            if (!Globals.TryGetEntity(EntityType.Pet, id, out var entity))
             {
                 return;
             }
 
-            en = Globals.Entities[id];
+            en = entity;
+        }
+        else if (IsGlobalEntityType(type))
+        {
+            if (!Globals.Entities.TryGetValue(id, out var entity))
+            {
+                return;
+            }
+
+            en = entity;
         }
         else
         {
@@ -1160,17 +1171,12 @@ internal sealed partial class PacketHandler
                 return;
             }
 
-            if (!entityMap.LocalEntities.ContainsKey(id))
+            if (!entityMap.LocalEntities.TryGetValue(id, out var entity))
             {
                 return;
             }
 
-            en = entityMap.LocalEntities[id];
-        }
-
-        if (en == null)
-        {
-            return;
+            en = entity;
         }
 
         en.Stat = packet.Stats;
@@ -1182,15 +1188,24 @@ internal sealed partial class PacketHandler
         var id = packet.Id;
         var type = packet.Type;
         var mapId = packet.MapId;
-        Entity en = null;
-        if (IsGlobalEntityType(type))
+        Entity en;
+        if (type == EntityType.Pet)
         {
-            if (!Globals.Entities.ContainsKey(id))
+            if (!Globals.TryGetEntity(EntityType.Pet, id, out var entity))
             {
                 return;
             }
 
-            en = Globals.Entities[id];
+            en = entity;
+        }
+        else if (IsGlobalEntityType(type))
+        {
+            if (!Globals.Entities.TryGetValue(id, out var entity))
+            {
+                return;
+            }
+
+            en = entity;
         }
         else
         {
@@ -1200,17 +1215,12 @@ internal sealed partial class PacketHandler
                 return;
             }
 
-            if (!entityMap.LocalEntities.ContainsKey(id))
+            if (!entityMap.LocalEntities.TryGetValue(id, out var entity))
             {
                 return;
             }
 
-            en = entityMap.LocalEntities[id];
-        }
-
-        if (en == null)
-        {
-            return;
+            en = entity;
         }
 
         en.DirectionFacing = (Direction)packet.Direction;
@@ -1224,15 +1234,24 @@ internal sealed partial class PacketHandler
         var mapId = packet.MapId;
         var attackTimer = packet.AttackTimer;
 
-        Entity en = null;
-        if (IsGlobalEntityType(type))
+        Entity en;
+        if (type == EntityType.Pet)
         {
-            if (!Globals.Entities.ContainsKey(id))
+            if (!Globals.TryGetEntity(EntityType.Pet, id, out var entity))
             {
                 return;
             }
 
-            en = Globals.Entities[id];
+            en = entity;
+        }
+        else if (IsGlobalEntityType(type))
+        {
+            if (!Globals.Entities.TryGetValue(id, out var entity))
+            {
+                return;
+            }
+
+            en = entity;
         }
         else
         {
@@ -1242,17 +1261,12 @@ internal sealed partial class PacketHandler
                 return;
             }
 
-            if (!entityMap.LocalEntities.ContainsKey(id))
+            if (!entityMap.LocalEntities.TryGetValue(id, out var entity))
             {
                 return;
             }
 
-            en = entityMap.LocalEntities[id];
-        }
-
-        if (en == null)
-        {
-            return;
+            en = entity;
         }
 
         var isSelf = en == Globals.Me;
@@ -1275,15 +1289,24 @@ internal sealed partial class PacketHandler
         var type = packet.Type;
         var mapId = packet.MapId;
 
-        Entity? en = null;
-        if (IsGlobalEntityType(type))
+        Entity en;
+        if (type == EntityType.Pet)
         {
-            if (!Globals.Entities.ContainsKey(id))
+            if (!Globals.TryGetEntity(EntityType.Pet, id, out var entity))
             {
                 return;
             }
 
-            en = Globals.Entities[id];
+            en = entity;
+        }
+        else if (IsGlobalEntityType(type))
+        {
+            if (!Globals.Entities.TryGetValue(id, out var entity))
+            {
+                return;
+            }
+
+            en = entity;
         }
         else
         {
@@ -1293,17 +1316,12 @@ internal sealed partial class PacketHandler
                 return;
             }
 
-            if (!entityMap.LocalEntities.ContainsKey(id))
+            if (!entityMap.LocalEntities.TryGetValue(id, out var entity))
             {
                 return;
             }
 
-            en = entityMap.LocalEntities[id];
-        }
-
-        if (en == null)
-        {
-            return;
+            en = entity;
         }
 
         en.ClearAnimations();
@@ -2124,15 +2142,24 @@ internal sealed partial class PacketHandler
         var id = packet.EntityId;
         var type = packet.Type;
         var mapId = packet.MapId;
-        IEntity en = null;
-        if (IsGlobalEntityType(type))
+        IEntity en;
+        if (type == EntityType.Pet)
         {
-            if (!Globals.Entities.ContainsKey(id))
+            if (!Globals.TryGetEntity(EntityType.Pet, id, out var entity))
             {
                 return;
             }
 
-            en = Globals.Entities[id];
+            en = entity;
+        }
+        else if (IsGlobalEntityType(type))
+        {
+            if (!Globals.Entities.TryGetValue(id, out var entity))
+            {
+                return;
+            }
+
+            en = entity;
         }
         else
         {
@@ -2142,17 +2169,12 @@ internal sealed partial class PacketHandler
                 return;
             }
 
-            if (!entityMap.LocalEntities.ContainsKey(id))
-                return;
+            if (!entityMap.LocalEntities.TryGetValue(id, out var entity))
             {
+                return;
             }
 
-            en = entityMap.LocalEntities[id];
-        }
-
-        if (en == null)
-        {
-            return;
+            en = entity;
         }
 
         en.AddChatBubble(packet.Text);


### PR DESCRIPTION
## Summary
- stop treating pets as global entities when resolving entity handlers
- route pet lookups through Globals.TryGetEntity in movement, vitals, stats, direction, attack, death, and chat bubble handlers
- simplify global entity helper so pets are managed separately from other global entities

## Testing
- dotnet build Intersect.Client.Core/Intersect.Client.Core.csproj *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68cd773867a4832b9d906ccabdcb7102