### PR TITLE
Ensure pet despawns rely on internal notifications

### DIFF
--- a/Intersect.Server.Core/Maps/MapController.cs
+++ b/Intersect.Server.Core/Maps/MapController.cs
@@ -821,10 +821,7 @@ public partial class MapController : MapDescriptor
         {
             try
             {
-                // 1) Avisar YA a los clientes que se va (antes de remover)
-                PacketSender.SendEntityLeave(pet);
-
-                // 2) Despawnear tolerante (si ya murió/disposed no rompe)
+                // Despawnear tolerante (si ya murió/disposed no rompe). Pet.Despawn se encarga de notificar a los clientes.
                 lock (pet.EntityLock)
                 {
                     if (!pet.IsDisposed)

--- a/Intersect.Server.Core/Maps/MapInstance.cs
+++ b/Intersect.Server.Core/Maps/MapInstance.cs
@@ -403,10 +403,7 @@ public partial class MapInstance : IMapInstance
                 {
                     try
                     {
-                        // Avisar a los clientes YA
-                        PacketSender.SendEntityLeave(existing);
-
-                        // Intentar despawn real (si ya está disposed no pasa nada)
+                        // Pet.Despawn se encarga de notificar a los clientes y limpiar la instancia.
                         lock (existing.EntityLock)
                         {
                             if (!existing.IsDisposed)
@@ -477,12 +474,8 @@ public partial class MapInstance : IMapInstance
         // 2) Para cada pet:
         foreach (var pet in toDespawn)
         {
-            // a) Notificar de inmediato a TODOS los jugadores de la instancia
-            //    que esta entidad sale del mapa (esto evita que “desaparezca” recién al cambiar de mapa).
-            //    Usa el mismo helper que para NPCs y Players.
-            PacketSender.SendEntityLeave(pet);
-
-            // b) Intentar despawn “real”
+            // Pet.Despawn se encarga de enviar la notificación de salida y limpiar la instancia.
+            // Intentar despawn “real”
             try
             {
                 pet.Despawn(killIfDespawnable);

--- a/Intersect.Tests.Server/Entities/PetTests.CalculateAttackTime.cs
+++ b/Intersect.Tests.Server/Entities/PetTests.CalculateAttackTime.cs
@@ -91,7 +91,12 @@ public class PetTests
         var pet = new Pet(descriptor, owner);
 
         var leaveCount = 0;
-        void Handler(Entity _) => leaveCount++;
+        var leaveAfterDeath = false;
+        void Handler(Entity entity)
+        {
+            leaveCount++;
+            leaveAfterDeath = entity.IsDead;
+        }
 
         try
         {
@@ -108,5 +113,7 @@ public class PetTests
             Is.EqualTo(1),
             "Pet despawn should emit exactly one leave packet when kill cleanup is requested."
         );
+
+        Assert.That(leaveAfterDeath, Is.True, "Pet should already be dead when the leave packet is emitted.");
     }
 }


### PR DESCRIPTION
## Summary
- rely on `Pet.Despawn` to notify clients when removing pets from map instances and controllers
- tidy pet removal comments to reflect centralized notification logic
- extend pet despawn unit test to assert a single leave packet emitted after death

## Testing
- `dotnet test Intersect.Tests.Server` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d5edfa3b74832b91ee89384ade8277