### PR TITLE
Ensure dismissing pet hub closes on request

### DIFF
--- a/Intersect.Client.Core/Interface/Game/Pets/PetHubWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Pets/PetHubWindow.cs
@@ -194,6 +194,13 @@ namespace Intersect.Client.Interface.Game.Pets
             Globals.PetHub.SpawnStateChanged += OnPetHubStateChanged;
         }
 
+        protected override void OnClose(Base control, EventArgs args)
+        {
+            _ = Globals.PetHub.DismissPet(closePetHub: true);
+
+            base.OnClose(control, args);
+        }
+
         protected override void EnsureInitialized()
         {
             LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
@@ -395,7 +402,7 @@ namespace Intersect.Client.Interface.Game.Pets
 
         private void OnDismissClicked(Base sender, MouseButtonState arguments)
         {
-            if (Globals.PetHub.DismissPet())
+            if (Globals.PetHub.DismissPet(closePetHub: true))
             {
                 _dismissButton.IsDisabled = true;
                 _invokeButton.IsDisabled = false;


### PR DESCRIPTION
## Summary
- dismiss the active pet hub spawn when the hub window is closed via its title bar
- request the server to close the pet hub when the dismiss button is used

## Testing
- not run (dotnet CLI is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d053845288832bbe7d7485a3036b90