### PR TITLE
Handle experience when pets defeat entities

### DIFF
--- a/Intersect.Server/Entities/IPet.cs
+++ b/Intersect.Server/Entities/IPet.cs
@@ -1,0 +1,12 @@
+namespace Intersect.Server.Entities
+{
+    public interface IPet
+    {
+        Player Owner { get; }
+
+        bool IsLeveable { get; }
+
+        void GivePetExperience(long amount);
+    }
+}
+

--- a/Intersect.Server/Entities/Player.cs
+++ b/Intersect.Server/Entities/Player.cs
@@ -1162,6 +1162,13 @@ namespace Intersect.Server.Entities
         //Combat
         public override void KilledEntity(Entity entity)
         {
+            if (this is IPet pet)
+            {
+                HandlePetKill(pet, entity);
+
+                return;
+            }
+
             switch (entity)
             {
                 case Npc npc:
@@ -1219,6 +1226,34 @@ namespace Intersect.Server.Entities
                         break;
                     }
             }
+        }
+
+        private void HandlePetKill(IPet pet, Entity entity)
+        {
+            var owner = pet.Owner;
+            if (owner != null && !ReferenceEquals(owner, this))
+            {
+                owner.KilledEntity(entity);
+            }
+
+            if (!pet.IsLeveable || entity is not Npc npc)
+            {
+                return;
+            }
+
+            var descriptor = npc.Base;
+            if (descriptor == null)
+            {
+                return;
+            }
+
+            var experience = descriptor.Experience;
+            if (experience <= 0)
+            {
+                return;
+            }
+
+            pet.GivePetExperience(experience);
         }
 
         public void UpdateQuestKillTasks(Entity en)


### PR DESCRIPTION
## Summary
- add an `IPet` interface that exposes the owning player, whether the pet can level, and how it gains experience
- update `Player.KilledEntity` to detect pet killers, forward kill handling to their owner, and award pet experience when applicable

## Testing
- `dotnet build Intersect.Server/Intersect.Server.csproj` *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d063143334832ba067d5d785826250