### PR TITLE
Avoid teleporting pets between adjacent maps

### DIFF
--- a/Intersect.Server.Core/Entities/Pet.cs
+++ b/Intersect.Server.Core/Entities/Pet.cs
@@ -953,6 +953,31 @@ public sealed class Pet : Entity
             return;
         }
 
+        var ownerMapId = owner.MapId;
+        var ownerMapInstanceId = owner.MapInstanceId;
+
+        if (MapInstanceId == ownerMapInstanceId &&
+            MapController.TryGet(MapId, out var petMap) &&
+            MapController.TryGet(ownerMapId, out var ownerMap) &&
+            petMap.MapGrid >= 0 &&
+            ownerMap.MapGrid >= 0 &&
+            petMap.MapGridX >= 0 &&
+            petMap.MapGridY >= 0 &&
+            ownerMap.MapGridX >= 0 &&
+            ownerMap.MapGridY >= 0 &&
+            petMap.MapGrid == ownerMap.MapGrid)
+        {
+            var gridDeltaX = Math.Abs(petMap.MapGridX - ownerMap.MapGridX);
+            var gridDeltaY = Math.Abs(petMap.MapGridY - ownerMap.MapGridY);
+
+            if (gridDeltaX <= 1 && gridDeltaY <= 1)
+            {
+                _ownerMapId = ownerMapId;
+                _ownerMapInstanceId = ownerMapInstanceId;
+                return;
+            }
+        }
+
         var previousMapId = MapId;
         var previousInstanceId = MapInstanceId;
 
@@ -968,15 +993,15 @@ public sealed class Pet : Entity
 
         lock (EntityLock)
         {
-            MapId = owner.MapId;
-            MapInstanceId = owner.MapInstanceId;
+            MapId = ownerMapId;
+            MapInstanceId = ownerMapInstanceId;
             X = owner.X;
             Y = owner.Y;
             Z = owner.Z;
             Dir = owner.Dir;
 
-            _ownerMapId = owner.MapId;
-            _ownerMapInstanceId = owner.MapInstanceId;
+            _ownerMapId = ownerMapId;
+            _ownerMapInstanceId = ownerMapInstanceId;
         }
 
         if (MapController.TryGetInstanceFromMap(MapId, MapInstanceId, out var newInstance))


### PR DESCRIPTION
## Summary
- add logic to keep pets using the pathfinder when the owner changes to an adjacent map in the same instance
- retain teleport fallback for instance changes and non-adjacent transitions

## Testing
- dotnet build Intersect.Server.Core/Intersect.Server.Core.csproj *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d05006f070832bb80fc0468b45b121