### PR TITLE
Fix pet despawn when unequipping active pet

### DIFF
--- a/Intersect.Server.Core/Entities/Player.cs
+++ b/Intersect.Server.Core/Entities/Player.cs
@@ -1413,27 +1413,18 @@ public partial class Player : Entity
             return;
         }
 
-        if (petData.DespawnOnUnequip)
+        var currentPet = CurrentPet;
+        if (currentPet != null)
         {
-            var currentPet = CurrentPet;
-            if (currentPet != null)
-            {
-                DespawnPet(currentPet);
-            }
-
-            ActivePet = null;
-            ActivePetId = null;
-            PacketSender.SendOpenPetHub(this, close: true);
-
-            return;
+            DespawnPet(currentPet, killIfDespawnable: petData.DespawnOnUnequip);
         }
 
-        ActivePetMode = PetBehavior.Stay;
+        ActivePet = null;
+        ActivePetId = null;
 
-        var existingPet = CurrentPet;
-        if (existingPet != null && !existingPet.IsDisposed)
+        if (petData.DespawnOnUnequip)
         {
-            existingPet.SetBehavior(PetBehavior.Stay);
+            PacketSender.SendOpenPetHub(this, close: true);
         }
     }
 

--- a/Intersect.Tests.Server/Entities/PlayerTests.Pets.cs
+++ b/Intersect.Tests.Server/Entities/PlayerTests.Pets.cs
@@ -4,6 +4,7 @@ using Intersect.Enums;
 using Intersect.Framework.Core.GameObjects.Items;
 using Intersect.Framework.Core.GameObjects.Pets;
 using Intersect.Server.Entities;
+using Intersect.Shared.Pets;
 using NUnit.Framework;
 
 namespace Intersect.Tests.Server.Entities;
@@ -104,6 +105,84 @@ public partial class PlayerTests
             {
                 Assert.That(storedSecondPet.Level, Is.EqualTo(3));
                 Assert.That(storedSecondPet.Experience, Is.EqualTo(30));
+            }
+        );
+    }
+
+    [Test]
+    public void TestUnequippingSummonedPetDespawnsActiveInstance()
+    {
+        var petDescriptor = new PetDescriptor(Guid.NewGuid())
+        {
+            Name = "Summoned Pet",
+        };
+        PetDescriptor.Lookup.Set(petDescriptor.Id, petDescriptor);
+
+        var itemDescriptor = new ItemDescriptor(Guid.NewGuid())
+        {
+            Name = "Summoned Pet Collar",
+            ItemType = ItemType.Equipment,
+            EquipmentSlot = 0,
+            Pet = new PetItemData
+            {
+                PetDescriptorId = petDescriptor.Id,
+                SummonOnEquip = true,
+                DespawnOnUnequip = false,
+                BindOnEquip = false,
+            },
+        };
+        ItemDescriptor.Lookup.Set(itemDescriptor.Id, itemDescriptor);
+
+        Player player = new()
+        {
+            MapId = _mapId,
+        };
+
+        Assert.That(player.TryGiveItem(itemDescriptor.Id, 1), Is.True);
+
+        var inventorySlot = player.FindInventoryItemSlots(itemDescriptor.Id).Single();
+        var slotIndex = player.FindInventoryItemSlotIndex(inventorySlot);
+
+        player.ActivePetMode = PetBehavior.Passive;
+
+        player.EquipItem(itemDescriptor, slotIndex, updateCooldown: false);
+
+        Assert.That(player.ActivePet, Is.Not.Null);
+        var petInstanceId = player.ActivePet!.PetInstanceId;
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(player.ActivePetId, Is.EqualTo(player.ActivePet!.Id));
+                Assert.That(player.CurrentPet, Is.Not.Null);
+                Assert.That(player.CurrentPet!.Behavior, Is.EqualTo(player.ActivePetMode));
+                Assert.That(player.SpawnedPets, Has.Count.EqualTo(1));
+            }
+        );
+
+        player.UnequipItem(itemDescriptor.EquipmentSlot, sendUpdate: false);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(player.ActivePet, Is.Null);
+                Assert.That(player.ActivePetId, Is.Null);
+                Assert.That(player.CurrentPet, Is.Null);
+                Assert.That(player.SpawnedPets, Is.Empty);
+                Assert.That(player.ActivePetMode, Is.EqualTo(PetBehavior.Passive));
+            }
+        );
+
+        player.EquipItem(itemDescriptor, slotIndex, updateCooldown: false);
+
+        Assert.Multiple(
+            () =>
+            {
+                Assert.That(player.ActivePet, Is.Not.Null);
+                Assert.That(player.ActivePet!.PetInstanceId, Is.EqualTo(petInstanceId));
+                Assert.That(player.CurrentPet, Is.Not.Null);
+                Assert.That(player.CurrentPet!.Behavior, Is.EqualTo(PetBehavior.Passive));
+                Assert.That(player.SpawnedPets, Has.Count.EqualTo(1));
             }
         );
     }


### PR DESCRIPTION
## Summary
- ensure HandlePetUnequipped always despawns the matching pet, clears active pet state, and only closes the pet hub when configured
- preserve the selected pet behavior mode across despawns
- add a regression test that verifies unequipping a summoned pet leaves no active instance and prevents duplication on re-equip

## Testing
- dotnet test Intersect.Tests.Server/Intersect.Tests.Server.csproj *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68cde1c25ba0832bbce25c303a1614cb