### PR TITLE
Guard against invalid equipment slot index

### DIFF
--- a/Intersect.Server.Core/Entities/Player.cs
+++ b/Intersect.Server.Core/Entities/Player.cs
@@ -6244,6 +6244,11 @@ public partial class Player : Entity
     }
     private void AddEquipmentSlot(int equipmentSlot, int inventorySlot)
     {
+        if (equipmentSlot < 0 || equipmentSlot >= Options.Instance.Equipment.EquipmentSlots.Count)
+        {
+            return;
+        }
+
         if (!Equipment.ContainsKey(equipmentSlot))
         {
             Equipment[equipmentSlot] = new List<int>();


### PR DESCRIPTION
## Summary
- add a guard to avoid indexing equipment slots with invalid values
- prevent equipment handling from crashing when items reference out-of-range slots

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a81a6072c832b87d196ecc61acda0)