### PR TITLE
Handle pet loot ownership for drops and threat

### DIFF
--- a/Intersect.Server.Core/Entities/Entity.cs
+++ b/Intersect.Server.Core/Entities/Entity.cs
@@ -2294,7 +2294,8 @@ public abstract partial class Entity : IEntity
                     dmgMap.TryGetValue(this, out var damage);
                     dmgMap[this] = damage + baseDamage;
 
-                    enemyNpc.LootMap.TryAdd(Id, true);
+                    var lootOwnerId = ResolveLootOwnerId(this, Id);
+                    enemyNpc.LootMap.TryAdd(lootOwnerId, true);
                     enemyNpc.LootMapCache = enemyNpc.LootMap.Keys.ToArray();
                     enemyNpc.TryFindNewTarget(Timing.Global.Milliseconds, default, false, this);
                 }
@@ -3226,9 +3227,10 @@ public abstract partial class Entity : IEntity
         }
 
         // Run events and other things.
-        killer?.KilledEntity(this);
+        var lootContext = ResolveLootSource(killer);
+        lootContext?.KilledEntity(this);
 
-        if (killer is Player attacker && this is Player victim)
+        if (lootContext is Player attacker && this is Player victim)
         {
             AlignmentPvPService.HandleKill(attacker, victim);
         }
@@ -3283,7 +3285,7 @@ public abstract partial class Entity : IEntity
             else
             {
                 // Drop as normal.
-                DropItems(killer);
+                DropItems(lootContext ?? killer);
             }
         }
 
@@ -3301,9 +3303,29 @@ public abstract partial class Entity : IEntity
         IsDead = true;
     }
 
+    protected static Entity? ResolveLootSource(Entity? entity)
+    {
+        if (entity is Pet pet)
+        {
+            return pet.Owner ?? entity;
+        }
+
+        return entity;
+    }
+
+    protected static Guid ResolveLootOwnerId(Entity? entity, Guid fallback)
+    {
+        return entity switch
+        {
+            Player player => player.Id,
+            Pet pet when pet.OwnerId != Guid.Empty => pet.OwnerId,
+            _ => fallback,
+        };
+    }
+
     protected virtual bool ShouldDropItem(Entity killer, ItemDescriptor itemDescriptor, Item item, float dropRateModifier, out Guid lootOwner)
     {
-        lootOwner = default;
+        lootOwner = ResolveLootOwnerId(killer, Guid.Empty);
 
         var dropRate = item.DropChance * 1000 * dropRateModifier;
         var dropResult = Randomization.Next(1, 100001);
@@ -3326,6 +3348,8 @@ public abstract partial class Entity : IEntity
             return;
         }
 
+        var lootSource = ResolveLootSource(killer);
+
         // Drop items
         foreach (var slot in Items)
         {
@@ -3343,10 +3367,10 @@ public abstract partial class Entity : IEntity
                 continue;
             }
 
-            var playerKiller = killer as Player;
+            var playerKiller = lootSource as Player;
             var dropRateModifier = 1 + (playerKiller?.GetEquipmentBonusEffect(ItemEffect.Luck) / 100f ?? 0);
-         
-            if (!ShouldDropItem(killer, itemDescriptor, drop, dropRateModifier, out Guid lootOwner))
+
+            if (!ShouldDropItem(lootSource ?? killer, itemDescriptor, drop, dropRateModifier, out Guid lootOwner))
             {
                 continue;
             }

--- a/Intersect.Server.Core/Entities/Npc.cs
+++ b/Intersect.Server.Core/Entities/Npc.cs
@@ -283,7 +283,7 @@ public partial class Npc : Entity
 
     protected override bool ShouldDropItem(Entity killer, ItemDescriptor itemDescriptor, Item item, float dropRateModifier, out Guid lootOwner)
     {
-        lootOwner = (killer as Player)?.Id ?? Id;
+        lootOwner = ResolveLootOwnerId(killer, Id);
         return base.ShouldDropItem(killer, itemDescriptor, item, dropRateModifier, out _);
     }
 

--- a/Intersect.Server.Core/Entities/Player.cs
+++ b/Intersect.Server.Core/Entities/Player.cs
@@ -3932,7 +3932,7 @@ public partial class Player : Entity
 
     protected override bool ShouldDropItem(Entity killer, ItemDescriptor itemDescriptor, Item item, float dropRateModifier, out Guid lootOwner)
     {
-        lootOwner = (killer as Player)?.Id ?? Id;
+        lootOwner = ResolveLootOwnerId(killer, Id);
 
         if (itemDescriptor.DropChanceOnDeath == 0)
         {

--- a/Intersect.Server.Core/Entities/Resource.cs
+++ b/Intersect.Server.Core/Entities/Resource.cs
@@ -1,3 +1,4 @@
+using System;
 using Intersect.Enums;
 using Intersect.Framework.Core.GameObjects.Items;
 using Intersect.Framework.Core.GameObjects.Resources;
@@ -197,14 +198,14 @@ public partial class Resource : Entity
                     if (MapController.TryGetInstanceFromMap(mapId, MapInstanceId, out var mapInstance))
                     {
                         var quantity = item.Quantity;
-                      
+
                         mapInstance.SpawnItem(
                             itemSource,
                             selectedTile.GetX(),
                             selectedTile.GetY(),
                             item,
                             quantity,
-                            killer.Id
+                            ResolveLootOwnerId(killer, killer?.Id ?? Guid.Empty)
                         );
                     }
                 }


### PR DESCRIPTION
## Summary
- credit pet kills to their owners for death handling and loot distribution
- ensure NPC threat and loot tables track the owning player when pets attack
- update loot owner calculations, including resource drops, to respect pet ownership

## Testing
- dotnet test Intersect.Tests.Server/Intersect.Tests.Server.csproj *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cdb1d7b97c832b9c0518fc6228a076