### PR TITLE
Handle missing cache textures in renderer

### DIFF
--- a/Intersect.Client.Framework/Gwen/Renderer/IntersectRenderer.cs
+++ b/Intersect.Client.Framework/Gwen/Renderer/IntersectRenderer.cs
@@ -382,12 +382,22 @@ public partial class IntersectRenderer : Base, ICacheToTexture
     {
         m_RealRT = mRenderTarget;
         m_Stack.Push(mRenderTarget); // save current RT
-        if (!m_RT.ContainsKey(control))
+        if (!m_RT.TryGetValue(control, out var renderTarget))
         {
             var keys = m_RT.Keys.Select(key => key.ParentQualifiedName);
-            ApplicationContext.Context.Value?.Logger.LogError($"{control.ParentQualifiedName} not found in the list of render targets: {string.Join(", ", keys)}");
+            ApplicationContext.Context.Value?.Logger.LogError(
+                $"{control.ParentQualifiedName} not found in the list of render targets: {string.Join(", ", keys)}"
+            );
+
+            var width = Math.Max(1, control.Width);
+            var height = Math.Max(1, control.Height);
+
+            renderTarget = mRenderer.CreateRenderTexture(width, height);
+            renderTarget.Clear(Color.Transparent);
+            m_RT[control] = renderTarget;
         }
-        mRenderTarget = m_RT[control]; // make cache current RT
+
+        mRenderTarget = renderTarget; // make cache current RT
         mRenderTarget.Begin();
         mRenderTarget.Clear(Color.Transparent);
     }


### PR DESCRIPTION
## Summary
- prevent crashes when a control lacks a cached render target by creating one on demand
- retain diagnostic logging of unexpected cache misses while ensuring rendering continues

## Testing
- dotnet test Intersect.Client.Framework/Intersect.Client.Framework.csproj *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cdd00e6eb0832b91fde20968e082b7