### PR TITLE
Add Pet hub window with JSON layout

### DIFF
--- a/Intersect.Client.Core/Interface/Game/GameInterface.cs
+++ b/Intersect.Client.Core/Interface/Game/GameInterface.cs
@@ -113,7 +113,7 @@ public partial class GameInterface : MutableInterface
 
     public PlayerStatusWindow PlayerStatusWindow;
 
-    private PetBehaviorWidget? _petBehaviorWidget;
+    private PetHubWindow? _petHubWindow;
 
 
     private SettingsWindow GetOrCreateSettingsWindow()
@@ -186,19 +186,19 @@ public partial class GameInterface : MutableInterface
         mQuestOfferWindow = new QuestOfferWindow(GameCanvas);
         mMapItemWindow = new MapItemWindow(GameCanvas);
 
-        _petBehaviorWidget ??= new PetBehaviorWidget(GameCanvas);
-        _petBehaviorWidget.Hide();
+        _petHubWindow ??= new PetHubWindow(GameCanvas);
+        _petHubWindow.Hide();
 
     }
     public void ShowPetHub()
     {
-        _petBehaviorWidget ??= new PetBehaviorWidget(GameCanvas);
-        _petBehaviorWidget.Show();
+        _petHubWindow ??= new PetHubWindow(GameCanvas);
+        _petHubWindow.Show();
     }
 
     public void HidePetHub()
     {
-        _petBehaviorWidget?.Hide();
+        _petHubWindow?.Hide();
     }
     public void OpenEnchantWindow()
     {

--- a/Intersect.Client.Core/Interface/Game/Pets/PetBehaviorWidget.cs
+++ b/Intersect.Client.Core/Interface/Game/Pets/PetBehaviorWidget.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using Intersect.Client.General;
+using Intersect.Client.Framework.File_Management;
 using Intersect.Client.Framework.Gwen;
 using Intersect.Client.Framework.Gwen.Control;
 using Intersect.Client.Framework.Gwen.Control.EventArguments;
@@ -14,9 +15,10 @@ public sealed class PetBehaviorWidget : RadioButtonGroup
     private readonly Dictionary<PetBehavior, LabeledRadioButton> _options = new();
     private bool _suppressSelectionChanged;
 
-    public PetBehaviorWidget(Canvas parent) : base(parent)
+    public PetBehaviorWidget(Base parent) : base(parent)
     {
         Name = nameof(PetBehaviorWidget);
+
         Alignment = [Alignments.Bottom, Alignments.Left];
         AlignmentPadding = new Padding { Bottom = 4, Left = 4 };
         Padding = new Padding(4);
@@ -28,6 +30,8 @@ public sealed class PetBehaviorWidget : RadioButtonGroup
         CreateOption(PetBehavior.Stay, Strings.Pets.BehaviorStay);
         CreateOption(PetBehavior.Defend, Strings.Pets.BehaviorDefend);
         CreateOption(PetBehavior.Passive, Strings.Pets.BehaviorPassive);
+
+        LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
 
         SelectionChanged += OnSelectionChanged;
         Globals.PetHub.ActivePetChanged += OnPetHubStateChanged;

--- a/Intersect.Client.Core/Interface/Game/Pets/PetHubWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Pets/PetHubWindow.cs
@@ -1,0 +1,67 @@
+using Intersect.Client.Framework.File_Management;
+using Intersect.Client.Framework.Gwen;
+using Intersect.Client.Framework.Gwen.Control;
+using Intersect.Client.General;
+using Intersect.Client.Localization;
+
+namespace Intersect.Client.Interface.Game.Pets;
+
+public sealed class PetHubWindow : Window
+{
+    private readonly Label _statusLabel;
+    private readonly PetBehaviorWidget _behaviorWidget;
+
+    public PetHubWindow(Canvas gameCanvas)
+        : base(gameCanvas, Strings.Pets.HubTitle, modal: false, name: nameof(PetHubWindow))
+    {
+        DisableResizing();
+        IsClosable = true;
+        RestrictToParent = true;
+
+        Alignment = [Alignments.Bottom, Alignments.Left];
+        AlignmentPadding = new Padding { Left = 8, Bottom = 8 };
+
+        _statusLabel = new Label(this, "StatusLabel")
+        {
+            Text = Strings.Pets.StatusNoPet.ToString(),
+        };
+
+        _behaviorWidget = new PetBehaviorWidget(this);
+
+        Globals.PetHub.ActivePetChanged += OnPetHubStateChanged;
+        Globals.PetHub.BehaviorChanged += OnPetHubStateChanged;
+    }
+
+    protected override void EnsureInitialized()
+    {
+        LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
+        RefreshState();
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            Globals.PetHub.ActivePetChanged -= OnPetHubStateChanged;
+            Globals.PetHub.BehaviorChanged -= OnPetHubStateChanged;
+        }
+
+        base.Dispose(disposing);
+    }
+
+    private void OnPetHubStateChanged()
+    {
+        RefreshState();
+    }
+
+    private void RefreshState()
+    {
+        if (!Globals.PetHub.HasActivePet || Globals.PetHub.ActivePet is not { } pet)
+        {
+            _statusLabel.Text = Strings.Pets.StatusNoPet.ToString();
+            return;
+        }
+
+        _statusLabel.Text = Strings.Pets.StatusWithPet.ToString(pet.Name);
+    }
+}

--- a/Intersect.Client.Core/Localization/Translations/en-US.json
+++ b/Intersect.Client.Core/Localization/Translations/en-US.json
@@ -15,6 +15,9 @@
     "FactionNidrajName": "Nidraj"
   },
   "Pets": {
+    "HubTitle": "Pet Hub",
+    "StatusNoPet": "You do not have an active pet.",
+    "StatusWithPet": "Active pet: {0}",
     "WidgetTitle": "Pet Modes",
     "BehaviorFollow": "Follow",
     "BehaviorStay": "Stay",

--- a/Intersect.Client.Core/Localization/Translations/es-ES.json
+++ b/Intersect.Client.Core/Localization/Translations/es-ES.json
@@ -15,6 +15,9 @@
     "FactionNidrajName": "Nidraj"
   },
   "Pets": {
+    "HubTitle": "Centro de mascotas",
+    "StatusNoPet": "No tienes una mascota activa.",
+    "StatusWithPet": "Mascota activa: {0}",
     "WidgetTitle": "Modos de mascota",
     "BehaviorFollow": "Seguir",
     "BehaviorStay": "Quieto",

--- a/resources/gui/layouts/game/PetBehaviorWidget.json
+++ b/resources/gui/layouts/game/PetBehaviorWidget.json
@@ -1,0 +1,18 @@
+{
+  "Bounds": "0,0,256,120",
+  "Padding": "8,8,8,8",
+  "Children": {
+    "Follow": {
+      "Bounds": "0,0,240,24"
+    },
+    "Stay": {
+      "Bounds": "0,28,240,24"
+    },
+    "Defend": {
+      "Bounds": "0,56,240,24"
+    },
+    "Passive": {
+      "Bounds": "0,84,240,24"
+    }
+  }
+}

--- a/resources/gui/layouts/game/PetHubWindow.json
+++ b/resources/gui/layouts/game/PetHubWindow.json
@@ -1,0 +1,17 @@
+{
+  "Bounds": "0,0,280,180",
+  "Alignments": "Bottom,Left",
+  "AlignmentEdgeDistances": "16,0,0,16",
+  "Padding": "12,12,12,12",
+  "Children": {
+    "StatusLabel": {
+      "Bounds": "12,40,256,24",
+      "FontSize": 12,
+      "Alignments": "Top,Left"
+    },
+    "PetBehaviorWidget": {
+      "Bounds": "12,72,256,96",
+      "Alignments": "Top,Left"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- replace the in-game pet behaviour widget popup with a full Pet Hub window that can load from JSON layouts
- update the pet behaviour selector to support JSON-driven layout and reuse it inside the new window
- add localisation entries and default JSON layout files for the pet hub and behaviour widget

## Testing
- `dotnet build Intersect.sln` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68cea3f68c5c832ba6b66385b7d09eaa