### PR TITLE
Harden pet sync when inventory not ready

### DIFF
--- a/Intersect.Client.Core/Pets/PetHub.cs
+++ b/Intersect.Client.Core/Pets/PetHub.cs
@@ -624,15 +624,20 @@ RaiseEvents:
                     }
 
                     foundDescriptor = descriptor;
-                    foundPetName = string.IsNullOrWhiteSpace(petData.PetNameOverride) ? null : petData.PetNameOverride;
+                    foundPetName = string.IsNullOrWhiteSpace(petData.PetNameOverride)
+                        ? null
+                        : petData.PetNameOverride;
 
-                    // Ya encontramos uno válido; salimos
-                    goto FoundDescriptor;
+                    break;
+                }
+
+                if (foundDescriptor != null)
+                {
+                    break;
                 }
             }
 
-FoundDescriptor:
-// Caso: NO hay mascota equipada actualmente (se quitó el item)
+            // Caso: NO hay mascota equipada actualmente (se quitó el item)
             if (foundDescriptor == null)
             {
                 // Si hay una pet activa, despawnea


### PR DESCRIPTION
## Summary
- stop using a goto when scanning equipped slots and break out of the loops once the first valid pet descriptor is discovered
- keep the early boot null/bounds guards so dismiss/update logic can run safely even if inventory data is missing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d0b48bbb04832b89a266c864d61e54