### PR TITLE
Allow allies to pass through owned pets

### DIFF
--- a/Intersect.Client.Core/Entities/Entity.cs
+++ b/Intersect.Client.Core/Entities/Entity.cs
@@ -2593,6 +2593,64 @@ public partial class Entity : IEntity
                                     }
 
                                     break;
+                                case Pet pet when !pet.Passable:
+                                    if (projectileTrigger)
+                                    {
+                                        break;
+                                    }
+
+                                    var ignorePetBlocking = false;
+
+                                    if (pet.OwnerId == Id)
+                                    {
+                                        ignorePetBlocking = true;
+                                    }
+                                    else
+                                    {
+                                        switch (this)
+                                        {
+                                            case Player movingPlayer:
+                                                if (movingPlayer.Id == pet.OwnerId)
+                                                {
+                                                    ignorePetBlocking = true;
+                                                    break;
+                                                }
+
+                                                var petOwner = pet.Owner;
+                                                if (petOwner != null && movingPlayer.IsInMyParty(petOwner))
+                                                {
+                                                    ignorePetBlocking = true;
+                                                }
+
+                                                break;
+
+                                            case Pet movingPet:
+                                                if (movingPet.OwnerId == pet.OwnerId)
+                                                {
+                                                    ignorePetBlocking = true;
+                                                    break;
+                                                }
+
+                                                var movingPetOwner = movingPet.Owner;
+                                                var blockingPetOwner = pet.Owner;
+
+                                                if (movingPetOwner != null &&
+                                                    blockingPetOwner != null &&
+                                                    movingPetOwner.IsInMyParty(blockingPetOwner))
+                                                {
+                                                    ignorePetBlocking = true;
+                                                }
+
+                                                break;
+                                        }
+                                    }
+
+                                    if (ignorePetBlocking)
+                                    {
+                                        continue;
+                                    }
+
+                                    break;
                             }
 
                             blockedBy = en.Value;


### PR DESCRIPTION
## Summary
- allow entities to ignore allied pets when checking tile collisions on the client
- mirror the server's CanPassPet ownership and party checks while preserving projectile collisions

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cecf86bd68832ba4d0d8b3588ea90f