### PR TITLE
Ensure pet hub requests synchronize with updates

### DIFF
--- a/Intersect.Server.Core/Entities/Player.cs
+++ b/Intersect.Server.Core/Entities/Player.cs
@@ -1147,26 +1147,29 @@ public partial class Player : Entity
 
     public bool SetPetHubSpawnRequested(bool requested, bool openPetHub = false, bool closePetHub = false)
     {
-        if (requested)
+        lock (EntityLock)
         {
-            SetPetHubSpawnFlag(true);
-
-            var descriptor = ActivePet?.Descriptor;
-            if (descriptor == null)
+            if (requested)
             {
-                if (openPetHub)
+                SetPetHubSpawnFlag(true);
+
+                var descriptor = ActivePet?.Descriptor;
+                if (descriptor == null)
                 {
-                    PacketSender.SendOpenPetHub(this);
+                    if (openPetHub)
+                    {
+                        PacketSender.SendOpenPetHub(this);
+                    }
+
+                    return false;
                 }
 
-                return false;
+                return TrySpawnActivePet(descriptor, openPetHub);
             }
 
-            return TrySpawnActivePet(descriptor, openPetHub);
+            SetPetHubSpawnFlag(false);
+            return DismissActivePet(closePetHub);
         }
-
-        SetPetHubSpawnFlag(false);
-        return DismissActivePet(closePetHub);
     }
 
     private void UpdatePetState(long timeMs)


### PR DESCRIPTION
## Summary
- guard Player.SetPetHubSpawnRequested with EntityLock so hub-driven spawns and dismissals cannot overlap with UpdatePetState

## Testing
- dotnet test Intersect.Tests.Server/Intersect.Tests.Server.csproj *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68d0969f20a0832b955da0cfed1688ea