### PR TITLE
Allow party members to move through allied pets

### DIFF
--- a/Intersect.Server.Core/Entities/Entity.cs
+++ b/Intersect.Server.Core/Entities/Entity.cs
@@ -611,6 +611,11 @@ public abstract partial class Entity : IEntity
                     blockingEntity = mapEntity;
                     return false;
                 case Pet pet when !pet.Passable:
+                    if (CanPassPet(pet))
+                    {
+                        continue;
+                    }
+
                     blockerType = MovementBlockerType.Entity;
                     entityType = EntityType.Pet;
                     blockingEntity = mapEntity;
@@ -685,6 +690,46 @@ public abstract partial class Entity : IEntity
     }
 
     protected virtual bool CanPassPlayer(MapController targetMap) => false;
+
+    protected virtual bool CanPassPet(Pet pet)
+    {
+        if (pet.OwnerId == Id)
+        {
+            return true;
+        }
+
+        if (this is Player player)
+        {
+            if (player.Id == pet.OwnerId)
+            {
+                return true;
+            }
+
+            var petOwner = pet.Owner;
+            if (petOwner != null && player.InParty(petOwner))
+            {
+                return true;
+            }
+        }
+
+        if (this is Pet movingPet)
+        {
+            if (movingPet.OwnerId == pet.OwnerId)
+            {
+                return true;
+            }
+
+            var movingPetOwner = movingPet.Owner;
+            var blockingPetOwner = pet.Owner;
+
+            if (movingPetOwner != null && blockingPetOwner != null && movingPetOwner.InParty(blockingPetOwner))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
 
     protected virtual bool IsBlockedByEvent(
         MapInstance mapInstance,


### PR DESCRIPTION
## Summary
- prevent movement blocking when an entity tries to walk through its own pet by checking the pet owner id
- allow party members and their pets to walk through allied pets while keeping collisions for unrelated entities

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd9f089d28832bb74472ffd3cc48f4