### PR TITLE
Handle pet death and despawn

### DIFF
--- a/Intersect.Server.Core/Entities/Pet.cs
+++ b/Intersect.Server.Core/Entities/Pet.cs
@@ -787,6 +787,30 @@ public sealed class Pet : Entity
         }
     }
 
+    public override void Die(bool dropItems = true, Entity killer = null)
+    {
+        var shouldDespawn = false;
+
+        lock (EntityLock)
+        {
+            if (IsDead || IsDisposed)
+            {
+                return;
+            }
+
+            base.Die(dropItems, killer);
+
+            PacketSender.SendEntityDie(this);
+
+            shouldDespawn = true;
+        }
+
+        if (shouldDespawn)
+        {
+            Despawn(killIfDespawnable: false);
+        }
+    }
+
 
     private void UpdateTarget(Player owner, long timeMs)
     {


### PR DESCRIPTION
## Summary
- add a pet-specific Die override that guards against repeated calls, invokes the base logic, and sends the death packet before clearing map metadata
- reuse the existing Despawn workflow so dead pets are removed from their map instance and marked disposed

## Testing
- `dotnet build Intersect.Server.Core/Intersect.Server.Core.csproj` *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d071c96674832bb4db3de35cc52b80