### PR TITLE
Prevent pet level clamp from throwing

### DIFF
--- a/Intersect.Server.Core/Entities/Player.cs
+++ b/Intersect.Server.Core/Entities/Player.cs
@@ -1369,7 +1369,8 @@ public partial class Player : Entity
 
         EnsurePlayerPetArraySizes(playerPet);
 
-        playerPet.Level = Math.Clamp(pet.Level, 1, pet.MaxLevel);
+        var maxLevel = Math.Max(1, pet.MaxLevel);
+        playerPet.Level = Math.Clamp(pet.Level, 1, maxLevel);
         playerPet.Experience = Math.Max(0, pet.Experience);
         playerPet.StatPoints = Math.Max(0, pet.StatPoints);
         playerPet.Energy = pet.Energy;


### PR DESCRIPTION
## Summary
- ensure persisted pet level clamping uses a minimum max level of 1 to avoid runtime exceptions when max level is 0

## Testing
- dotnet build Intersect.Server.Core/Intersect.Server.Core.csproj *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d86dd3fe6c832ba676819c873c5eca