### PR TITLE
Track pet item instances for player pets

### DIFF
--- a/Intersect.Server.Core/Database/PlayerData/PlayerContext.cs
+++ b/Intersect.Server.Core/Database/PlayerData/PlayerContext.cs
@@ -109,7 +109,7 @@ public abstract partial class PlayerContext : IntersectDbContext<PlayerContext>,
         modelBuilder.Entity<Player>().HasMany(b => b.Variables).WithOne(p => p.Player);
         modelBuilder.Entity<Player>().HasMany(b => b.BestiaryUnlocks).WithOne(p => p.Player);
         modelBuilder.Entity<Player>().HasMany(b => b.Pets).WithOne(p => p.Player).OnDelete(DeleteBehavior.Cascade);
-        modelBuilder.Entity<PlayerPet>().HasIndex(p => new { p.PlayerId, p.PetDescriptorId }).IsUnique();
+        modelBuilder.Entity<PlayerPet>().HasIndex(p => new { p.PlayerId, p.PetInstanceId }).IsUnique();
         modelBuilder.Entity<Player>()
             .HasOne(p => p.ActivePet)
             .WithMany()

--- a/Intersect.Server.Core/Database/PlayerData/Players/PlayerPet.cs
+++ b/Intersect.Server.Core/Database/PlayerData/Players/PlayerPet.cs
@@ -19,6 +19,8 @@ public partial class PlayerPet : IPlayerOwned
 
     public Guid PetDescriptorId { get; set; }
 
+    public Guid PetInstanceId { get; set; }
+
     public string CustomName { get; set; } = string.Empty;
 
     public int Level { get; set; } = 1;

--- a/Intersect.Server.Core/Migrations/Sqlite/Player/20251001000000_AddPetInstanceIdentifiers.Designer.cs
+++ b/Intersect.Server.Core/Migrations/Sqlite/Player/20251001000000_AddPetInstanceIdentifiers.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Intersect.Server.Database.PlayerData;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Intersect.Server.Migrations.Sqlite.Player
 {
     [DbContext(typeof(SqlitePlayerContext))]
-    partial class SqlitePlayerContextModelSnapshot : ModelSnapshot
+    [Migration("20251001000000_AddPetInstanceIdentifiers")]
+    partial class AddPetInstanceIdentifiers
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "8.0.11");

--- a/Intersect.Server.Core/Migrations/Sqlite/Player/20251001000000_AddPetInstanceIdentifiers.cs
+++ b/Intersect.Server.Core/Migrations/Sqlite/Player/20251001000000_AddPetInstanceIdentifiers.cs
@@ -1,0 +1,102 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Intersect.Server.Migrations.Sqlite.Player
+{
+    /// <inheritdoc />
+    public partial class AddPetInstanceIdentifiers : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Player_Pets_PlayerId_PetDescriptorId",
+                table: "Player_Pets");
+
+            migrationBuilder.AddColumn<Guid?>
+            (
+                name: "PetInstanceId",
+                table: "Player_Items",
+                type: "TEXT",
+                nullable: true
+            );
+
+            migrationBuilder.AddColumn<Guid?>
+            (
+                name: "PetInstanceId",
+                table: "Player_Bank",
+                type: "TEXT",
+                nullable: true
+            );
+
+            migrationBuilder.AddColumn<Guid?>
+            (
+                name: "PetInstanceId",
+                table: "Bag_Items",
+                type: "TEXT",
+                nullable: true
+            );
+
+            migrationBuilder.AddColumn<Guid?>
+            (
+                name: "PetInstanceId",
+                table: "Guild_Bank",
+                type: "TEXT",
+                nullable: true
+            );
+
+            migrationBuilder.AddColumn<Guid>
+            (
+                name: "PetInstanceId",
+                table: "Player_Pets",
+                type: "TEXT",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000")
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Player_Pets_PlayerId_PetInstanceId",
+                table: "Player_Pets",
+                columns: new[] { "PlayerId", "PetInstanceId" },
+                unique: true
+            );
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Player_Pets_PlayerId_PetInstanceId",
+                table: "Player_Pets");
+
+            migrationBuilder.DropColumn(
+                name: "PetInstanceId",
+                table: "Player_Items");
+
+            migrationBuilder.DropColumn(
+                name: "PetInstanceId",
+                table: "Player_Bank");
+
+            migrationBuilder.DropColumn(
+                name: "PetInstanceId",
+                table: "Bag_Items");
+
+            migrationBuilder.DropColumn(
+                name: "PetInstanceId",
+                table: "Guild_Bank");
+
+            migrationBuilder.DropColumn(
+                name: "PetInstanceId",
+                table: "Player_Pets");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Player_Pets_PlayerId_PetDescriptorId",
+                table: "Player_Pets",
+                columns: new[] { "PlayerId", "PetDescriptorId" },
+                unique: true
+            );
+        }
+    }
+}

--- a/Intersect.Tests.Server/Entities/PlayerTests.Pets.cs
+++ b/Intersect.Tests.Server/Entities/PlayerTests.Pets.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Linq;
+using Intersect.Enums;
+using Intersect.Framework.Core.GameObjects.Items;
+using Intersect.Framework.Core.GameObjects.Pets;
+using Intersect.Server.Entities;
+using NUnit.Framework;
+
+namespace Intersect.Tests.Server.Entities;
+
+public partial class PlayerTests
+{
+    [Test]
+    public void TestEquippingDuplicatePetItemsMaintainsIndependentProgress()
+    {
+        var petDescriptor = new PetDescriptor(Guid.NewGuid())
+        {
+            Name = "Test Pet",
+        };
+        PetDescriptor.Lookup.Set(petDescriptor.Id, petDescriptor);
+
+        var itemDescriptor = new ItemDescriptor(Guid.NewGuid())
+        {
+            Name = "Pet Collar",
+            ItemType = ItemType.Equipment,
+            EquipmentSlot = 0,
+            Pet = new PetItemData
+            {
+                PetDescriptorId = petDescriptor.Id,
+                SummonOnEquip = false,
+                DespawnOnUnequip = false,
+                BindOnEquip = false,
+            },
+        };
+        ItemDescriptor.Lookup.Set(itemDescriptor.Id, itemDescriptor);
+
+        Player player = new()
+        {
+            MapId = _mapId,
+        };
+
+        Assert.That(player.TryGiveItem(itemDescriptor.Id, 1), Is.True);
+        Assert.That(player.TryGiveItem(itemDescriptor.Id, 1), Is.True);
+
+        var inventorySlots = player.FindInventoryItemSlots(itemDescriptor.Id);
+        Assert.That(inventorySlots, Has.Count.GreaterThanOrEqualTo(2));
+
+        var orderedSlots = inventorySlots.OrderBy(slot => slot.Slot).Take(2).ToArray();
+        var firstSlot = orderedSlots[0];
+        var secondSlot = orderedSlots[1];
+
+        var firstSlotIndex = player.FindInventoryItemSlotIndex(firstSlot);
+        var secondSlotIndex = player.FindInventoryItemSlotIndex(secondSlot);
+
+        var firstInstanceId = firstSlot.PetInstanceId;
+        var secondInstanceId = secondSlot.PetInstanceId;
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(firstInstanceId, Is.Not.Null);
+                Assert.That(secondInstanceId, Is.Not.Null);
+                Assert.That(firstInstanceId, Is.Not.EqualTo(secondInstanceId));
+            }
+        );
+
+        player.EquipItem(itemDescriptor, firstSlotIndex, updateCooldown: false);
+
+        Assert.That(player.ActivePet, Is.Not.Null);
+        Assert.That(player.ActivePet!.PetInstanceId, Is.EqualTo(firstInstanceId));
+
+        player.ActivePet.Level = 5;
+        player.ActivePet.Experience = 50;
+
+        player.UnequipItem(itemDescriptor.EquipmentSlot, sendUpdate: false);
+        Assert.That(player.ActivePet, Is.Null);
+
+        player.EquipItem(itemDescriptor, secondSlotIndex, updateCooldown: false);
+
+        Assert.That(player.ActivePet, Is.Not.Null);
+        Assert.That(player.ActivePet!.PetInstanceId, Is.EqualTo(secondInstanceId));
+
+        player.ActivePet.Level = 3;
+        player.ActivePet.Experience = 30;
+
+        player.UnequipItem(itemDescriptor.EquipmentSlot, sendUpdate: false);
+
+        player.EquipItem(itemDescriptor, firstSlotIndex, updateCooldown: false);
+
+        Assert.That(player.ActivePet, Is.Not.Null);
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(player.ActivePet!.PetInstanceId, Is.EqualTo(firstInstanceId));
+                Assert.That(player.ActivePet.Level, Is.EqualTo(5));
+                Assert.That(player.ActivePet.Experience, Is.EqualTo(50));
+            }
+        );
+
+        var storedSecondPet = player.Pets.Single(pet => pet.PetInstanceId == secondInstanceId);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(storedSecondPet.Level, Is.EqualTo(3));
+                Assert.That(storedSecondPet.Experience, Is.EqualTo(30));
+            }
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- persist a pet instance identifier on item records and update player pet lookup to use the per-item guid
- add a new migration and snapshot updates so player pet data is keyed by the item instance id instead of the descriptor id
- add a regression test covering equipping two identical pet items to ensure their progress remains independent

## Testing
- `dotnet test Intersect.Tests.Server` *(fails: dotnet CLI is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cdb13581d8832b97ce0fa62542f75f