### PR TITLE
Limit pet state updates to owner

### DIFF
--- a/Intersect.Server.Core/Networking/PacketSender.cs
+++ b/Intersect.Server.Core/Networking/PacketSender.cs
@@ -1046,12 +1046,9 @@ public static partial class PacketSender
             owner.SendPacket(packet, TransmissionMode.Any);
         }
 
-        if (pet.MapId == Guid.Empty || pet.MapInstanceId == Guid.Empty)
-        {
-            return;
-        }
-
-        SendDataToProximityOnMapInstance(pet.MapId, pet.MapInstanceId, packet, owner, TransmissionMode.Any);
+        // Los cambios en el estado de la mascota se propagan al resto de jugadores
+        // cuando la instancia del mapa procesa las entidades sucias en el siguiente tick.
+        // Aquí solo necesitamos notificar inmediatamente al propietario.
     }
 
     public static void SendOpenPetHub(Player player, bool close = false)


### PR DESCRIPTION
## Summary
- stop pet state packets from being broadcast to nearby players immediately and document why

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd9eab6a2c832b8c3cc9e996d6581a