### PR TITLE
Add client pet hub and behavior controls

### DIFF
--- a/Intersect.Client.Core/Core/Input.cs
+++ b/Intersect.Client.Core/Core/Input.cs
@@ -15,6 +15,7 @@ using Intersect.Client.Networking;
 using Intersect.Configuration;
 using Intersect.Enums;
 using Intersect.Framework.Core;
+using Intersect.Shared.Pets;
 
 namespace Intersect.Client.Core;
 
@@ -352,6 +353,22 @@ public static partial class Input
 
                         case Control.OpenGuild:
                             _ = Interface.Interface.GameUi.GameMenu?.ToggleGuildWindow();
+                            break;
+
+                        case Control.PetModeFollow:
+                            _ = Globals.PetHub.SetBehavior(PetBehavior.Follow);
+                            break;
+
+                        case Control.PetModeStay:
+                            _ = Globals.PetHub.SetBehavior(PetBehavior.Stay);
+                            break;
+
+                        case Control.PetModeDefend:
+                            _ = Globals.PetHub.SetBehavior(PetBehavior.Defend);
+                            break;
+
+                        case Control.PetModePassive:
+                            _ = Globals.PetHub.SetBehavior(PetBehavior.Passive);
                             break;
 
                         case Control.TargetParty1:

--- a/Intersect.Client.Core/Core/Main.cs
+++ b/Intersect.Client.Core/Core/Main.cs
@@ -314,6 +314,7 @@ internal static partial class Main
         //Dump Game Objects
         Globals.Me = null;
         Globals.HasGameData = false;
+        Globals.PetHub.Reset();
         foreach (var map in MapInstance.Lookup)
         {
             var mp = (MapInstance) map.Value;

--- a/Intersect.Client.Core/General/Globals.cs
+++ b/Intersect.Client.Core/General/Globals.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
+using Intersect.Client.Core.Pets;
 using Intersect.Client.Entities;
 using Intersect.Client.Entities.Events;
 using Intersect.Client.Framework.Database;
@@ -43,6 +44,8 @@ public static partial class Globals
     internal static readonly List<IClientLifecycleHelper> ClientLifecycleHelpers = [];
 
     public static event Action<Pet>? PetMetadataChanged;
+
+    public static PetHub PetHub { get; } = new();
 
     private static GameStates mGameState = GameStates.Intro;
 

--- a/Intersect.Client.Core/Interface/Game/GameInterface.cs
+++ b/Intersect.Client.Core/Interface/Game/GameInterface.cs
@@ -26,6 +26,7 @@ using Microsoft.Extensions.Logging;
 using Intersect.Framework.Core.GameObjects.Items;
 using Intersect.Client.Interface.Game.Spells;
 using Intersect.Client.Interface.Game.Market;
+using Intersect.Client.Interface.Game.Pets;
 using Intersect.Network.Packets.Server;
 
 namespace Intersect.Client.Interface.Game;
@@ -112,6 +113,8 @@ public partial class GameInterface : MutableInterface
 
     public PlayerStatusWindow PlayerStatusWindow;
 
+    private PetBehaviorWidget? _petBehaviorWidget;
+
 
     private SettingsWindow GetOrCreateSettingsWindow()
     {
@@ -182,6 +185,8 @@ public partial class GameInterface : MutableInterface
 
         mQuestOfferWindow = new QuestOfferWindow(GameCanvas);
         mMapItemWindow = new MapItemWindow(GameCanvas);
+
+        _petBehaviorWidget ??= new PetBehaviorWidget(GameCanvas);
 
     }
     public void OpenEnchantWindow()

--- a/Intersect.Client.Core/Interface/Game/Pets/PetBehaviorWidget.cs
+++ b/Intersect.Client.Core/Interface/Game/Pets/PetBehaviorWidget.cs
@@ -1,0 +1,109 @@
+using System.Collections.Generic;
+using Intersect.Client.General;
+using Intersect.Client.Framework.Gwen;
+using Intersect.Client.Framework.Gwen.Control;
+using Intersect.Client.Framework.Gwen.Control.EventArguments;
+using Intersect.Client.Localization;
+using Intersect.Localization;
+using Intersect.Shared.Pets;
+
+namespace Intersect.Client.Interface.Game.Pets;
+
+public sealed class PetBehaviorWidget : RadioButtonGroup
+{
+    private readonly Dictionary<PetBehavior, LabeledRadioButton> _options = new();
+    private bool _suppressSelectionChanged;
+
+    public PetBehaviorWidget(Canvas parent) : base(parent)
+    {
+        Name = nameof(PetBehaviorWidget);
+        Alignment = [Alignments.Bottom, Alignments.Left];
+        AlignmentPadding = new Padding { Bottom = 4, Left = 4 };
+        Padding = new Padding(4);
+        RestrictToParent = true;
+        ShouldCacheToTexture = true;
+        Text = Strings.Pets.WidgetTitle.ToString();
+
+        CreateOption(PetBehavior.Follow, Strings.Pets.BehaviorFollow);
+        CreateOption(PetBehavior.Stay, Strings.Pets.BehaviorStay);
+        CreateOption(PetBehavior.Defend, Strings.Pets.BehaviorDefend);
+        CreateOption(PetBehavior.Passive, Strings.Pets.BehaviorPassive);
+
+        SelectionChanged += OnSelectionChanged;
+        Globals.PetHub.ActivePetChanged += OnPetHubStateChanged;
+        Globals.PetHub.BehaviorChanged += OnPetHubStateChanged;
+
+        RefreshState();
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            Globals.PetHub.ActivePetChanged -= OnPetHubStateChanged;
+            Globals.PetHub.BehaviorChanged -= OnPetHubStateChanged;
+            SelectionChanged -= OnSelectionChanged;
+        }
+
+        base.Dispose(disposing);
+    }
+
+    private void CreateOption(PetBehavior behavior, LocalizedString label)
+    {
+        var option = AddOption(label.ToString(), behavior.ToString());
+        option.UserData = behavior;
+        option.IsTabable = false;
+        option.Margin = new Margin(0, 0, 0, 2);
+        _options[behavior] = option;
+    }
+
+    private void OnPetHubStateChanged()
+    {
+        RefreshState();
+    }
+
+    private void OnSelectionChanged(Base sender, ItemSelectedEventArgs args)
+    {
+        if (_suppressSelectionChanged)
+        {
+            return;
+        }
+
+        if (args.Selected is not LabeledRadioButton option || option.UserData is not PetBehavior behavior)
+        {
+            return;
+        }
+
+        _ = Globals.PetHub.SetBehavior(behavior);
+        RefreshState();
+    }
+
+    private void RefreshState()
+    {
+        _suppressSelectionChanged = true;
+
+        try
+        {
+            var hasPet = Globals.PetHub.HasActivePet;
+            var activeBehavior = Globals.PetHub.Behavior;
+
+            foreach (var (behavior, option) in _options)
+            {
+                option.IsDisabled = !hasPet;
+                option.RadioButton.IsChecked = hasPet && activeBehavior == behavior;
+            }
+
+            if (!hasPet)
+            {
+                foreach (var option in _options.Values)
+                {
+                    option.RadioButton.IsChecked = false;
+                }
+            }
+        }
+        finally
+        {
+            _suppressSelectionChanged = false;
+        }
+    }
+}

--- a/Intersect.Client.Core/Localization/Strings.cs
+++ b/Intersect.Client.Core/Localization/Strings.cs
@@ -1267,11 +1267,33 @@ public static partial class Strings
             {"holdtozoomout", "Hold to Zoom Out:"},
             {"togglefullscreen", "Toggle Fullscreen:"},
             {nameof(Control.ToggleAutoSoftRetargetOnSelfCast).ToLowerInvariant(), "Toggle Auto Soft-Retarget on Self-Cast:"},
+            {nameof(Control.PetModeFollow).ToLowerInvariant(), @"Pet Mode - Follow:"},
+            {nameof(Control.PetModeStay).ToLowerInvariant(), @"Pet Mode - Stay:"},
+            {nameof(Control.PetModeDefend).ToLowerInvariant(), @"Pet Mode - Defend:"},
+            {nameof(Control.PetModePassive).ToLowerInvariant(), @"Pet Mode - Passive:"},
         };
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public static LocalizedString Listening = @"Listening";
 
+    }
+
+    public partial struct Pets
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString WidgetTitle = @"Pet Modes";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString BehaviorFollow = @"Follow";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString BehaviorStay = @"Stay";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString BehaviorDefend = @"Defend";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString BehaviorPassive = @"Passive";
     }
 
     public partial struct Crafting

--- a/Intersect.Client.Core/Localization/Translations/en-US.json
+++ b/Intersect.Client.Core/Localization/Translations/en-US.json
@@ -13,5 +13,12 @@
     "FactionNeutralName": "Neutral",
     "FactionSerolfName": "Serolf",
     "FactionNidrajName": "Nidraj"
+  },
+  "Pets": {
+    "WidgetTitle": "Pet Modes",
+    "BehaviorFollow": "Follow",
+    "BehaviorStay": "Stay",
+    "BehaviorDefend": "Defend",
+    "BehaviorPassive": "Passive"
   }
 }

--- a/Intersect.Client.Core/Localization/Translations/es-ES.json
+++ b/Intersect.Client.Core/Localization/Translations/es-ES.json
@@ -13,5 +13,12 @@
     "FactionNeutralName": "Neutral",
     "FactionSerolfName": "Serolf",
     "FactionNidrajName": "Nidraj"
+  },
+  "Pets": {
+    "WidgetTitle": "Modos de mascota",
+    "BehaviorFollow": "Seguir",
+    "BehaviorStay": "Quieto",
+    "BehaviorDefend": "Defender",
+    "BehaviorPassive": "Pasivo"
   }
 }

--- a/Intersect.Client.Core/Pets/PetHub.cs
+++ b/Intersect.Client.Core/Pets/PetHub.cs
@@ -1,0 +1,299 @@
+using System;
+using Intersect.Client.Entities;
+using Intersect.Client.General;
+using Intersect.Client.Networking;
+using Intersect.Enums;
+using Intersect.Network.Packets.Client;
+using Intersect.Network.Packets.Server;
+using Intersect.Shared.Pets;
+
+namespace Intersect.Client.Core.Pets;
+
+public sealed class PetHub
+{
+    private readonly object _syncRoot = new();
+    private Pet? _activePet;
+    private PetBehavior _behavior = PetBehavior.Follow;
+    private PetBehavior? _pendingBehavior;
+
+    public PetHub()
+    {
+        Globals.PetMetadataChanged += OnPetMetadataChanged;
+    }
+
+    public event Action? ActivePetChanged;
+
+    public event Action? BehaviorChanged;
+
+    public Pet? ActivePet
+    {
+        get
+        {
+            lock (_syncRoot)
+            {
+                return _activePet;
+            }
+        }
+    }
+
+    public PetBehavior Behavior
+    {
+        get
+        {
+            lock (_syncRoot)
+            {
+                return _behavior;
+            }
+        }
+    }
+
+    public bool HasActivePet
+    {
+        get
+        {
+            lock (_syncRoot)
+            {
+                return _activePet is { IsDisposed: false };
+            }
+        }
+    }
+
+    public void HandlePetLeft(Guid petId)
+    {
+        bool activeChanged;
+        bool behaviorChanged;
+
+        lock (_syncRoot)
+        {
+            if (_activePet?.Id != petId)
+            {
+                return;
+            }
+
+            (activeChanged, behaviorChanged) = UpdateState(null, PetBehavior.Follow, true);
+        }
+
+        if (behaviorChanged)
+        {
+            BehaviorChanged?.Invoke();
+        }
+
+        if (activeChanged)
+        {
+            ActivePetChanged?.Invoke();
+        }
+    }
+
+    public void Process(PetEntityPacket packet)
+    {
+        if (packet == null)
+        {
+            return;
+        }
+
+        bool activeChanged = false;
+        bool behaviorChanged = false;
+
+        lock (_syncRoot)
+        {
+            if (!Globals.TryGetEntity(EntityType.Pet, packet.EntityId, out var entity) || entity is not Pet pet)
+            {
+                if (_activePet?.Id == packet.EntityId)
+                {
+                    (activeChanged, behaviorChanged) = UpdateState(null, PetBehavior.Follow, true);
+                }
+
+                goto RaiseEvents;
+            }
+
+            if (!pet.IsOwnedByLocalPlayer)
+            {
+                if (_activePet?.Id == pet.Id)
+                {
+                    (activeChanged, behaviorChanged) = UpdateState(null, PetBehavior.Follow, true);
+                }
+
+                goto RaiseEvents;
+            }
+
+            (activeChanged, behaviorChanged) = UpdateState(pet, packet.Behavior, true);
+        }
+
+RaiseEvents:
+        if (behaviorChanged)
+        {
+            BehaviorChanged?.Invoke();
+        }
+
+        if (activeChanged)
+        {
+            ActivePetChanged?.Invoke();
+        }
+    }
+
+    public void Process(PetStateUpdatePacket packet)
+    {
+        if (packet == null)
+        {
+            return;
+        }
+
+        bool activeChanged = false;
+        bool behaviorChanged = false;
+
+        lock (_syncRoot)
+        {
+            if (!Globals.TryGetEntity(EntityType.Pet, packet.PetId, out var entity) || entity is not Pet pet)
+            {
+                if (_activePet?.Id == packet.PetId)
+                {
+                    (activeChanged, behaviorChanged) = UpdateState(null, PetBehavior.Follow, true);
+                }
+
+                goto RaiseEvents;
+            }
+
+            if (!pet.IsOwnedByLocalPlayer)
+            {
+                if (_activePet?.Id == pet.Id)
+                {
+                    (activeChanged, behaviorChanged) = UpdateState(null, PetBehavior.Follow, true);
+                }
+
+                goto RaiseEvents;
+            }
+
+            (activeChanged, behaviorChanged) = UpdateState(pet, packet.Behavior, true);
+        }
+
+RaiseEvents:
+        if (behaviorChanged)
+        {
+            BehaviorChanged?.Invoke();
+        }
+
+        if (activeChanged)
+        {
+            ActivePetChanged?.Invoke();
+        }
+    }
+
+    public void Reset()
+    {
+        bool activeChanged;
+        bool behaviorChanged;
+
+        lock (_syncRoot)
+        {
+            activeChanged = _activePet != null;
+            _activePet = null;
+            _pendingBehavior = null;
+            behaviorChanged = _behavior != PetBehavior.Follow;
+            _behavior = PetBehavior.Follow;
+        }
+
+        if (behaviorChanged)
+        {
+            BehaviorChanged?.Invoke();
+        }
+
+        if (activeChanged)
+        {
+            ActivePetChanged?.Invoke();
+        }
+    }
+
+    public bool SetBehavior(PetBehavior behavior)
+    {
+        Pet? pet;
+        Guid? petToClear = null;
+        bool shouldSend;
+
+        lock (_syncRoot)
+        {
+            pet = _activePet;
+            if (pet == null)
+            {
+                return false;
+            }
+
+            if (pet.IsDisposed)
+            {
+                petToClear = pet.Id;
+                shouldSend = false;
+            }
+            else
+            {
+                shouldSend = _behavior != behavior || _pendingBehavior != behavior;
+                _pendingBehavior = behavior;
+            }
+        }
+
+        if (petToClear.HasValue)
+        {
+            HandlePetLeft(petToClear.Value);
+            return false;
+        }
+
+        if (!shouldSend || pet == null)
+        {
+            return false;
+        }
+
+        Network.SendPacket(new PetBehaviorChangePacket(behavior, pet.Id));
+        return true;
+    }
+
+    private void OnPetMetadataChanged(Pet pet)
+    {
+        bool activeChanged = false;
+        bool behaviorChanged = false;
+
+        lock (_syncRoot)
+        {
+            if (pet.IsOwnedByLocalPlayer)
+            {
+                (activeChanged, behaviorChanged) = UpdateState(pet, pet.Behavior, true);
+            }
+            else if (_activePet?.Id == pet.Id)
+            {
+                (activeChanged, behaviorChanged) = UpdateState(null, PetBehavior.Follow, true);
+            }
+        }
+
+        if (behaviorChanged)
+        {
+            BehaviorChanged?.Invoke();
+        }
+
+        if (activeChanged)
+        {
+            ActivePetChanged?.Invoke();
+        }
+    }
+
+    private (bool activeChanged, bool behaviorChanged) UpdateState(Pet? pet, PetBehavior behavior, bool clearPending)
+    {
+        var activeChanged = false;
+        var behaviorChanged = false;
+
+        if (!ReferenceEquals(_activePet, pet))
+        {
+            _activePet = pet;
+            activeChanged = true;
+        }
+
+        if (clearPending)
+        {
+            _pendingBehavior = null;
+        }
+
+        if (_behavior != behavior)
+        {
+            _behavior = behavior;
+            behaviorChanged = true;
+        }
+
+        return (activeChanged, behaviorChanged);
+    }
+}

--- a/Intersect.Client.Framework/Input/BuiltinControlsProvider.cs
+++ b/Intersect.Client.Framework/Input/BuiltinControlsProvider.cs
@@ -46,6 +46,10 @@ internal sealed class BuiltinControlsProvider : IControlsProvider
         { Control.HoldToZoomIn, new ControlMapping(ControlBinding.Default, ControlBinding.Default) },
         { Control.HoldToZoomOut, new ControlMapping(ControlBinding.Default, ControlBinding.Default) },
         { Control.ToggleFullscreen, new ControlMapping(new ControlBinding(Keys.Alt, Keys.Enter), ControlBinding.Default) },
+        { Control.PetModeFollow, new ControlMapping(new ControlBinding(Keys.None, Keys.F5), ControlBinding.Default) },
+        { Control.PetModeStay, new ControlMapping(new ControlBinding(Keys.None, Keys.F6), ControlBinding.Default) },
+        { Control.PetModeDefend, new ControlMapping(new ControlBinding(Keys.None, Keys.F7), ControlBinding.Default) },
+        { Control.PetModePassive, new ControlMapping(new ControlBinding(Keys.None, Keys.F8), ControlBinding.Default) },
 
         // Hotkeys should be at the end of the list
         { Control.Hotkey1, new ControlMapping(new ControlBinding(Keys.None, Keys.D1), ControlBinding.Default) },

--- a/Intersect.Client.Framework/Input/Control.cs
+++ b/Intersect.Client.Framework/Input/Control.cs
@@ -75,6 +75,14 @@ public enum Control
 
     ToggleFullscreen,
 
+    PetModeFollow,
+
+    PetModeStay,
+
+    PetModeDefend,
+
+    PetModePassive,
+
     // Add new controls above this line
     // If new controls are added that are similar to hotkeys (in that they map to some configurable slot count)
     // they should have an explicit offset like hotkeys, and the offset should be >0x1000 and far enough away from


### PR DESCRIPTION
## Summary
- add a client-side PetHub to track the active pet, mirror server state updates, and send behavior change requests
- surface pet behavior controls through a new HUD widget, localized strings, and dedicated hotkeys
- hook packet handling and input to the PetHub to keep the UI in sync with server responses

## Testing
- Not run (dotnet CLI is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68cd775cbc14832b9f674293749bef3c