### PR TITLE
Remove pet evolution mechanics

### DIFF
--- a/Framework/Intersect.Framework.Core/GameObjects/Pets/PetDescriptor.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Pets/PetDescriptor.cs
@@ -108,20 +108,6 @@ public partial class PetDescriptor : DatabaseObject<PetDescriptor>, IFolderable
 
     public PetLevelingMode LevelingMode { get; set; } = PetLevelingMode.Experience;
 
-    public bool CanEvolve { get; set; }
-
-    public int EvolutionLevel { get; set; }
-
-    [Column("EvolutionTarget")]
-    public Guid EvolutionTargetId { get; set; }
-
-    [NotMapped, JsonIgnore]
-    public PetDescriptor? EvolutionTarget
-    {
-        get => EvolutionTargetId == Guid.Empty ? null : Get(EvolutionTargetId);
-        set => EvolutionTargetId = value?.Id ?? Guid.Empty;
-    }
-
     public string Sprite { get; set; } = string.Empty;
 
     [Column("Spells"), JsonIgnore]

--- a/Intersect.Editor/Forms/Editors/frmPet.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/frmPet.Designer.cs
@@ -110,12 +110,6 @@ namespace Intersect.Editor.Forms.Editors
             toolStripItemUndo = new ToolStripButton();
             DarkGroupBox4 = new DarkGroupBox();
             pnlPetlevel = new Panel();
-            DarkGroupBox5 = new DarkGroupBox();
-            cmbEvolve = new DarkComboBox();
-            DarkLabel15 = new DarkLabel();
-            nudEvolveLvl = new DarkNumericUpDown();
-            DarkLabel14 = new DarkLabel();
-            chkEvolve = new DarkCheckBox();
             nudMaxLevel = new DarkNumericUpDown();
             DarkLabel12 = new DarkLabel();
             nudPetPnts = new DarkNumericUpDown();
@@ -153,8 +147,6 @@ namespace Intersect.Editor.Forms.Editors
             toolStrip.SuspendLayout();
             DarkGroupBox4.SuspendLayout();
             pnlPetlevel.SuspendLayout();
-            DarkGroupBox5.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)nudEvolveLvl).BeginInit();
             ((System.ComponentModel.ISupportInitialize)nudMaxLevel).BeginInit();
             ((System.ComponentModel.ISupportInitialize)nudPetPnts).BeginInit();
             ((System.ComponentModel.ISupportInitialize)nudPetExp).BeginInit();
@@ -1224,7 +1216,6 @@ namespace Intersect.Editor.Forms.Editors
             // 
             // pnlPetlevel
             // 
-            pnlPetlevel.Controls.Add(DarkGroupBox5);
             pnlPetlevel.Controls.Add(nudMaxLevel);
             pnlPetlevel.Controls.Add(DarkLabel12);
             pnlPetlevel.Controls.Add(nudPetPnts);
@@ -1236,95 +1227,8 @@ namespace Intersect.Editor.Forms.Editors
             pnlPetlevel.Name = "pnlPetlevel";
             pnlPetlevel.Size = new Size(582, 136);
             pnlPetlevel.TabIndex = 2;
-            // 
-            // DarkGroupBox5
-            // 
-            DarkGroupBox5.BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
-            DarkGroupBox5.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
-            DarkGroupBox5.Controls.Add(cmbEvolve);
-            DarkGroupBox5.Controls.Add(DarkLabel15);
-            DarkGroupBox5.Controls.Add(nudEvolveLvl);
-            DarkGroupBox5.Controls.Add(DarkLabel14);
-            DarkGroupBox5.Controls.Add(chkEvolve);
-            DarkGroupBox5.ForeColor = System.Drawing.Color.Gainsboro;
-            DarkGroupBox5.Location = new System.Drawing.Point(7, 44);
-            DarkGroupBox5.Margin = new Padding(4, 3, 4, 3);
-            DarkGroupBox5.Name = "DarkGroupBox5";
-            DarkGroupBox5.Padding = new Padding(4, 3, 4, 3);
-            DarkGroupBox5.Size = new Size(567, 87);
-            DarkGroupBox5.TabIndex = 7;
-            DarkGroupBox5.TabStop = false;
-            DarkGroupBox5.Text = "Evolution";
-            // 
-            // cmbEvolve
-            // 
-            cmbEvolve.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
-            cmbEvolve.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
-            cmbEvolve.BorderStyle = ButtonBorderStyle.Solid;
-            cmbEvolve.ButtonColor = System.Drawing.Color.FromArgb(43, 43, 43);
-            cmbEvolve.DrawDropdownHoverOutline = false;
-            cmbEvolve.DrawFocusRectangle = false;
-            cmbEvolve.DrawMode = DrawMode.OwnerDrawFixed;
-            cmbEvolve.DropDownStyle = ComboBoxStyle.DropDownList;
-            cmbEvolve.FlatStyle = FlatStyle.Flat;
-            cmbEvolve.ForeColor = System.Drawing.Color.Gainsboro;
-            cmbEvolve.FormattingEnabled = true;
-            cmbEvolve.Location = new System.Drawing.Point(117, 52);
-            cmbEvolve.Margin = new Padding(4, 3, 4, 3);
-            cmbEvolve.Name = "cmbEvolve";
-            cmbEvolve.Size = new Size(443, 24);
-            cmbEvolve.TabIndex = 4;
-            cmbEvolve.Text = null;
-            cmbEvolve.TextPadding = new Padding(2);
-            cmbEvolve.SelectedIndexChanged += cmbEvolve_SelectedIndexChanged;
-            // 
-            // DarkLabel15
-            // 
-            DarkLabel15.AutoSize = true;
-            DarkLabel15.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
-            DarkLabel15.Location = new System.Drawing.Point(8, 55);
-            DarkLabel15.Margin = new Padding(4, 0, 4, 0);
-            DarkLabel15.Name = "DarkLabel15";
-            DarkLabel15.Size = new Size(73, 15);
-            DarkLabel15.TabIndex = 3;
-            DarkLabel15.Text = "Evolves into:";
-            // 
-            // nudEvolveLvl
-            // 
-            nudEvolveLvl.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
-            nudEvolveLvl.ForeColor = System.Drawing.Color.Gainsboro;
-            nudEvolveLvl.Location = new System.Drawing.Point(486, 24);
-            nudEvolveLvl.Margin = new Padding(4, 3, 4, 3);
-            nudEvolveLvl.Name = "nudEvolveLvl";
-            nudEvolveLvl.Size = new Size(74, 23);
-            nudEvolveLvl.TabIndex = 2;
-            nudEvolveLvl.Value = new decimal(new int[] { 0, 0, 0, 0 });
-            nudEvolveLvl.ValueChanged += nudEvolveLvl_ValueChanged;
-            // 
-            // DarkLabel14
-            // 
-            DarkLabel14.AutoSize = true;
-            DarkLabel14.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
-            DarkLabel14.Location = new System.Drawing.Point(382, 26);
-            DarkLabel14.Margin = new Padding(4, 0, 4, 0);
-            DarkLabel14.Name = "DarkLabel14";
-            DarkLabel14.Size = new Size(96, 15);
-            DarkLabel14.TabIndex = 1;
-            DarkLabel14.Text = "Evolves on Level:";
-            // 
-            // chkEvolve
-            // 
-            chkEvolve.AutoSize = true;
-            chkEvolve.Location = new System.Drawing.Point(8, 22);
-            chkEvolve.Margin = new Padding(4, 3, 4, 3);
-            chkEvolve.Name = "chkEvolve";
-            chkEvolve.Size = new Size(104, 19);
-            chkEvolve.TabIndex = 0;
-            chkEvolve.Text = "Pet Can Evolve";
-            chkEvolve.CheckedChanged += chkEvolve_CheckedChanged;
-            // 
             // nudMaxLevel
-            // 
+            //
             nudMaxLevel.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
             nudMaxLevel.ForeColor = System.Drawing.Color.Gainsboro;
             nudMaxLevel.Location = new System.Drawing.Point(379, 14);
@@ -1474,9 +1378,6 @@ namespace Intersect.Editor.Forms.Editors
             DarkGroupBox4.PerformLayout();
             pnlPetlevel.ResumeLayout(false);
             pnlPetlevel.PerformLayout();
-            DarkGroupBox5.ResumeLayout(false);
-            DarkGroupBox5.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)nudEvolveLvl).EndInit();
             ((System.ComponentModel.ISupportInitialize)nudMaxLevel).EndInit();
             ((System.ComponentModel.ISupportInitialize)nudPetPnts).EndInit();
             ((System.ComponentModel.ISupportInitialize)nudPetExp).EndInit();
@@ -1571,12 +1472,6 @@ namespace Intersect.Editor.Forms.Editors
         public ToolStripButton toolStripItemUndo;
         internal DarkGroupBox DarkGroupBox4;
         internal Panel pnlPetlevel;
-        internal DarkGroupBox DarkGroupBox5;
-        internal DarkComboBox cmbEvolve;
-        internal DarkLabel DarkLabel15;
-        internal DarkNumericUpDown nudEvolveLvl;
-        internal DarkLabel DarkLabel14;
-        internal DarkCheckBox chkEvolve;
         internal DarkNumericUpDown nudMaxLevel;
         internal DarkLabel DarkLabel12;
         internal DarkNumericUpDown nudPetPnts;

--- a/Intersect.Editor/Forms/Editors/frmPet.cs
+++ b/Intersect.Editor/Forms/Editors/frmPet.cs
@@ -295,14 +295,6 @@ public partial class FrmPet : EditorForm
             cmbDamageType.SelectedIndex = 0;
         }
 
-        cmbEvolve.Items.Clear();
-        cmbEvolve.Items.Add(Strings.General.None);
-        cmbEvolve.Items.AddRange(PetDescriptor.Names);
-        if (cmbEvolve.Items.Count > 0)
-        {
-            cmbEvolve.SelectedIndex = 0;
-        }
-
         cmbAttackSpeedModifier.Items.Clear();
         foreach (var modifier in Strings.NpcEditor.attackspeedmodifiers)
         {
@@ -469,20 +461,6 @@ public partial class FrmPet : EditorForm
             nudPetExp.Value = Math.Max(nudPetExp.Minimum, Math.Min(nudPetExp.Maximum, _editorItem.ExperienceRate));
             nudPetPnts.Value = Math.Max(nudPetPnts.Minimum, Math.Min(nudPetPnts.Maximum, _editorItem.StatPointsPerLevel));
             nudMaxLevel.Value = Math.Max(nudMaxLevel.Minimum, Math.Min(nudMaxLevel.Maximum, _editorItem.MaxLevel));
-            chkEvolve.Checked = _editorItem.CanEvolve;
-            nudEvolveLvl.Value = Math.Max(nudEvolveLvl.Minimum, Math.Min(nudEvolveLvl.Maximum, _editorItem.EvolutionLevel));
-            cmbEvolve.Enabled = _editorItem.CanEvolve;
-            nudEvolveLvl.Enabled = _editorItem.CanEvolve;
-            var evolveIndex = PetDescriptor.ListIndex(_editorItem.EvolutionTargetId);
-            if (evolveIndex >= 0 && evolveIndex + 1 < cmbEvolve.Items.Count)
-            {
-                cmbEvolve.SelectedIndex = evolveIndex + 1;
-            }
-            else if (cmbEvolve.Items.Count > 0)
-            {
-                cmbEvolve.SelectedIndex = 0;
-            }
-
             foreach (var (stat, control) in _statControls)
             {
                 control.Value = Math.Max(control.Minimum, Math.Min(control.Maximum, _editorItem.Stats[(int)stat]));
@@ -732,45 +710,6 @@ public partial class FrmPet : EditorForm
         }
 
         _editorItem.MaxLevel = (int)nudMaxLevel.Value;
-    }
-
-    private void chkEvolve_CheckedChanged(object sender, EventArgs e)
-    {
-        if (_editorItem == null)
-        {
-            return;
-        }
-
-        _editorItem.CanEvolve = chkEvolve.Checked;
-        cmbEvolve.Enabled = chkEvolve.Checked;
-        nudEvolveLvl.Enabled = chkEvolve.Checked;
-    }
-
-    private void nudEvolveLvl_ValueChanged(object sender, EventArgs e)
-    {
-        if (_editorItem == null)
-        {
-            return;
-        }
-
-        _editorItem.EvolutionLevel = (int)nudEvolveLvl.Value;
-    }
-
-    private void cmbEvolve_SelectedIndexChanged(object sender, EventArgs e)
-    {
-        if (_editorItem == null)
-        {
-            return;
-        }
-
-        if (cmbEvolve.SelectedIndex <= 0)
-        {
-            _editorItem.EvolutionTargetId = Guid.Empty;
-            return;
-        }
-
-        var targetId = PetDescriptor.IdFromList(cmbEvolve.SelectedIndex - 1);
-        _editorItem.EvolutionTargetId = targetId;
     }
 
     private void chkKnockback_CheckedChanged(object sender, EventArgs e) => UpdateImmunity(SpellEffect.Knockback, chkKnockback.Checked);

--- a/Intersect.Server.Core/Entities/Pet.cs
+++ b/Intersect.Server.Core/Entities/Pet.cs
@@ -65,12 +65,6 @@ public sealed class Pet : Entity
 
     public PetLevelingMode LevelingMode { get; private set; }
 
-    public bool CanEvolve { get; private set; }
-
-    public int EvolutionLevel { get; private set; }
-
-    public Guid EvolutionTargetId { get; private set; }
-       
     public Guid OwnerId { get; }
 
     public bool Despawnable { get; } = true;
@@ -178,9 +172,6 @@ public sealed class Pet : Entity
         StatPointsPerLevel = Math.Max(0, descriptor.StatPointsPerLevel);
         MaxLevel = Math.Max(1, descriptor.MaxLevel);
         LevelingMode = descriptor.LevelingMode;
-        CanEvolve = descriptor.CanEvolve;
-        EvolutionLevel = Math.Max(0, descriptor.EvolutionLevel);
-        EvolutionTargetId = descriptor.EvolutionTargetId;
 
         Experience = 0;
         StatPoints = 0;
@@ -473,16 +464,7 @@ public sealed class Pet : Entity
 
         NotifyOwnerOfLevelUp(levelsGained, statPointsGained);
 
-        var evolved = false;
-        while (TryEvolve())
-        {
-            evolved = true;
-        }
-
-        if (!evolved)
-        {
-            Owner?.PersistPetProgress(this);
-        }
+        Owner?.PersistPetProgress(this);
     }
 
     private void NotifyOwnerOfLevelUp(int levelsGained, int statPointsGained)
@@ -1601,149 +1583,5 @@ public sealed class Pet : Entity
         return null;
     }
 
-    private bool TryEvolve()
-    {
-        if (!CanEvolve || EvolutionTargetId == Guid.Empty)
-        {
-            return false;
-        }
-
-        if (Level < EvolutionLevel)
-        {
-            return false;
-        }
-
-        var targetDescriptor = PetDescriptor.Get(EvolutionTargetId);
-        if (targetDescriptor == null)
-        {
-            return false;
-        }
-
-        var previousDescriptor = Descriptor;
-        if (previousDescriptor != null && previousDescriptor.Id == targetDescriptor.Id)
-        {
-            return false;
-        }
-
-        ApplyEvolutionDescriptor(previousDescriptor, targetDescriptor);
-
-        var owner = Owner ?? Player.FindOnline(OwnerId);
-        if (owner != null && owner.IsDisposed)
-        {
-            owner = null;
-        }
-        PlayerPet? playerPet = null;
-
-        if (owner != null)
-        {
-            if (PetInstanceId != Guid.Empty)
-            {
-                playerPet = owner.Pets.FirstOrDefault(pet => pet.PetInstanceId == PetInstanceId);
-            }
-
-            if (playerPet == null && previousDescriptor != null)
-            {
-                playerPet = owner.Pets.FirstOrDefault(pet => pet.PetDescriptorId == previousDescriptor.Id);
-            }
-
-            playerPet ??= owner.ActivePet;
-
-            if (playerPet != null)
-            {
-                playerPet.PetDescriptorId = Descriptor.Id;
-                owner.UpdatePetItemReferences(playerPet, previousDescriptor?.Id ?? Guid.Empty);
-                Name = string.IsNullOrWhiteSpace(playerPet.CustomName) ? Descriptor.Name : playerPet.CustomName;
-            }
-            else if (string.IsNullOrWhiteSpace(Name))
-            {
-                Name = Descriptor.Name;
-            }
-
-            owner.PersistPetProgress(this);
-            owner.Save();
-        }
-        else if (string.IsNullOrWhiteSpace(Name))
-        {
-            Name = Descriptor.Name;
-        }
-
-        MarkMetadataDirty();
-
-        PacketSender.SendEntityDataToProximity(this);
-        PacketSender.SendPetProgress(this);
-
-        return true;
-    }
-
-    private void ApplyEvolutionDescriptor(PetDescriptor? previousDescriptor, PetDescriptor targetDescriptor)
-    {
-        Descriptor = targetDescriptor;
-
-        ExperienceRate = Math.Max(0, targetDescriptor.ExperienceRate);
-        StatPointsPerLevel = Math.Max(0, targetDescriptor.StatPointsPerLevel);
-        MaxLevel = Math.Max(1, targetDescriptor.MaxLevel);
-        LevelingMode = targetDescriptor.LevelingMode;
-        CanEvolve = targetDescriptor.CanEvolve;
-        EvolutionLevel = Math.Max(0, targetDescriptor.EvolutionLevel);
-        EvolutionTargetId = targetDescriptor.EvolutionTargetId;
-
-        Sprite = targetDescriptor.Sprite;
-        Immunities = targetDescriptor.Immunities?.ToList() ?? [];
-
-        var statCount = Enum.GetValues<Stat>().Length;
-        for (var index = 0; index < statCount; index++)
-        {
-            BaseStats[index] = targetDescriptor.Stats[index];
-        }
-
-        var vitalCount = Enum.GetValues<Vital>().Length;
-        for (var index = 0; index < vitalCount; index++)
-        {
-            var maximum = targetDescriptor.MaxVitals[index];
-            SetMaxVital(index, maximum);
-            SetVital(index, maximum);
-        }
-
-        Array.Clear(_vitalAccumulators, 0, _vitalAccumulators.Length);
-
-        if (previousDescriptor != null && previousDescriptor.IdleAnimationId != Guid.Empty)
-        {
-            _ = Animations.Remove(previousDescriptor.IdleAnimationId);
-        }
-
-        if (targetDescriptor.IdleAnimationId != Guid.Empty && !Animations.Contains(targetDescriptor.IdleAnimationId))
-        {
-            Animations.Add(targetDescriptor.IdleAnimationId);
-        }
-
-        DeathAnimation = targetDescriptor.DeathAnimationId;
-
-        Spells.Clear();
-        var spellSlot = 0;
-        foreach (var spellId in targetDescriptor.Spells)
-        {
-            var slot = new PlayerSpell(spellSlot++);
-            slot.Set(new Spell(spellId));
-            Spells.Add(slot);
-        }
-
-        if (Level > MaxLevel)
-        {
-            Level = MaxLevel;
-            Experience = 0;
-        }
-
-        if (LevelingMode == PetLevelingMode.Experience)
-        {
-            var experienceToNext = GetExperienceToNextLevel(Level);
-            if (experienceToNext > 0 && Experience >= experienceToNext)
-            {
-                Experience = Math.Max(0, experienceToNext - 1);
-            }
-        }
-        else
-        {
-            Experience = 0;
-        }
     }
 }


### PR DESCRIPTION
## Summary
- remove the pet evolution properties from the shared pet descriptor model
- delete server-side evolution handling so pets retain their descriptors when leveling up
- strip the editor UI of evolution controls and related event handlers

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d609e4087c832bb9d7f8c312738d95