### PR TITLE
Implement pet binding and invocation on equipment

### DIFF
--- a/Framework/Intersect.Framework.Core/GameObjects/Items/ItemProperties.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Items/ItemProperties.cs
@@ -1,3 +1,4 @@
+using System;
 using Intersect.Enums;
 using MessagePack;
 
@@ -20,7 +21,7 @@ public partial class ItemProperties
         EnchantmentLevel = other.EnchantmentLevel;
         Array.Copy(other.StatModifiers, StatModifiers, Enum.GetValues<Stat>().Length);
         Array.Copy(other.VitalModifiers, VitalModifiers, Enum.GetValues<Vital>().Length);
-      
+        BoundPlayerId = other.BoundPlayerId;
     }
 
     [Key(0)]
@@ -34,4 +35,7 @@ public partial class ItemProperties
     public int[] VitalModifiers { get; set; } = new int[Enum.GetValues<Vital>().Length];
     [Key(4)]
     public int MageSink { get;  set; }
+
+    [Key(5)]
+    public Guid? BoundPlayerId { get; set; }
 }

--- a/Framework/Intersect.Framework.Core/Network/Packets/Server/OpenPetHubPacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Server/OpenPetHubPacket.cs
@@ -1,0 +1,20 @@
+using MessagePack;
+
+namespace Intersect.Network.Packets.Server;
+
+[MessagePackObject]
+public sealed class OpenPetHubPacket : IntersectPacket
+{
+    public OpenPetHubPacket()
+    {
+    }
+
+    public OpenPetHubPacket(bool close)
+    {
+        Close = close;
+    }
+
+    [Key(0)]
+    public bool Close { get; set; }
+}
+

--- a/Intersect.Client.Core/Interface/Game/GameInterface.cs
+++ b/Intersect.Client.Core/Interface/Game/GameInterface.cs
@@ -187,7 +187,18 @@ public partial class GameInterface : MutableInterface
         mMapItemWindow = new MapItemWindow(GameCanvas);
 
         _petBehaviorWidget ??= new PetBehaviorWidget(GameCanvas);
+        _petBehaviorWidget.Hide();
 
+    }
+    public void ShowPetHub()
+    {
+        _petBehaviorWidget ??= new PetBehaviorWidget(GameCanvas);
+        _petBehaviorWidget.Show();
+    }
+
+    public void HidePetHub()
+    {
+        _petBehaviorWidget?.Hide();
     }
     public void OpenEnchantWindow()
     {

--- a/Intersect.Client.Core/Networking/PacketHandler.cs
+++ b/Intersect.Client.Core/Networking/PacketHandler.cs
@@ -477,6 +477,26 @@ internal sealed partial class PacketHandler
         pet.ApplyMetadata(pet.OwnerId, pet.DescriptorId, packet.State, pet.Despawnable, packet.Behavior);
     }
 
+    public void HandlePacket(IPacketSender packetSender, OpenPetHubPacket packet)
+    {
+        if (packet == null)
+        {
+            return;
+        }
+
+        Interface.Interface.EnqueueInGame(gameInterface =>
+        {
+            if (packet.Close)
+            {
+                gameInterface.HidePetHub();
+            }
+            else
+            {
+                gameInterface.ShowPetHub();
+            }
+        });
+    }
+
     //ResourceEntityPacket
     public void HandlePacket(IPacketSender packetSender, ResourceEntityPacket packet)
     {

--- a/Intersect.Server.Core/Database/Item.cs
+++ b/Intersect.Server.Core/Database/Item.cs
@@ -1,3 +1,4 @@
+using System;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -92,6 +93,27 @@ public class Item : IItem
     }
 
     [JsonIgnore, NotMapped] public ItemDescriptor Descriptor => ItemDescriptor.Get(ItemId);
+
+    [JsonIgnore, NotMapped]
+    public Guid? BoundPlayerId
+    {
+        get => Properties?.BoundPlayerId;
+        set
+        {
+            if (Properties != null)
+            {
+                Properties.BoundPlayerId = value;
+            }
+        }
+    }
+
+    [JsonIgnore, NotMapped]
+    public bool IsBound => BoundPlayerId.HasValue && BoundPlayerId.Value != Guid.Empty;
+
+    public bool IsBoundTo(Guid playerId)
+    {
+        return IsBound && BoundPlayerId.Value == playerId;
+    }
 
     public static Item None => new();
 

--- a/Intersect.Server.Core/Networking/PacketSender.cs
+++ b/Intersect.Server.Core/Networking/PacketSender.cs
@@ -1054,6 +1054,16 @@ public static partial class PacketSender
         SendDataToProximityOnMapInstance(pet.MapId, pet.MapInstanceId, packet, owner, TransmissionMode.Any);
     }
 
+    public static void SendOpenPetHub(Player player, bool close = false)
+    {
+        if (player == null)
+        {
+            return;
+        }
+
+        player.SendPacket(new OpenPetHubPacket(close), TransmissionMode.Any);
+    }
+
     //EntityStatsPacket
     public static void SendEntityStats(Entity en)
     {


### PR DESCRIPTION
## Summary
- add per-item bound tracking so pet equipment can mark itself as non-tradeable when equipped
- extend player equip/unequip flow to create or summon pets, expose InvokePet, and respect pet item rules
- introduce an OpenPetHub server packet with client handling to show or hide the pet panel on summon/despawn

## Testing
- `dotnet build` *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd902945a8832bb684d346ce14b7da