### PR TITLE
Prevent null slot lists when syncing equipped pet

### DIFF
--- a/Intersect.Client.Core/Pets/PetHub.cs
+++ b/Intersect.Client.Core/Pets/PetHub.cs
@@ -396,6 +396,11 @@ RaiseEvents:
         {
             foreach (var slotIndices in player.MyEquipment.Values)
             {
+                if (slotIndices == null)
+                {
+                    continue;
+                }
+
                 foreach (var slotIndex in slotIndices)
                 {
                     if (slotIndex < 0 || slotIndex >= player.Inventory.Length)


### PR DESCRIPTION
## Summary
- guard against null equipment slot lists when syncing equipped pet data

## Testing
- `dotnet build Intersect.sln -c Release` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68d0215c07e4832b953854a86b8fd0c3