### PR TITLE
Add pet experience tracking and synchronization

### DIFF
--- a/Framework/Intersect.Framework.Core/Network/Packets/Server/PetProgressPacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Server/PetProgressPacket.cs
@@ -1,0 +1,46 @@
+using System;
+using MessagePack;
+
+namespace Intersect.Network.Packets.Server;
+
+/// <summary>
+///     Broadcasts progression related information for a pet to its owner.
+/// </summary>
+[MessagePackObject]
+public sealed class PetProgressPacket : IntersectPacket
+{
+    // Parameterless constructor for MessagePack
+    public PetProgressPacket()
+    {
+    }
+
+    public PetProgressPacket(
+        Guid petId,
+        long experience,
+        long experienceToNextLevel,
+        int statPoints,
+        int[] statPointAllocations
+    )
+    {
+        PetId = petId;
+        Experience = experience;
+        ExperienceToNextLevel = experienceToNextLevel;
+        StatPoints = statPoints;
+        StatPointAllocations = statPointAllocations ?? Array.Empty<int>();
+    }
+
+    [Key(0)]
+    public Guid PetId { get; set; }
+
+    [Key(1)]
+    public long Experience { get; set; }
+
+    [Key(2)]
+    public long ExperienceToNextLevel { get; set; }
+
+    [Key(3)]
+    public int StatPoints { get; set; }
+
+    [Key(4)]
+    public int[] StatPointAllocations { get; set; } = Array.Empty<int>();
+}

--- a/Intersect.Client.Core/General/Globals.cs
+++ b/Intersect.Client.Core/General/Globals.cs
@@ -45,6 +45,8 @@ public static partial class Globals
 
     public static event Action<Pet>? PetMetadataChanged;
 
+    public static event Action<Pet>? PetProgressChanged;
+
     public static PetHub PetHub { get; } = new();
 
     private static GameStates mGameState = GameStates.Intro;
@@ -208,6 +210,17 @@ public static partial class Globals
         }
 
         PetMetadataChanged?.Invoke(pet);
+        RefreshEntityWidgets(pet);
+    }
+
+    public static void NotifyPetProgressApplied(Pet pet)
+    {
+        if (pet == null)
+        {
+            return;
+        }
+
+        PetProgressChanged?.Invoke(pet);
         RefreshEntityWidgets(pet);
     }
 

--- a/Intersect.Client.Core/Networking/PacketHandler.cs
+++ b/Intersect.Client.Core/Networking/PacketHandler.cs
@@ -471,6 +471,21 @@ internal sealed partial class PacketHandler
         pet.ApplyMetadata(pet.OwnerId, pet.DescriptorId, pet.Despawnable, packet.Behavior);
     }
 
+    public void HandlePacket(IPacketSender packetSender, PetProgressPacket packet)
+    {
+        if (packet == null)
+        {
+            return;
+        }
+
+        if (!Globals.TryGetEntity(EntityType.Pet, packet.PetId, out var entity) || entity is not Pet pet)
+        {
+            return;
+        }
+
+        pet.ApplyProgress(packet.Experience, packet.ExperienceToNextLevel, packet.StatPoints, packet.StatPointAllocations);
+    }
+
     public void HandlePacket(IPacketSender packetSender, PetHubStatePacket packet)
     {
         Globals.PetHub.Process(packet);

--- a/Intersect.Server.Core/Entities/Player.cs
+++ b/Intersect.Server.Core/Entities/Player.cs
@@ -1292,7 +1292,7 @@ public partial class Player : Entity
         }
     }
 
-    private void PersistPetProgress(Pet pet)
+    internal void PersistPetProgress(Pet pet)
     {
         PlayerPet? playerPet = null;
 
@@ -2287,7 +2287,16 @@ public partial class Player : Entity
             DonateGuildExperience(guildExp);
         }
 
-        // Agregar la experiencia restante al jugador  
+        if (playerExp > 0)
+        {
+            var pet = CurrentPet;
+            if (pet is { IsDisposed: false })
+            {
+                pet.GiveExperience(playerExp);
+            }
+        }
+
+        // Agregar la experiencia restante al jugador
         Exp += (int)playerExp;
 
         if (Exp < 0)

--- a/Intersect.Server.Core/Localization/Strings.cs
+++ b/Intersect.Server.Core/Localization/Strings.cs
@@ -1263,6 +1263,15 @@ public static partial class Strings
 
     }
 
+    public sealed partial class PetsNamespace : LocaleNamespace
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString LevelUp = @"Your pet {00} reached level {01}!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString StatPoints = @"Your pet {00} gained {01} stat points.";
+    }
+
     public sealed partial class PortcheckingNamespace : LocaleNamespace
     {
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
@@ -1477,6 +1486,7 @@ public static partial class Strings
     }
 
     public static MarketNamespace Market => Root.Market;
+    public static PetsNamespace Pets => Root.Pets;
 
     public sealed class MarketNamespace : LocaleNamespace
     {
@@ -1642,6 +1652,8 @@ public static partial class Strings
             new PasswordResetNotificationNamespace();
 
         public readonly PlayerNamespace Player = new PlayerNamespace();
+
+        public readonly PetsNamespace Pets = new PetsNamespace();
 
         public readonly PortcheckingNamespace Portchecking = new PortcheckingNamespace();
 

--- a/Intersect.Server.Core/Maps/MapInstance.cs
+++ b/Intersect.Server.Core/Maps/MapInstance.cs
@@ -418,6 +418,7 @@ public partial class MapInstance : IMapInstance
         AddEntity(pet);
         PetInstances[pet.Id] = pet;
         PacketSender.SendEntityDataToProximity(pet);
+        PacketSender.SendPetProgress(pet);
 
         return pet;
     }

--- a/Intersect.Server.Core/Networking/PacketSender.cs
+++ b/Intersect.Server.Core/Networking/PacketSender.cs
@@ -1050,6 +1050,33 @@ public static partial class PacketSender
         // Aquí solo necesitamos notificar inmediatamente al propietario.
     }
 
+    public static void SendPetProgress(Pet pet)
+    {
+        if (pet == null)
+        {
+            return;
+        }
+
+        var owner = pet.Owner ?? Player.FindOnline(pet.OwnerId);
+        if (owner == null || owner.IsDisposed)
+        {
+            return;
+        }
+
+        var allocations = pet.StatPointAllocations ?? Array.Empty<int>();
+
+        owner.SendPacket(
+            new PetProgressPacket(
+                pet.Id,
+                pet.Experience,
+                pet.ExperienceToNextLevel,
+                pet.StatPoints,
+                allocations.ToArray()
+            ),
+            TransmissionMode.Any
+        );
+    }
+
     public static void SendPetHubState(Player player)
     {
         if (player == null)


### PR DESCRIPTION
## Summary
- extend server-side pet entities with experience accumulation, stat point allocation helpers, and level-up notifications for their owners
- award a share of player experience to active pets and broadcast their progress with the new `PetProgressPacket`
- localize and surface pet progress data on the client so the UI can react to experience and stat point updates

## Testing
- `dotnet build Intersect.sln` *(fails: dotnet CLI is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d06df6bf30832ba354cf7b28be0243