### PR TITLE
Ensure map instances synchronize active pets

### DIFF
--- a/Intersect.Server.Core/Entities/Pet.cs
+++ b/Intersect.Server.Core/Entities/Pet.cs
@@ -874,7 +874,7 @@ public sealed class Pet : Entity
         return canMove;
     }
 
-    private void SynchronizeWithOwner(Player owner)
+    internal void SynchronizeWithOwner(Player owner)
     {
         if (owner.MapId == _ownerMapId && owner.MapInstanceId == _ownerMapInstanceId)
         {

--- a/Intersect.Server.Core/Entities/Player.cs
+++ b/Intersect.Server.Core/Entities/Player.cs
@@ -1254,7 +1254,7 @@ public partial class Player : Entity
         return true;
     }
 
-    private Pet[] GetActivePetsSnapshot()
+    internal Pet[] GetActivePetsSnapshot()
     {
         var pets = new List<Pet>();
 

--- a/Intersect.Server.Core/Maps/MapInstance.cs
+++ b/Intersect.Server.Core/Maps/MapInstance.cs
@@ -383,6 +383,16 @@ public partial class MapInstance : IMapInstance
         AddEntity(player);
         player.LastMapEntered = mMapController.Id;
 
+        foreach (var pet in player.GetActivePetsSnapshot())
+        {
+            if (pet == null)
+            {
+                continue;
+            }
+
+            pet.SynchronizeWithOwner(player);
+        }
+
         // Send the entities/items of this current MapInstance to the player
         SendMapEntitiesTo(player);
 


### PR DESCRIPTION
## Summary
- ensure map instances resynchronize a player's active pets when the player enters
- expose the active pet snapshot helper and pet synchronization routine for reuse

## Testing
- `dotnet test` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ceba90e620832ba0c2fd813b06be99