### PR TITLE
Avoid dismissing active pet when closing hub

### DIFF
--- a/Intersect.Client.Core/Interface/Game/Pets/PetHubWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Pets/PetHubWindow.cs
@@ -196,7 +196,10 @@ namespace Intersect.Client.Interface.Game.Pets
 
         protected override void OnClose(Base control, EventArgs args)
         {
-            _ = Globals.PetHub.DismissPet(closePetHub: true);
+            if (Globals.PetHub.ActivePet == null && Globals.PetHub.IsSpawnRequested)
+            {
+                _ = Globals.PetHub.DismissPet(closePetHub: true);
+            }
 
             base.OnClose(control, args);
         }


### PR DESCRIPTION
## Summary
- guard the pet hub window close handler so it only dismisses pending spawn requests when no pet is active

## Testing
- `dotnet test Intersect.Tests.Client` *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d05a544130832b83a5ec3b3a5e7c1c