### PR TITLE
Ensure pets keep pursuing valid targets

### DIFF
--- a/Intersect.Server.Core/AI/Pets/PetBrain.cs
+++ b/Intersect.Server.Core/AI/Pets/PetBrain.cs
@@ -194,7 +194,21 @@ namespace Intersect.Server.AI.Pets
                 return;
             }
 
-            // 4) Posicionamiento según behavior
+            var currentTarget = _bb.CurrentTarget;
+            var hasValidTarget = IsValidEnemy(currentTarget);
+            if (!hasValidTarget)
+            {
+                _bb.CurrentTarget = null;
+            }
+
+            if (hasValidTarget && currentTarget != null)
+            {
+                // Mantener persecución o posicionamiento en torno al objetivo actual
+                MoveIntoAttackRange(currentTarget);
+                return;
+            }
+
+            // 4) Posicionamiento según behavior cuando no hay objetivo válido
             switch (_pet.Behavior)
             {
                 case PetState.Follow:


### PR DESCRIPTION
## Summary
- validate the pet's current target before falling back to non-combat positioning
- keep pets chasing valid targets by re-entering attack range instead of returning to the owner

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8777fff98832b8fc8cd2747ee2e1e