### PR TITLE
Update pet item references after evolution

### DIFF
--- a/Intersect.Server.Core/Entities/Pet.cs
+++ b/Intersect.Server.Core/Entities/Pet.cs
@@ -1514,6 +1514,7 @@ public sealed class Pet : Entity
             if (playerPet != null)
             {
                 playerPet.PetDescriptorId = Descriptor.Id;
+                owner.UpdatePetItemReferences(playerPet, previousDescriptor?.Id ?? Guid.Empty);
                 Name = string.IsNullOrWhiteSpace(playerPet.CustomName) ? Descriptor.Name : playerPet.CustomName;
             }
             else if (string.IsNullOrWhiteSpace(Name))


### PR DESCRIPTION
## Summary
- update pet evolution handling to resync any player items referencing the pet
- add a helper on Player to rebind inventory slots to the evolved pet instance

## Testing
- `dotnet test Intersect.Tests.Server/Intersect.Tests.Server.csproj` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68d0d285c194832bb440c986fb714009