### PR TITLE
Stabilize player shop browse scrolling

### DIFF
--- a/Intersect.Client.Core/Interface/Game/Shops/PlayerShopBrowseItemRow.cs
+++ b/Intersect.Client.Core/Interface/Game/Shops/PlayerShopBrowseItemRow.cs
@@ -42,7 +42,7 @@ namespace Intersect.Client.Interface.Game.Shops
 
             // Tamaño y layout básico
             SetSize(_owner.RowWidth, 64);
-            Dock = Pos.Top;
+            Dock = Pos.None;
             Margin = new Margin(0, 0, 0, 4);
 
             // Icono

--- a/Intersect.Client.Core/Interface/Game/Shops/PlayerShopBrowseWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Shops/PlayerShopBrowseWindow.cs
@@ -111,7 +111,7 @@ namespace Intersect.Client.Interface.Game.Shops
             {
                 _emptyLabel.IsVisibleInParent = true;
 
-                _itemsScroll.UpdateScrollBars();
+                LayoutRows();
                 if (scrollBar != null)
                 {
                     scrollBar.ScrollAmount = 0f;
@@ -132,8 +132,7 @@ namespace Intersect.Client.Interface.Game.Shops
                 _rows.Add(row);
             }
 
-            // Dejar que el ScrollControl recalcule content size y barras
-            _itemsScroll.UpdateScrollBars();
+            LayoutRows();
 
             // Como cambió la estructura, ponemos el scroll arriba para evitar huecos locos
             if (scrollBar != null)
@@ -193,10 +192,35 @@ namespace Intersect.Client.Interface.Game.Shops
 
         public void Update()
         {
+            LayoutRows();
+        }
+
+        private void LayoutRows()
+        {
+            if (_itemsScroll == null)
+            {
+                return;
+            }
+
+            if (_rows.Count == 0)
+            {
+                _itemsScroll.SetInnerSize(RowWidth, _itemsScroll.Height);
+                _itemsScroll.UpdateScrollBars();
+                return;
+            }
+
+            var rowWidth = RowWidth;
+            var offsetY = 0;
+
             foreach (var row in _rows)
             {
-                row.Width = RowWidth;
+                row.SetBounds(0, offsetY, rowWidth, row.Height);
+                var outerHeight = row.Height + row.Margin.Top + row.Margin.Bottom;
+                offsetY += outerHeight;
             }
+
+            _itemsScroll.SetInnerSize(rowWidth, offsetY);
+            _itemsScroll.UpdateScrollBars();
         }
 
         internal void RequestPurchase(PlayerShopBrowseItemRow row)


### PR DESCRIPTION
## Summary
- switch player shop browse rows to manual layout and disable docking so widths stay stable
- recalculate row positions and scroll inner size explicitly to prevent erratic scrollbar sizing

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e829fa2bc832ba2c01469adde87b1)