### PR TITLE
Improve pet follow recovery with teleport leash

### DIFF
--- a/Framework/Intersect.Framework.Core/Config/Options.cs
+++ b/Framework/Intersect.Framework.Core/Config/Options.cs
@@ -205,6 +205,7 @@ public partial record Options
     public MapOptions Map { get; set; } = new();
 
     public PlayerOptions Player { get; set; } = new();
+    public PetOptions Pets { get; set; } = new();
     public JobOptions JobOpts { get; set; } = new();
     public PartyOptions Party { get; set; } = new();
 

--- a/Framework/Intersect.Framework.Core/Config/PetOptions.cs
+++ b/Framework/Intersect.Framework.Core/Config/PetOptions.cs
@@ -1,0 +1,25 @@
+namespace Intersect.Config;
+
+/// <summary>
+/// Configuration values controlling pet behaviour.
+/// </summary>
+public partial class PetOptions
+{
+    /// <summary>
+    /// Distance (in tiles) at which pets are teleported back to their owner.
+    /// Set to 0 or less to disable leash-based teleporting.
+    /// </summary>
+    public int FollowLeashDistance { get; set; } = 12;
+
+    /// <summary>
+    /// Number of consecutive pathfinding failures before a pet is teleported to its owner.
+    /// Set to 0 or less to disable failure-based teleporting.
+    /// </summary>
+    public int FollowFailureTeleportThreshold { get; set; } = 3;
+
+    /// <summary>
+    /// Milliseconds without pathfinding failures before the failure counter resets.
+    /// Set to 0 or less to disable the automatic reset.
+    /// </summary>
+    public int FollowFailureResetMilliseconds { get; set; } = 5000;
+}


### PR DESCRIPTION
## Summary
- add configurable pet follow leash and failure thresholds
- teleport pets to their owner when out of leash range or after repeated pathfinder failures and reset the follow state

## Testing
- `dotnet build Intersect.sln` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68cddd00e590832bb42211a1e1fd2715