### PR TITLE
Clear pets on player death

### DIFF
--- a/Intersect.Server.Core/Entities/Player.cs
+++ b/Intersect.Server.Core/Entities/Player.cs
@@ -2015,6 +2015,7 @@ public partial class Player : Entity
     {
         CastTime = 0;
         CastTarget = null;
+        ClearPets(true);
 
         //Flag death to the client
         PlayDeathAnimation();


### PR DESCRIPTION
## Summary
- ensure player deaths despawn any active pets by clearing them immediately after entering the death routine

## Testing
- dotnet build Intersect.sln *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68d0a074d9a0832b8ed6829d5ae16732