### PR TITLE
Fix pet owner kill credit when loot context unresolved

### DIFF
--- a/Intersect.Server.Core/Entities/Entity.cs
+++ b/Intersect.Server.Core/Entities/Entity.cs
@@ -3230,7 +3230,7 @@ public abstract partial class Entity : IEntity
         var lootContext = ResolveLootSource(killer);
         lootContext?.KilledEntity(this);
 
-        if (killer is Pet pet && lootContext is not Pet)
+        if (killer is Pet pet && lootContext is Pet)
         {
             var owner = pet.Owner ?? Player.FindOnline(pet.OwnerId);
             if (owner != null && !owner.IsDisposed && !ReferenceEquals(owner, lootContext))


### PR DESCRIPTION
## Summary
- ensure pet kill credit falls back to owner lookup when loot context resolves to the pet

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d0abcee00c832bae293f46a174a0cd