### PR TITLE
Fix pet widget and descriptor build issues

### DIFF
--- a/Intersect.Client.Core/Interface/Game/Pets/PetBehaviorWidget.cs
+++ b/Intersect.Client.Core/Interface/Game/Pets/PetBehaviorWidget.cs
@@ -90,14 +90,14 @@ public sealed class PetBehaviorWidget : RadioButtonGroup
             foreach (var (behavior, option) in _options)
             {
                 option.IsDisabled = !hasPet;
-                option.RadioButton.IsChecked = hasPet && activeBehavior == behavior;
+                option.IsChecked = hasPet && activeBehavior == behavior;
             }
 
             if (!hasPet)
             {
                 foreach (var option in _options.Values)
                 {
-                    option.RadioButton.IsChecked = false;
+                    option.IsChecked = false;
                 }
             }
         }

--- a/Intersect.Client.Core/Pets/PetHub.cs
+++ b/Intersect.Client.Core/Pets/PetHub.cs
@@ -240,7 +240,7 @@ RaiseEvents:
             return false;
         }
 
-        Network.SendPacket(new PetBehaviorChangePacket(behavior, pet.Id));
+        Intersect.Client.Networking.Network.SendPacket(new PetBehaviorChangePacket(behavior, pet.Id));
         return true;
     }
 

--- a/Intersect.Client.Framework/Gwen/Control/LabeledRadioButton.cs
+++ b/Intersect.Client.Framework/Gwen/Control/LabeledRadioButton.cs
@@ -56,6 +56,12 @@ public partial class LabeledRadioButton : Base, ITextContainer
     // todo: would be nice to remove that
     internal RadioButton RadioButton => mRadioButton;
 
+    public bool IsChecked
+    {
+        get => mRadioButton.IsChecked;
+        set => mRadioButton.IsChecked = value;
+    }
+
     protected override void Layout(Skin.Base skin)
     {
         // ugly stuff because we don't have anchoring without docking (docking resizes children)

--- a/Intersect.Server.Core/Entities/Player.cs
+++ b/Intersect.Server.Core/Entities/Player.cs
@@ -1314,6 +1314,8 @@ public partial class Player : Entity
             return false;
         }
 
+        var descriptorId = descriptor.Id;
+
         var petInstanceId = sourceItem?.EnsurePetInstanceId();
         if (!petInstanceId.HasValue || petInstanceId == Guid.Empty)
         {
@@ -1323,8 +1325,8 @@ public partial class Player : Entity
         playerPet = Pets.FirstOrDefault(pet => pet.PetInstanceId == petInstanceId);
         if (playerPet == null)
         {
-            playerPet = Pets.FirstOrDefault(pet => pet.PetInstanceId == Guid.Empty && pet.PetDescriptorId == descriptor.Id)
-                ?? Pets.FirstOrDefault(pet => pet.PetDescriptorId == descriptor.Id && pet.PetInstanceId == default);
+            playerPet = Pets.FirstOrDefault(pet => pet.PetInstanceId == Guid.Empty && pet.PetDescriptorId == descriptorId)
+                ?? Pets.FirstOrDefault(pet => pet.PetDescriptorId == descriptorId && pet.PetInstanceId == default);
         }
 
         if (playerPet == null)


### PR DESCRIPTION
## Summary
- expose a public IsChecked property on LabeledRadioButton for external callers
- update the pet behavior widget to rely on the new helper and ensure packets send via the client networking class
- adjust player pet lookups to avoid capturing the descriptor out parameter in lambdas

## Testing
- dotnet build Intersect.sln *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cdc8d61d80832b835c4bb4e2c034ab