### PR TITLE
Add explicit pet hub spawn state synchronization

### DIFF
--- a/Framework/Intersect.Framework.Core/Network/Packets/Client/DespawnPetRequestPacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Client/DespawnPetRequestPacket.cs
@@ -1,0 +1,19 @@
+using MessagePack;
+
+namespace Intersect.Network.Packets.Client;
+
+[MessagePackObject]
+public sealed class DespawnPetRequestPacket : IntersectPacket
+{
+    public DespawnPetRequestPacket()
+    {
+    }
+
+    public DespawnPetRequestPacket(bool closePetHub)
+    {
+        ClosePetHub = closePetHub;
+    }
+
+    [Key(0)]
+    public bool ClosePetHub { get; set; }
+}

--- a/Framework/Intersect.Framework.Core/Network/Packets/Client/SpawnPetRequestPacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Client/SpawnPetRequestPacket.cs
@@ -1,0 +1,19 @@
+using MessagePack;
+
+namespace Intersect.Network.Packets.Client;
+
+[MessagePackObject]
+public sealed class SpawnPetRequestPacket : IntersectPacket
+{
+    public SpawnPetRequestPacket()
+    {
+    }
+
+    public SpawnPetRequestPacket(bool openPetHub)
+    {
+        OpenPetHub = openPetHub;
+    }
+
+    [Key(0)]
+    public bool OpenPetHub { get; set; }
+}

--- a/Framework/Intersect.Framework.Core/Network/Packets/Server/PetHubStatePacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Server/PetHubStatePacket.cs
@@ -1,0 +1,19 @@
+using MessagePack;
+
+namespace Intersect.Network.Packets.Server;
+
+[MessagePackObject]
+public sealed class PetHubStatePacket : IntersectPacket
+{
+    public PetHubStatePacket()
+    {
+    }
+
+    public PetHubStatePacket(bool isActive)
+    {
+        IsActive = isActive;
+    }
+
+    [Key(0)]
+    public bool IsActive { get; set; }
+}

--- a/Intersect.Client.Core/Interface/Game/Pets/PetHubWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Pets/PetHubWindow.cs
@@ -135,6 +135,7 @@ public sealed class PetHubWindow : Window
 
         Globals.PetHub.ActivePetChanged += OnPetHubStateChanged;
         Globals.PetHub.BehaviorChanged += OnPetHubStateChanged;
+        Globals.PetHub.SpawnStateChanged += OnPetHubStateChanged;
     }
 
     protected override void EnsureInitialized()
@@ -149,6 +150,7 @@ public sealed class PetHubWindow : Window
         {
             Globals.PetHub.ActivePetChanged -= OnPetHubStateChanged;
             Globals.PetHub.BehaviorChanged -= OnPetHubStateChanged;
+            Globals.PetHub.SpawnStateChanged -= OnPetHubStateChanged;
         }
 
         base.Dispose(disposing);
@@ -162,6 +164,7 @@ public sealed class PetHubWindow : Window
     private void RefreshState()
     {
         var hasPet = Globals.PetHub.HasActivePet && Globals.PetHub.ActivePet is { } pet;
+        var isSpawnRequested = Globals.PetHub.IsSpawnRequested;
 
         _invokeButton.Text = Strings.Pets.InvokeButton.ToString();
         _dismissButton.Text = Strings.Pets.DismissButton.ToString();
@@ -175,8 +178,8 @@ public sealed class PetHubWindow : Window
         _statsHeader.IsHidden = !hasPet;
         _statsPanel.IsHidden = !hasPet;
         _behaviorWidget.IsHidden = !hasPet;
-        _invokeButton.IsDisabled = hasPet;
-        _dismissButton.IsDisabled = !hasPet;
+        _invokeButton.IsDisabled = isSpawnRequested;
+        _dismissButton.IsDisabled = !isSpawnRequested;
 
         if (!hasPet)
         {

--- a/Intersect.Client.Core/Networking/PacketHandler.cs
+++ b/Intersect.Client.Core/Networking/PacketHandler.cs
@@ -471,6 +471,11 @@ internal sealed partial class PacketHandler
         pet.ApplyMetadata(pet.OwnerId, pet.DescriptorId, pet.Despawnable, packet.Behavior);
     }
 
+    public void HandlePacket(IPacketSender packetSender, PetHubStatePacket packet)
+    {
+        Globals.PetHub.Process(packet);
+    }
+
     public void HandlePacket(IPacketSender packetSender, OpenPetHubPacket packet)
     {
         if (packet == null)

--- a/Intersect.Server.Core/Networking/PacketHandler.cs
+++ b/Intersect.Server.Core/Networking/PacketHandler.cs
@@ -3287,6 +3287,36 @@ internal sealed partial class PacketHandler
         player.ActivePetMode = packet.Behavior;
     }
 
+    public void HandlePacket(Client client, SpawnPetRequestPacket packet)
+    {
+        if (client?.Entity is not Player player || packet == null)
+        {
+            return;
+        }
+
+        if (!player.IsActivePetEquipped())
+        {
+            return;
+        }
+
+        _ = player.SetPetHubSpawnRequested(true, packet.OpenPetHub);
+    }
+
+    public void HandlePacket(Client client, DespawnPetRequestPacket packet)
+    {
+        if (client?.Entity is not Player player || packet == null)
+        {
+            return;
+        }
+
+        if (!player.IsActivePetEquipped())
+        {
+            return;
+        }
+
+        _ = player.SetPetHubSpawnRequested(false, closePetHub: packet.ClosePetHub);
+    }
+
     public void HandlePacket(Client client, InvokePetPacket packet)
     {
         if (client?.Entity is not Player player || packet == null)
@@ -3294,7 +3324,12 @@ internal sealed partial class PacketHandler
             return;
         }
 
-        _ = player.InvokePet(openPetHub: packet.OpenPetHub);
+        if (!player.IsActivePetEquipped())
+        {
+            return;
+        }
+
+        _ = player.SetPetHubSpawnRequested(true, packet.OpenPetHub);
     }
 
     public void HandlePacket(Client client, DismissPetPacket packet)
@@ -3304,7 +3339,12 @@ internal sealed partial class PacketHandler
             return;
         }
 
-        _ = player.DismissActivePet(closePetHub: packet.ClosePetHub);
+        if (!player.IsActivePetEquipped())
+        {
+            return;
+        }
+
+        _ = player.SetPetHubSpawnRequested(false, closePetHub: packet.ClosePetHub);
     }
 
     //SetAlignmentRequestPacket

--- a/Intersect.Server.Core/Networking/PacketSender.cs
+++ b/Intersect.Server.Core/Networking/PacketSender.cs
@@ -1050,6 +1050,16 @@ public static partial class PacketSender
         // Aquí solo necesitamos notificar inmediatamente al propietario.
     }
 
+    public static void SendPetHubState(Player player)
+    {
+        if (player == null)
+        {
+            return;
+        }
+
+        player.SendPacket(new PetHubStatePacket(player.IsPetSpawnedViaHub), TransmissionMode.Any);
+    }
+
     public static void SendOpenPetHub(Player player, bool close = false)
     {
         if (player == null)


### PR DESCRIPTION
## Summary
- track whether a player's pet should be spawned via a dedicated hub flag and gate pet lifecycle updates on it
- add client/server packets and handlers to request spawning or despawning pets while validating equipped pet items
- synchronize the spawn flag to the client and refresh the pet hub UI so buttons reflect the requested state

## Testing
- `dotnet build Intersect.sln` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68cf628c897c832b9377e03197ab413c