### PR TITLE
Fix pet despawn cleanup when map instance id missing

### DIFF
--- a/Intersect.Server.Core/Entities/Pet.cs
+++ b/Intersect.Server.Core/Entities/Pet.cs
@@ -817,7 +817,7 @@ public sealed class Pet : Entity
             var hasNotifiedLeave = false;
 
             // 3) Notificar a clientes y sacar de la instancia (si todavía estaba en mapa)
-            if (mapId != Guid.Empty && mapInstanceId != Guid.Empty)
+            if (mapId != Guid.Empty)
             {
                 // primero broadcast del leave
                 PacketSender.SendEntityLeave(this);


### PR DESCRIPTION
## Summary
- allow pet despawn cleanup to run whenever the pet has a map id, even if the instance id is empty
- keep clearing the pet's map identifiers after attempting to remove it from the captured map instance

## Testing
- ⚠️ `dotnet test Intersect.Tests.Server/Intersect.Tests.Server.csproj` *(dotnet CLI unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d1ef7aa9c8832bb7554f0b571889a4