### PR TITLE
Restrict hide entity flag to players

### DIFF
--- a/Intersect.Client.Core/Entities/Entity.cs
+++ b/Intersect.Client.Core/Entities/Entity.cs
@@ -110,6 +110,8 @@ public partial class Entity : IEntity
 
     public bool IsHidden { get; set; } = false;
 
+    protected virtual bool SupportsHideEntity => false;
+
     public bool HideName { get; set; }
 
     //Core Values
@@ -415,7 +417,7 @@ public partial class Entity : IEntity
         DirectionFacing = (Direction)packet.Dir;
         Passable = packet.Passable;
         HideName = packet.HideName;
-        IsHidden = packet.HideEntity;
+        IsHidden = SupportsHideEntity && packet.HideEntity;
         NameColor = packet.NameColor;
         HeaderLabel = new Label(packet.HeaderLabel.Label, packet.HeaderLabel.Color);
         FooterLabel = new Label(packet.FooterLabel.Label, packet.FooterLabel.Color);

--- a/Intersect.Client.Core/Entities/Player.cs
+++ b/Intersect.Client.Core/Entities/Player.cs
@@ -40,6 +40,8 @@ namespace Intersect.Client.Entities;
 
 public partial class Player : Entity, IPlayer
 {
+    protected override bool SupportsHideEntity => true;
+
     public delegate void InventoryUpdatedEventHandler(Player player, int slotIndex);
 
     private Guid _class;


### PR DESCRIPTION
## Summary
- ignore server HideEntity flag for non-player entities on the client
- allow the player entity class to keep honoring HideEntity for hide/show player events

## Testing
- `dotnet build Intersect.Client.Core/Intersect.Client.Core.csproj` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68cde5470398832bbefecfb6abca583e