### PR TITLE
Fix IPetRuntime vital property name collision

### DIFF
--- a/Intersect.Server.Core/AI/Pets/PetBrain.cs
+++ b/Intersect.Server.Core/AI/Pets/PetBrain.cs
@@ -77,8 +77,8 @@ namespace Intersect.Server.AI.Pets
         Player? Owner { get; }
         PetState Behavior { get; }
 
-        long[] MaxVital { get; }
-        long[] Vital { get; }
+        long[] MaxVitals { get; }
+        long[] Vitals { get; }
 
         bool HasManaFor(SpellDescriptor spell);
         bool IsInLineOfSight(Entity target);
@@ -226,7 +226,7 @@ namespace Intersect.Server.AI.Pets
         private bool TryHealIfNeeded(Player owner)
         {
             // Evitar gastar maná muy bajo
-            if (Percent(_pet.Vital[(int)Vital.Mana], _pet.MaxVital[(int)Vital.Mana]) < _cfg.MinManaPercentToCast)
+            if (Percent(_pet.Vitals[(int)Vital.Mana], _pet.MaxVitals[(int)Vital.Mana]) < _cfg.MinManaPercentToCast)
             {
                 return false;
             }
@@ -243,7 +243,7 @@ namespace Intersect.Server.AI.Pets
             }
 
             // Curarse a sí misma si está mal
-            var selfHpPct = Percent(_pet.Vital[(int)Vital.Health], _pet.MaxVital[(int)Vital.Health]);
+            var selfHpPct = Percent(_pet.Vitals[(int)Vital.Health], _pet.MaxVitals[(int)Vital.Health]);
             if (selfHpPct < _cfg.HealSelfThresholdPercent)
             {
                 var selfHeal = FindBestHealSpell(targetSelf: true);
@@ -388,7 +388,7 @@ namespace Intersect.Server.AI.Pets
             }
 
             // ¿tenemos maná decente?
-            if (Percent(_pet.Vital[(int)Vital.Mana], _pet.MaxVital[(int)Vital.Mana]) < _cfg.MinManaPercentToCast)
+            if (Percent(_pet.Vitals[(int)Vital.Mana], _pet.MaxVitals[(int)Vital.Mana]) < _cfg.MinManaPercentToCast)
             {
                 // acercarse/mejor posición si no puede castear, o autoataque si existe
                 return MoveIntoAttackRange(target);

--- a/Intersect.Server.Core/AI/Pets/PetRuntimeAdapter.cs
+++ b/Intersect.Server.Core/AI/Pets/PetRuntimeAdapter.cs
@@ -33,8 +33,8 @@ namespace Intersect.Server.AI.Pets
         public Player? Owner => _pet.Owner;
         public PetState Behavior => _pet.Behavior;
 
-        public long[] MaxVital => _pet.GetMaxVitals();
-        public long[] Vital => _pet.GetVitals();
+        public long[] MaxVitals => _pet.GetMaxVitals();
+        public long[] Vitals => _pet.GetVitals();
 
         public PetDescriptor? Descriptor => _pet.Descriptor;
 


### PR DESCRIPTION
## Summary
- rename IPetRuntime vital array properties to avoid clashing with the Vital enum
- update the pet brain logic to use the new property names when evaluating vitals

## Testing
- not run (not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68d6082feeb8832b9dc431b6e21c33ac