### PR TITLE
Ensure pet equipment swaps manage active pets

### DIFF
--- a/Intersect.Server.Core/Maps/MapInstance.cs
+++ b/Intersect.Server.Core/Maps/MapInstance.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Linq;
 using Intersect.Core;
 using Intersect.Enums;
 using Intersect.Framework.Core;
@@ -385,6 +386,20 @@ public partial class MapInstance : IMapInstance
         if (spawnInstanceId != MapInstanceId)
         {
             return null;
+        }
+
+        foreach (var entity in mEntities.Values.ToArray())
+        {
+            if (entity is Pet existing && !existing.IsDisposed && existing.OwnerId == owner.Id
+                && existing.MapInstanceId == MapInstanceId)
+            {
+                lock (existing.EntityLock)
+                {
+                    existing.Despawn(true);
+                }
+
+                RemoveEntity(existing);
+            }
         }
 
         var pet = new Pet(


### PR DESCRIPTION
## Summary
- ensure equipping pet items always spawns the configured pet while cleaning up any existing one
- despawn the player's active pet when pet-slot gear is removed
- guard map instances against duplicate pet spawns for the same owner

## Testing
- `dotnet build Intersect.Server.Core/Intersect.Server.Core.csproj` *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cee8d607d4832baf3ad3bbfef3ff03