### PR TITLE
Guard active pet despawn on unrelated unequip

### DIFF
--- a/Intersect.Server.Core/Entities/Player.cs
+++ b/Intersect.Server.Core/Entities/Player.cs
@@ -1475,12 +1475,17 @@ public partial class Player : Entity
             despawnedAny = true;
         }
 
-        if (MapController.TryGetInstanceFromMap(MapId, MapInstanceId, out var instance) && instance != null)
+        var shouldClearActivePet = activeMatches
+            || (despawnedAny && activePet != null && activePet.PetDescriptorId == descriptorId);
+
+        if (shouldClearActivePet
+            && MapController.TryGetInstanceFromMap(MapId, MapInstanceId, out var instance)
+            && instance != null)
         {
             instance.DespawnActivePetOf(this, killIfDespawnable: true);
         }
 
-        if (activeMatches || (despawnedAny && activePet != null && activePet.PetDescriptorId == descriptorId))
+        if (shouldClearActivePet)
         {
             ActivePet = null;
             ActivePetId = null;


### PR DESCRIPTION
## Summary
- ensure map-level active pet despawn only happens when the unequipped item matches the active pet
- keep active pet data intact when removing unrelated pet equipment

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cefa4512c0832bb2e5c7d300786216