### PR TITLE
Ensure pet metadata updates only send when metadata changes

### DIFF
--- a/Intersect.Server.Core/Maps/MapInstance.cs
+++ b/Intersect.Server.Core/Maps/MapInstance.cs
@@ -1336,12 +1336,9 @@ public partial class MapInstance : IMapInstance
                 }
             }
 
-            if (entity is Pet pet)
+            if (entity is Pet pet && pet.MetadataDirty)
             {
-                if (vitalsChanged || pet.MetadataDirty)
-                {
-                    petMetadataUpdates.Add(pet);
-                }
+                petMetadataUpdates.Add(pet);
             }
         }
 


### PR DESCRIPTION
## Summary
- only enqueue pet metadata updates when a pet reports metadata changes instead of any vital change
- continue resetting the metadata dirty flag after sending pet entity updates

## Testing
- dotnet build Intersect.Server.Core/Intersect.Server.Core.csproj *(fails: dotnet command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd9dc62e98832bb7517ebd78279479