### PR TITLE
Adjust pet facing when blocked by entity

### DIFF
--- a/Intersect.Server.Core/Entities/Pet.cs
+++ b/Intersect.Server.Core/Entities/Pet.cs
@@ -843,7 +843,13 @@ public sealed class Pet : Entity
                 {
                     if (!blockingEntity.IsDisposed && CanAttack(blockingEntity, null))
                     {
-                        ChangeDir(direction);
+                        var face = DirectionToTarget(blockingEntity);
+
+                        if (!IsFacingTarget(blockingEntity))
+                        {
+                            ChangeDir(face);
+                        }
+
                         TryAttack(blockingEntity);
                         madeProgress = true;
                     }


### PR DESCRIPTION
## Summary
- ensure pets update their facing toward blocking entities before attacking during pathfinding

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cecafff9dc832bbc73c667adcbf535