### PR TITLE
Ensure pet kills credit owners

### DIFF
--- a/Intersect.Server.Core/Entities/Entity.cs
+++ b/Intersect.Server.Core/Entities/Entity.cs
@@ -3230,6 +3230,15 @@ public abstract partial class Entity : IEntity
         var lootContext = ResolveLootSource(killer);
         lootContext?.KilledEntity(this);
 
+        if (killer is Pet pet && lootContext is not Pet)
+        {
+            var owner = pet.Owner ?? Player.FindOnline(pet.OwnerId);
+            if (owner != null && !owner.IsDisposed && !ReferenceEquals(owner, lootContext))
+            {
+                owner.KilledEntity(this);
+            }
+        }
+
         if (lootContext is Player attacker && this is Player victim)
         {
             AlignmentPvPService.HandleKill(attacker, victim);


### PR DESCRIPTION
## Summary
- ensure pet kills credit owners so their owner still receives kill credit even when the finishing blow was dealt by the pet

## Testing
- dotnet test Intersect.Tests.Server *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68d0a60c1704832b9b6a0c00dc7046c3