### PR TITLE
Fix PetHub active pet state when equipping

### DIFF
--- a/Intersect.Client.Core/Entities/Player.cs
+++ b/Intersect.Client.Core/Entities/Player.cs
@@ -117,6 +117,11 @@ public partial class Player : Entity, IPlayer
 
             Inventory[slotIndex] = null;
             InventoryUpdated?.Invoke(this, slotIndex);
+            if (this == Globals.Me)
+            {
+                Globals.PetHub.SyncEquippedPet(this);
+            }
+
             return;
         }
 
@@ -138,6 +143,10 @@ public partial class Player : Entity, IPlayer
         }
 
         InventoryUpdated?.Invoke(this, slotIndex);
+        if (this == Globals.Me)
+        {
+            Globals.PetHub.SyncEquippedPet(this);
+        }
     }
 
     IReadOnlyDictionary<Guid, long> IPlayer.ItemCooldowns => ItemCooldowns;
@@ -424,6 +433,7 @@ public partial class Player : Entity, IPlayer
             if (this == Globals.Me && playerPacket.Equipment.InventorySlots != null)
             {
                 MyEquipment = playerPacket.Equipment.InventorySlots;
+                Globals.PetHub.SyncEquippedPet(this);
             }
             else if (playerPacket.Equipment.ItemIds != null)
             {

--- a/Intersect.Client.Core/Interface/Game/Pets/PetBehaviorWidget.cs
+++ b/Intersect.Client.Core/Interface/Game/Pets/PetBehaviorWidget.cs
@@ -119,7 +119,7 @@ public sealed class PetBehaviorWidget : RadioButtonGroup
 
         try
         {
-            var hasPet = Globals.PetHub.HasActivePet;
+            var hasPet = Globals.PetHub.ActivePet != null;
             var activeBehavior = Globals.PetHub.Behavior;
 
             foreach (var (behavior, option) in _options)

--- a/Intersect.Client.Core/Networking/PacketHandler.cs
+++ b/Intersect.Client.Core/Networking/PacketHandler.cs
@@ -1613,6 +1613,7 @@ internal sealed partial class PacketHandler
                 if (entity == Globals.Me && packet.InventorySlots != null)
                 {
                     entity.MyEquipment = packet.InventorySlots;
+                    Globals.PetHub.SyncEquippedPet(Globals.Me);
                 }
                 else if (packet.ItemIds != null)
                 {


### PR DESCRIPTION
## Summary
- track the equipped pet descriptor/name in the client PetHub so HasActivePet stays true even before the pet is spawned
- refresh the stored pet descriptor whenever local inventory or equipment packets change
- update the Pet Hub window to use descriptor data when no entity is spawned and keep the behavior widget disabled until a pet is active

## Testing
- `dotnet build Intersect.Client.Core/Intersect.Client.Core.csproj` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d010d47664832bae6d2f3275e52656