### PR TITLE
Adjust pet interface layout and styling

### DIFF
--- a/Intersect.Client.Core/Interface/Game/Pets/PetBehaviorWidget.cs
+++ b/Intersect.Client.Core/Interface/Game/Pets/PetBehaviorWidget.cs
@@ -1,18 +1,26 @@
 using System.Collections.Generic;
-using Intersect.Client.General;
+using Intersect.Client.Core;
 using Intersect.Client.Framework.File_Management;
+using Intersect.Client.Framework.Graphics;
 using Intersect.Client.Framework.Gwen;
 using Intersect.Client.Framework.Gwen.Control;
 using Intersect.Client.Framework.Gwen.Control.EventArguments;
+using Intersect.Client.General;
 using Intersect.Client.Localization;
-using Intersect.Localization;
 using Intersect.Enums;
-using Intersect.Client.Core;
+using Intersect.Localization;
 
 namespace Intersect.Client.Interface.Game.Pets;
 
 public sealed class PetBehaviorWidget : RadioButtonGroup
 {
+    private const string DefaultFontName = "Arial";
+    private const int DefaultFontSize = 14;
+    private static readonly Color NormalTextColor = Color.White;
+    private static readonly Color HoveredTextColor = Color.FromArgb(230, 230, 230);
+    private static readonly Color ActiveTextColor = Color.FromArgb(200, 200, 200);
+    private static readonly Color DisabledTextColor = Color.FromArgb(140, 140, 140);
+
     private readonly Dictionary<PetState, LabeledRadioButton> _options = new();
     private bool _suppressSelectionChanged;
 
@@ -21,8 +29,8 @@ public sealed class PetBehaviorWidget : RadioButtonGroup
         Name = nameof(PetBehaviorWidget);
 
         // Establecer tamaño y posición del widget principal
-        SetSize(220, 120); // ejemplo de tamaño
-        SetPosition(20, 20); // ejemplo de posición
+        SetSize(248, 120);
+        SetPosition(16, 0);
 
         Alignment = [Alignments.Bottom, Alignments.Left];
         AlignmentPadding = new Padding { Bottom = 4, Left = 4 };
@@ -32,8 +40,9 @@ public sealed class PetBehaviorWidget : RadioButtonGroup
         Text = Strings.Pets.WidgetTitle.ToString();
 
         // Establecer fuente y tamaño de fuente del widget principal
-        FontName = "Arial";
-        FontSize = 14;
+        FontName = DefaultFontName;
+        FontSize = DefaultFontSize;
+        TextColor = NormalTextColor;
 
         CreateOption(PetState.Follow, Strings.Pets.BehaviorFollow, 0, 0);
         CreateOption(PetState.Stay, Strings.Pets.BehaviorStay, 0, 30);
@@ -68,10 +77,17 @@ public sealed class PetBehaviorWidget : RadioButtonGroup
         option.IsTabable = false;
         option.Margin = new Margin(0, 0, 0, 2);
 
-        // Establecer tamaño, posición, fuente y tamaño de fuente de cada opción
-        option.SetSize(200, 28);
+        // Establecer tamaño, posición, fuente, tamaño de fuente y color de texto de cada opción
+        option.SetSize(248, 28);
         option.SetPosition(x, y);
-      
+        option.FontName = DefaultFontName;
+        option.FontSize = DefaultFontSize;
+        option.TextColor = NormalTextColor;
+        option.SetTextColor(NormalTextColor, ComponentState.Normal);
+        option.SetTextColor(HoveredTextColor, ComponentState.Hovered);
+        option.SetTextColor(ActiveTextColor, ComponentState.Active);
+        option.SetTextColor(DisabledTextColor, ComponentState.Disabled);
+
 
         _options[behavior] = option;
     }

--- a/Intersect.Client.Core/Interface/Game/Pets/PetHubWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Pets/PetHubWindow.cs
@@ -1,5 +1,6 @@
 using Intersect.Client.Core;
 using Intersect.Client.Framework.File_Management;
+using Intersect.Client.Framework.Graphics;
 using Intersect.Client.Framework.Gwen;
 using Intersect.Client.Framework.Gwen.Control;
 using Intersect.Client.General;
@@ -21,21 +22,28 @@ public sealed class PetHubWindow : Window
 
         Alignment = [Alignments.Bottom, Alignments.Left];
         AlignmentPadding = new Padding { Left = 8, Bottom = 8 };
+        SetSize(280, 160);
+        SetPosition(16, 16);
+
+        TitleLabel.FontName = "Arial";
+        TitleLabel.FontSize = 16;
+        TitleLabel.TextColorOverride = Color.White;
 
         _statusLabel = new Label(this, "StatusLabel")
         {
             Text = Strings.Pets.StatusNoPet.ToString(),
             FontName = "Arial",
             FontSize = 14,
+            TextColor = Color.White,
         };
         _statusLabel.SetPosition(16, 32);
-        _statusLabel.SetSize(200, 32);
+        _statusLabel.SetSize(248, 32);
 
         _behaviorWidget = new PetBehaviorWidget(this);
-        _behaviorWidget.Font = _statusLabel.Font;
+        _behaviorWidget.FontName = "Arial";
         _behaviorWidget.FontSize = 14;
+        _behaviorWidget.TextColor = Color.White;
         _behaviorWidget.SetPosition(16, 72);
-        _behaviorWidget.SetSize(200, 48);
 
         Globals.PetHub.ActivePetChanged += OnPetHubStateChanged;
         Globals.PetHub.BehaviorChanged += OnPetHubStateChanged;

--- a/Intersect.Client.Framework/Gwen/Control/LabeledRadioButton.cs
+++ b/Intersect.Client.Framework/Gwen/Control/LabeledRadioButton.cs
@@ -1,3 +1,4 @@
+using Intersect.Client.Framework.Graphics;
 using Intersect.Client.Framework.Gwen.Control.EventArguments;
 using Intersect.Client.Framework.Gwen.Input;
 
@@ -51,6 +52,36 @@ public partial class LabeledRadioButton : Base, ITextContainer
         set => mLabel.Text = value;
     }
 
+    public IFont? Font
+    {
+        get => mLabel.Font;
+        set => mLabel.Font = value;
+    }
+
+    public string? FontName
+    {
+        get => mLabel.FontName;
+        set => mLabel.FontName = value;
+    }
+
+    public int FontSize
+    {
+        get => mLabel.FontSize;
+        set => mLabel.FontSize = value;
+    }
+
+    public Color? TextColor
+    {
+        get => mLabel.TextColor;
+        set => mLabel.TextColor = value;
+    }
+
+    public Color? TextColorOverride
+    {
+        get => mLabel.TextColorOverride;
+        set => mLabel.TextColorOverride = value;
+    }
+
     public Color? TextPaddingDebugColor { get; set; }
 
     // todo: would be nice to remove that
@@ -60,6 +91,11 @@ public partial class LabeledRadioButton : Base, ITextContainer
     {
         get => mRadioButton.IsChecked;
         set => mRadioButton.IsChecked = value;
+    }
+
+    public void SetTextColor(Color clr, ComponentState state)
+    {
+        mLabel.SetTextColor(clr, state);
     }
 
     protected override void Layout(Skin.Base skin)


### PR DESCRIPTION
## Summary
- set explicit size, position, and font styling for the pet hub window controls
- update the pet behavior widget and its options with consistent fonts and text colors
- expose font and text color configuration on labeled radio buttons to support styling

## Testing
- dotnet build Intersect.Client.Core/Intersect.Client.Core.csproj *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cf5d99f090832b85d278a3fe08b891