### PR TITLE
Update EF SQLite snapshots for pet gender support

### DIFF
--- a/Framework/Intersect.Framework.Core/GameObjects/Pets/PetDescriptor.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Pets/PetDescriptor.cs
@@ -127,6 +127,44 @@ public partial class PetDescriptor : DatabaseObject<PetDescriptor>, IFolderable
 
     public string Sprite { get; set; } = string.Empty;
 
+    [Column("MaleSprite")]
+    [JsonProperty(nameof(MaleSprite))]
+    public string MaleSprite { get; set; } = string.Empty;
+
+    [Column("FemaleSprite")]
+    [JsonProperty(nameof(FemaleSprite))]
+    public string FemaleSprite { get; set; } = string.Empty;
+
+    public string GetSpriteForGender(PetGender gender)
+    {
+        return gender switch
+        {
+            PetGender.Male when !string.IsNullOrWhiteSpace(MaleSprite) => MaleSprite,
+            PetGender.Female when !string.IsNullOrWhiteSpace(FemaleSprite) => FemaleSprite,
+            _ => ResolveFallbackSprite(),
+        };
+    }
+
+    private string ResolveFallbackSprite()
+    {
+        if (!string.IsNullOrWhiteSpace(Sprite))
+        {
+            return Sprite;
+        }
+
+        if (!string.IsNullOrWhiteSpace(MaleSprite))
+        {
+            return MaleSprite;
+        }
+
+        if (!string.IsNullOrWhiteSpace(FemaleSprite))
+        {
+            return FemaleSprite;
+        }
+
+        return string.Empty;
+    }
+
     [Column("Spells"), JsonIgnore]
     public string SpellsJson
     {

--- a/Framework/Intersect.Framework.Core/GameObjects/Pets/PetGender.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Pets/PetGender.cs
@@ -1,0 +1,8 @@
+namespace Intersect.Enums;
+
+public enum PetGender
+{
+    Unspecified = 0,
+    Male = 1,
+    Female = 2,
+}

--- a/Framework/Intersect.Framework.Core/Network/Packets/Server/PetEntityPacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Server/PetEntityPacket.cs
@@ -24,4 +24,7 @@ public sealed class PetEntityPacket : EntityPacket
 
     [Key(28)]
     public PetState Behavior { get; set; }
+
+    [Key(29)]
+    public PetGender Gender { get; set; }
 }

--- a/Intersect.Client.Core/Entities/Pet.cs
+++ b/Intersect.Client.Core/Entities/Pet.cs
@@ -18,6 +18,8 @@ public sealed class Pet : Entity
 
     private PetDescriptor? _cachedDescriptor;
     private Guid _descriptorId;
+    private bool _shouldRefreshSprite = true;
+    private string? _lastResolvedSprite;
 
     private int[] _statPointAllocations = Array.Empty<int>();
 
@@ -57,6 +59,7 @@ public sealed class Pet : Entity
 
             _descriptorId = value;
             _cachedDescriptor = null;
+            _shouldRefreshSprite = true;
         }
     }
 
@@ -67,12 +70,12 @@ public sealed class Pet : Entity
     {
         get
         {
-            if (_cachedDescriptor == null && DescriptorId != Guid.Empty)
+            if (TryResolveDescriptor(out var descriptor) && _shouldRefreshSprite)
             {
-                PetDescriptor.Lookup.TryGetValue(DescriptorId, out _cachedDescriptor);
+                UpdateSpriteFromDescriptor(force: true);
             }
 
-            return _cachedDescriptor;
+            return descriptor;
         }
     }
 
@@ -93,6 +96,23 @@ public sealed class Pet : Entity
     ///     Returns <c>true</c> when the local player owns this pet.
     /// </summary>
     public bool IsOwnedByLocalPlayer => IsOwner(Globals.Me);
+
+    private PetGender _gender = PetGender.Unspecified;
+
+    public PetGender Gender
+    {
+        get => _gender;
+        private set
+        {
+            if (_gender == value)
+            {
+                return;
+            }
+
+            _gender = value;
+            _shouldRefreshSprite = true;
+        }
+    }
 
     public long Experience { get; private set; }
 
@@ -123,7 +143,14 @@ public sealed class Pet : Entity
     /// <param name="descriptorId">Identifier of the descriptor that spawned the pet.</param>
     /// <param name="despawnable">Indicates whether the pet can despawn automatically.</param>
     /// <param name="behavior">Behaviour reported by the server.</param>
-    public void ApplyMetadata(Guid ownerId, Guid descriptorId, bool despawnable, PetState behavior)
+    /// <param name="gender">Gender assigned by the server.</param>
+    public void ApplyMetadata(
+        Guid ownerId,
+        Guid descriptorId,
+        bool despawnable,
+        PetState behavior,
+        PetGender gender
+    )
     {
         if (behavior is not (PetState.Follow or PetState.Stay or PetState.Defend or PetState.Passive))
         {
@@ -136,13 +163,20 @@ public sealed class Pet : Entity
         const bool normalizedDespawnable = true;
         var despawnableChanged = Despawnable != normalizedDespawnable;
         var behaviorChanged = Behavior != behavior;
+        var genderChanged = Gender != gender;
 
         OwnerId = ownerId;
         DescriptorId = descriptorId;
         Despawnable = normalizedDespawnable;
         Behavior = behavior;
+        Gender = gender;
 
-        if (ownerChanged || descriptorChanged || despawnableChanged || behaviorChanged)
+        if (descriptorChanged || genderChanged || _shouldRefreshSprite)
+        {
+            UpdateSpriteFromDescriptor(force: descriptorChanged || genderChanged);
+        }
+
+        if (ownerChanged || descriptorChanged || despawnableChanged || behaviorChanged || genderChanged)
         {
             Globals.NotifyPetMetadataApplied(this);
         }
@@ -208,6 +242,9 @@ public sealed class Pet : Entity
         CareMilliseconds = 0;
         WhimsFulfilled = 0;
         LastWhimFulfillmentTicks = 0;
+        Gender = PetGender.Unspecified;
+        _lastResolvedSprite = null;
+        _shouldRefreshSprite = true;
     }
 
     /// <inheritdoc />
@@ -220,14 +257,50 @@ public sealed class Pet : Entity
             return;
         }
 
+        _lastResolvedSprite = Sprite;
+
         ApplyMetadata(
             petPacket.OwnerId,
             petPacket.DescriptorId,
             petPacket.Despawnable,
-            petPacket.Behavior
+            petPacket.Behavior,
+            petPacket.Gender
         );
-}
+    }
 
     private static int ClampAttribute(int value, int baseValue) =>
         Math.Clamp(value, 0, Math.Max(DefaultAttributeCap, baseValue));
+
+    private bool TryResolveDescriptor(out PetDescriptor? descriptor)
+    {
+        if (_cachedDescriptor == null && DescriptorId != Guid.Empty)
+        {
+            PetDescriptor.Lookup.TryGetValue(DescriptorId, out _cachedDescriptor);
+        }
+
+        descriptor = _cachedDescriptor;
+        return descriptor != null;
+    }
+
+    private void UpdateSpriteFromDescriptor(bool force = false)
+    {
+        if (!TryResolveDescriptor(out var descriptor))
+        {
+            _shouldRefreshSprite = true;
+            return;
+        }
+
+        var resolvedSprite = descriptor.GetSpriteForGender(Gender);
+        resolvedSprite ??= string.Empty;
+
+        if (!force && string.Equals(_lastResolvedSprite, resolvedSprite, StringComparison.Ordinal))
+        {
+            _shouldRefreshSprite = false;
+            return;
+        }
+
+        _lastResolvedSprite = resolvedSprite;
+        Sprite = resolvedSprite;
+        _shouldRefreshSprite = false;
+    }
 }

--- a/Intersect.Editor/Forms/Editors/frmPet.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/frmPet.Designer.cs
@@ -86,8 +86,12 @@ namespace Intersect.Editor.Forms.Editors
             lblHP = new Label();
             nudHp = new DarkNumericUpDown();
             grpGeneral = new DarkGroupBox();
-            lblPic = new Label();
-            cmbSprite = new DarkComboBox();
+            lblMaleSprite = new Label();
+            cmbMaleSprite = new DarkComboBox();
+            lblFemaleSprite = new Label();
+            cmbFemaleSprite = new DarkComboBox();
+            rdoPreviewMale = new DarkRadioButton();
+            rdoPreviewFemale = new DarkRadioButton();
             picPet = new PictureBox();
             lblBaseMaturity = new Label();
             nudBaseMaturity = new DarkNumericUpDown();
@@ -949,8 +953,12 @@ namespace Intersect.Editor.Forms.Editors
             // 
             grpGeneral.BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
             grpGeneral.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
-            grpGeneral.Controls.Add(lblPic);
-            grpGeneral.Controls.Add(cmbSprite);
+            grpGeneral.Controls.Add(rdoPreviewFemale);
+            grpGeneral.Controls.Add(rdoPreviewMale);
+            grpGeneral.Controls.Add(lblFemaleSprite);
+            grpGeneral.Controls.Add(cmbFemaleSprite);
+            grpGeneral.Controls.Add(lblMaleSprite);
+            grpGeneral.Controls.Add(cmbMaleSprite);
             grpGeneral.Controls.Add(picPet);
             grpGeneral.Controls.Add(lblBaseMaturity);
             grpGeneral.Controls.Add(nudBaseMaturity);
@@ -968,39 +976,90 @@ namespace Intersect.Editor.Forms.Editors
             grpGeneral.ForeColor = System.Drawing.Color.Gainsboro;
             grpGeneral.Location = new System.Drawing.Point(7, 8);
             grpGeneral.Name = "grpGeneral";
-            grpGeneral.Size = new Size(280, 256);
+            grpGeneral.Size = new Size(280, 300);
             grpGeneral.TabIndex = 0;
             grpGeneral.TabStop = false;
             grpGeneral.Text = "General";
             // 
-            // lblPic
-            // 
-            lblPic.AutoSize = true;
-            lblPic.Location = new System.Drawing.Point(13, 92);
-            lblPic.Name = "lblPic";
-            lblPic.Size = new Size(37, 15);
-            lblPic.TabIndex = 7;
-            lblPic.Text = "Sprite";
-            // 
-            // cmbSprite
-            // 
-            cmbSprite.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
-            cmbSprite.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
-            cmbSprite.BorderStyle = ButtonBorderStyle.Solid;
-            cmbSprite.ButtonColor = System.Drawing.Color.FromArgb(43, 43, 43);
-            cmbSprite.DrawDropdownHoverOutline = false;
-            cmbSprite.DrawFocusRectangle = false;
-            cmbSprite.DrawMode = DrawMode.OwnerDrawVariable;
-            cmbSprite.DropDownStyle = ComboBoxStyle.DropDownList;
-            cmbSprite.FlatStyle = FlatStyle.Flat;
-            cmbSprite.ForeColor = System.Drawing.Color.Gainsboro;
-            cmbSprite.Location = new System.Drawing.Point(60, 90);
-            cmbSprite.Name = "cmbSprite";
-            cmbSprite.Size = new Size(122, 24);
-            cmbSprite.TabIndex = 3;
-            cmbSprite.Text = null;
-            cmbSprite.TextPadding = new Padding(2);
-            cmbSprite.SelectedIndexChanged += cmbSprite_SelectedIndexChanged;
+            // lblMaleSprite
+            //
+            lblMaleSprite.AutoSize = true;
+            lblMaleSprite.Location = new System.Drawing.Point(13, 92);
+            lblMaleSprite.Name = "lblMaleSprite";
+            lblMaleSprite.Size = new Size(71, 15);
+            lblMaleSprite.TabIndex = 7;
+            lblMaleSprite.Text = "Male Sprite";
+            //
+            // cmbMaleSprite
+            //
+            cmbMaleSprite.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            cmbMaleSprite.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            cmbMaleSprite.BorderStyle = ButtonBorderStyle.Solid;
+            cmbMaleSprite.ButtonColor = System.Drawing.Color.FromArgb(43, 43, 43);
+            cmbMaleSprite.DrawDropdownHoverOutline = false;
+            cmbMaleSprite.DrawFocusRectangle = false;
+            cmbMaleSprite.DrawMode = DrawMode.OwnerDrawVariable;
+            cmbMaleSprite.DropDownStyle = ComboBoxStyle.DropDownList;
+            cmbMaleSprite.FlatStyle = FlatStyle.Flat;
+            cmbMaleSprite.ForeColor = System.Drawing.Color.Gainsboro;
+            cmbMaleSprite.Location = new System.Drawing.Point(60, 90);
+            cmbMaleSprite.Name = "cmbMaleSprite";
+            cmbMaleSprite.Size = new Size(122, 24);
+            cmbMaleSprite.TabIndex = 3;
+            cmbMaleSprite.Text = null;
+            cmbMaleSprite.TextPadding = new Padding(2);
+            cmbMaleSprite.SelectedIndexChanged += cmbMaleSprite_SelectedIndexChanged;
+            //
+            // lblFemaleSprite
+            //
+            lblFemaleSprite.AutoSize = true;
+            lblFemaleSprite.Location = new System.Drawing.Point(13, 122);
+            lblFemaleSprite.Name = "lblFemaleSprite";
+            lblFemaleSprite.Size = new Size(81, 15);
+            lblFemaleSprite.TabIndex = 8;
+            lblFemaleSprite.Text = "Female Sprite";
+            //
+            // cmbFemaleSprite
+            //
+            cmbFemaleSprite.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            cmbFemaleSprite.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            cmbFemaleSprite.BorderStyle = ButtonBorderStyle.Solid;
+            cmbFemaleSprite.ButtonColor = System.Drawing.Color.FromArgb(43, 43, 43);
+            cmbFemaleSprite.DrawDropdownHoverOutline = false;
+            cmbFemaleSprite.DrawFocusRectangle = false;
+            cmbFemaleSprite.DrawMode = DrawMode.OwnerDrawVariable;
+            cmbFemaleSprite.DropDownStyle = ComboBoxStyle.DropDownList;
+            cmbFemaleSprite.FlatStyle = FlatStyle.Flat;
+            cmbFemaleSprite.ForeColor = System.Drawing.Color.Gainsboro;
+            cmbFemaleSprite.Location = new System.Drawing.Point(60, 120);
+            cmbFemaleSprite.Name = "cmbFemaleSprite";
+            cmbFemaleSprite.Size = new Size(122, 24);
+            cmbFemaleSprite.TabIndex = 4;
+            cmbFemaleSprite.Text = null;
+            cmbFemaleSprite.TextPadding = new Padding(2);
+            cmbFemaleSprite.SelectedIndexChanged += cmbFemaleSprite_SelectedIndexChanged;
+            //
+            // rdoPreviewMale
+            //
+            rdoPreviewMale.AutoSize = true;
+            rdoPreviewMale.Location = new System.Drawing.Point(188, 122);
+            rdoPreviewMale.Name = "rdoPreviewMale";
+            rdoPreviewMale.Size = new Size(100, 19);
+            rdoPreviewMale.TabIndex = 5;
+            rdoPreviewMale.TabStop = true;
+            rdoPreviewMale.Text = "Preview Male";
+            rdoPreviewMale.Checked = true;
+            rdoPreviewMale.CheckedChanged += rdoPreviewMale_CheckedChanged;
+            //
+            // rdoPreviewFemale
+            //
+            rdoPreviewFemale.AutoSize = true;
+            rdoPreviewFemale.Location = new System.Drawing.Point(188, 147);
+            rdoPreviewFemale.Name = "rdoPreviewFemale";
+            rdoPreviewFemale.Size = new Size(110, 19);
+            rdoPreviewFemale.TabIndex = 6;
+            rdoPreviewFemale.Text = "Preview Female";
+            rdoPreviewFemale.CheckedChanged += rdoPreviewFemale_CheckedChanged;
             // 
             // picPet
             // 
@@ -1014,7 +1073,7 @@ namespace Intersect.Editor.Forms.Editors
             // lblBaseMaturity
             // 
             lblBaseMaturity.AutoSize = true;
-            lblBaseMaturity.Location = new System.Drawing.Point(13, 191);
+            lblBaseMaturity.Location = new System.Drawing.Point(13, 236);
             lblBaseMaturity.Name = "lblBaseMaturity";
             lblBaseMaturity.Size = new Size(79, 15);
             lblBaseMaturity.TabIndex = 13;
@@ -1024,18 +1083,18 @@ namespace Intersect.Editor.Forms.Editors
             // 
             nudBaseMaturity.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
             nudBaseMaturity.ForeColor = System.Drawing.Color.Gainsboro;
-            nudBaseMaturity.Location = new System.Drawing.Point(110, 187);
+            nudBaseMaturity.Location = new System.Drawing.Point(110, 232);
             nudBaseMaturity.Maximum = new decimal(new int[] { 1000, 0, 0, 0 });
             nudBaseMaturity.Name = "nudBaseMaturity";
             nudBaseMaturity.Size = new Size(105, 23);
-            nudBaseMaturity.TabIndex = 6;
+            nudBaseMaturity.TabIndex = 9;
             nudBaseMaturity.Value = new decimal(new int[] { 0, 0, 0, 0 });
             nudBaseMaturity.ValueChanged += nudBaseMaturity_ValueChanged;
             // 
             // lblBaseMood
             // 
             lblBaseMood.AutoSize = true;
-            lblBaseMood.Location = new System.Drawing.Point(13, 161);
+            lblBaseMood.Location = new System.Drawing.Point(13, 206);
             lblBaseMood.Name = "lblBaseMood";
             lblBaseMood.Size = new Size(66, 15);
             lblBaseMood.TabIndex = 12;
@@ -1045,18 +1104,18 @@ namespace Intersect.Editor.Forms.Editors
             // 
             nudBaseMood.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
             nudBaseMood.ForeColor = System.Drawing.Color.Gainsboro;
-            nudBaseMood.Location = new System.Drawing.Point(110, 157);
+            nudBaseMood.Location = new System.Drawing.Point(110, 202);
             nudBaseMood.Maximum = new decimal(new int[] { 1000, 0, 0, 0 });
             nudBaseMood.Name = "nudBaseMood";
             nudBaseMood.Size = new Size(105, 23);
-            nudBaseMood.TabIndex = 5;
+            nudBaseMood.TabIndex = 8;
             nudBaseMood.Value = new decimal(new int[] { 0, 0, 0, 0 });
             nudBaseMood.ValueChanged += nudBaseMood_ValueChanged;
             // 
             // lblBaseEnergy
             // 
             lblBaseEnergy.AutoSize = true;
-            lblBaseEnergy.Location = new System.Drawing.Point(13, 131);
+            lblBaseEnergy.Location = new System.Drawing.Point(13, 176);
             lblBaseEnergy.Name = "lblBaseEnergy";
             lblBaseEnergy.Size = new Size(70, 15);
             lblBaseEnergy.TabIndex = 11;
@@ -1066,18 +1125,18 @@ namespace Intersect.Editor.Forms.Editors
             // 
             nudBaseEnergy.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
             nudBaseEnergy.ForeColor = System.Drawing.Color.Gainsboro;
-            nudBaseEnergy.Location = new System.Drawing.Point(110, 127);
+            nudBaseEnergy.Location = new System.Drawing.Point(110, 172);
             nudBaseEnergy.Maximum = new decimal(new int[] { 1000, 0, 0, 0 });
             nudBaseEnergy.Name = "nudBaseEnergy";
             nudBaseEnergy.Size = new Size(105, 23);
-            nudBaseEnergy.TabIndex = 4;
+            nudBaseEnergy.TabIndex = 7;
             nudBaseEnergy.Value = new decimal(new int[] { 0, 0, 0, 0 });
             nudBaseEnergy.ValueChanged += nudBaseEnergy_ValueChanged;
             // 
             // lblFeedingItem
             // 
             lblFeedingItem.AutoSize = true;
-            lblFeedingItem.Location = new System.Drawing.Point(13, 221);
+            lblFeedingItem.Location = new System.Drawing.Point(13, 266);
             lblFeedingItem.Name = "lblFeedingItem";
             lblFeedingItem.Size = new Size(76, 15);
             lblFeedingItem.TabIndex = 16;
@@ -1095,10 +1154,10 @@ namespace Intersect.Editor.Forms.Editors
             cmbFeedingItem.DropDownStyle = ComboBoxStyle.DropDownList;
             cmbFeedingItem.FlatStyle = FlatStyle.Flat;
             cmbFeedingItem.ForeColor = System.Drawing.Color.Gainsboro;
-            cmbFeedingItem.Location = new System.Drawing.Point(110, 217);
+            cmbFeedingItem.Location = new System.Drawing.Point(110, 264);
             cmbFeedingItem.Name = "cmbFeedingItem";
             cmbFeedingItem.Size = new Size(164, 24);
-            cmbFeedingItem.TabIndex = 7;
+            cmbFeedingItem.TabIndex = 10;
             cmbFeedingItem.Text = null;
             cmbFeedingItem.TextPadding = new Padding(2);
             cmbFeedingItem.SelectedIndexChanged += cmbFeedingItem_SelectedIndexChanged;
@@ -1617,8 +1676,12 @@ namespace Intersect.Editor.Forms.Editors
         private Label lblHP;
         private DarkNumericUpDown nudHp;
         private DarkGroupBox grpGeneral;
-        private Label lblPic;
-        private DarkComboBox cmbSprite;
+        private Label lblMaleSprite;
+        private DarkComboBox cmbMaleSprite;
+        private Label lblFemaleSprite;
+        private DarkComboBox cmbFemaleSprite;
+        private DarkRadioButton rdoPreviewMale;
+        private DarkRadioButton rdoPreviewFemale;
         private PictureBox picPet;
         private DarkButton btnAddFolder;
         private Label lblFolder;

--- a/Intersect.Editor/Forms/Editors/frmPet.cs
+++ b/Intersect.Editor/Forms/Editors/frmPet.cs
@@ -1,7 +1,10 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Drawing;
+using System.Drawing.Imaging;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Windows.Forms;
 using DarkUI.Controls;
 using DarkUI.Forms;
@@ -17,6 +20,9 @@ using Intersect.Framework.Core.GameObjects.Pets;
 using Intersect.Framework.Core.GameObjects.Spells;
 using Intersect.GameObjects;
 using Intersect.Utilities;
+using Microsoft.Xna.Framework.Graphics;
+using XnaColor = Microsoft.Xna.Framework.Color;
+using XnaRectangle = Microsoft.Xna.Framework.Rectangle;
 
 namespace Intersect.Editor.Forms.Editors;
 
@@ -34,6 +40,7 @@ public partial class FrmPet : EditorForm
     private string? _copiedItem;
     private PetDescriptor? _editorItem;
     private bool _isClosing;
+    private bool _suppressPreviewUpdate;
 
     public FrmPet()
     {
@@ -275,11 +282,12 @@ public partial class FrmPet : EditorForm
 
     private void frmPet_Load(object sender, EventArgs e)
     {
-        cmbSprite.Items.Clear();
-        cmbSprite.Items.Add(Strings.General.None);
-        cmbSprite.Items.AddRange(
-            GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Entity)
+        var entitySprites = GameContentManager.GetSmartSortedTextureNames(
+            GameContentManager.TextureType.Entity
         );
+
+        InitializeSpriteCombo(cmbMaleSprite, entitySprites);
+        InitializeSpriteCombo(cmbFemaleSprite, entitySprites);
 
         cmbFeedingItem.Items.Clear();
         cmbFeedingItem.Items.Add(Strings.General.None);
@@ -364,7 +372,10 @@ public partial class FrmPet : EditorForm
         lblBaseMood.Text = Strings.Pets.basemood;
         lblBaseMaturity.Text = Strings.Pets.basematurity;
         lblFeedingItem.Text = Strings.Pets.feedingitem;
-        lblPic.Text = Strings.Pets.sprite;
+        lblMaleSprite.Text = Strings.Pets.malesprite;
+        lblFemaleSprite.Text = Strings.Pets.femalesprite;
+        rdoPreviewMale.Text = Strings.Pets.previewmale;
+        rdoPreviewFemale.Text = Strings.Pets.previewfemale;
         lblHP.Text = $"{Strings.Combat.vitals[(int)Vital.Health]}:";
         lblMana.Text = $"{Strings.Combat.vitals[(int)Vital.Mana]}:";
         lblStr.Text = $"{Strings.Combat.stats[(int)Stat.Attack]}:";
@@ -396,6 +407,119 @@ public partial class FrmPet : EditorForm
         btnRemove.Text = Strings.Pets.removespell;
         btnSave.Text = Strings.Pets.save;
         btnCancel.Text = Strings.Pets.cancel;
+    }
+
+    private static void InitializeSpriteCombo(DarkComboBox combo, string[] sprites)
+    {
+        combo.Items.Clear();
+        combo.Items.Add(Strings.General.None);
+        combo.Items.AddRange(sprites);
+
+        if (combo.Items.Count > 0)
+        {
+            combo.SelectedIndex = 0;
+        }
+    }
+
+    private static void SetSpriteSelection(DarkComboBox combo, string value)
+    {
+        var index = combo.FindString(value);
+        combo.SelectedIndex = index >= 0 ? index : 0;
+    }
+
+    private void UpdateDescriptorFallbackSprite()
+    {
+        if (_editorItem == null)
+        {
+            return;
+        }
+
+        var fallback = _editorItem.MaleSprite;
+        if (string.IsNullOrWhiteSpace(fallback))
+        {
+            fallback = _editorItem.FemaleSprite;
+        }
+
+        _editorItem.Sprite = fallback ?? string.Empty;
+    }
+
+    private string GetPreviewSpriteName()
+    {
+        return rdoPreviewFemale.Checked
+            ? TextUtils.SanitizeNone(cmbFemaleSprite.Text)
+            : TextUtils.SanitizeNone(cmbMaleSprite.Text);
+    }
+
+    private void UpdatePreview()
+    {
+        if (_suppressPreviewUpdate || _editorItem == null)
+        {
+            return;
+        }
+
+        picPet.BackgroundImage?.Dispose();
+        picPet.BackgroundImage = null;
+
+        var spriteName = GetPreviewSpriteName();
+        if (string.IsNullOrWhiteSpace(spriteName))
+        {
+            return;
+        }
+
+        var texture = GameContentManager.GetTexture(GameContentManager.TextureType.Entity, spriteName);
+        if (texture == null)
+        {
+            return;
+        }
+
+        var frames = Math.Max(1, Options.Instance.Sprites.NormalFrames);
+        var directions = Math.Max(1, Options.Instance.Sprites.Directions);
+        var frameWidth = texture.Width / frames;
+        var frameHeight = texture.Height / directions;
+
+        if (frameWidth <= 0 || frameHeight <= 0)
+        {
+            return;
+        }
+
+        var colors = new XnaColor[frameWidth * frameHeight];
+        var sourceRectangle = new XnaRectangle(0, 0, frameWidth, frameHeight);
+        texture.GetData(0, sourceRectangle, colors, 0, colors.Length);
+
+        var pixelData = new byte[colors.Length * 4];
+        for (var i = 0; i < colors.Length; i++)
+        {
+            var color = colors[i];
+            var offset = i * 4;
+            pixelData[offset] = color.B;
+            pixelData[offset + 1] = color.G;
+            pixelData[offset + 2] = color.R;
+            pixelData[offset + 3] = color.A;
+        }
+
+        using var frameBitmap = new Bitmap(frameWidth, frameHeight, PixelFormat.Format32bppArgb);
+        var bitmapData = frameBitmap.LockBits(
+            new Rectangle(0, 0, frameWidth, frameHeight),
+            ImageLockMode.WriteOnly,
+            PixelFormat.Format32bppArgb
+        );
+        Marshal.Copy(pixelData, 0, bitmapData.Scan0, pixelData.Length);
+        frameBitmap.UnlockBits(bitmapData);
+
+        var previewBitmap = new Bitmap(picPet.Width, picPet.Height);
+        using (var graphics = Graphics.FromImage(previewBitmap))
+        {
+            graphics.FillRectangle(Brushes.Black, new Rectangle(0, 0, previewBitmap.Width, previewBitmap.Height));
+            var destination = new Rectangle(
+                (previewBitmap.Width - frameBitmap.Width) / 2,
+                (previewBitmap.Height - frameBitmap.Height) / 2,
+                frameBitmap.Width,
+                frameBitmap.Height
+            );
+            graphics.DrawImage(frameBitmap, destination);
+        }
+
+        picPet.BackgroundImage = previewBitmap;
     }
 
     private void AssignEditorItem(Guid id)
@@ -466,17 +590,24 @@ public partial class FrmPet : EditorForm
         if (_editorItem != null)
         {
             pnlContainer.Show();
+            _suppressPreviewUpdate = true;
+            try
+            {
+                SetSpriteSelection(cmbMaleSprite, TextUtils.NullToNone(_editorItem.MaleSprite));
+                SetSpriteSelection(cmbFemaleSprite, TextUtils.NullToNone(_editorItem.FemaleSprite));
+
+                var useMalePreview = !string.IsNullOrWhiteSpace(_editorItem.MaleSprite)
+                                     || string.IsNullOrWhiteSpace(_editorItem.FemaleSprite);
+                rdoPreviewMale.Checked = useMalePreview;
+                rdoPreviewFemale.Checked = !useMalePreview;
+            }
+            finally
+            {
+                _suppressPreviewUpdate = false;
+            }
+
             txtName.Text = _editorItem.Name;
             cmbFolder.Text = _editorItem.Folder;
-            var spriteIndex = cmbSprite.FindString(TextUtils.NullToNone(_editorItem.Sprite));
-            if (spriteIndex >= 0)
-            {
-                cmbSprite.SelectedIndex = spriteIndex;
-            }
-            else if (cmbSprite.Items.Count > 0)
-            {
-                cmbSprite.SelectedIndex = 0;
-            }
             nudBaseEnergy.Value = Math.Max(nudBaseEnergy.Minimum, Math.Min(nudBaseEnergy.Maximum, _editorItem.BaseEnergy));
             nudBaseMood.Value = Math.Max(nudBaseMood.Minimum, Math.Min(nudBaseMood.Maximum, _editorItem.BaseMood));
             nudBaseMaturity.Value = Math.Max(nudBaseMaturity.Minimum, Math.Min(nudBaseMaturity.Maximum, _editorItem.BaseMaturity));
@@ -543,10 +674,15 @@ public partial class FrmPet : EditorForm
                 _changed.Add(_editorItem);
                 _editorItem.MakeBackup();
             }
+
+            UpdateDescriptorFallbackSprite();
+            UpdatePreview();
         }
         else
         {
             pnlContainer.Hide();
+            picPet.BackgroundImage?.Dispose();
+            picPet.BackgroundImage = null;
         }
 
         var hasItem = _editorItem != null;
@@ -565,14 +701,52 @@ public partial class FrmPet : EditorForm
         lstGameObjects.UpdateText(txtName.Text);
     }
 
-    private void cmbSprite_SelectedIndexChanged(object sender, EventArgs e)
+    private void cmbMaleSprite_SelectedIndexChanged(object sender, EventArgs e)
     {
-        if (_editorItem == null)
+        if (_editorItem == null || cmbMaleSprite.SelectedIndex < 0)
         {
             return;
         }
 
-        _editorItem.Sprite = TextUtils.SanitizeNone(cmbSprite.Text);
+        _editorItem.MaleSprite = TextUtils.SanitizeNone(cmbMaleSprite.Text);
+        UpdateDescriptorFallbackSprite();
+
+        if (!_suppressPreviewUpdate)
+        {
+            UpdatePreview();
+        }
+    }
+
+    private void cmbFemaleSprite_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        if (_editorItem == null || cmbFemaleSprite.SelectedIndex < 0)
+        {
+            return;
+        }
+
+        _editorItem.FemaleSprite = TextUtils.SanitizeNone(cmbFemaleSprite.Text);
+        UpdateDescriptorFallbackSprite();
+
+        if (!_suppressPreviewUpdate)
+        {
+            UpdatePreview();
+        }
+    }
+
+    private void rdoPreviewMale_CheckedChanged(object sender, EventArgs e)
+    {
+        if (!_suppressPreviewUpdate && rdoPreviewMale.Checked)
+        {
+            UpdatePreview();
+        }
+    }
+
+    private void rdoPreviewFemale_CheckedChanged(object sender, EventArgs e)
+    {
+        if (!_suppressPreviewUpdate && rdoPreviewFemale.Checked)
+        {
+            UpdatePreview();
+        }
     }
 
     private void cmbFeedingItem_SelectedIndexChanged(object sender, EventArgs e)

--- a/Intersect.Editor/Localization/Strings.cs
+++ b/Intersect.Editor/Localization/Strings.cs
@@ -4946,6 +4946,14 @@ Tick timer saved in server config.json.";
 
         public static LocalizedString sprite = @"Sprite";
 
+        public static LocalizedString malesprite = @"Male Sprite:";
+
+        public static LocalizedString femalesprite = @"Female Sprite:";
+
+        public static LocalizedString previewmale = @"Preview Male";
+
+        public static LocalizedString previewfemale = @"Preview Female";
+
         public static LocalizedString baseenergy = @"Base Energy:";
 
         public static LocalizedString basemood = @"Base Mood:";

--- a/Intersect.Server.Core/Database/GameData/GameContext.cs
+++ b/Intersect.Server.Core/Database/GameData/GameContext.cs
@@ -131,6 +131,11 @@ public abstract partial class GameContext : IntersectDbContext<GameContext>, IGa
         {
             FixQuestTaskCompletionEventsMigration.Run(this);
         }
+
+        if (migrations.IndexOf("20240601000000_PetGenderSpritesMigration") > -1)
+        {
+            PetSpriteGenderMigration.Run(this);
+        }
     }
 
     internal static partial class Queries

--- a/Intersect.Server.Core/Database/GameData/Migrations/PetSpriteGenderMigration.cs
+++ b/Intersect.Server.Core/Database/GameData/Migrations/PetSpriteGenderMigration.cs
@@ -1,0 +1,25 @@
+namespace Intersect.Server.Database.GameData.Migrations;
+
+public static class PetSpriteGenderMigration
+{
+    public static void Run(GameContext context)
+    {
+        foreach (var pet in context.Pets)
+        {
+            var baseSprite = pet.Sprite ?? string.Empty;
+
+            if (string.IsNullOrWhiteSpace(pet.MaleSprite))
+            {
+                pet.MaleSprite = baseSprite;
+            }
+
+            if (string.IsNullOrWhiteSpace(pet.FemaleSprite))
+            {
+                pet.FemaleSprite = baseSprite;
+            }
+        }
+
+        context.ChangeTracker.DetectChanges();
+        context.SaveChanges();
+    }
+}

--- a/Intersect.Server.Core/Database/PlayerData/Migrations/PlayerPetGenderMigration.cs
+++ b/Intersect.Server.Core/Database/PlayerData/Migrations/PlayerPetGenderMigration.cs
@@ -1,0 +1,22 @@
+using Intersect.Enums;
+
+namespace Intersect.Server.Database.PlayerData.Migrations;
+
+public static class PlayerPetGenderMigration
+{
+    public static void Run(PlayerContext context)
+    {
+        foreach (var pet in context.Player_Pets)
+        {
+            if (pet.Gender is PetGender.Male or PetGender.Female)
+            {
+                continue;
+            }
+
+            pet.Gender = PetGender.Unspecified;
+        }
+
+        context.ChangeTracker.DetectChanges();
+        context.SaveChanges();
+    }
+}

--- a/Intersect.Server.Core/Database/PlayerData/PlayerContext.cs
+++ b/Intersect.Server.Core/Database/PlayerData/PlayerContext.cs
@@ -1,3 +1,4 @@
+using Intersect.Enums;
 using Intersect.Extensions;
 using Intersect.Server.Database.PlayerData.Api;
 using Intersect.Server.Database.PlayerData.Migrations;
@@ -116,6 +117,7 @@ public abstract partial class PlayerContext : IntersectDbContext<PlayerContext>,
         modelBuilder.Entity<PlayerPet>().Property(pet => pet.CareMilliseconds).HasDefaultValue(0L);
         modelBuilder.Entity<PlayerPet>().Property(pet => pet.WhimsFulfilled).HasDefaultValue(0);
         modelBuilder.Entity<PlayerPet>().Property(pet => pet.LastWhimFulfillmentTicks).HasDefaultValue(0L);
+        modelBuilder.Entity<PlayerPet>().Property(pet => pet.Gender).HasDefaultValue(PetGender.Unspecified);
         modelBuilder.Entity<Player>()
             .HasOne(p => p.ActivePet)
             .WithMany()
@@ -180,6 +182,11 @@ public abstract partial class PlayerContext : IntersectDbContext<PlayerContext>,
         if (migrations.IndexOf("20220331140427_GuildBankMaxSlotsMigration") > -1)
         {
             GuildBankMaxSlotMigration.Run(this);
+        }
+
+        if (migrations.IndexOf("20240601000001_PlayerPetGenderMigration") > -1)
+        {
+            PlayerPetGenderMigration.Run(this);
         }
     }
 

--- a/Intersect.Server.Core/Database/PlayerData/Players/PlayerPet.cs
+++ b/Intersect.Server.Core/Database/PlayerData/Players/PlayerPet.cs
@@ -24,6 +24,8 @@ public partial class PlayerPet : IPlayerOwned
 
     public Guid PetInstanceId { get; set; }
 
+    public PetGender Gender { get; set; } = PetGender.Unspecified;
+
     public string CustomName { get; set; } = string.Empty;
 
     public int Level { get; set; } = 1;

--- a/Intersect.Server.Core/Entities/Pet.cs
+++ b/Intersect.Server.Core/Entities/Pet.cs
@@ -17,6 +17,7 @@ using Intersect.Server.Framework.Items;
 using Intersect.Server.Localization;
 using Intersect.Server.Maps;
 using Intersect.Server.Networking;
+using Intersect.Utilities;
 namespace Intersect.Server.Entities;
 
 public sealed class Pet : Entity, IPet
@@ -109,6 +110,23 @@ public sealed class Pet : Entity, IPet
     public int WhimsFulfilled => _whimsFulfilled;
 
     public long LastWhimFulfillmentTicks => _lastWhimFulfillmentTicks;
+
+    private PetGender _gender = PetGender.Unspecified;
+
+    public PetGender Gender
+    {
+        get => _gender;
+        private set
+        {
+            if (_gender == value)
+            {
+                return;
+            }
+
+            _gender = value;
+            MarkMetadataDirty();
+        }
+    }
 
     public long CareMilliseconds => _totalCareMilliseconds;
 
@@ -333,6 +351,8 @@ public sealed class Pet : Entity, IPet
 
         PetInstanceId = persistedPet?.PetInstanceId ?? Guid.Empty;
 
+        InitializeGender(descriptor, persistedPet);
+
         ExperienceRate = Math.Max(0, descriptor.ExperienceRate);
         StatPointsPerLevel = Math.Max(0, descriptor.StatPointsPerLevel);
         MaxLevel = Math.Max(1, descriptor.MaxLevel);
@@ -355,7 +375,6 @@ public sealed class Pet : Entity, IPet
         Name = string.IsNullOrWhiteSpace(owner.ActivePet?.CustomName)
             ? descriptor.Name
             : owner.ActivePet.CustomName;
-        Sprite = descriptor.Sprite;
         Level = Math.Clamp(descriptor.Level, 1, Math.Max(1, MaxLevel));
         Immunities = descriptor.Immunities?.ToList() ?? [];
 
@@ -771,10 +790,46 @@ public sealed class Pet : Entity, IPet
         petPacket.DescriptorId = Descriptor.Id;
         petPacket.Behavior = Behavior;
         petPacket.Despawnable = Despawnable;
+        petPacket.Gender = Gender;
 
         ResetMetadataDirty();
 
         return petPacket;
+    }
+
+    private void InitializeGender(PetDescriptor descriptor, PlayerPet? persistedPet)
+    {
+        ArgumentNullException.ThrowIfNull(descriptor);
+
+        var resolvedGender = persistedPet?.Gender switch
+        {
+            PetGender.Male or PetGender.Female => persistedPet.Gender,
+            _ => Randomization.Next(0, 2) == 0 ? PetGender.Male : PetGender.Female,
+        };
+
+        Gender = resolvedGender;
+
+        ApplySprite(descriptor.GetSpriteForGender(Gender));
+
+        if (persistedPet != null && persistedPet.Gender != Gender)
+        {
+            persistedPet.Gender = Gender;
+
+            // Persist immediately so migrated pets retain their assigned gender.
+            Owner?.PersistPetProgress(this);
+        }
+    }
+
+    private void ApplySprite(string? sprite)
+    {
+        var resolvedSprite = sprite ?? string.Empty;
+        if (string.Equals(Sprite, resolvedSprite, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        Sprite = resolvedSprite;
+        MarkMetadataDirty();
     }
 
     public override void Update(long timeMs)

--- a/Intersect.Server.Core/Entities/Player.cs
+++ b/Intersect.Server.Core/Entities/Player.cs
@@ -1394,6 +1394,8 @@ public partial class Player : Entity
             playerPet.Vitals[index] = pet.GetVital(vital);
         }
 
+        playerPet.Gender = pet.Gender;
+
         if (playerPet.PetInstanceId == Guid.Empty && pet.PetInstanceId != Guid.Empty)
         {
             playerPet.PetInstanceId = pet.PetInstanceId;
@@ -1819,6 +1821,8 @@ public partial class Player : Entity
             CareMilliseconds = (long)Math.Max(0, descriptor.BaseMaturity)
                                 * Pet.CareMillisecondsPerMaturityPoint,
         };
+
+        playerPet.Gender = Randomization.Next(0, 2) == 0 ? PetGender.Male : PetGender.Female;
 
         var initialName = petData.PetNameOverride;
         if (!string.IsNullOrWhiteSpace(initialName))

--- a/Intersect.Server.Core/Migrations/Sqlite/Game/20240601000000_PetGenderSpritesMigration.cs
+++ b/Intersect.Server.Core/Migrations/Sqlite/Game/20240601000000_PetGenderSpritesMigration.cs
@@ -1,0 +1,38 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Intersect.Server.Migrations.Sqlite.Game
+{
+    /// <inheritdoc />
+    public partial class PetGenderSpritesMigration : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "MaleSprite",
+                table: "Pets",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "FemaleSprite",
+                table: "Pets",
+                type: "TEXT",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "MaleSprite",
+                table: "Pets");
+
+            migrationBuilder.DropColumn(
+                name: "FemaleSprite",
+                table: "Pets");
+        }
+    }
+}

--- a/Intersect.Server.Core/Migrations/Sqlite/Game/SqliteGameContextModelSnapshot.cs
+++ b/Intersect.Server.Core/Migrations/Sqlite/Game/SqliteGameContextModelSnapshot.cs
@@ -651,6 +651,9 @@ namespace Intersect.Server.Migrations.Sqlite.Game
                     b.Property<int>("ExperienceRate")
                         .HasColumnType("INTEGER");
 
+                    b.Property<string>("FemaleSprite")
+                        .HasColumnType("TEXT");
+
                     b.Property<string>("Folder")
                         .HasColumnType("TEXT");
 
@@ -688,6 +691,9 @@ namespace Intersect.Server.Migrations.Sqlite.Game
                     b.Property<string>("SpellsJson")
                         .HasColumnType("TEXT")
                         .HasColumnName("Spells");
+
+                    b.Property<string>("MaleSprite")
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Sprite")
                         .HasColumnType("TEXT");

--- a/Intersect.Server.Core/Migrations/Sqlite/Player/20240601000001_PlayerPetGenderMigration.cs
+++ b/Intersect.Server.Core/Migrations/Sqlite/Player/20240601000001_PlayerPetGenderMigration.cs
@@ -1,0 +1,29 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Intersect.Server.Migrations.Sqlite.Player
+{
+    /// <inheritdoc />
+    public partial class PlayerPetGenderMigration : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "Gender",
+                table: "Player_Pets",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Gender",
+                table: "Player_Pets");
+        }
+    }
+}

--- a/Intersect.Server.Core/Migrations/Sqlite/Player/SqlitePlayerContextModelSnapshot.cs
+++ b/Intersect.Server.Core/Migrations/Sqlite/Player/SqlitePlayerContextModelSnapshot.cs
@@ -558,6 +558,21 @@ namespace Intersect.Server.Migrations.Sqlite.Player
                     b.Property<string>("CustomName")
                         .HasColumnType("TEXT");
 
+                    b.Property<long>("CareMilliseconds")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("INTEGER")
+                        .HasDefaultValue(0L);
+
+                    b.Property<int>("Energy")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("INTEGER")
+                        .HasDefaultValue(-1);
+
+                    b.Property<int>("Gender")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("INTEGER")
+                        .HasDefaultValue(0);
+
                     b.Property<long>("Experience")
                         .HasColumnType("INTEGER");
 
@@ -567,6 +582,16 @@ namespace Intersect.Server.Migrations.Sqlite.Player
                     b.Property<string>("MaxVitalsJson")
                         .HasColumnType("TEXT")
                         .HasColumnName("PetMaxVitals");
+
+                    b.Property<int>("Mood")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("INTEGER")
+                        .HasDefaultValue(-1);
+
+                    b.Property<int>("Maturity")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("INTEGER")
+                        .HasDefaultValue(-1);
 
                     b.Property<Guid>("PetDescriptorId")
                         .HasColumnType("TEXT");
@@ -584,8 +609,18 @@ namespace Intersect.Server.Migrations.Sqlite.Player
                     b.Property<int>("StatPoints")
                         .HasColumnType("INTEGER");
 
+                    b.Property<long>("LastWhimFulfillmentTicks")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("INTEGER")
+                        .HasDefaultValue(0L);
+
                     b.Property<long>("TimeCreated")
                         .HasColumnType("INTEGER");
+
+                    b.Property<int>("WhimsFulfilled")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("INTEGER")
+                        .HasDefaultValue(0);
 
                     b.Property<string>("VitalsJson")
                         .HasColumnType("TEXT")


### PR DESCRIPTION
## Summary
- add the MaleSprite and FemaleSprite columns to the SQLite game-context snapshot so the new pet descriptor fields are tracked
- extend the SQLite player-context snapshot with the persisted pet gender defaults and related state columns

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d85696910c832bb6ca9c844451d594