### PR TITLE
Fix pet despawn double leave packet and add test

### DIFF
--- a/Intersect.Server.Core/Entities/Pet.cs
+++ b/Intersect.Server.Core/Entities/Pet.cs
@@ -803,6 +803,7 @@ public sealed class Pet : Entity
             {
                 // No dropeamos nada, ni contamos muerte del owner: es un despawn “limpio”
                 Die(false, killer: Owner);
+                return;
             }
 
             // 2) Limpieza de estado interno

--- a/Intersect.Server.Core/Intersect.Server.Core.csproj
+++ b/Intersect.Server.Core/Intersect.Server.Core.csproj
@@ -12,6 +12,9 @@
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
       <_Parameter1>Intersect.SinglePlayer</_Parameter1>
     </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>Intersect.Tests.Server</_Parameter1>
+    </AssemblyAttribute>
   </ItemGroup>
 
   <ItemGroup>

--- a/Intersect.Server.Core/Networking/PacketSender.cs
+++ b/Intersect.Server.Core/Networking/PacketSender.cs
@@ -55,6 +55,8 @@ public static partial class PacketSender
 
     public static long SentBytes { get; set; }
 
+    internal static event Action<Entity>? EntityLeaveSent;
+
     public static void ResetMetrics()
     {
         SentPackets = 0;
@@ -669,7 +671,9 @@ public static partial class PacketSender
     //EntityLeftPacket
     public static void SendEntityLeave(Entity en)
     {
-        SendDataToProximityOnMapInstance(en.MapId, en.MapInstanceId, new EntityLeftPacket(en.Id, en.GetEntityType(), en.MapId));
+        var packet = new EntityLeftPacket(en.Id, en.GetEntityType(), en.MapId);
+        EntityLeaveSent?.Invoke(en);
+        SendDataToProximityOnMapInstance(en.MapId, en.MapInstanceId, packet);
     }
 
     //EntityLeftPacket


### PR DESCRIPTION
## Summary
- stop `Pet.Despawn(true)` from running cleanup twice by returning immediately after delegating to `Die`
- expose a test hook in `PacketSender.SendEntityLeave` so tests can count leave packets
- allow the core assembly to share internals with the server test suite
- add a regression test that ensures despawning a pet with `killIfDespawnable = true` only emits one leave packet

## Testing
- `dotnet test Intersect.Tests.Server/Intersect.Tests.Server.csproj` *(fails: `dotnet` is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5eb98768c832b98078da7abd123cd