### PR TITLE
Add pet equipment slot option

### DIFF
--- a/Framework/Intersect.Framework.Core/Config/EquipmentOptions.cs
+++ b/Framework/Intersect.Framework.Core/Config/EquipmentOptions.cs
@@ -23,6 +23,7 @@ public partial class EquipmentOptions
     new("Accessory"),   // Accesorio extra (ej: colgante especial)
     new("Ring", 2),     // Dos anillos
     new("Karma", 5),    // Cinco karmas/trofeos
+    new("Pet"),         // Mascota
 ];
 
 

--- a/Framework/Intersect.Framework.Core/Config/ItemOptions.cs
+++ b/Framework/Intersect.Framework.Core/Config/ItemOptions.cs
@@ -56,6 +56,7 @@ public class ItemOptions
             "Accessory",
             "Ring",
             "Karma",
+            "Pet",
         }
     },
     { ItemType.Resource, new()

--- a/Framework/Intersect.Framework.Core/Config/PaperdollOptions.cs
+++ b/Framework/Intersect.Framework.Core/Config/PaperdollOptions.cs
@@ -20,6 +20,7 @@ public partial class PaperdollOptions
         "Boots",
         "Ring",
         "Trophy",
+        "Pet",
     ];
 
     public List<string> Left { get; set; } =
@@ -32,6 +33,7 @@ public partial class PaperdollOptions
         "Boots",
         "Ring",
         "Trophy",
+        "Pet",
     ];
 
     public List<string> Right { get; set; } =
@@ -44,6 +46,7 @@ public partial class PaperdollOptions
         "Boots",
         "Ring",
         "Trophy",
+        "Pet",
     ];
 
     public List<string> Up { get; set; } =
@@ -56,6 +59,7 @@ public partial class PaperdollOptions
         "Boots",
         "Ring",
         "Trophy",
+        "Pet",
     ];
 
     public PaperdollOptions()


### PR DESCRIPTION
## Summary
- add a new Pet slot to the equipment configuration
- allow item subtypes to include Pet equipment
- include the Pet slot in each paperdoll direction list so it can render

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cde516a808832ba78e75a1877e0e4c