### PR TITLE
Adjust pet attack speed handling

### DIFF
--- a/Intersect.Server.Core/Entities/Pet.cs
+++ b/Intersect.Server.Core/Entities/Pet.cs
@@ -394,6 +394,16 @@ public sealed class Pet : Entity
         PacketSender.SendEntityAttack(this, CalculateAttackTime());
     }
 
+    public override int CalculateAttackTime()
+    {
+        if (Descriptor.AttackSpeedModifier == 1)
+        {
+            return Descriptor.AttackSpeedValue;
+        }
+
+        return base.CalculateAttackTime();
+    }
+
     public void NotifyOwnerDamaged(Entity? attacker)
     {
         var owner = Owner;

--- a/Intersect.Tests.Server/Entities/PetTests.CalculateAttackTime.cs
+++ b/Intersect.Tests.Server/Entities/PetTests.CalculateAttackTime.cs
@@ -1,0 +1,78 @@
+using System;
+using Intersect.Config;
+using Intersect.Enums;
+using Intersect.Framework.Core.GameObjects.Pets;
+using Intersect.Server.Entities;
+using Intersect.Server.Maps;
+using NUnit.Framework;
+
+namespace Intersect.Tests.Server.Entities;
+
+[TestFixture]
+public class PetTests
+{
+    private Guid _mapId;
+
+    [SetUp]
+    public void Setup()
+    {
+        Options.EnsureCreated();
+
+        _mapId = Guid.NewGuid();
+        MapController.Lookup.Set(_mapId, new MapController(_mapId));
+    }
+
+    private static Player CreateOwner(Guid mapId)
+    {
+        return new Player
+        {
+            MapId = mapId,
+            MapInstanceId = Guid.NewGuid(),
+            X = 0,
+            Y = 0,
+            Z = 0,
+            Dir = Direction.Down,
+        };
+    }
+
+    [Test]
+    public void CalculateAttackTime_UsesStaticValueWhenModifierIndicatesStatic()
+    {
+        var descriptor = new PetDescriptor(Guid.NewGuid())
+        {
+            Name = "Static Pet",
+            AttackSpeedModifier = 1,
+            AttackSpeedValue = 123,
+        };
+
+        var owner = CreateOwner(_mapId);
+
+        var pet = new Pet(descriptor, owner);
+
+        Assert.That(pet.CalculateAttackTime(), Is.EqualTo(descriptor.AttackSpeedValue));
+    }
+
+    [Test]
+    public void CalculateAttackTime_UsesBaseCalculationWhenModifierIsNotStatic()
+    {
+        var descriptor = new PetDescriptor(Guid.NewGuid())
+        {
+            Name = "Dynamic Pet",
+            AttackSpeedModifier = 0,
+            AttackSpeedValue = 5,
+        };
+
+        descriptor.Stats[(int)Stat.Agility] = 10;
+
+        var owner = CreateOwner(_mapId);
+
+        var pet = new Pet(descriptor, owner);
+
+        var expected = (int)(Options.Instance.Combat.MaxAttackRate +
+            (Options.Instance.Combat.MinAttackRate - Options.Instance.Combat.MaxAttackRate) *
+            (((float)Options.Instance.Player.MaxStat - pet.Stat[(int)Stat.Agility].Value()) /
+             Options.Instance.Player.MaxStat));
+
+        Assert.That(pet.CalculateAttackTime(), Is.EqualTo(expected));
+    }
+}


### PR DESCRIPTION
## Summary
- override pet attack timing to honour static attack speed descriptors
- add server tests ensuring pet attack speed modifiers affect cadence

## Testing
- dotnet test Intersect.Tests.Server/Intersect.Tests.Server.csproj *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ced906670c832ba181f82fa8b03d37