### PR TITLE
Fix pathfinding queue update and allow grappling pets

### DIFF
--- a/Intersect.Server.Core/Entities/Pathfinding/PriorityQueue.cs
+++ b/Intersect.Server.Core/Entities/Pathfinding/PriorityQueue.cs
@@ -126,16 +126,55 @@ internal partial class PriorityQueue<T> where T : IIndexedObject
     public void Update(T item)
     {
         var count = mInnerList.Count;
+        var index = item.Index;
 
-        // usually we only need to switch some elements, since estimation won't change that much.
-        while (item.Index - 1 >= 0 && OnCompare(item.Index - 1, item.Index) > 0)
+        if (index < 0 || index >= count)
         {
-            SwitchElements(item.Index - 1, item.Index);
+            return;
         }
 
-        while (item.Index + 1 < count && OnCompare(item.Index + 1, item.Index) < 0)
+        // Bubble up until the heap invariant is restored with the parent node.
+        while (index > 0)
         {
-            SwitchElements(item.Index + 1, item.Index);
+            var parentIndex = (index - 1) / 2;
+
+            if (OnCompare(index, parentIndex) < 0)
+            {
+                SwitchElements(index, parentIndex);
+                index = parentIndex;
+            }
+            else
+            {
+                break;
+            }
+        }
+
+        // Bubble down to ensure the children also respect the heap invariant.
+        while (true)
+        {
+            var leftChild = index * 2 + 1;
+            if (leftChild >= count)
+            {
+                break;
+            }
+
+            var rightChild = leftChild + 1;
+            var smallestChild = leftChild;
+
+            if (rightChild < count && OnCompare(rightChild, leftChild) < 0)
+            {
+                smallestChild = rightChild;
+            }
+
+            if (OnCompare(index, smallestChild) > 0)
+            {
+                SwitchElements(index, smallestChild);
+                index = smallestChild;
+            }
+            else
+            {
+                break;
+            }
         }
     }
 

--- a/Intersect.Server.Core/Entities/ProjectileSpawn.cs
+++ b/Intersect.Server.Core/Entities/ProjectileSpawn.cs
@@ -181,6 +181,7 @@ public partial class ProjectileSpawn
         {
             Player => ProjectileDescriptor.GrappleHookOptions.Contains(Enums.GrappleOption.Player),
             Npc => ProjectileDescriptor.GrappleHookOptions.Contains(Enums.GrappleOption.NPC),
+            Pet => ProjectileDescriptor.GrappleHookOptions.Contains(Enums.GrappleOption.NPC),
             Resource => ProjectileDescriptor.GrappleHookOptions.Contains(Enums.GrappleOption.Resource),
             _ => throw new ArgumentException($"Unsupported entity type {en.GetType().FullName}", nameof(en)),
         };


### PR DESCRIPTION
## Summary
- fix the priority queue Update logic to properly maintain heap ordering and guard against invalid indices
- allow grappling projectiles to hook pet entities using the existing NPC grapple option

## Testing
- `dotnet test Intersect.Server.Core/Intersect.Server.Core.csproj` *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cea808e2f8832b9510386e2e605ab3