### PR TITLE
Forward pet kill rewards to owners

### DIFF
--- a/Intersect.Server.Core/Entities/Pet.cs
+++ b/Intersect.Server.Core/Entities/Pet.cs
@@ -968,6 +968,14 @@ public sealed class Pet : Entity
         PacketSender.SendPetStateUpdate(this);
     }
 
+    public override void KilledEntity(Entity entity)
+    {
+        base.KilledEntity(entity);
+
+        var owner = Owner ?? Player.FindOnline(OwnerId);
+        owner?.KilledEntity(entity);
+    }
+
     internal bool MetadataDirty => _metadataDirty;
 
     internal void ResetMetadataDirty()


### PR DESCRIPTION
## Summary
- forward pet kill notifications to the owning player when the pet is credited with a kill
- ensure owners receive the same kill handling (experience, quests, etc.) as if they dealt the final blow

## Testing
- `dotnet test Intersect.Tests.Server/Intersect.Tests.Server.csproj` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68cef25d3ce8832b874d6eaef66d4156