### PR TITLE
Handle pets in projectile grapple hook check

### DIFF
--- a/Intersect.Server.Core/Entities/ProjectileSpawn.cs
+++ b/Intersect.Server.Core/Entities/ProjectileSpawn.cs
@@ -181,6 +181,7 @@ public partial class ProjectileSpawn
         {
             Player => ProjectileDescriptor.GrappleHookOptions.Contains(Enums.GrappleOption.Player),
             Npc => ProjectileDescriptor.GrappleHookOptions.Contains(Enums.GrappleOption.NPC),
+            Pet => ProjectileDescriptor.GrappleHookOptions.Contains(Enums.GrappleOption.NPC),
             Resource => ProjectileDescriptor.GrappleHookOptions.Contains(Enums.GrappleOption.Resource),
             _ => throw new ArgumentException($"Unsupported entity type {en.GetType().FullName}", nameof(en)),
         };


### PR DESCRIPTION
## Summary
- allow projectile grapple hook eligibility checks to handle pet entities by reusing the NPC option

## Testing
- `dotnet test Intersect.Tests.Server` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68cdd0c3746c832ba15647c6466166b2