### PR TITLE
Fix pet healing spell selection for owner vs self

### DIFF
--- a/Intersect.Server.Core/AI/Pets/PetBrain.cs
+++ b/Intersect.Server.Core/AI/Pets/PetBrain.cs
@@ -261,6 +261,7 @@ namespace Intersect.Server.AI.Pets
             return _pet
                 .GetUsableSpells()
                 .Where(IsHealingSpell)
+                .Where(spell => CanTargetRecipient(spell, targetSelf))
                 .OrderByDescending(EstimatedHealPower)
                 .FirstOrDefault();
         }
@@ -278,6 +279,25 @@ namespace Intersect.Server.AI.Pets
             }
 
             return spell.Combat.VitalDiff[(int)Vital.Health] > 0;
+        }
+
+        private static bool CanTargetRecipient(SpellDescriptor? spell, bool targetSelf)
+        {
+            if (spell?.Combat == null)
+            {
+                return false;
+            }
+
+            return spell.Combat.TargetType switch
+            {
+                SpellTargetType.Self => targetSelf,
+                SpellTargetType.Single => true,
+                SpellTargetType.AoE => targetSelf,
+                SpellTargetType.Projectile => !targetSelf,
+                SpellTargetType.OnHit => false,
+                SpellTargetType.Trap => false,
+                _ => false,
+            };
         }
 
         private static long EstimatedHealPower(SpellDescriptor spell)


### PR DESCRIPTION
## Summary
- filter pet healing spells by target type to respect whether the heal is for the pet or its owner
- add helper to determine if a spell can target the intended recipient before ranking by heal power

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6085c77e0832bbf4f6adfdd55aafb