### PR TITLE
Add pet death cooldown and context menu hub access

### DIFF
--- a/Framework/Intersect.Framework.Core/Network/Packets/Client/OpenPetHubRequestPacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Client/OpenPetHubRequestPacket.cs
@@ -1,0 +1,8 @@
+using MessagePack;
+
+namespace Intersect.Network.Packets.Client;
+
+[MessagePackObject]
+public sealed class OpenPetHubRequestPacket : IntersectPacket
+{
+}

--- a/Intersect.Client.Core/Localization/Strings.cs
+++ b/Intersect.Client.Core/Localization/Strings.cs
@@ -1348,6 +1348,9 @@ public static partial class Strings
         public static LocalizedString NoStats = @"No stats available.";
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString OpenHub = @"Open Pet Hub";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public static LocalizedString InvokeButton = @"Summon";
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]

--- a/Intersect.Server.Core/Entities/Pet.cs
+++ b/Intersect.Server.Core/Entities/Pet.cs
@@ -857,6 +857,7 @@ public sealed class Pet : Entity
     public override void Die(bool dropItems = true, Entity killer = null)
     {
         var shouldDespawn = false;
+        Player? owner = null;
 
         lock (EntityLock)
         {
@@ -867,10 +868,14 @@ public sealed class Pet : Entity
 
             base.Die(dropItems, killer);
 
+            owner = Owner;
+
             PacketSender.SendEntityDie(this);
 
             shouldDespawn = true;
         }
+
+        owner?.NotifyPetDied(this);
 
         if (shouldDespawn)
         {

--- a/Intersect.Server.Core/Networking/PacketHandler.cs
+++ b/Intersect.Server.Core/Networking/PacketHandler.cs
@@ -3344,7 +3344,17 @@ internal sealed partial class PacketHandler
             return;
         }
 
-        _ = player.SetPetHubSpawnRequested(false, closePetHub: packet.ClosePetHub);
+        _ = player.SetPetHubSpawnRequested(false, closePetHub: false);
+    }
+
+    public void HandlePacket(Client client, OpenPetHubRequestPacket packet)
+    {
+        if (client?.Entity is not Player player)
+        {
+            return;
+        }
+
+        PacketSender.SendOpenPetHub(player);
     }
 
     //SetAlignmentRequestPacket


### PR DESCRIPTION
## Summary
- add a death reinvoke cooldown that blocks pet respawns until it expires and notifies players when it starts
- notify the owning player when a pet dies and keep the pet hub open when dismissing a pet
- add a client request packet and inventory context action to open the pet hub from equipped pet items

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d5f82c1f0c832b99faf4bb92a3c47b