### PR TITLE
Populate pet evolution editor controls

### DIFF
--- a/Intersect.Editor/Forms/Editors/frmPet.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/frmPet.Designer.cs
@@ -1276,6 +1276,7 @@ namespace Intersect.Editor.Forms.Editors
             cmbEvolve.TabIndex = 4;
             cmbEvolve.Text = null;
             cmbEvolve.TextPadding = new Padding(2);
+            cmbEvolve.SelectedIndexChanged += cmbEvolve_SelectedIndexChanged;
             // 
             // DarkLabel15
             // 
@@ -1298,6 +1299,7 @@ namespace Intersect.Editor.Forms.Editors
             nudEvolveLvl.Size = new Size(74, 23);
             nudEvolveLvl.TabIndex = 2;
             nudEvolveLvl.Value = new decimal(new int[] { 0, 0, 0, 0 });
+            nudEvolveLvl.ValueChanged += nudEvolveLvl_ValueChanged;
             // 
             // DarkLabel14
             // 
@@ -1319,6 +1321,7 @@ namespace Intersect.Editor.Forms.Editors
             chkEvolve.Size = new Size(104, 19);
             chkEvolve.TabIndex = 0;
             chkEvolve.Text = "Pet Can Evolve";
+            chkEvolve.CheckedChanged += chkEvolve_CheckedChanged;
             // 
             // nudMaxLevel
             // 
@@ -1330,6 +1333,7 @@ namespace Intersect.Editor.Forms.Editors
             nudMaxLevel.Size = new Size(187, 23);
             nudMaxLevel.TabIndex = 6;
             nudMaxLevel.Value = new decimal(new int[] { 100, 0, 0, 0 });
+            nudMaxLevel.ValueChanged += nudMaxLevel_ValueChanged;
             // 
             // DarkLabel12
             // 
@@ -1353,6 +1357,7 @@ namespace Intersect.Editor.Forms.Editors
             nudPetPnts.Size = new Size(52, 23);
             nudPetPnts.TabIndex = 4;
             nudPetPnts.Value = new decimal(new int[] { 10, 0, 0, 0 });
+            nudPetPnts.ValueChanged += nudPetPnts_ValueChanged;
             // 
             // DarkLabel13
             // 
@@ -1375,6 +1380,7 @@ namespace Intersect.Editor.Forms.Editors
             nudPetExp.Size = new Size(62, 23);
             nudPetExp.TabIndex = 1;
             nudPetExp.Value = new decimal(new int[] { 100, 0, 0, 0 });
+            nudPetExp.ValueChanged += nudPetExp_ValueChanged;
             // 
             // DarkLabel11
             // 
@@ -1396,6 +1402,7 @@ namespace Intersect.Editor.Forms.Editors
             optDoNotLevel.Size = new Size(119, 19);
             optDoNotLevel.TabIndex = 1;
             optDoNotLevel.Text = "Does Not LevelUp";
+            optDoNotLevel.CheckedChanged += optDoNotLevel_CheckedChanged;
             // 
             // optLevel
             // 
@@ -1406,6 +1413,7 @@ namespace Intersect.Editor.Forms.Editors
             optLevel.Size = new Size(128, 19);
             optLevel.TabIndex = 0;
             optLevel.Text = "Level by Experience";
+            optLevel.CheckedChanged += optLevel_CheckedChanged;
             // 
             // FrmPet
             // 

--- a/Intersect.Editor/Forms/Editors/frmPet.cs
+++ b/Intersect.Editor/Forms/Editors/frmPet.cs
@@ -295,6 +295,14 @@ public partial class FrmPet : EditorForm
             cmbDamageType.SelectedIndex = 0;
         }
 
+        cmbEvolve.Items.Clear();
+        cmbEvolve.Items.Add(Strings.General.None);
+        cmbEvolve.Items.AddRange(PetDescriptor.Names);
+        if (cmbEvolve.Items.Count > 0)
+        {
+            cmbEvolve.SelectedIndex = 0;
+        }
+
         cmbAttackSpeedModifier.Items.Clear();
         foreach (var modifier in Strings.NpcEditor.attackspeedmodifiers)
         {
@@ -455,6 +463,25 @@ public partial class FrmPet : EditorForm
             SetComboIndex(cmbAttackSpeedModifier, _editorItem.AttackSpeedModifier);
             nudAttackSpeedValue.Value = Math.Max(nudAttackSpeedValue.Minimum, Math.Min(nudAttackSpeedValue.Maximum, _editorItem.AttackSpeedValue));
             nudTenacity.Value = (decimal)_editorItem.Tenacity;
+            optLevel.Checked = _editorItem.LevelingMode == PetLevelingMode.Experience;
+            optDoNotLevel.Checked = _editorItem.LevelingMode == PetLevelingMode.Disabled;
+            pnlPetlevel.Visible = _editorItem.LevelingMode == PetLevelingMode.Experience;
+            nudPetExp.Value = Math.Max(nudPetExp.Minimum, Math.Min(nudPetExp.Maximum, _editorItem.ExperienceRate));
+            nudPetPnts.Value = Math.Max(nudPetPnts.Minimum, Math.Min(nudPetPnts.Maximum, _editorItem.StatPointsPerLevel));
+            nudMaxLevel.Value = Math.Max(nudMaxLevel.Minimum, Math.Min(nudMaxLevel.Maximum, _editorItem.MaxLevel));
+            chkEvolve.Checked = _editorItem.CanEvolve;
+            nudEvolveLvl.Value = Math.Max(nudEvolveLvl.Minimum, Math.Min(nudEvolveLvl.Maximum, _editorItem.EvolutionLevel));
+            cmbEvolve.Enabled = _editorItem.CanEvolve;
+            nudEvolveLvl.Enabled = _editorItem.CanEvolve;
+            var evolveIndex = PetDescriptor.ListIndex(_editorItem.EvolutionTargetId);
+            if (evolveIndex >= 0 && evolveIndex + 1 < cmbEvolve.Items.Count)
+            {
+                cmbEvolve.SelectedIndex = evolveIndex + 1;
+            }
+            else if (cmbEvolve.Items.Count > 0)
+            {
+                cmbEvolve.SelectedIndex = 0;
+            }
 
             foreach (var (stat, control) in _statControls)
             {
@@ -654,6 +681,97 @@ public partial class FrmPet : EditorForm
     }
 
     private void nudTenacity_ValueChanged(object sender, EventArgs e) => UpdateTenacity();
+
+    private void optLevel_CheckedChanged(object sender, EventArgs e)
+    {
+        if (_editorItem == null || !optLevel.Checked)
+        {
+            return;
+        }
+
+        _editorItem.LevelingMode = PetLevelingMode.Experience;
+        pnlPetlevel.Visible = true;
+    }
+
+    private void optDoNotLevel_CheckedChanged(object sender, EventArgs e)
+    {
+        if (_editorItem == null || !optDoNotLevel.Checked)
+        {
+            return;
+        }
+
+        _editorItem.LevelingMode = PetLevelingMode.Disabled;
+        pnlPetlevel.Visible = false;
+    }
+
+    private void nudPetExp_ValueChanged(object sender, EventArgs e)
+    {
+        if (_editorItem == null)
+        {
+            return;
+        }
+
+        _editorItem.ExperienceRate = (int)nudPetExp.Value;
+    }
+
+    private void nudPetPnts_ValueChanged(object sender, EventArgs e)
+    {
+        if (_editorItem == null)
+        {
+            return;
+        }
+
+        _editorItem.StatPointsPerLevel = (int)nudPetPnts.Value;
+    }
+
+    private void nudMaxLevel_ValueChanged(object sender, EventArgs e)
+    {
+        if (_editorItem == null)
+        {
+            return;
+        }
+
+        _editorItem.MaxLevel = (int)nudMaxLevel.Value;
+    }
+
+    private void chkEvolve_CheckedChanged(object sender, EventArgs e)
+    {
+        if (_editorItem == null)
+        {
+            return;
+        }
+
+        _editorItem.CanEvolve = chkEvolve.Checked;
+        cmbEvolve.Enabled = chkEvolve.Checked;
+        nudEvolveLvl.Enabled = chkEvolve.Checked;
+    }
+
+    private void nudEvolveLvl_ValueChanged(object sender, EventArgs e)
+    {
+        if (_editorItem == null)
+        {
+            return;
+        }
+
+        _editorItem.EvolutionLevel = (int)nudEvolveLvl.Value;
+    }
+
+    private void cmbEvolve_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        if (_editorItem == null)
+        {
+            return;
+        }
+
+        if (cmbEvolve.SelectedIndex <= 0)
+        {
+            _editorItem.EvolutionTargetId = Guid.Empty;
+            return;
+        }
+
+        var targetId = PetDescriptor.IdFromList(cmbEvolve.SelectedIndex - 1);
+        _editorItem.EvolutionTargetId = targetId;
+    }
 
     private void chkKnockback_CheckedChanged(object sender, EventArgs e) => UpdateImmunity(SpellEffect.Knockback, chkKnockback.Checked);
 


### PR DESCRIPTION
## Summary
- populate the pet evolution combo box during form load and default to "None"
- sync the leveling and evolution controls with the current pet descriptor values when editing
- update the descriptor immediately when the new leveling and evolution controls change so their values persist

## Testing
- `dotnet build Intersect.Editor/Intersect.Editor.csproj` *(fails: `dotnet` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d061d37638832b84e07af6be62fc34