### PR TITLE
Add support for player shop map entities

### DIFF
--- a/Documentation/Features.md
+++ b/Documentation/Features.md
@@ -14,4 +14,8 @@ The homepage is accessible at [http://localhost:5400](http://localhost:5400) for
 
 ![Homepage Leaderboard](Features.HomepageLeaderboard.png)
 
+### Admin Commands
+
+Server administrators can now distribute items without leaving the admin window. The client includes item selectors that let you give items directly to a player (with optional bank overflow) or spawn items at their feet with an optional pickup reservation for that player.
+
 [API]: https://docs.freemmorpgmaker.com/en-US/api/v1/introduction/setup/

--- a/Framework/Intersect.Framework.Core/Entities/EntityType.cs
+++ b/Framework/Intersect.Framework.Core/Entities/EntityType.cs
@@ -10,5 +10,7 @@ public enum EntityType
 
     Projectile = 3,
 
-    Event = 4,
+    PlayerShop = 4,
+
+    Event = 5,
 }

--- a/Framework/Intersect.Framework.Core/Features/Admin/Actions/AdminAction.cs
+++ b/Framework/Intersect.Framework.Core/Features/Admin/Actions/AdminAction.cs
@@ -17,6 +17,9 @@ namespace Intersect.Admin.Actions;
 [Union(11, typeof(WarpToMapAction))]
 [Union(12, typeof(WarpToMeAction))]
 [Union(13, typeof(ReturnToOverworldAction))]
+[Union(14, typeof(GiveItemAction))]
+[Union(15, typeof(SpawnItemAction))]
+[Union(16, typeof(BroadcastMailAction))]
 public abstract partial class AdminAction
 {
     [Key(0)]

--- a/Framework/Intersect.Framework.Core/Features/Admin/Actions/BroadcastMailAction.cs
+++ b/Framework/Intersect.Framework.Core/Features/Admin/Actions/BroadcastMailAction.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using MessagePack;
+
+namespace Intersect.Admin.Actions;
+
+[MessagePackObject]
+public partial class BroadcastMailAction : AdminAction
+{
+    public BroadcastMailAction()
+    {
+    }
+
+    public const int MaxAttachments = 5;
+
+    public BroadcastMailAction(
+        string title,
+        string message,
+        IEnumerable<BroadcastMailAttachment> attachments,
+        bool onlineOnly
+    )
+    {
+        Title = title;
+        Message = message;
+        OnlineOnly = onlineOnly;
+        Attachments =
+            attachments?.Where(attachment => attachment != null)
+                .Select(attachment => new BroadcastMailAttachment(attachment.ItemId, attachment.Quantity))
+                .ToList() ?? new List<BroadcastMailAttachment>();
+    }
+
+    [Key(1)]
+    public override Enums.AdminAction Action { get; } = Enums.AdminAction.BroadcastMail;
+
+    [Key(2)]
+    public string Title { get; set; } = string.Empty;
+
+    [Key(3)]
+    public string Message { get; set; } = string.Empty;
+
+    [Key(4)]
+    public bool OnlineOnly { get; set; }
+
+    [Key(5)]
+    public List<BroadcastMailAttachment> Attachments { get; set; } = new();
+}
+
+[MessagePackObject]
+public sealed class BroadcastMailAttachment
+{
+    public BroadcastMailAttachment()
+    {
+    }
+
+    public BroadcastMailAttachment(Guid itemId, int quantity)
+    {
+        ItemId = itemId;
+        Quantity = quantity;
+    }
+
+    [Key(0)]
+    public Guid ItemId { get; set; } = Guid.Empty;
+
+    [Key(1)]
+    public int Quantity { get; set; } = 1;
+}

--- a/Framework/Intersect.Framework.Core/Features/Admin/Actions/GiveItemAction.cs
+++ b/Framework/Intersect.Framework.Core/Features/Admin/Actions/GiveItemAction.cs
@@ -1,0 +1,36 @@
+using System;
+using MessagePack;
+
+namespace Intersect.Admin.Actions;
+
+[MessagePackObject]
+public partial class GiveItemAction : AdminAction
+{
+    public GiveItemAction()
+    {
+
+    }
+
+    public GiveItemAction(string name, Guid itemId, int quantity, bool allowBankOverflow)
+    {
+        Name = name;
+        ItemId = itemId;
+        Quantity = quantity;
+        AllowBankOverflow = allowBankOverflow;
+    }
+
+    [Key(1)]
+    public override Enums.AdminAction Action { get; } = Enums.AdminAction.GiveItem;
+
+    [Key(2)]
+    public string Name { get; set; } = string.Empty;
+
+    [Key(3)]
+    public Guid ItemId { get; set; }
+
+    [Key(4)]
+    public int Quantity { get; set; }
+
+    [Key(5)]
+    public bool AllowBankOverflow { get; set; }
+}

--- a/Framework/Intersect.Framework.Core/Features/Admin/Actions/SpawnItemAction.cs
+++ b/Framework/Intersect.Framework.Core/Features/Admin/Actions/SpawnItemAction.cs
@@ -1,0 +1,36 @@
+using System;
+using MessagePack;
+
+namespace Intersect.Admin.Actions;
+
+[MessagePackObject]
+public partial class SpawnItemAction : AdminAction
+{
+    public SpawnItemAction()
+    {
+
+    }
+
+    public SpawnItemAction(string name, Guid itemId, int quantity, bool reserveForTarget)
+    {
+        Name = name;
+        ItemId = itemId;
+        Quantity = quantity;
+        ReserveForTarget = reserveForTarget;
+    }
+
+    [Key(1)]
+    public override Enums.AdminAction Action { get; } = Enums.AdminAction.SpawnItem;
+
+    [Key(2)]
+    public string Name { get; set; } = string.Empty;
+
+    [Key(3)]
+    public Guid ItemId { get; set; }
+
+    [Key(4)]
+    public int Quantity { get; set; }
+
+    [Key(5)]
+    public bool ReserveForTarget { get; set; }
+}

--- a/Framework/Intersect.Framework.Core/Features/Admin/AdminAction.cs
+++ b/Framework/Intersect.Framework.Core/Features/Admin/AdminAction.cs
@@ -30,5 +30,11 @@ public enum AdminAction
 
     SetAccess,
 
+    GiveItem,
+
+    SpawnItem,
+
     ReturnToOverworld,
+
+    BroadcastMail,
 }

--- a/Framework/Intersect.Framework.Core/Network/Packets/Server/EntityPacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Server/EntityPacket.cs
@@ -9,6 +9,7 @@ namespace Intersect.Network.Packets.Server;
 [Union(2, typeof(NpcEntityPacket))]
 [Union(3, typeof(ProjectileEntityPacket))]
 [Union(4, typeof(ResourceEntityPacket))]
+[Union(5, typeof(PlayerShopEntityPacket))]
 public abstract partial class EntityPacket : IntersectPacket
 {
 

--- a/Framework/Intersect.Framework.Core/Network/Packets/Server/PlayerShopEntityPacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Server/PlayerShopEntityPacket.cs
@@ -1,0 +1,15 @@
+using System;
+using MessagePack;
+
+namespace Intersect.Network.Packets.Server;
+
+[MessagePackObject]
+public partial class PlayerShopEntityPacket : EntityPacket
+{
+    public PlayerShopEntityPacket()
+    {
+    }
+
+    [Key(24)]
+    public Guid ShopId { get; set; }
+}

--- a/Intersect.Client.Core/Entities/Player.cs
+++ b/Intersect.Client.Core/Entities/Player.cs
@@ -1931,7 +1931,7 @@ public partial class Player : Entity, IPlayer
                     }
                 }
 
-                if (en.Value.Type is EntityType.GlobalEntity or EntityType.Player)
+                if (en.Value.Type is EntityType.GlobalEntity or EntityType.Player or EntityType.PlayerShop)
                 {
                     // Already in our list?
                     if (mlastTargetList.TryGetValue(en.Value, out var value))
@@ -2055,6 +2055,9 @@ public partial class Player : Entity, IPlayer
                 break;
             case Event:
                 TargetBox?.SetEntity(targetEntity, EntityType.Event);
+                break;
+            case PlayerShopEntity:
+                TargetBox?.SetEntity(targetEntity, EntityType.PlayerShop);
                 break;
             default:
                 TargetBox?.SetEntity(targetEntity, EntityType.GlobalEntity);

--- a/Intersect.Client.Core/Entities/PlayerShopEntity.cs
+++ b/Intersect.Client.Core/Entities/PlayerShopEntity.cs
@@ -1,0 +1,26 @@
+using System;
+using Intersect.Enums;
+using Intersect.Network.Packets.Server;
+
+namespace Intersect.Client.Entities;
+
+public sealed class PlayerShopEntity : Entity
+{
+    public PlayerShopEntity(Guid id, PlayerShopEntityPacket packet) : base(id, packet, EntityType.PlayerShop)
+    {
+    }
+
+    public Guid ShopId { get; private set; }
+
+    public override void Load(EntityPacket? packet)
+    {
+        base.Load(packet);
+
+        if (packet is not PlayerShopEntityPacket shopEntityPacket)
+        {
+            return;
+        }
+
+        ShopId = shopEntityPacket.ShopId;
+    }
+}

--- a/Intersect.Client.Core/Interface/Game/Admin/AdminItemManagementWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Admin/AdminItemManagementWindow.cs
@@ -1,0 +1,254 @@
+using System;
+using System.Linq;
+using Intersect.Admin.Actions;
+using Intersect.Client.Core;
+using Intersect.Client.Framework.Content;
+using Intersect.Client.Framework.Graphics;
+using Intersect.Client.Framework.Gwen;
+using Intersect.Client.Framework.Gwen.Control;
+using Intersect.Client.Framework.Gwen.Control.EventArguments;
+using Intersect.Client.Framework.Gwen.Control.Layout;
+using Intersect.Client.Interface.Shared;
+using Intersect.Client.Localization;
+using Intersect.Client.Networking;
+using Intersect.Framework.Core.GameObjects.Items;
+using static Intersect.Client.Framework.File_Management.GameContentManager;
+
+namespace Intersect.Client.Interface.Game.Admin;
+
+public sealed class AdminItemManagementWindow : Window
+{
+    private readonly IFont? _defaultFont;
+    private readonly TextBox _playerNameInput;
+    private readonly LabeledComboBox _itemDropdown;
+    private readonly TextBoxNumeric _quantityInput;
+    private readonly LabeledCheckBox _overflowCheckbox;
+    private readonly LabeledCheckBox _reserveCheckbox;
+    private readonly Button _giveItemButton;
+    private readonly Button _spawnItemButton;
+
+    public AdminItemManagementWindow() : base(
+        Interface.GameUi.GameCanvas,
+        Strings.AdminWindow.ItemManagement,
+        false,
+        nameof(AdminItemManagementWindow)
+    )
+    {
+        _defaultFont = Skin?.DefaultFont ?? Current.GetFont(TitleLabel.FontName);
+
+        IsResizable = false;
+        MinimumSize = new Point(460, 320);
+        InnerPanelPadding = new Padding(8);
+        InnerPanel.DockChildSpacing = new Padding(0, 8, 0, 0);
+
+        var contentPanel = new Panel(this, "ContentPanel")
+        {
+            Dock = Pos.Fill,
+            ShouldDrawBackground = false,
+            DockChildSpacing = new Padding(0, 8, 0, 0),
+        };
+
+        _ = new Label(contentPanel, "PlayerNameLabel")
+        {
+            Dock = Pos.Top,
+            Font = _defaultFont,
+            FontSize = 12,
+            Text = Strings.AdminWindow.Name,
+        };
+
+        _playerNameInput = new TextBox(contentPanel, nameof(_playerNameInput))
+        {
+            Dock = Pos.Top,
+            Font = _defaultFont,
+            FontSize = 12,
+            PlaceholderText = Strings.AdminWindow.NamePlaceholder,
+        };
+        Interface.FocusComponents.Add(_playerNameInput);
+        _playerNameInput.TextChanged += (_, _) => UpdateActionControls();
+
+        _itemDropdown = new LabeledComboBox(contentPanel, nameof(_itemDropdown))
+        {
+            Dock = Pos.Top,
+            Font = _defaultFont,
+            FontSize = 12,
+            Label = Strings.AdminWindow.Item,
+            TextPadding = new Padding(8, 4, 0, 4),
+        };
+        PopulateItemDropdown(_itemDropdown);
+        _itemDropdown.ItemSelected += (_, _) => UpdateActionControls();
+
+        var quantityPanel = new Panel(contentPanel, "QuantityPanel")
+        {
+            Dock = Pos.Top,
+            ShouldDrawBackground = false,
+        };
+
+        _ = new Label(quantityPanel, "QuantityLabel")
+        {
+            Dock = Pos.Left,
+            Font = _defaultFont,
+            FontSize = 12,
+            Margin = new Margin(0, 0, 4, 0),
+            Text = Strings.AdminWindow.Quantity,
+            TextAlign = Pos.Left | Pos.CenterV,
+        };
+
+        _quantityInput = new TextBoxNumeric(quantityPanel, nameof(_quantityInput))
+        {
+            Dock = Pos.Fill,
+            Font = _defaultFont,
+            FontSize = 12,
+            Padding = new Padding(8, 4),
+        };
+        _quantityInput.SetRange(1, int.MaxValue);
+        _quantityInput.Value = 1;
+        _quantityInput.ValueChanged += (_, _) => UpdateActionControls();
+        Interface.FocusComponents.Add(_quantityInput);
+
+        _overflowCheckbox = new LabeledCheckBox(contentPanel, nameof(_overflowCheckbox))
+        {
+            Dock = Pos.Top,
+            Font = _defaultFont,
+            FontSize = 12,
+            Margin = new Margin(0, 4, 0, 0),
+            Text = Strings.AdminWindow.AllowOverflow,
+        };
+
+        _reserveCheckbox = new LabeledCheckBox(contentPanel, nameof(_reserveCheckbox))
+        {
+            Dock = Pos.Top,
+            Font = _defaultFont,
+            FontSize = 12,
+            Margin = new Margin(0, 4, 0, 0),
+            Text = Strings.AdminWindow.ReserveSpawn,
+        };
+
+        var buttonsPanel = new Panel(contentPanel, "ButtonsPanel")
+        {
+            Dock = Pos.Top,
+            ShouldDrawBackground = false,
+            DockChildSpacing = new Padding(8, 0, 0, 0),
+        };
+
+        _giveItemButton = new Button(buttonsPanel, nameof(_giveItemButton))
+        {
+            Dock = Pos.Left,
+            Text = Strings.AdminWindow.GiveItem,
+        };
+        StyleButton(_giveItemButton);
+        _giveItemButton.Clicked += GiveItemButtonOnClicked;
+
+        _spawnItemButton = new Button(buttonsPanel, nameof(_spawnItemButton))
+        {
+            Dock = Pos.Left,
+            Text = Strings.AdminWindow.SpawnItem,
+        };
+        StyleButton(_spawnItemButton);
+        _spawnItemButton.Clicked += SpawnItemButtonOnClicked;
+
+        UpdateActionControls();
+    }
+
+    private string PlayerName => _playerNameInput.Text?.Trim() ?? string.Empty;
+
+    private static Padding StdPad(int x = 8, int y = 4) => new(x, y);
+
+    private void StyleButton(Button button)
+    {
+        button.MinimumSize = new Point(120, 28);
+        button.Padding = StdPad();
+        button.Margin = new Margin(0, 0, 8, 0);
+        button.Font = _defaultFont;
+        button.FontSize = 12;
+    }
+
+    private static void PopulateItemDropdown(LabeledComboBox dropdown)
+    {
+        dropdown.ClearItems();
+
+        var noneItem = dropdown.AddItem(Strings.AdminWindow.None, userData: Guid.Empty);
+
+        foreach (var descriptor in ItemDescriptor.Lookup.Values
+                     .OfType<ItemDescriptor>()
+                     .OrderBy(descriptor => descriptor?.Name ?? string.Empty, StringComparer.CurrentCultureIgnoreCase))
+        {
+            if (descriptor == null)
+            {
+                continue;
+            }
+
+            var displayName = descriptor.Name;
+            if (string.IsNullOrWhiteSpace(displayName))
+            {
+                displayName = descriptor.Id.ToString();
+            }
+
+            _ = dropdown.AddItem(displayName, userData: descriptor.Id);
+        }
+
+        dropdown.SelectedItem = noneItem;
+    }
+
+    private bool TryGetItemActionParameters(out string playerName, out Guid itemId, out int quantity)
+    {
+        playerName = PlayerName;
+        if (playerName.Length == 0)
+        {
+            itemId = Guid.Empty;
+            quantity = 0;
+            return false;
+        }
+
+        if (!(_itemDropdown.SelectedItem?.UserData is Guid selectedItemId) || selectedItemId == Guid.Empty)
+        {
+            itemId = Guid.Empty;
+            quantity = 0;
+            return false;
+        }
+
+        quantity = (int)Math.Max(1, Math.Round(_quantityInput.Value));
+        itemId = selectedItemId;
+        return true;
+    }
+
+    private void GiveItemButtonOnClicked(Base sender, MouseButtonState args)
+    {
+        if (!TryGetItemActionParameters(out var playerName, out var itemId, out var quantity))
+        {
+            return;
+        }
+
+        PacketSender.SendAdminAction(
+            new GiveItemAction(playerName, itemId, quantity, _overflowCheckbox.IsChecked)
+        );
+    }
+
+    private void SpawnItemButtonOnClicked(Base sender, MouseButtonState args)
+    {
+        if (!TryGetItemActionParameters(out var playerName, out var itemId, out var quantity))
+        {
+            return;
+        }
+
+        PacketSender.SendAdminAction(
+            new SpawnItemAction(playerName, itemId, quantity, _reserveCheckbox.IsChecked)
+        );
+    }
+
+    private void UpdateActionControls()
+    {
+        var hasPlayer = PlayerName.Length > 0;
+        var quantityValid = _quantityInput.Value >= 1;
+        var hasItem = _itemDropdown.SelectedItem?.UserData is Guid selectedItemId && selectedItemId != Guid.Empty;
+
+        var shouldEnable = hasPlayer && quantityValid && hasItem;
+
+        _giveItemButton.IsDisabled = !shouldEnable;
+        _spawnItemButton.IsDisabled = !shouldEnable;
+    }
+
+    protected override void EnsureInitialized()
+    {
+        LoadJsonUi(UI.InGame, Graphics.Renderer?.GetResolutionString(), saveOutput: true);
+    }
+}

--- a/Intersect.Client.Core/Interface/Game/Admin/AdminMailBroadcastWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Admin/AdminMailBroadcastWindow.cs
@@ -1,0 +1,290 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Intersect.Admin.Actions;
+using Intersect.Client.Core;
+using Intersect.Client.Framework.Content;
+using Intersect.Client.Framework.Graphics;
+using Intersect.Client.Framework.Gwen;
+using Intersect.Client.Framework.Gwen.Control;
+using Intersect.Client.Framework.Gwen.Control.EventArguments;
+using Intersect.Client.Framework.Gwen.Control.Layout;
+using Intersect.Client.Interface.Shared;
+using Intersect.Client.Localization;
+using Intersect.Client.Networking;
+using Intersect.Framework.Core.GameObjects.Items;
+using static Intersect.Client.Framework.File_Management.GameContentManager;
+
+namespace Intersect.Client.Interface.Game.Admin;
+
+public sealed class AdminMailBroadcastWindow : Window
+{
+    private const int MailAttachmentSlotCount = BroadcastMailAction.MaxAttachments;
+
+    private readonly IFont? _defaultFont;
+    private readonly TextBox _subjectInput;
+    private readonly MultilineTextBox _messageInput;
+    private readonly LabeledComboBox[] _attachmentDropdowns;
+    private readonly TextBoxNumeric[] _attachmentQuantityInputs;
+    private readonly LabeledCheckBox _onlineOnlyCheckbox;
+    private readonly Button _sendButton;
+
+    public AdminMailBroadcastWindow() : base(
+        Interface.GameUi.GameCanvas,
+        Strings.AdminWindow.MailBroadcast,
+        false,
+        nameof(AdminMailBroadcastWindow)
+    )
+    {
+        _defaultFont = Skin?.DefaultFont ?? Current.GetFont(TitleLabel.FontName);
+
+        IsResizable = false;
+        MinimumSize = new Point(520, 520);
+        InnerPanelPadding = new Padding(8);
+        InnerPanel.DockChildSpacing = new Padding(0, 8, 0, 0);
+
+        _attachmentDropdowns = new LabeledComboBox[MailAttachmentSlotCount];
+        _attachmentQuantityInputs = new TextBoxNumeric[MailAttachmentSlotCount];
+
+        var contentPanel = new Panel(this, "ContentPanel")
+        {
+            Dock = Pos.Fill,
+            ShouldDrawBackground = false,
+            DockChildSpacing = new Padding(0, 8, 0, 0),
+        };
+
+        _ = new Label(contentPanel, "SubjectLabel")
+        {
+            Dock = Pos.Top,
+            Font = _defaultFont,
+            FontSize = 12,
+            Text = Strings.AdminWindow.MailSubject,
+        };
+
+        _subjectInput = new TextBox(contentPanel, nameof(_subjectInput))
+        {
+            Dock = Pos.Top,
+            Font = _defaultFont,
+            FontSize = 12,
+        };
+        Interface.FocusComponents.Add(_subjectInput);
+        _subjectInput.TextChanged += (_, _) => UpdateActionControls();
+
+        _ = new Label(contentPanel, "MessageLabel")
+        {
+            Dock = Pos.Top,
+            Font = _defaultFont,
+            FontSize = 12,
+            Text = Strings.AdminWindow.MailMessage,
+        };
+
+        _messageInput = new MultilineTextBox(contentPanel)
+        {
+            Dock = Pos.Top,
+            Font = _defaultFont,
+            FontSize = 12,
+            Height = 200,
+        };
+        _messageInput.Name = nameof(_messageInput);
+        Interface.FocusComponents.Add(_messageInput);
+        _messageInput.TextChanged += (_, _) => UpdateActionControls();
+
+        var attachmentsContainer = new Panel(contentPanel, "AttachmentsContainer")
+        {
+            Dock = Pos.Top,
+            ShouldDrawBackground = false,
+            DockChildSpacing = new Padding(0, 8, 0, 0),
+        };
+
+        for (var index = 0; index < MailAttachmentSlotCount; index++)
+        {
+            var attachmentPanel = new Panel(attachmentsContainer, $"Attachment{index}")
+            {
+                Dock = Pos.Top,
+                ShouldDrawBackground = false,
+            };
+
+            var dropdown = new LabeledComboBox(attachmentPanel, $"AttachmentDropdown{index}")
+            {
+                Dock = Pos.Top,
+                Font = _defaultFont,
+                FontSize = 12,
+                Label = Strings.AdminWindow.MailAttachmentItem.ToString(index + 1),
+                TextPadding = new Padding(8, 4, 0, 4),
+            };
+            PopulateItemDropdown(dropdown);
+            dropdown.ItemSelected += (_, _) => UpdateActionControls();
+
+            var quantityPanel = new Panel(attachmentPanel, $"AttachmentQuantityPanel{index}")
+            {
+                Dock = Pos.Top,
+                ShouldDrawBackground = false,
+                Margin = new Margin(0, 4, 0, 0),
+            };
+
+            _ = new Label(quantityPanel, $"AttachmentQuantityLabel{index}")
+            {
+                Dock = Pos.Left,
+                Font = _defaultFont,
+                FontSize = 12,
+                Margin = new Margin(0, 0, 4, 0),
+                Text = Strings.AdminWindow.MailAttachmentQuantity.ToString(index + 1),
+                TextAlign = Pos.Left | Pos.CenterV,
+            };
+
+            var quantityInput = new TextBoxNumeric(quantityPanel, $"AttachmentQuantityInput{index}")
+            {
+                Dock = Pos.Fill,
+                Font = _defaultFont,
+                FontSize = 12,
+                Padding = new Padding(8, 4),
+            };
+            quantityInput.SetRange(1, int.MaxValue);
+            quantityInput.Value = 1;
+            quantityInput.ValueChanged += (_, _) => UpdateActionControls();
+            Interface.FocusComponents.Add(quantityInput);
+
+            _attachmentDropdowns[index] = dropdown;
+            _attachmentQuantityInputs[index] = quantityInput;
+        }
+
+        _onlineOnlyCheckbox = new LabeledCheckBox(contentPanel, nameof(_onlineOnlyCheckbox))
+        {
+            Dock = Pos.Top,
+            Font = _defaultFont,
+            FontSize = 12,
+            Text = Strings.AdminWindow.MailOnlineOnly,
+        };
+
+        var buttonsPanel = new Panel(contentPanel, "ButtonsPanel")
+        {
+            Dock = Pos.Top,
+            ShouldDrawBackground = false,
+        };
+
+        _sendButton = new Button(buttonsPanel, nameof(_sendButton))
+        {
+            Dock = Pos.Left,
+            Text = Strings.AdminWindow.MailSend,
+        };
+        StyleButton(_sendButton);
+        _sendButton.Clicked += SendButtonOnClicked;
+
+        UpdateActionControls();
+    }
+
+    private static Padding StdPad(int x = 8, int y = 4) => new(x, y);
+
+    private void StyleButton(Button button)
+    {
+        button.MinimumSize = new Point(140, 32);
+        button.Padding = StdPad();
+        button.Margin = new Margin(0, 0, 8, 0);
+        button.Font = _defaultFont;
+        button.FontSize = 12;
+    }
+
+    private static void PopulateItemDropdown(LabeledComboBox dropdown)
+    {
+        dropdown.ClearItems();
+
+        var noneItem = dropdown.AddItem(Strings.AdminWindow.None, userData: Guid.Empty);
+
+        foreach (var descriptor in ItemDescriptor.Lookup.Values
+                     .OfType<ItemDescriptor>()
+                     .OrderBy(descriptor => descriptor?.Name ?? string.Empty, StringComparer.CurrentCultureIgnoreCase))
+        {
+            if (descriptor == null)
+            {
+                continue;
+            }
+
+            var displayName = descriptor.Name;
+            if (string.IsNullOrWhiteSpace(displayName))
+            {
+                displayName = descriptor.Id.ToString();
+            }
+
+            _ = dropdown.AddItem(displayName, userData: descriptor.Id);
+        }
+
+        dropdown.SelectedItem = noneItem;
+    }
+
+    private void SendButtonOnClicked(Base sender, MouseButtonState args)
+    {
+        var subject = _subjectInput.Text?.Trim() ?? string.Empty;
+        var message = _messageInput.Text?.Trim() ?? string.Empty;
+
+        if (string.IsNullOrWhiteSpace(subject) || string.IsNullOrWhiteSpace(message))
+        {
+            return;
+        }
+
+        PacketSender.SendAdminAction(
+            new BroadcastMailAction(
+                subject,
+                message,
+                CollectAttachments(),
+                _onlineOnlyCheckbox.IsChecked
+            )
+        );
+    }
+
+    private List<BroadcastMailAttachment> CollectAttachments()
+    {
+        var attachments = new List<BroadcastMailAttachment>();
+
+        for (var index = 0; index < _attachmentDropdowns.Length; index++)
+        {
+            var dropdown = _attachmentDropdowns[index];
+            var quantityInput = _attachmentQuantityInputs[index];
+
+            if (!(dropdown?.SelectedItem?.UserData is Guid itemId) || itemId == Guid.Empty)
+            {
+                continue;
+            }
+
+            var quantity = (int)Math.Max(1, Math.Round(quantityInput?.Value ?? 0));
+            if (quantity <= 0)
+            {
+                continue;
+            }
+
+            attachments.Add(new BroadcastMailAttachment(itemId, quantity));
+        }
+
+        return attachments;
+    }
+
+    private void UpdateActionControls()
+    {
+        var hasSubject = !string.IsNullOrWhiteSpace(_subjectInput.Text);
+        var hasMessage = !string.IsNullOrWhiteSpace(_messageInput.Text);
+        var attachmentsValid = true;
+
+        for (var index = 0; index < _attachmentDropdowns.Length; index++)
+        {
+            var dropdown = _attachmentDropdowns[index];
+            var quantityInput = _attachmentQuantityInputs[index];
+
+            if (!(dropdown?.SelectedItem?.UserData is Guid attachmentItemId) || attachmentItemId == Guid.Empty)
+            {
+                continue;
+            }
+
+            if ((quantityInput?.Value ?? 0) < 1)
+            {
+                attachmentsValid = false;
+                break;
+            }
+        }
+
+        _sendButton.IsDisabled = !(hasSubject && hasMessage && attachmentsValid);
+    }
+
+    protected override void EnsureInitialized()
+    {
+        LoadJsonUi(UI.InGame, Graphics.Renderer?.GetResolutionString(), saveOutput: true);
+    }
+}

--- a/Intersect.Client.Core/Interface/Game/Admin/AdminWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Admin/AdminWindow.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using Intersect.Admin.Actions;
 using Intersect.Client.Core;
 using Intersect.Client.Framework.Content;
@@ -20,6 +23,8 @@ namespace Intersect.Client.Interface.Game.Admin;
 
 public partial class AdminWindow : Window
 {
+    private readonly Panel _contentPanel;
+
     private readonly LabeledComboBox _accessDropdown;
 
     private readonly Panel _accessPanel;
@@ -27,6 +32,10 @@ public partial class AdminWindow : Window
 
     private readonly Panel _actionPanel;
     private readonly Table _actionTable;
+    private readonly Button _openItemWindowButton;
+    private readonly Button _openMailWindowButton;
+    private readonly ScrollControl _leftColumn;
+    private readonly TabControl _leftTabs;
     private readonly Button _banButton;
     private readonly IFont? _defaultFont;
     private readonly TexturePicker _faceTexturePicker;
@@ -37,11 +46,12 @@ public partial class AdminWindow : Window
 
     private readonly Panel _mapListPanel;
     private readonly Panel _mapListPanelHeader;
+    private readonly Panel _mapTreeContainer;
     private readonly LabeledCheckBox _mapSortCheckbox;
     private readonly Button _muteButton;
     private readonly TextBox _nameInput;
     private readonly Label _nameLabel;
-
+    private readonly Panel? _leftHeader;
     private readonly Panel _namePanel;
 
     private readonly TexturePicker _spriteTexturePicker;
@@ -52,7 +62,6 @@ public partial class AdminWindow : Window
 
     private BanMuteBox? _banOrMuteWindow;
     private TreeControl? _mapTree;
-
     public AdminWindow(Base gameCanvas) : base(
         gameCanvas,
         Strings.AdminWindow.Title,
@@ -60,18 +69,62 @@ public partial class AdminWindow : Window
         nameof(AdminWindow)
     )
     {
-        _defaultFont = Current.GetFont(TitleLabel.FontName);
+        _defaultFont = Skin?.DefaultFont ?? Current.GetFont(TitleLabel.FontName);
 
         IsResizable = false;
         TitleLabel.FontSize = 14;
 
-        MinimumSize = new Point(396, 600);
+        MinimumSize = new Point(720, 600);
         InnerPanelPadding = new Padding(8);
         InnerPanel.DockChildSpacing = new Padding(8);
 
+        _contentPanel = new Panel(this, nameof(_contentPanel))
+        {
+            Dock = Pos.Fill,
+            ShouldDrawBackground = false,
+            DockChildSpacing = new Padding(8),
+        };
+
+        _leftColumn = new ScrollControl(_contentPanel, nameof(_leftColumn))
+        {
+            AutoHideBars = true,
+            Dock = Pos.Left,
+            InnerPanelPadding = Padding.Zero,
+            Margin = new Margin(0, 0, 8, 0),
+            ShouldDrawBackground = false,
+            Width = 360,
+        };
+        _leftColumn.SetOverflow(OverflowBehavior.Hidden, OverflowBehavior.Auto);
+
+        _leftTabs = new TabControl(_leftColumn, nameof(_leftTabs))
+        {
+            Dock = Pos.Fill,
+            ShouldDrawBackground = false,
+        };
+
+        ScrollControl AddTab(string name)
+        {
+            var page = _leftTabs.AddPage(name).Page;
+            page.Dock = Pos.Fill;
+
+            var scroll = new ScrollControl(page, $"{name}Scroll")
+            {
+                Dock = Pos.Fill,
+                AutoHideBars = true,
+                ShouldDrawBackground = false,
+                InnerPanelPadding = Padding.Zero,
+            };
+            scroll.SetOverflow(OverflowBehavior.Hidden, OverflowBehavior.Auto);
+            scroll.InnerPanel.DockChildSpacing = new Padding(0, 12, 0, 0);
+            return scroll;
+        }
+
+        var actionsTab = AddTab(Strings.AdminWindow.QuickActions);
+        var appearTab = AddTab(Strings.AdminWindow.Appearance);
+
         #region Name Input
 
-        _namePanel = new Panel(this, nameof(_namePanel))
+        _namePanel = new Panel(actionsTab, nameof(_namePanel))
         {
             Dock = Pos.Top, ShouldDrawBackground = false,
         };
@@ -98,7 +151,7 @@ public partial class AdminWindow : Window
 
         #region Access
 
-        _accessPanel = new Panel(this, nameof(_accessPanel))
+        _accessPanel = new Panel(actionsTab, nameof(_accessPanel))
         {
             Dock = Pos.Top, ShouldDrawBackground = false,
         };
@@ -131,113 +184,106 @@ public partial class AdminWindow : Window
 
         #region Quick Admin Actions
 
-        _actionPanel = new Panel(this, nameof(_actionPanel))
+        var quickActionsSection = new Panel(actionsTab, "QuickActionsSection")
         {
-            Dock = Pos.Top, ShouldDrawBackground = false,
+            Dock = Pos.Top,
+            DockChildSpacing = new Padding(0, 8, 0, 0),
+            ShouldDrawBackground = false,
+        };
+
+        _ = new Label(quickActionsSection, "QuickActionsLabel")
+        {
+            Dock = Pos.Top,
+            Font = _defaultFont,
+            FontSize = 12,
+            Text = Strings.AdminWindow.QuickActions,
+        };
+
+        _actionPanel = new Panel(quickActionsSection, nameof(_actionPanel))
+        {
+            Dock = Pos.Top,
+            ShouldDrawBackground = false,
         };
 
         _actionTable = new Table(_actionPanel, nameof(_actionTable))
         {
             CellSpacing = new Point(8, 8),
             ColumnCount = 3,
-            Dock = Pos.Fill,
+            Dock = Pos.Top,
             FitRowHeightToContents = true,
             Font = _defaultFont,
             FontSize = 12,
             SizeToContents = true,
         };
+        _actionTable.AutoSizeToContentWidth = true;
+        _actionTable.AutoSizeToContentHeight = true;
+        _actionTable.AutoSizeToContentWidthOnChildResize = true;
+        _actionTable.AutoSizeToContentHeightOnChildResize = true;
 
         _warpMeToPlayerButton = new Button(_actionPanel, nameof(_warpMeToPlayerButton))
         {
-            Font = _defaultFont,
-            FontSize = 12,
-            MinimumSize = new Point(120, 0),
-            Padding = new Padding(8, 4),
             Text = Strings.AdminWindow.WarpMeToPlayer,
         };
+        StyleButton(_warpMeToPlayerButton);
         _warpMeToPlayerButton.Clicked += WarpMeToPlayerButtonOnClicked;
 
         _kickPlayerButton = new Button(_actionPanel, nameof(_kickPlayerButton))
         {
-            Font = _defaultFont,
-            FontSize = 12,
-            MinimumSize = new Point(120, 0),
-            Padding = new Padding(8, 4),
             Text = Strings.AdminWindow.KickPlayer,
         };
+        StyleButton(_kickPlayerButton);
         _kickPlayerButton.Clicked += KickPlayerButtonOnClicked;
 
         _killPlayerButton = new Button(_actionPanel, nameof(_killPlayerButton))
         {
-            Font = _defaultFont,
-            FontSize = 12,
-            MinimumSize = new Point(120, 0),
-            Padding = new Padding(8, 4),
             Text = Strings.AdminWindow.KillPlayer,
         };
+        StyleButton(_killPlayerButton);
         _killPlayerButton.Clicked += KillPlayerButtonOnClicked;
 
         _warpPlayerToMeButton = new Button(_actionPanel, nameof(_warpPlayerToMeButton))
         {
-            Font = _defaultFont,
-            FontSize = 12,
-            MinimumSize = new Point(120, 0),
-            Padding = new Padding(8, 4),
             Text = Strings.AdminWindow.WarpPlayerToMe,
         };
+        StyleButton(_warpPlayerToMeButton);
         _warpPlayerToMeButton.Clicked += WarpPlayerToMeButtonOnClicked;
 
         _muteButton = new Button(_actionPanel, nameof(_muteButton))
         {
-            Font = _defaultFont,
-            FontSize = 12,
-            MinimumSize = new Point(120, 0),
-            Padding = new Padding(8, 4),
             Text = Strings.AdminWindow.Mute,
         };
+        StyleButton(_muteButton);
         _muteButton.Clicked += MuteButtonOnClicked;
 
         _unmuteButton = new Button(_actionPanel, nameof(_unmuteButton))
         {
-            Font = _defaultFont,
-            FontSize = 12,
-            MinimumSize = new Point(120, 0),
-            Padding = new Padding(8, 4),
             Text = Strings.AdminWindow.Unmute,
         };
+        StyleButton(_unmuteButton);
         _unmuteButton.Clicked += UnmuteButtonOnClicked;
 
         _leaveInstanceButton = new Button(_actionPanel, nameof(_leaveInstanceButton))
         {
-            Font = _defaultFont,
-            FontSize = 12,
-            MinimumSize = new Point(120, 0),
-            Padding = new Padding(8, 4),
             Text = Strings.AdminWindow.LeaveInstance,
         };
+        StyleButton(_leaveInstanceButton);
         _leaveInstanceButton.Clicked += LeaveInstanceButtonOnClicked;
 
         _banButton = new Button(_actionPanel, nameof(_banButton))
         {
-            Font = _defaultFont,
-            FontSize = 12,
-            MinimumSize = new Point(120, 0),
-            Padding = new Padding(8, 4),
             Text = Strings.AdminWindow.Ban,
         };
+        StyleButton(_banButton);
         _banButton.Clicked += BanButtonOnClicked;
 
         _unbanButton = new Button(_actionPanel, nameof(_unbanButton))
         {
-            Font = _defaultFont,
-            FontSize = 12,
-            MinimumSize = new Point(120, 0),
-            Padding = new Padding(8, 4),
             Text = Strings.AdminWindow.Unban,
         };
+        StyleButton(_unbanButton);
         _unbanButton.Clicked += UnbanButtonOnClicked;
 
-        var rowsAdded = _actionTable.AddCells(
+        _actionTable.AddCells(
             _warpMeToPlayerButton,
             _kickPlayerButton,
             _killPlayerButton,
@@ -249,11 +295,92 @@ public partial class AdminWindow : Window
             _unbanButton
         );
 
+#if DEBUG
+        foreach (var button in new[]
+                 {
+                     _warpMeToPlayerButton,
+                     _kickPlayerButton,
+                     _killPlayerButton,
+                     _warpPlayerToMeButton,
+                     _muteButton,
+                     _unmuteButton,
+                     _leaveInstanceButton,
+                     _banButton,
+                     _unbanButton,
+                 })
+        {
+            button.IsDisabled = false;
+        }
+#endif
+
+        _actionPanel.SizeToChildren(recursive: true);
+        quickActionsSection.SizeToChildren(recursive: true);
+
         #endregion Quick Admin Actions
+
+        #region Additional Interfaces
+
+        var externalInterfacesSection = new Panel(actionsTab, "ExternalInterfacesSection")
+        {
+            Dock = Pos.Top,
+            ShouldDrawBackground = false,
+            DockChildSpacing = new Padding(0, 8, 0, 0),
+        };
+
+        _ = new Label(externalInterfacesSection, "ExternalInterfacesLabel")
+        {
+            Dock = Pos.Top,
+            Font = _defaultFont,
+            FontSize = 12,
+            Text = Strings.AdminWindow.AdditionalInterfaces,
+        };
+
+        var externalButtonsPanel = new Panel(externalInterfacesSection, "ExternalButtonsPanel")
+        {
+            Dock = Pos.Top,
+            ShouldDrawBackground = false,
+        };
+
+        _openItemWindowButton = new Button(externalButtonsPanel, nameof(_openItemWindowButton))
+        {
+            Dock = Pos.Left,
+            Text = Strings.AdminWindow.ItemManagement,
+        };
+        StyleButton(_openItemWindowButton);
+        _openItemWindowButton.Clicked += OpenItemWindowButtonOnClicked;
+
+        _openMailWindowButton = new Button(externalButtonsPanel, nameof(_openMailWindowButton))
+        {
+            Dock = Pos.Left,
+            Text = Strings.AdminWindow.MailBroadcast,
+        };
+        StyleButton(_openMailWindowButton);
+        _openMailWindowButton.Clicked += OpenMailWindowButtonOnClicked;
+
+        externalInterfacesSection.SizeToChildren(recursive: true);
+
+        #endregion Additional Interfaces
+
+
 
         #region Sprite/Face Pickers
 
-        _spriteTexturePicker = new TexturePicker(this, nameof(_spriteTexturePicker))
+        var appearanceSection = new Panel(appearTab, "AppearanceSection")
+        {
+            Dock = Pos.Top,
+            DockChildSpacing = new Padding(0, 8, 0, 0),
+            ShouldDrawBackground = false,
+        };
+
+        _ = new Label(appearanceSection, "AppearanceLabel")
+        {
+            Dock = Pos.Top,
+            Font = _defaultFont,
+            FontSize = 12,
+            Text = Strings.AdminWindow.Appearance,
+        };
+
+        _spriteTexturePicker = new TexturePicker(appearanceSection, nameof(_spriteTexturePicker))
         {
             Dock = Pos.Top,
             Font = _defaultFont,
@@ -264,29 +391,36 @@ public partial class AdminWindow : Window
         };
         _spriteTexturePicker.Submitted += SpriteTexturePickerOnSubmitted;
 
-        _faceTexturePicker = new TexturePicker(this, nameof(_faceTexturePicker))
+        _faceTexturePicker = new TexturePicker(appearanceSection, nameof(_faceTexturePicker))
         {
             Dock = Pos.Top,
             Font = _defaultFont,
             FontSize = 12,
             ButtonText = Strings.AdminWindow.SetFace,
             LabelText = Strings.AdminWindow.Face,
+            Margin = new Margin(0, 4, 0, 0),
             TextureType = TextureType.Face,
         };
         _faceTexturePicker.Submitted += FaceTexturePickerOnSubmitted;
+
+        appearanceSection.SizeToChildren(recursive: true);
 
         #endregion Sprite/Face Pickers
 
         #region Map List
 
-        _mapListPanel = new Panel(this, nameof(_mapListPanel))
+        _mapListPanel = new Panel(_contentPanel, nameof(_mapListPanel))
         {
-            Dock = Pos.Fill, ShouldDrawBackground = false,
+            Dock = Pos.Fill,
+            DockChildSpacing = new Padding(0, 8, 0, 0),
+            ShouldDrawBackground = false,
         };
 
         _mapListPanelHeader = new Panel(_mapListPanel, nameof(_mapListPanelHeader))
         {
-            Dock = Pos.Top, ShouldDrawBackground = false,
+            Dock = Pos.Top,
+            DockChildSpacing = new Padding(8, 0, 0, 0),
+            ShouldDrawBackground = false,
         };
 
         _mapListLabel = new Label(_mapListPanelHeader, nameof(_mapListLabel))
@@ -302,6 +436,7 @@ public partial class AdminWindow : Window
             Dock = Pos.Right,
             Font = _defaultFont,
             FontSize = 12,
+            Margin = new Margin(8, 0, 0, 0),
             Text = Strings.AdminWindow.SortMapList,
             TooltipText = Strings.AdminWindow.SortMapListTooltip,
             TooltipFont = _defaultFont,
@@ -310,12 +445,29 @@ public partial class AdminWindow : Window
 
         _mapSortCheckbox.CheckChanged += MapSortCheckboxOnCheckChanged;
 
-        _mapListPanel.SizeToChildren(recursive: true);
+        _mapTreeContainer = new Panel(_mapListPanel, nameof(_mapTreeContainer))
+        {
+            Dock = Pos.Fill,
+            ShouldDrawBackground = false,
+        };
 
         #endregion Map List
 
         SkipRender();
     }
+
+    private static Padding StdPad(int x = 8, int y = 4) => new Padding(x, y);
+
+    private void StyleButton(Button button)
+    {
+        button.MinimumSize = new Point(120, 28);
+        button.Padding = StdPad();
+        button.Margin = new Margin(0, 0, 8, 0);
+        button.Font = _defaultFont;
+        button.FontSize = 12;
+    }
+
+
 
     protected override void EnsureInitialized()
     {
@@ -323,10 +475,33 @@ public partial class AdminWindow : Window
 
         LoadJsonUi(UI.InGame, Graphics.Renderer?.GetResolutionString(), saveOutput: true);
 
+        // Asegura layout correcto aunque el JSON no tenga todo
+        ForcePostJsonLayout();
+
         UpdateMapList();
     }
 
     #region Action Handlers
+
+
+
+
+
+
+
+    private void OpenItemWindowButtonOnClicked(Base sender, MouseButtonState args)
+    {
+        Interface.GameUi.OpenAdminItemManagementWindow();
+    }
+
+    private void OpenMailWindowButtonOnClicked(Base sender, MouseButtonState args)
+    {
+        Interface.GameUi.OpenAdminMailBroadcastWindow();
+    }
+
+
+
+
 
     private void UnbanButtonOnClicked(Base s, MouseButtonState e)
     {
@@ -401,7 +576,10 @@ public partial class AdminWindow : Window
     public string? PlayerName
     {
         get => _nameInput.Text?.Trim();
-        set => _nameInput.Text = value;
+        set
+        {
+            _nameInput.Text = value;
+        }
     }
 
     private void FaceTexturePickerOnSubmitted(TexturePicker sender, ValueChangedEventArgs<string?> arguments)
@@ -514,6 +692,8 @@ public partial class AdminWindow : Window
         );
     }
 
+
+
     private void MapSortCheckboxOnCheckChanged(ICheckbox sender, ValueChangedEventArgs<bool> eventArgs)
     {
         UpdateMapList();
@@ -523,7 +703,7 @@ public partial class AdminWindow : Window
     {
         _mapTree?.DelayedDelete();
 
-        _mapTree = new TreeControl(_mapListPanel, nameof(_mapTree))
+        _mapTree = new TreeControl(_mapTreeContainer, nameof(_mapTree))
         {
             Dock = Pos.Fill,
             Font = _defaultFont,
@@ -612,6 +792,64 @@ public partial class AdminWindow : Window
         }
 
         PacketSender.SendAdminAction(new WarpToMapAction(mapId));
+    }
+    /// <summary>
+    /// Reaplica un layout seguro después de cargar/mergear el JSON.
+    /// Garantiza que los contenedores críticos queden con Dock/Width/Margins correctos,
+    /// aun cuando el JSON no defina o cambie estos valores.
+    /// </summary>
+    private void ForcePostJsonLayout()
+    {
+        // Columna izquierda
+        if (_leftColumn != null)
+        {
+            _leftColumn.Dock = Pos.Left;
+            _leftColumn.Width = 360;
+            _leftColumn.Margin = new Margin(0, 0, 8, 0);
+            _leftColumn.ShouldDrawBackground = false;
+            _leftColumn.SetOverflow(OverflowBehavior.Hidden, OverflowBehavior.Auto);
+            // Asegura que su InnerPanel no “coma” espacio inesperado
+            _leftColumn.InnerPanelPadding = Padding.Zero;
+        }
+
+        // Header fijo
+        if (_leftHeader != null)
+        {
+            _leftHeader.Dock = Pos.Top;
+            _leftHeader.DockChildSpacing = new Padding(0, 12, 0, 0);
+            _leftHeader.ShouldDrawBackground = false;
+        }
+
+        // Tabs
+        if (_leftTabs != null)
+        {
+            _leftTabs.Dock = Pos.Fill;
+            _leftTabs.ShouldDrawBackground = false;
+            _leftTabs.Font ??= _defaultFont;
+            if (_leftTabs.FontSize <= 0) _leftTabs.FontSize = 12;
+        }
+
+        // Panel de mapas a la derecha
+        if (_mapListPanel != null)
+        {
+            _mapListPanel.Dock = Pos.Fill;
+            _mapListPanel.ShouldDrawBackground = false;
+        }
+        if (_mapListPanelHeader != null)
+        {
+            _mapListPanelHeader.Dock = Pos.Top;
+            _mapListPanelHeader.ShouldDrawBackground = false;
+        }
+        if (_mapTreeContainer != null)
+        {
+            _mapTreeContainer.Dock = Pos.Fill;
+            _mapTreeContainer.ShouldDrawBackground = false;
+        }
+
+        // Recalcular tamaños y disposición
+        _contentPanel?.SizeToChildren(recursive: true);
+        InnerPanel?.SizeToChildren(recursive: true);
+        SizeToChildren(recursive: true);
     }
 
     #endregion

--- a/Intersect.Client.Core/Interface/Game/Admin/AdminWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Admin/AdminWindow.cs
@@ -10,6 +10,7 @@ using Intersect.Client.Framework.Gwen.Control;
 using Intersect.Client.Framework.Gwen.Control.EventArguments;
 using Intersect.Client.Framework.Gwen.Control.Layout;
 using Intersect.Client.General;
+using Intersect.Client.Interface;
 using Intersect.Client.Interface.Shared;
 using Intersect.Client.Localization;
 using Intersect.Client.Networking;
@@ -42,6 +43,7 @@ public partial class AdminWindow : Window
     private readonly Button _kickPlayerButton;
     private readonly Button _killPlayerButton;
     private readonly Button _leaveInstanceButton;
+    private readonly Button _mailBroadcastButton;
     private readonly Label _mapListLabel;
 
     private readonly Panel _mapListPanel;
@@ -54,6 +56,7 @@ public partial class AdminWindow : Window
     private readonly Panel? _leftHeader;
     private readonly Panel _namePanel;
 
+    private readonly Button _spawnItemButton;
     private readonly TexturePicker _spriteTexturePicker;
     private readonly Button _unbanButton;
     private readonly Button _unmuteButton;
@@ -269,6 +272,26 @@ public partial class AdminWindow : Window
         StyleButton(_leaveInstanceButton);
         _leaveInstanceButton.Clicked += LeaveInstanceButtonOnClicked;
 
+        _spawnItemButton = new Button(_actionPanel, nameof(_spawnItemButton))
+        {
+            Font = _defaultFont,
+            FontSize = 12,
+            MinimumSize = new Point(120, 0),
+            Padding = new Padding(8, 4),
+            Text = Strings.AdminWindow.SpawnItem,
+        };
+        _spawnItemButton.Clicked += SpawnItemButtonOnClicked;
+
+        _mailBroadcastButton = new Button(_actionPanel, nameof(_mailBroadcastButton))
+        {
+            Font = _defaultFont,
+            FontSize = 12,
+            MinimumSize = new Point(120, 0),
+            Padding = new Padding(8, 4),
+            Text = Strings.AdminWindow.MailBroadcast,
+        };
+        _mailBroadcastButton.Clicked += MailBroadcastButtonOnClicked;
+
         _banButton = new Button(_actionPanel, nameof(_banButton))
         {
             Text = Strings.AdminWindow.Ban,
@@ -291,6 +314,8 @@ public partial class AdminWindow : Window
             _muteButton,
             _unmuteButton,
             _leaveInstanceButton,
+            _spawnItemButton,
+            _mailBroadcastButton,
             _banButton,
             _unbanButton
         );
@@ -482,26 +507,15 @@ public partial class AdminWindow : Window
     }
 
     #region Action Handlers
-
-
-
-
-
-
-
-    private void OpenItemWindowButtonOnClicked(Base sender, MouseButtonState args)
+ private void SpawnItemButtonOnClicked(Base sender, MouseButtonState e)
     {
-        Interface.GameUi.OpenAdminItemManagementWindow();
+        Interface.Interface.GameUi.OpenAdminItemManagementWindow();
     }
 
-    private void OpenMailWindowButtonOnClicked(Base sender, MouseButtonState args)
+    private void MailBroadcastButtonOnClicked(Base sender, MouseButtonState e)
     {
-        Interface.GameUi.OpenAdminMailBroadcastWindow();
+        Interface.Interface.GameUi.OpenAdminMailBroadcastWindow();
     }
-
-
-
-
 
     private void UnbanButtonOnClicked(Base s, MouseButtonState e)
     {

--- a/Intersect.Client.Core/Interface/Game/EntityPanel/EntityBox.cs
+++ b/Intersect.Client.Core/Interface/Game/EntityPanel/EntityBox.cs
@@ -319,6 +319,17 @@ public partial class EntityBox
                 EntityLevel.Show();
 
                 break;
+            case EntityType.PlayerShop:
+                EventDesc.Hide();
+                ExpBackground.Hide();
+                ExpBar.Hide();
+                ExpLbl.Hide();
+                ExpTitle.Hide();
+                _contextMenuButton.Hide();
+                EntityMap.Hide();
+                EntityLevel.Hide();
+
+                break;
             case EntityType.Event:
                 EventDesc.Show();
                 EntityLevel.Hide();

--- a/Intersect.Client.Core/Interface/Game/GameInterface.cs
+++ b/Intersect.Client.Core/Interface/Game/GameInterface.cs
@@ -45,6 +45,10 @@ public partial class GameInterface : MutableInterface
 
     private AdminWindow? mAdminWindow;
 
+    private AdminItemManagementWindow? _adminItemManagementWindow;
+
+    private AdminMailBroadcastWindow? _adminMailBroadcastWindow;
+
     private BagWindow _bagWindow;
 
     private BankWindow? _bankWindow;
@@ -280,6 +284,52 @@ public partial class GameInterface : MutableInterface
         }
 
         return mAdminWindow.IsVisibleInParent;
+    }
+
+    public void OpenAdminItemManagementWindow()
+    {
+        if (_adminItemManagementWindow == null)
+        {
+            _adminItemManagementWindow = new AdminItemManagementWindow();
+            _adminItemManagementWindow.Disposed += (_, _) => _adminItemManagementWindow = null;
+        }
+
+        _adminItemManagementWindow.Show();
+        _adminItemManagementWindow.BringToFront();
+    }
+
+    public void OpenAdminMailBroadcastWindow()
+    {
+        if (_adminMailBroadcastWindow == null)
+        {
+            _adminMailBroadcastWindow = new AdminMailBroadcastWindow();
+            _adminMailBroadcastWindow.Disposed += (_, _) => _adminMailBroadcastWindow = null;
+        }
+
+        _adminMailBroadcastWindow.Show();
+        _adminMailBroadcastWindow.BringToFront();
+    }
+
+    private bool CloseAdminItemManagementWindow()
+    {
+        if (_adminItemManagementWindow is not { } window || !window.IsVisibleInTree)
+        {
+            return false;
+        }
+
+        window.Close();
+        return true;
+    }
+
+    private bool CloseAdminMailBroadcastWindow()
+    {
+        if (_adminMailBroadcastWindow is not { } window || !window.IsVisibleInTree)
+        {
+            return false;
+        }
+
+        window.Close();
+        return true;
     }
 
     //Shop
@@ -764,12 +814,31 @@ public partial class GameInterface : MutableInterface
             closedWindows = true;
         }
 
+        if (CloseAdminItemManagementWindow())
+        {
+            closedWindows = true;
+        }
+
+        if (CloseAdminMailBroadcastWindow())
+        {
+            closedWindows = true;
+        }
+
         return closedWindows;
     }
 
     //Dispose
     public void Dispose()
     {
+        _adminItemManagementWindow?.Dispose();
+        _adminItemManagementWindow = null;
+
+        _adminMailBroadcastWindow?.Dispose();
+        _adminMailBroadcastWindow = null;
+
+        mAdminWindow?.Dispose();
+        mAdminWindow = null;
+
         CloseBagWindow();
         CloseBank();
         CloseCraftingTable();

--- a/Intersect.Client.Core/Localization/Strings.cs
+++ b/Intersect.Client.Core/Localization/Strings.cs
@@ -878,6 +878,12 @@ public static partial class Strings
         public static LocalizedString KillPlayer = @"Kill";
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString QuickActions = @"Quick Actions";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString AdditionalInterfaces = @"Additional Tools";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public static LocalizedString MapList = @"Map List";
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
@@ -911,7 +917,52 @@ public static partial class Strings
         public static LocalizedString SetSprite = @"Set Sprite";
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Appearance = @"Appearance";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public static LocalizedString Sprite = @"Sprite:";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Item = @"Item";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString ItemManagement = @"Items";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Quantity = @"Quantity";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString AllowOverflow = @"Allow bank overflow";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString ReserveSpawn = @"Reserve spawn for player";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString GiveItem = @"Give Item";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString SpawnItem = @"Spawn Item";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString MailBroadcast = @"Mail Broadcast";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString MailSubject = @"Subject";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString MailMessage = @"Message";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString MailAttachmentItem = @"Attachment {00} item";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString MailAttachmentQuantity = @"Attachment {00} quantity";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString MailOnlineOnly = @"Only online players";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString MailSend = @"Send Mail";
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public static LocalizedString Title = @"Administration";

--- a/Intersect.Client.Core/Networking/PacketHandler.cs
+++ b/Intersect.Client.Core/Networking/PacketHandler.cs
@@ -414,6 +414,27 @@ internal sealed partial class PacketHandler
         }
     }
 
+    //PlayerShopEntityPacket
+    public void HandlePacket(IPacketSender packetSender, PlayerShopEntityPacket packet)
+    {
+        if (Globals.TryGetEntity(EntityType.PlayerShop, packet.EntityId, out var entity))
+        {
+            entity.Load(packet);
+            return;
+        }
+
+        var shopEntity = new PlayerShopEntity(packet.EntityId, packet);
+        if (!Globals.Entities.TryAdd(shopEntity.Id, shopEntity))
+        {
+            ApplicationContext.CurrentContext.Logger.LogError(
+                "Failed to register new {EntityType} {EntityId} ({EntityName})",
+                EntityType.PlayerShop,
+                packet.EntityId,
+                packet.Name
+            );
+        }
+    }
+
     //ProjectileEntityPacket
     public void HandlePacket(IPacketSender packetSender, ProjectileEntityPacket packet)
     {

--- a/Intersect.Client.Framework/Gwen/Control/Label.cs
+++ b/Intersect.Client.Framework/Gwen/Control/Label.cs
@@ -786,7 +786,7 @@ public partial class Label : Base, ILabel, IFontProvider
 
     protected virtual Point GetContentSize()
     {
-        return _textElement.Size;
+        return _textElement == null ? default : _textElement.Size;
     }
 
     protected virtual Padding GetContentPadding() => Padding + _textPadding;
@@ -805,6 +805,12 @@ public partial class Label : Base, ILabel, IFontProvider
 
     public virtual bool SizeToContents(out Point contentSize)
     {
+        if (_textElement == null)
+        {
+            contentSize = Size;
+            return false;
+        }
+
         _textElement.SizeToChildren();
 
         contentSize = MeasureShrinkToContents();

--- a/Intersect.Client.Framework/Gwen/Control/MultilineTextBox.cs
+++ b/Intersect.Client.Framework/Gwen/Control/MultilineTextBox.cs
@@ -374,7 +374,7 @@ public partial class MultilineTextBox : Label
         MakeCaretVisible();
 
         var pA = GetCharacterPosition(CursorPosition);
-        var pB = GetCharacterPosition(mCursorEnd);
+        var pB = GetCharacterPosition(CursorEnd);
 
         //m_SelectionBounds.X = Math.Min(pA.X, pB.X);
         //m_SelectionBounds.Y = TextY - 1;
@@ -1132,14 +1132,17 @@ public partial class MultilineTextBox : Label
     {
         if (_textLines.Count == 0)
         {
-            return new Point(0, 0);
+            return new Point(_textElement.X, _textElement.Y + Padding.Top);
         }
 
-        var currLine = _textLines[cursorPosition.Y]
-            .Substring(0, Math.Min(cursorPosition.X, _textLines[cursorPosition.Y].Length));
+        var lineIndex = Math.Max(0, Math.Min(cursorPosition.Y, _textLines.Count - 1));
+        var charIndex = Math.Max(0, Math.Min(cursorPosition.X, _textLines[lineIndex].Length));
+
+        var currLine = _textLines[lineIndex]
+            .Substring(0, charIndex);
 
         var sub = string.Empty;
-        for (var i = 0; i < cursorPosition.Y; i++)
+        for (var i = 0; i < lineIndex; i++)
         {
             sub += _textLines[i] + "\n";
         }

--- a/Intersect.Server.Core/CustomChanges/PacketHandlerCustom.cs
+++ b/Intersect.Server.Core/CustomChanges/PacketHandlerCustom.cs
@@ -735,6 +735,18 @@ internal sealed partial class PacketHandler
             return;
         }
 
+        if (player.ActivePlayerShopId.HasValue && player.ActivePlayerShopStatus == PlayerShopStatus.Active)
+        {
+            PacketSender.SendChatMsg(
+                player,
+                "❌ Ya tienes una tienda activa.",
+                ChatMessageType.Error,
+                CustomColors.Alerts.Error
+            );
+            PacketSender.SendPlayerShopWindow(player, false, true, false);
+            return;
+        }
+
         if (player.MapId == Guid.Empty)
         {
             PacketSender.SendChatMsg(player, "❌ No puedes abrir una tienda aquí.", ChatMessageType.Error, CustomColors.Alerts.Error);

--- a/Intersect.Server.Core/CustomChanges/PacketHandlerCustom.cs
+++ b/Intersect.Server.Core/CustomChanges/PacketHandlerCustom.cs
@@ -923,6 +923,12 @@ internal sealed partial class PacketHandler
             return;
         }
 
+        if (!IsWithinPlayerShopInteractionRange(player, runtime))
+        {
+            PacketSender.SendChatMsg(player, "Debes estar junto a la tienda para comprar.", ChatMessageType.Error, CustomColors.Alerts.Error);
+            return;
+        }
+
         var currencyDescriptor = GetDefaultCurrencyDescriptor();
         if (currencyDescriptor == null)
         {
@@ -1030,5 +1036,23 @@ internal sealed partial class PacketHandler
         }
 
         return false;
+    }
+
+    private const int PlayerShopInteractionRange = 1;
+
+    private static bool IsWithinPlayerShopInteractionRange(Player player, PlayerShopManager.PlayerShopRuntime runtime)
+    {
+        if (player.MapId != runtime.MapId || player.Z != runtime.Z)
+        {
+            return false;
+        }
+
+        if (!MapController.TryGet(runtime.MapId, out var shopMap))
+        {
+            return false;
+        }
+
+        var distance = player.GetDistanceTo(shopMap, runtime.X, runtime.Y);
+        return distance <= PlayerShopInteractionRange;
     }
 }

--- a/Intersect.Server.Core/Database/PlayerData/Shops/PlayerShopManager.cs
+++ b/Intersect.Server.Core/Database/PlayerData/Shops/PlayerShopManager.cs
@@ -16,6 +16,26 @@ public static class PlayerShopManager
 {
     private static readonly ConcurrentDictionary<Guid, PlayerShopRuntime> ActiveShops = new();
 
+    private static void UpdatePlayerActiveShop(Guid ownerId, Guid? shopId, PlayerShopStatus? status, Player? owner = null)
+    {
+        if (ownerId == Guid.Empty)
+        {
+            return;
+        }
+
+        owner ??= Player.FindOnline(ownerId);
+        if (owner != null)
+        {
+            owner.ActivePlayerShopId = shopId;
+            owner.ActivePlayerShopStatus = status;
+        }
+
+        using var context = DbInterface.CreatePlayerContext(readOnly: false);
+        context.Database.ExecuteSqlInterpolated(
+            $"UPDATE Players SET ActivePlayerShopId = {shopId}, ActivePlayerShopStatus = {status} WHERE Id = {ownerId}"
+        );
+    }
+
     public static IReadOnlyCollection<PlayerShopRuntime> GetActiveShops()
         => ActiveShops.Values.ToList().AsReadOnly();
 
@@ -37,6 +57,7 @@ public static class PlayerShopManager
         foreach (var shop in shops)
         {
             ActiveShops[shop.Id] = new PlayerShopRuntime(shop);
+            UpdatePlayerActiveShop(shop.OwnerId, shop.Id, PlayerShopStatus.Active);
         }
 
         Log.Information("Loaded {Count} active player shops", ActiveShops.Count);
@@ -80,6 +101,8 @@ public static class PlayerShopManager
 
         var runtime = new PlayerShopRuntime(shop, ownerName);
         ActiveShops[shop.Id] = runtime;
+
+        UpdatePlayerActiveShop(owner.Id, shop.Id, PlayerShopStatus.Active, owner);
 
         return runtime;
     }
@@ -275,6 +298,8 @@ public static class PlayerShopManager
             runtime.UpdateStatus(status);
         }
 
+        UpdatePlayerActiveShop(runtime?.OwnerId ?? shop.OwnerId, null, status);
+
         return true;
     }
 
@@ -291,14 +316,22 @@ public static class PlayerShopManager
             return 0;
         }
 
+        var owners = new List<Guid>(expired.Count);
         foreach (var shop in expired)
         {
             shop.Status = PlayerShopStatus.Expired;
             shop.ClosedAt = now;
+            owners.Add(shop.OwnerId);
             ActiveShops.TryRemove(shop.Id, out _);
         }
 
         context.SaveChanges();
+
+        foreach (var ownerId in owners)
+        {
+            UpdatePlayerActiveShop(ownerId, null, PlayerShopStatus.Expired);
+        }
+
         return expired.Count;
     }
 

--- a/Intersect.Server.Core/Entities/Combat/Dash.cs
+++ b/Intersect.Server.Core/Entities/Combat/Dash.cs
@@ -114,6 +114,7 @@ public partial class Dash
                                 return;
 
                             case EntityType.Event:
+                            case EntityType.PlayerShop:
                             case EntityType.Player:
                                 return;
 

--- a/Intersect.Server.Core/Entities/Entity.cs
+++ b/Intersect.Server.Core/Entities/Entity.cs
@@ -615,6 +615,11 @@ public abstract partial class Entity : IEntity
                     entityType = EntityType.Resource;
                     blockingEntity = mapEntity;
                     return false;
+                case PlayerShopEntity:
+                    blockerType = MovementBlockerType.Entity;
+                    entityType = EntityType.PlayerShop;
+                    blockingEntity = mapEntity;
+                    return false;
             }
         }
 

--- a/Intersect.Server.Core/Entities/Pathfinding/Pathfinder.cs
+++ b/Intersect.Server.Core/Entities/Pathfinding/Pathfinder.cs
@@ -192,15 +192,16 @@ partial class Pathfinder
 
                                                 if (!en.IsPassable() && en.X > -1 && en.X < Options.Instance.Map.MapWidth && en.Y > -1 && en.Y < Options.Instance.Map.MapHeight)
                                                 {
-                                                    mapGrid[mx + en.X, my + en.Y].BlockType = en.GetEntityType() switch
-                                                    {
-                                                        EntityType.GlobalEntity => PathNodeBlockType.Npc,
-                                                        EntityType.Player => PathNodeBlockType.Player,
-                                                        EntityType.Resource => PathNodeBlockType.Entity,
-                                                        EntityType.Projectile => PathNodeBlockType.Entity,
-                                                        EntityType.Event => PathNodeBlockType.Entity,
-                                                        _ => throw new UnreachableException($"{nameof(EntityType)} is not (but should be) handled in this switch expression"),
-                                                    };
+                    mapGrid[mx + en.X, my + en.Y].BlockType = en.GetEntityType() switch
+                    {
+                        EntityType.GlobalEntity => PathNodeBlockType.Npc,
+                        EntityType.Player => PathNodeBlockType.Player,
+                        EntityType.Resource => PathNodeBlockType.Entity,
+                        EntityType.PlayerShop => PathNodeBlockType.Entity,
+                        EntityType.Projectile => PathNodeBlockType.Entity,
+                        EntityType.Event => PathNodeBlockType.Entity,
+                        _ => throw new UnreachableException($"{nameof(EntityType)} is not (but should be) handled in this switch expression"),
+                    };
                                                 }
                                             }
 

--- a/Intersect.Server.Core/Entities/Player.cs
+++ b/Intersect.Server.Core/Entities/Player.cs
@@ -1903,6 +1903,16 @@ public partial class Player : Entity
             return;
         }
 
+        if (target is PlayerShopEntity shopEntity)
+        {
+            if (PlayerShopManager.TryBuildSnapshot(shopEntity.ShopId, out var snapshot))
+            {
+                PacketSender.SendPlayerShopSnapshot(this, snapshot);
+            }
+
+            return;
+        }
+
         List<Item> items;
         var weapon = TryGetEquippedItem(Options.Instance.Equipment.WeaponSlot, out items)
             ? items.FirstOrDefault()?.Descriptor

--- a/Intersect.Server.Core/Entities/Player.cs
+++ b/Intersect.Server.Core/Entities/Player.cs
@@ -31,6 +31,7 @@ using Intersect.Server.Database;
 using Intersect.Server.Database.Logging.Entities;
 using Intersect.Server.Database.PlayerData;
 using Intersect.Server.Database.PlayerData.Players;
+using Intersect.Server.Database.PlayerData.Shops;
 using Intersect.Server.Database.PlayerData.Security;
 using Intersect.Server.Entities.Events;
 using Intersect.Server.Framework.Entities;
@@ -80,6 +81,10 @@ public partial class Player : Entity
 
     //Name, X, Y, Dir, Etc all in the base Entity Class
     public Guid ClassId { get; set; }
+
+    public Guid? ActivePlayerShopId { get; set; }
+
+    public PlayerShopStatus? ActivePlayerShopStatus { get; set; }
 
     [NotMapped]
     public string ClassName => ClassDescriptor.GetName(ClassId);

--- a/Intersect.Server.Core/Entities/PlayerShopEntity.cs
+++ b/Intersect.Server.Core/Entities/PlayerShopEntity.cs
@@ -1,0 +1,69 @@
+using System;
+using Intersect.Enums;
+using Intersect.Framework.Core;
+using Intersect.Network.Packets.Server;
+using Intersect.Server.Database.PlayerData.Shops;
+using Intersect.Server.Framework.Entities;
+
+namespace Intersect.Server.Entities;
+
+public sealed class PlayerShopEntity : Entity
+{
+    public PlayerShopEntity(
+        PlayerShopManager.PlayerShopRuntime runtime,
+        Guid mapInstanceId,
+        string? sprite = null,
+        string? face = null,
+        Color? nameColor = null,
+        Label? headerLabel = null,
+        Label? footerLabel = null
+    ) : base(runtime?.ShopId ?? throw new ArgumentNullException(nameof(runtime)), mapInstanceId)
+    {
+        MapId = runtime.MapId;
+        X = runtime.X;
+        Y = runtime.Y;
+        Z = runtime.Z;
+        Dir = Direction.Down;
+        Name = runtime.Title;
+
+        ShopId = runtime.ShopId;
+        OwnerId = runtime.OwnerId;
+        OwnerName = runtime.OwnerName;
+
+        Sprite = sprite ?? string.Empty;
+        Face = face ?? string.Empty;
+        NameColor = nameColor ?? Color.White;
+        HeaderLabel = headerLabel ?? new Label(runtime.Title, Color.White);
+        FooterLabel = footerLabel ?? new Label(runtime.OwnerName, Color.White);
+
+        Passable = false;
+        HideName = false;
+    }
+
+    public Guid ShopId { get; }
+
+    public Guid OwnerId { get; }
+
+    public string OwnerName { get; }
+
+    public override EntityType GetEntityType() => EntityType.PlayerShop;
+
+    protected override EntityItemSource? AsItemSource() => null;
+
+    public override EntityPacket EntityPacket(EntityPacket? packet = null, Player? forPlayer = null)
+    {
+        packet ??= new PlayerShopEntityPacket();
+        packet = base.EntityPacket(packet, forPlayer);
+
+        if (packet is not PlayerShopEntityPacket playerShopEntityPacket)
+        {
+            throw new InvalidOperationException(
+                $"Invalid packet type '{packet.GetType().FullName}', expected '{typeof(PlayerShopEntityPacket).FullName}'"
+            );
+        }
+
+        playerShopEntityPacket.ShopId = ShopId;
+
+        return playerShopEntityPacket;
+    }
+}

--- a/Intersect.Server.Core/Localization/Strings.cs
+++ b/Intersect.Server.Core/Localization/Strings.cs
@@ -1219,6 +1219,30 @@ public static partial class Strings
         public readonly LocalizedString PlayerNotFound = @"The player '{00}' was not found!";
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString InvalidItem = @"Invalid item selected.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString InvalidQuantity = @"Quantity must be greater than zero.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString ItemGiveFailed = @"Unable to give {00}x {01} to {02}.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString ItemGiveSuccess = @"You have given {00}x {01} to {02}.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString ItemReceivedFromAdmin = @"{00} gave you {01}x {02}.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString ItemSpawnFailed = @"Unable to spawn {00}x {01} for {02}.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString ItemSpawnSuccess = @"You spawned {00}x {01} for {02}.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString ItemSpawnedNearYou = @"{00} spawned {01}x {02} near you.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public readonly LocalizedString PowerChanged = @"Your power has been modified!";
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
@@ -1473,6 +1497,30 @@ public static partial class Strings
         public readonly LocalizedString mailnotfound = @"Mail not found!";
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public readonly LocalizedString invaliditem = @"The selected item is invalid or cannot be attached to the mail.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString broadcastsent = @"Broadcast mail sent.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString broadcastfailed = @"Failed to send broadcast mail.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString broadcastmissingtitle = @"Mail subject is required.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString broadcastmissingmessage = @"Mail message is required.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString broadcastmissingitem = @"At least one mail attachment item is required.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString broadcastinvalidquantity = @"Mail attachment quantities must be greater than zero.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString broadcasttoomanyattachments = @"Mail broadcast can include at most {00} attachment items.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString broadcastnorecipients = @"There were no recipients for the broadcast mail.";
 
     }
 

--- a/Intersect.Server.Core/Migrations/Sqlite/Player/20250924121500_PlayerShopFlags.Designer.cs
+++ b/Intersect.Server.Core/Migrations/Sqlite/Player/20250924121500_PlayerShopFlags.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Intersect.Server.Database.PlayerData;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Intersect.Server.Migrations.Sqlite.Player
 {
     [DbContext(typeof(SqlitePlayerContext))]
-    partial class SqlitePlayerContextModelSnapshot : ModelSnapshot
+    [Migration("20250924121500_PlayerShopFlags")]
+    partial class PlayerShopFlags
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "8.0.11");

--- a/Intersect.Server.Core/Migrations/Sqlite/Player/20250924121500_PlayerShopFlags.cs
+++ b/Intersect.Server.Core/Migrations/Sqlite/Player/20250924121500_PlayerShopFlags.cs
@@ -1,0 +1,39 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Intersect.Server.Migrations.Sqlite.Player
+{
+    /// <inheritdoc />
+    public partial class PlayerShopFlags : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "ActivePlayerShopId",
+                table: "Players",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "ActivePlayerShopStatus",
+                table: "Players",
+                type: "INTEGER",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ActivePlayerShopId",
+                table: "Players");
+
+            migrationBuilder.DropColumn(
+                name: "ActivePlayerShopStatus",
+                table: "Players");
+        }
+    }
+}

--- a/Intersect.Server/Admin/Actions/ActionProcessing.cs
+++ b/Intersect.Server/Admin/Actions/ActionProcessing.cs
@@ -1,11 +1,21 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using Intersect.Admin.Actions;
+using Intersect.Core;
 using Intersect.Enums;
+using Intersect.Framework.Core.GameObjects.Items;
+using Intersect.Server.Database;
 using Intersect.Server.Database.Logging.Entities;
 using Intersect.Server.Database.PlayerData;
 using Intersect.Server.Database.PlayerData.Security;
+
 using Intersect.Server.Entities;
 using Intersect.Server.Localization;
 using Intersect.Server.Networking;
+using Intersect.Server.Maps;
+using Microsoft.EntityFrameworkCore;
+using Intersect.Server.Database.PlayerData.Players;
 
 namespace Intersect.Server.Admin.Actions
 {
@@ -463,6 +473,312 @@ namespace Intersect.Server.Admin.Actions
                     target, Strings.Player.BeenWarpedTo.ToString(player.Name), ChatMessageType.Notice, player.Name
                 );
             }
+        }
+
+        //GiveItem
+        public static void ProcessAction(Player player, GiveItemAction action)
+        {
+            if (!player.Power.IsAdmin)
+            {
+                PacketSender.SendChatMsg(player, Strings.Account.NotAllowed, ChatMessageType.Admin, Color.Red);
+
+                return;
+            }
+
+            if (action.Quantity <= 0)
+            {
+                PacketSender.SendChatMsg(player, Strings.Player.InvalidQuantity, ChatMessageType.Admin, Color.Red);
+
+                return;
+            }
+
+            if (!ItemDescriptor.TryGet(action.ItemId, out var descriptor))
+            {
+                PacketSender.SendChatMsg(player, Strings.Player.InvalidItem, ChatMessageType.Admin, Color.Red);
+
+                return;
+            }
+
+            var target = Player.FindOnline(action.Name);
+            if (target == null)
+            {
+                PacketSender.SendChatMsg(player, Strings.Player.Offline, ChatMessageType.Admin, Color.Red);
+
+                return;
+            }
+
+            if (player.Power.CompareTo(target.Power) < 1)
+            {
+                PacketSender.SendChatMsg(
+                    player, Strings.Account.NotAllowed.ToString(target.Name), ChatMessageType.Admin, Color.Red
+                );
+
+                return;
+            }
+
+            var descriptorName = descriptor?.Name ?? action.ItemId.ToString();
+            if (!target.TryGiveItem(action.ItemId, action.Quantity, ItemHandling.Normal, action.AllowBankOverflow))
+            {
+                PacketSender.SendChatMsg(
+                    player,
+                    Strings.Player.ItemGiveFailed.ToString(action.Quantity, descriptorName, target.Name),
+                    ChatMessageType.Admin,
+                    Color.Red
+                );
+
+                return;
+        }
+
+        PacketSender.SendChatMsg(
+            player,
+            Strings.Player.ItemGiveSuccess.ToString(action.Quantity, descriptorName, target.Name),
+            ChatMessageType.Admin,
+            Color.Green
+        );
+
+        PacketSender.SendChatMsg(
+            target,
+            Strings.Player.ItemReceivedFromAdmin.ToString(player.Name, action.Quantity, descriptorName),
+            ChatMessageType.Admin,
+            Color.Green
+        );
+    }
+
+    //BroadcastMail
+    public static void ProcessAction(Player player, BroadcastMailAction action)
+    {
+        if (!player.Power.IsAdmin)
+        {
+            PacketSender.SendChatMsg(player, Strings.Account.NotAllowed, ChatMessageType.Admin, Color.Red);
+
+            return;
+        }
+
+        var subject = action.Title?.Trim() ?? string.Empty;
+        var message = action.Message?.Trim() ?? string.Empty;
+        var attachments = action.Attachments?.Where(attachment => attachment != null).ToList() ?? new List<BroadcastMailAttachment>();
+
+        if (string.IsNullOrWhiteSpace(subject))
+        {
+            PacketSender.SendChatMsg(player, Strings.Mails.broadcastmissingtitle, ChatMessageType.Admin, Color.Red);
+
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(message))
+        {
+            PacketSender.SendChatMsg(player, Strings.Mails.broadcastmissingmessage, ChatMessageType.Admin, Color.Red);
+
+            return;
+        }
+
+        if (attachments.Count == 0)
+        {
+            PacketSender.SendChatMsg(player, Strings.Mails.broadcastmissingitem, ChatMessageType.Admin, Color.Red);
+
+            return;
+        }
+
+        if (attachments.Count > BroadcastMailAction.MaxAttachments)
+        {
+            PacketSender.SendChatMsg(
+                player,
+                Strings.Mails.broadcasttoomanyattachments.ToString(BroadcastMailAction.MaxAttachments),
+                ChatMessageType.Admin,
+                Color.Red
+            );
+
+            return;
+        }
+
+        foreach (var attachment in attachments)
+        {
+            if (attachment.ItemId == Guid.Empty || !ItemDescriptor.TryGet(attachment.ItemId, out _))
+            {
+                PacketSender.SendChatMsg(player, Strings.Mails.broadcastmissingitem, ChatMessageType.Admin, Color.Red);
+
+                return;
+            }
+
+            if (attachment.Quantity <= 0)
+            {
+                PacketSender.SendChatMsg(player, Strings.Mails.broadcastinvalidquantity, ChatMessageType.Admin, Color.Red);
+
+                return;
+            }
+        }
+
+        var attachmentDefinitions = attachments
+            .Select(attachment => (attachment.ItemId, attachment.Quantity))
+            .ToList();
+
+        if (attachmentDefinitions.Count == 0)
+        {
+            PacketSender.SendChatMsg(player, Strings.Mails.broadcastmissingitem, ChatMessageType.Admin, Color.Red);
+
+            return;
+        }
+
+        try
+        {
+            using var context = DbInterface.CreatePlayerContext(readOnly: false);
+
+            var processedRecipients = new HashSet<Guid>();
+            var mailEntries = new List<MailBox>();
+            var onlineDeliveries = new List<(Player Recipient, MailBox Mail)>();
+            var onlinePlayersById = Player.OnlinePlayers.ToDictionary(p => p.Id);
+
+            void QueueMail(Guid recipientId)
+            {
+                if (!processedRecipients.Add(recipientId))
+                {
+                    return;
+                }
+
+                var mail = new MailBox
+                {
+                    PlayerId = recipientId,
+                    SenderId = player.Id,
+                    Title = subject,
+                    Message = message,
+                    Attachments = attachmentDefinitions
+                        .Select(definition => new MailAttachment
+                        {
+                            ItemId = definition.ItemId,
+                            Quantity = definition.Quantity,
+                        })
+                        .ToList(),
+                };
+
+                mailEntries.Add(mail);
+                context.Player_MailBox.Add(mail);
+
+                if (onlinePlayersById.TryGetValue(recipientId, out var onlineRecipient))
+                {
+                    onlineDeliveries.Add((onlineRecipient, mail));
+                }
+            }
+
+            if (action.OnlineOnly)
+            {
+                foreach (var onlineRecipient in onlinePlayersById.Values)
+                {
+                    QueueMail(onlineRecipient.Id);
+                }
+            }
+            else
+            {
+                foreach (var recipientId in context.Players.AsNoTracking().Select(p => p.Id))
+                {
+                    QueueMail(recipientId);
+                }
+            }
+
+            if (mailEntries.Count == 0)
+            {
+                PacketSender.SendChatMsg(player, Strings.Mails.broadcastnorecipients, ChatMessageType.Admin, Color.Red);
+
+                return;
+            }
+
+            context.SaveChanges();
+
+            foreach (var (recipient, mail) in onlineDeliveries)
+            {
+                mail.SenderPlayer = player;
+                recipient.MailBoxs.Add(mail);
+                PacketSender.SendChatMsg(recipient, Strings.Mails.newmail, ChatMessageType.Trading, Color.Green);
+                PacketSender.SendOpenMailBox(recipient);
+            }
+
+            PacketSender.SendChatMsg(player, Strings.Mails.broadcastsent, ChatMessageType.Admin, Color.Green);
+        }
+        catch (Exception exception)
+        {
+            ApplicationContext.CurrentContext.Logger.LogError(exception, "Failed to broadcast mail");
+            PacketSender.SendChatMsg(player, Strings.Mails.broadcastfailed, ChatMessageType.Admin, Color.Red);
+        }
+    }
+
+    //SpawnItem
+    public static void ProcessAction(Player player, SpawnItemAction action)
+    {
+        if (!player.Power.IsAdmin)
+            {
+                PacketSender.SendChatMsg(player, Strings.Account.NotAllowed, ChatMessageType.Admin, Color.Red);
+
+                return;
+            }
+
+            if (action.Quantity <= 0)
+            {
+                PacketSender.SendChatMsg(player, Strings.Player.InvalidQuantity, ChatMessageType.Admin, Color.Red);
+
+                return;
+            }
+
+            if (!ItemDescriptor.TryGet(action.ItemId, out var descriptor))
+            {
+                PacketSender.SendChatMsg(player, Strings.Player.InvalidItem, ChatMessageType.Admin, Color.Red);
+
+                return;
+            }
+
+            var target = Player.FindOnline(action.Name);
+            if (target == null)
+            {
+                PacketSender.SendChatMsg(player, Strings.Player.Offline, ChatMessageType.Admin, Color.Red);
+
+                return;
+            }
+
+            if (player.Power.CompareTo(target.Power) < 1)
+            {
+                PacketSender.SendChatMsg(
+                    player, Strings.Account.NotAllowed.ToString(target.Name), ChatMessageType.Admin, Color.Red
+                );
+
+                return;
+            }
+
+            if (!MapController.TryGetInstanceFromMap(target.MapId, target.MapInstanceId, out var mapInstance) ||
+                mapInstance == null)
+            {
+                var descriptorNameMissing = descriptor?.Name ?? action.ItemId.ToString();
+                PacketSender.SendChatMsg(
+                    player,
+                    Strings.Player.ItemSpawnFailed.ToString(action.Quantity, descriptorNameMissing, target.Name),
+                    ChatMessageType.Admin,
+                    Color.Red
+                );
+
+                return;
+            }
+
+            var descriptorName = descriptor?.Name ?? action.ItemId.ToString();
+            var spawnedItem = new Item(action.ItemId, action.Quantity);
+            mapInstance.SpawnItem(
+                null,
+                target.X,
+                target.Y,
+                spawnedItem,
+                action.Quantity,
+                action.ReserveForTarget ? target.Id : Guid.Empty
+            );
+
+            PacketSender.SendChatMsg(
+                player,
+                Strings.Player.ItemSpawnSuccess.ToString(action.Quantity, descriptorName, target.Name),
+                ChatMessageType.Admin,
+                Color.Green
+            );
+
+            PacketSender.SendChatMsg(
+                target,
+                Strings.Player.ItemSpawnedNearYou.ToString(player.Name, action.Quantity, descriptorName),
+                ChatMessageType.Admin,
+                Color.Green
+            );
         }
 
         //ReturnToOverworld

--- a/Intersect.Server/Migrations/MySql/Player/20250924121500_PlayerShopFlags.Designer.cs
+++ b/Intersect.Server/Migrations/MySql/Player/20250924121500_PlayerShopFlags.Designer.cs
@@ -4,6 +4,7 @@ using Intersect.Server.Database.PlayerData;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Intersect.Server.Migrations.MySql.Player
 {
     [DbContext(typeof(MySqlPlayerContext))]
-    partial class MySqlPlayerContextModelSnapshot : ModelSnapshot
+    [Migration("20250924121500_PlayerShopFlags")]
+    partial class PlayerShopFlags
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Intersect.Server/Migrations/MySql/Player/20250924121500_PlayerShopFlags.cs
+++ b/Intersect.Server/Migrations/MySql/Player/20250924121500_PlayerShopFlags.cs
@@ -1,0 +1,39 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Intersect.Server.Migrations.MySql.Player
+{
+    /// <inheritdoc />
+    public partial class PlayerShopFlags : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "ActivePlayerShopId",
+                table: "Players",
+                type: "char(36)",
+                nullable: true,
+                collation: "ascii_general_ci");
+
+            migrationBuilder.AddColumn<int>(
+                name: "ActivePlayerShopStatus",
+                table: "Players",
+                type: "int",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ActivePlayerShopId",
+                table: "Players");
+
+            migrationBuilder.DropColumn(
+                name: "ActivePlayerShopStatus",
+                table: "Players");
+        }
+    }
+}

--- a/Intersect.Server/Web/Controllers/Api/V1/PlayerController.cs
+++ b/Intersect.Server/Web/Controllers/Api/V1/PlayerController.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Net;
 using Intersect.Enums;
 using Intersect.Framework.Core.GameObjects.Events;
@@ -14,6 +15,7 @@ using Intersect.Server.Entities;
 using Intersect.Server.General;
 using Intersect.Server.Localization;
 using Intersect.Server.Networking;
+using Intersect.Server.Maps;
 using Intersect.Server.Web.Http;
 using Intersect.Server.Web.Types;
 using Intersect.Server.Web.Types.Player;
@@ -955,6 +957,126 @@ namespace Intersect.Server.Web.Controllers.Api.V1
                     }
 
                     break;
+
+                case AdminAction.GiveItem:
+                    if (player == null)
+                    {
+                        return NotFound(Strings.Player.Offline.ToString());
+                    }
+
+                    if (actionParameters.Quantity <= 0)
+                    {
+                        return BadRequest(Strings.Player.InvalidQuantity.ToString());
+                    }
+
+                    if (!ItemDescriptor.TryGet(actionParameters.ItemId, out var giveDescriptor))
+                    {
+                        return BadRequest(Strings.Player.InvalidItem.ToString());
+                    }
+
+                    if (actionPerformer.Power.CompareTo(player.Power) < 0)
+                    {
+                        return BadRequest(Strings.Account.NotAllowed.ToString(player.Name));
+                    }
+
+                    if (!player.TryGiveItem(
+                            actionParameters.ItemId,
+                            actionParameters.Quantity,
+                            ItemHandling.Normal,
+                            actionParameters.AllowBankOverflow
+                        ))
+                    {
+                        var giveDescriptorName = giveDescriptor?.Name ?? actionParameters.ItemId.ToString();
+                        return BadRequest(
+                            Strings.Player.ItemGiveFailed.ToString(
+                                actionParameters.Quantity,
+                                giveDescriptorName,
+                                player.Name
+                            )
+                        );
+                    }
+
+                    var givenDescriptorName = giveDescriptor?.Name ?? actionParameters.ItemId.ToString();
+                    PacketSender.SendChatMsg(
+                        player,
+                        Strings.Player.ItemReceivedFromAdmin.ToString(
+                            actionPerformer.Name,
+                            actionParameters.Quantity,
+                            givenDescriptorName
+                        ),
+                        ChatMessageType.Admin
+                    );
+
+                    return Ok(
+                        Strings.Player.ItemGiveSuccess.ToString(
+                            actionParameters.Quantity,
+                            givenDescriptorName,
+                            player.Name
+                        )
+                    );
+
+                case AdminAction.SpawnItem:
+                    if (player == null)
+                    {
+                        return NotFound(Strings.Player.Offline.ToString());
+                    }
+
+                    if (actionParameters.Quantity <= 0)
+                    {
+                        return BadRequest(Strings.Player.InvalidQuantity.ToString());
+                    }
+
+                    if (!ItemDescriptor.TryGet(actionParameters.ItemId, out var spawnDescriptor))
+                    {
+                        return BadRequest(Strings.Player.InvalidItem.ToString());
+                    }
+
+                    if (actionPerformer.Power.CompareTo(player.Power) < 0)
+                    {
+                        return BadRequest(Strings.Account.NotAllowed.ToString(player.Name));
+                    }
+
+                    if (!MapController.TryGetInstanceFromMap(player.MapId, player.MapInstanceId, out var mapInstance) ||
+                        mapInstance == null)
+                    {
+                        var spawnDescriptorName = spawnDescriptor?.Name ?? actionParameters.ItemId.ToString();
+                        return BadRequest(
+                            Strings.Player.ItemSpawnFailed.ToString(
+                                actionParameters.Quantity,
+                                spawnDescriptorName,
+                                player.Name
+                            )
+                        );
+                    }
+
+                    var itemDescriptorName = spawnDescriptor?.Name ?? actionParameters.ItemId.ToString();
+                    var spawnedItem = new Item(actionParameters.ItemId, actionParameters.Quantity);
+                    mapInstance.SpawnItem(
+                        null,
+                        player.X,
+                        player.Y,
+                        spawnedItem,
+                        actionParameters.Quantity,
+                        actionParameters.ReserveForTarget ? player.Id : Guid.Empty
+                    );
+
+                    PacketSender.SendChatMsg(
+                        player,
+                        Strings.Player.ItemSpawnedNearYou.ToString(
+                            actionPerformer.Name,
+                            actionParameters.Quantity,
+                            itemDescriptorName
+                        ),
+                        ChatMessageType.Admin
+                    );
+
+                    return Ok(
+                        Strings.Player.ItemSpawnSuccess.ToString(
+                            actionParameters.Quantity,
+                            itemDescriptorName,
+                            player.Name
+                        )
+                    );
 
                 case AdminAction.WarpMeTo:
                 case AdminAction.WarpToMe:

--- a/Intersect.Server/Web/Controllers/Api/V1/UserController.cs
+++ b/Intersect.Server/Web/Controllers/Api/V1/UserController.cs
@@ -1,6 +1,8 @@
+using System;
 using System.Net;
 using Intersect.Enums;
 using Intersect.Framework.Core.GameObjects.Events;
+using Intersect.Framework.Core.GameObjects.Items;
 using Intersect.Framework.Core.GameObjects.Variables;
 using Intersect.Security;
 using Intersect.Server.Collections.Indexing;
@@ -13,6 +15,7 @@ using Intersect.Server.Entities;
 using Intersect.Server.General;
 using Intersect.Server.Localization;
 using Intersect.Server.Networking;
+using Intersect.Server.Maps;
 using Intersect.Server.Notifications;
 using Intersect.Server.Web.Http;
 using Intersect.Server.Web.Types;
@@ -845,6 +848,126 @@ namespace Intersect.Server.Web.Controllers.Api.V1
                     }
 
                     break;
+
+                case AdminAction.GiveItem:
+                    if (player == null)
+                    {
+                        return NotFound(Strings.Player.Offline.ToString());
+                    }
+
+                    if (actionParameters.Quantity <= 0)
+                    {
+                        return BadRequest(Strings.Player.InvalidQuantity.ToString());
+                    }
+
+                    if (!ItemDescriptor.TryGet(actionParameters.ItemId, out var giveDescriptor))
+                    {
+                        return BadRequest(Strings.Player.InvalidItem.ToString());
+                    }
+
+                    if (actionPerformer.Power.CompareTo(player.Power) < 0)
+                    {
+                        return BadRequest(Strings.Account.NotAllowed.ToString(player.Name));
+                    }
+
+                    if (!player.TryGiveItem(
+                            actionParameters.ItemId,
+                            actionParameters.Quantity,
+                            ItemHandling.Normal,
+                            actionParameters.AllowBankOverflow
+                        ))
+                    {
+                        var giveDescriptorName = giveDescriptor?.Name ?? actionParameters.ItemId.ToString();
+                        return BadRequest(
+                            Strings.Player.ItemGiveFailed.ToString(
+                                actionParameters.Quantity,
+                                giveDescriptorName,
+                                player.Name
+                            )
+                        );
+                    }
+
+                    var givenDescriptorName = giveDescriptor?.Name ?? actionParameters.ItemId.ToString();
+                    PacketSender.SendChatMsg(
+                        player,
+                        Strings.Player.ItemReceivedFromAdmin.ToString(
+                            actionPerformer.Name,
+                            actionParameters.Quantity,
+                            givenDescriptorName
+                        ),
+                        ChatMessageType.Admin
+                    );
+
+                    return Ok(
+                        Strings.Player.ItemGiveSuccess.ToString(
+                            actionParameters.Quantity,
+                            givenDescriptorName,
+                            player.Name
+                        )
+                    );
+
+                case AdminAction.SpawnItem:
+                    if (player == null)
+                    {
+                        return NotFound(Strings.Player.Offline.ToString());
+                    }
+
+                    if (actionParameters.Quantity <= 0)
+                    {
+                        return BadRequest(Strings.Player.InvalidQuantity.ToString());
+                    }
+
+                    if (!ItemDescriptor.TryGet(actionParameters.ItemId, out var spawnDescriptor))
+                    {
+                        return BadRequest(Strings.Player.InvalidItem.ToString());
+                    }
+
+                    if (actionPerformer.Power.CompareTo(player.Power) < 0)
+                    {
+                        return BadRequest(Strings.Account.NotAllowed.ToString(player.Name));
+                    }
+
+                    if (!MapController.TryGetInstanceFromMap(player.MapId, player.MapInstanceId, out var mapInstance) ||
+                        mapInstance == null)
+                    {
+                        var spawnDescriptorName = spawnDescriptor?.Name ?? actionParameters.ItemId.ToString();
+                        return BadRequest(
+                            Strings.Player.ItemSpawnFailed.ToString(
+                                actionParameters.Quantity,
+                                spawnDescriptorName,
+                                player.Name
+                            )
+                        );
+                    }
+
+                    var itemDescriptorName = spawnDescriptor?.Name ?? actionParameters.ItemId.ToString();
+                    var spawnedItem = new Item(actionParameters.ItemId, actionParameters.Quantity);
+                    mapInstance.SpawnItem(
+                        null,
+                        player.X,
+                        player.Y,
+                        spawnedItem,
+                        actionParameters.Quantity,
+                        actionParameters.ReserveForTarget ? player.Id : Guid.Empty
+                    );
+
+                    PacketSender.SendChatMsg(
+                        player,
+                        Strings.Player.ItemSpawnedNearYou.ToString(
+                            actionPerformer.Name,
+                            actionParameters.Quantity,
+                            itemDescriptorName
+                        ),
+                        ChatMessageType.Admin
+                    );
+
+                    return Ok(
+                        Strings.Player.ItemSpawnSuccess.ToString(
+                            actionParameters.Quantity,
+                            itemDescriptorName,
+                            player.Name
+                        )
+                    );
 
                 case AdminAction.WarpMeTo:
                 case AdminAction.WarpToMe:

--- a/Intersect.Server/Web/Types/AdminActionParameters.cs
+++ b/Intersect.Server/Web/Types/AdminActionParameters.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Intersect.Server.Web.Types;
 
 public partial struct AdminActionParameters
@@ -15,4 +17,12 @@ public partial struct AdminActionParameters
     public byte Y { get; set; }
 
     public Guid MapId { get; set; }
+
+    public Guid ItemId { get; set; }
+
+    public int Quantity { get; set; }
+
+    public bool AllowBankOverflow { get; set; }
+
+    public bool ReserveForTarget { get; set; }
 }


### PR DESCRIPTION
## Summary
- add a new `PlayerShop` entity type together with a dedicated entity packet so that shops can be synchronized between server and client
- introduce concrete server and client `PlayerShopEntity` implementations and register packet handlers/rendering so the entities behave like static map actors
- update movement/combat logic so shops block movement and interacting with them from `Player.TryAttack` shows the shop snapshot instead of dealing damage

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917ec5168bc832bbe2edbbc9788dd39)