### PR TITLE
Fix pet synchronization on instance changes

### DIFF
--- a/Intersect.Server.Core/Entities/Player.cs
+++ b/Intersect.Server.Core/Entities/Player.cs
@@ -3463,6 +3463,7 @@ public partial class Player : Entity
         if (oldMap != null && oldMap.TryGetInstance(PreviousMapInstanceId, out var oldMapInstance))
         {
             PacketSender.SendMapInstanceChangedPacket(this, oldMap, PreviousMapInstanceId);
+            oldMapInstance.DespawnActivePetOf(this, killIfDespawnable: false);
             oldMapInstance.ClearEntityTargetsOf(this); // Remove targets of this entity
             RemoveFromInstanceController(PreviousMapInstanceId);
         }


### PR DESCRIPTION
## Summary
- resync player pets when entering map instances by re-adding them and sending entity data
- ensure map entity payloads are resent when pets join after their owners
- despawn player pets from the previous instance when changing map instances

## Testing
- `dotnet test Intersect.Tests.Server` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68d0b048467c832ba5c6d2b805084026