### PR TITLE
Make all pets despawnable

### DIFF
--- a/Intersect.Client.Core/Entities/Pet.cs
+++ b/Intersect.Client.Core/Entities/Pet.cs
@@ -30,7 +30,7 @@ public sealed class Pet : Entity
     /// <summary>
     ///     Gets a value indicating whether the server considers this pet despawnable.
     /// </summary>
-    public bool Despawnable { get; private set; }
+    public bool Despawnable { get; private set; } = true;
 
     /// <summary>
     ///     Gets the behaviour currently reported by the server for the pet.
@@ -105,12 +105,14 @@ public sealed class Pet : Entity
 
         var ownerChanged = OwnerId != ownerId;
         var descriptorChanged = DescriptorId != descriptorId;
-        var despawnableChanged = Despawnable != despawnable;
+        _ = despawnable;
+        const bool normalizedDespawnable = true;
+        var despawnableChanged = Despawnable != normalizedDespawnable;
         var behaviorChanged = Behavior != behavior;
 
         OwnerId = ownerId;
         DescriptorId = descriptorId;
-        Despawnable = despawnable;
+        Despawnable = normalizedDespawnable;
         Behavior = behavior;
 
         if (ownerChanged || descriptorChanged || despawnableChanged || behaviorChanged)
@@ -127,7 +129,7 @@ public sealed class Pet : Entity
         _cachedDescriptor = null;
         OwnerId = Guid.Empty;
         DescriptorId = Guid.Empty;
-        Despawnable = false;
+        Despawnable = true;
         Behavior = PetState.Follow;
     }
 

--- a/Intersect.Server.Core/Entities/Events/CommandProcessing.cs
+++ b/Intersect.Server.Core/Entities/Events/CommandProcessing.cs
@@ -1039,7 +1039,6 @@ public static partial class CommandProcessing
         var pet = instance.SpawnPetForPlayer(
             playerCaller,
             descriptor,
-            despawnable: true,
             mapIdOverride: spawnMapId,
             mapInstanceIdOverride: instance.MapInstanceId,
             xOverride: spawnX,

--- a/Intersect.Server.Core/Entities/Pet.cs
+++ b/Intersect.Server.Core/Entities/Pet.cs
@@ -50,7 +50,7 @@ public sealed class Pet : Entity
 
     public Guid OwnerId { get; }
 
-    public bool Despawnable { get; }
+    public bool Despawnable { get; } = true;
 
     public Player? Owner
     {
@@ -122,7 +122,6 @@ public sealed class Pet : Entity
     public Pet(
         PetDescriptor descriptor,
         Player owner,
-        bool despawnable = false,
         bool register = true,
         Guid? mapIdOverride = null,
         Guid? mapInstanceIdOverride = null,
@@ -137,7 +136,6 @@ public sealed class Pet : Entity
         Descriptor = descriptor;
         OwnerId = owner.Id;
         Owner = owner;
-        Despawnable = despawnable;
 
         var spawnMapId = mapIdOverride ?? owner.MapId;
         var spawnMapInstanceId = mapInstanceIdOverride ?? owner.MapInstanceId;
@@ -443,6 +441,8 @@ public sealed class Pet : Entity
 
     public void Despawn(bool killIfDespawnable = true)
     {
+        _ = killIfDespawnable;
+
         lock (EntityLock)
         {
             if (IsDisposed)
@@ -450,7 +450,7 @@ public sealed class Pet : Entity
                 return;
             }
 
-            if (killIfDespawnable && Despawnable && !IsDead)
+            if (!IsDead)
             {
                 Die(false, Owner);
             }

--- a/Intersect.Server.Core/Maps/MapInstance.cs
+++ b/Intersect.Server.Core/Maps/MapInstance.cs
@@ -367,7 +367,6 @@ public partial class MapInstance : IMapInstance
     public Pet? SpawnPetForPlayer(
         Player owner,
         PetDescriptor descriptor,
-        bool despawnable = false,
         Guid? mapIdOverride = null,
         Guid? mapInstanceIdOverride = null,
         int? xOverride = null,
@@ -405,7 +404,6 @@ public partial class MapInstance : IMapInstance
         var pet = new Pet(
             descriptor,
             owner,
-            despawnable: despawnable,
             register: false,
             mapIdOverride: spawnMapId,
             mapInstanceIdOverride: spawnInstanceId,


### PR DESCRIPTION
## Summary
- ensure server pets are always marked despawnable and kill them during despawn cleanup
- simplify pet spawning APIs by dropping the despawnable parameter everywhere
- keep client pet metadata consistent by always treating pets as despawnable

## Testing
- dotnet test Intersect.Tests.Server --no-build *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68d010f94f08832b99038ce0f0ceaa84