### PR TITLE
Integrate centralized pet spawning logic

### DIFF
--- a/Intersect.Server.Core/Entities/Events/CommandProcessing.cs
+++ b/Intersect.Server.Core/Entities/Events/CommandProcessing.cs
@@ -1036,20 +1036,21 @@ public static partial class CommandProcessing
             return;
         }
 
-        var pet = new Pet(
-            descriptor,
+        var pet = instance.SpawnPetForPlayer(
             playerCaller,
+            descriptor,
             despawnable: true,
-            register: false,
             mapIdOverride: spawnMapId,
             mapInstanceIdOverride: instance.MapInstanceId,
             xOverride: spawnX,
             yOverride: spawnY,
-            directionOverride: direction
+            dirOverride: direction
         );
 
-        instance.AddEntity(pet);
-        PacketSender.SendEntityDataToProximity(pet);
+        if (pet == null)
+        {
+            return;
+        }
 
         playerCaller.SpawnedPets.Add(pet);
     }

--- a/Intersect.Server.Core/Entities/Player.cs
+++ b/Intersect.Server.Core/Entities/Player.cs
@@ -1160,7 +1160,17 @@ public partial class Player : Entity
 
         if (currentPet == null)
         {
-            var newPet = new Pet(descriptor, this);
+            if (!MapController.TryGetInstanceFromMap(MapId, MapInstanceId, out var instance))
+            {
+                return;
+            }
+
+            var newPet = instance.SpawnPetForPlayer(this, descriptor);
+            if (newPet == null)
+            {
+                return;
+            }
+
             CurrentPet = newPet;
 
             lock (_spawnedPetsLock)
@@ -1373,7 +1383,17 @@ public partial class Player : Entity
             DespawnPet(currentPet);
         }
 
-        var newPet = new Pet(descriptor, this);
+        if (!MapController.TryGetInstanceFromMap(MapId, MapInstanceId, out var instance))
+        {
+            return false;
+        }
+
+        var newPet = instance.SpawnPetForPlayer(this, descriptor);
+        if (newPet == null)
+        {
+            return false;
+        }
+
         CurrentPet = newPet;
 
         lock (_spawnedPetsLock)


### PR DESCRIPTION
## Summary
- add `SpawnPetForPlayer` and `DespawnActivePetOf` helpers on `MapInstance` to manage pet entities centrally
- update player pet lifecycle to rely on the new spawn helper when invoking or restoring companions
- reuse the centralized pet spawn helper for event-driven pet summons and keep instance indices in sync

## Testing
- `dotnet build Intersect.Server.Core/Intersect.Server.Core.csproj` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68cec9e2d7a4832b80fb5c52bfad61ac