### PR TITLE
Adjust pet retrieval to respect per-item pet instances

### DIFF
--- a/Intersect.Server.Core/Entities/Player.cs
+++ b/Intersect.Server.Core/Entities/Player.cs
@@ -1738,8 +1738,10 @@ public partial class Player : Entity
         {
             playerPet = Pets.FirstOrDefault(pet => pet.PetInstanceId == instanceId);
         }
-
-        playerPet ??= Pets.FirstOrDefault(pet => pet.PetDescriptorId == descriptor.Id);
+        else
+        {
+            playerPet = Pets.FirstOrDefault(pet => pet.PetDescriptorId == descriptor.Id);
+        }
 
         if (playerPet == null)
         {


### PR DESCRIPTION
## Summary
- guard the descriptor-based lookup in `TryGetOrCreatePlayerPet` so it only runs when no instance identifier is present
- ensure items with their own pet instance IDs keep independent progress

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d873f05f58832bb3a4af9ed20ba531