### PR TITLE
Guard pet item reassignment to evolved instance

### DIFF
--- a/Intersect.Server.Core/Entities/Player.cs
+++ b/Intersect.Server.Core/Entities/Player.cs
@@ -1374,17 +1374,23 @@ public partial class Player : Entity
                 && slot.PetInstanceId.HasValue
                 && slot.PetInstanceId.Value == petInstanceId;
 
-            if (!referencesPreviousDescriptor && !referencesCurrentInstance)
+            var slotPetInstanceId = slot.PetInstanceId;
+            var isBoundToAnotherInstance =
+                slotPetInstanceId.HasValue
+                && slotPetInstanceId.Value != Guid.Empty
+                && slotPetInstanceId.Value != petInstanceId;
+
+            if (!referencesCurrentInstance && (!referencesPreviousDescriptor || isBoundToAnotherInstance))
             {
                 continue;
             }
 
-            if (petInstanceId != Guid.Empty)
+            if (petInstanceId != Guid.Empty && !isBoundToAnotherInstance)
             {
                 slot.PetInstanceId = petInstanceId;
             }
 
-            if (referencesPreviousDescriptor && newDescriptorId != Guid.Empty)
+            if (referencesPreviousDescriptor && newDescriptorId != Guid.Empty && !isBoundToAnotherInstance)
             {
                 // Ensure future lookups rely on the updated descriptor by binding the slot to the evolved pet instance.
                 // The descriptor itself is shared, so we avoid mutating it directly.


### PR DESCRIPTION
## Summary
- avoid rebinding pet inventory slots that belong to other pet instances when updating references
- preserve descriptor updates only for slots already tied to the evolving pet

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d0d781fb28832bbfd83cf8c13de425