### PR TITLE
Persist pet progress between spawns

### DIFF
--- a/Intersect.Server.Core/Database/PlayerData/Players/PlayerPet.cs
+++ b/Intersect.Server.Core/Database/PlayerData/Players/PlayerPet.cs
@@ -1,6 +1,8 @@
 using System;
 using System.ComponentModel.DataAnnotations.Schema;
+using Intersect.Enums;
 using Intersect.Framework.Core.GameObjects.Pets;
+using Intersect.Server.Database;
 using Intersect.Server.Entities;
 using Newtonsoft.Json;
 
@@ -27,7 +29,53 @@ public partial class PlayerPet : IPlayerOwned
 
     public long Experience { get; set; }
 
+    public int StatPoints { get; set; }
+
+    [NotMapped]
+    public int[] BaseStats { get; set; } = new int[Enum.GetValues<Stat>().Length];
+
+    [NotMapped]
+    public int[] StatPointAllocations { get; set; } = new int[Enum.GetValues<Stat>().Length];
+
+    [NotMapped]
+    public long[] MaxVitals { get; set; } = new long[Enum.GetValues<Vital>().Length];
+
+    [NotMapped]
+    public long[] Vitals { get; set; } = new long[Enum.GetValues<Vital>().Length];
+
     public long TimeCreated { get; set; } = DateTime.UtcNow.ToBinary();
+
+    [JsonIgnore]
+    [Column("PetBaseStats")]
+    public string BaseStatsJson
+    {
+        get => DatabaseUtils.SaveIntArray(BaseStats, Enum.GetValues<Stat>().Length);
+        set => BaseStats = DatabaseUtils.LoadIntArray(value, Enum.GetValues<Stat>().Length);
+    }
+
+    [JsonIgnore]
+    [Column("PetStatPointAllocations")]
+    public string StatPointAllocationsJson
+    {
+        get => DatabaseUtils.SaveIntArray(StatPointAllocations, Enum.GetValues<Stat>().Length);
+        set => StatPointAllocations = DatabaseUtils.LoadIntArray(value, Enum.GetValues<Stat>().Length);
+    }
+
+    [JsonIgnore]
+    [Column("PetMaxVitals")]
+    public string MaxVitalsJson
+    {
+        get => DatabaseUtils.SaveLongArray(MaxVitals, Enum.GetValues<Vital>().Length);
+        set => MaxVitals = DatabaseUtils.LoadLongArray(value, Enum.GetValues<Vital>().Length);
+    }
+
+    [JsonIgnore]
+    [Column("PetVitals")]
+    public string VitalsJson
+    {
+        get => DatabaseUtils.SaveLongArray(Vitals, Enum.GetValues<Vital>().Length);
+        set => Vitals = DatabaseUtils.LoadLongArray(value, Enum.GetValues<Vital>().Length);
+    }
 
     [NotMapped, JsonIgnore]
     public PetDescriptor? Descriptor

--- a/Intersect.Server.Core/Maps/MapInstance.cs
+++ b/Intersect.Server.Core/Maps/MapInstance.cs
@@ -13,6 +13,7 @@ using Intersect.Framework.Core.GameObjects.Resources;
 using Intersect.GameObjects;
 using Intersect.Network.Packets.Server;
 using Intersect.Server.Database;
+using Intersect.Server.Database.PlayerData.Players;
 using Intersect.Server.Entities.Events;
 using Intersect.Server.Networking;
 using Intersect.Utilities;
@@ -367,6 +368,7 @@ public partial class MapInstance : IMapInstance
     public Pet? SpawnPetForPlayer(
         Player owner,
         PetDescriptor descriptor,
+        PlayerPet? persistedPet = null,
         Guid? mapIdOverride = null,
         Guid? mapInstanceIdOverride = null,
         int? xOverride = null,
@@ -409,7 +411,8 @@ public partial class MapInstance : IMapInstance
             mapInstanceIdOverride: spawnInstanceId,
             xOverride: xOverride ?? owner.X,
             yOverride: yOverride ?? owner.Y,
-            directionOverride: dirOverride ?? owner.Dir
+            directionOverride: dirOverride ?? owner.Dir,
+            persistedPet: persistedPet
         );
 
         AddEntity(pet);


### PR DESCRIPTION
## Summary
- persist pet stat, vital, and progression data on the PlayerPet record
- pass the active PlayerPet when spawning pets so Pet instances restore stored level, experience, and allocations
- synchronize Pet progress back into the PlayerPet entry when despawning

## Testing
- dotnet build Intersect.Server.Core/Intersect.Server.Core.csproj *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d067f6d230832bb79f510fa47b0d71