### PR TITLE
Fix pet hub context menu request call

### DIFF
--- a/Intersect.Client.Core/Interface/Game/Inventory/InventoryItem.cs
+++ b/Intersect.Client.Core/Interface/Game/Inventory/InventoryItem.cs
@@ -230,7 +230,7 @@ public partial class InventoryItem : SlotItem
 
     private void _openPetHubMenuItem_Clicked(Base sender, MouseButtonState arguments)
     {
-        PacketSender.Send(new OpenPetHubRequestPacket());
+        PacketSender.SendOpenPetHubRequest();
     }
 
     private void _showItemContextItem_Clicked(Base sender, MouseButtonState arguments)

--- a/Intersect.Client.Core/Networking/PacketSender.cs
+++ b/Intersect.Client.Core/Networking/PacketSender.cs
@@ -148,6 +148,11 @@ public static partial class PacketSender
         Network.SendPacket(new SetAlignmentRequestPacket(alignment));
     }
 
+    public static void SendOpenPetHubRequest()
+    {
+        Network.SendPacket(new OpenPetHubRequestPacket());
+    }
+
 
     public static void SendActivateEvent(Guid eventId)
     {


### PR DESCRIPTION
## Summary
- add a dedicated PacketSender helper to request opening the pet hub
- update the inventory item context menu to call the new helper instead of a nonexistent generic Send method

## Testing
- ⚠️ `dotnet build Intersect.Client.Core/Intersect.Client.Core.csproj` *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d610ab7520832bb166f9507d84b48e