### PR TITLE
Ensure pets are cleared on player removal

### DIFF
--- a/Intersect.Server.Core/Entities/Player.cs
+++ b/Intersect.Server.Core/Entities/Player.cs
@@ -586,7 +586,7 @@ public partial class Player : Entity
             return;
         }
 
-        ClearPets(true);
+        ClearPets(killDespawnable: true);
 
         Guild?.NotifyPlayerDisposed(this);
 
@@ -675,7 +675,7 @@ public partial class Player : Entity
 
         SpawnedNpcs.Clear();
 
-        ClearPets(true);
+        ClearPets(killDespawnable: true);
 
         lock (mEventLock)
         {
@@ -2015,7 +2015,7 @@ public partial class Player : Entity
     {
         CastTime = 0;
         CastTarget = null;
-        ClearPets(true);
+        ClearPets(killDespawnable: true);
 
         //Flag death to the client
         PlayDeathAnimation();


### PR DESCRIPTION
## Summary
- force pet cleanup to kill despawnable companions when players dispose, logout, or die by explicitly setting `killDespawnable`

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d0b4af0a88832b8a9c2c6ebbdc7702