### PR TITLE
Handle player shop purchase errors by resetting buying state

### DIFF
--- a/Intersect.Client.Core/Interface/Game/Shops/PlayerShopBrowseWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Shops/PlayerShopBrowseWindow.cs
@@ -22,6 +22,7 @@ namespace Intersect.Client.Interface.Game.Shops
         private readonly List<PlayerShopBrowseItemRow> _rows = new();
 
         private bool _uiInitialized;
+        private bool _hasPendingPurchase;
 
         private ShopSnapshot _snapshot;
 
@@ -246,6 +247,7 @@ namespace Intersect.Client.Interface.Game.Shops
 
             PacketSender.SendBuyPlayerShopItem(_snapshot.ShopId, row.Snapshot.ShopItemId, quantity);
             row.SetBuying(true);
+            _hasPendingPurchase = true;
             _statusLabel.Text = Strings.PlayerShops.StatusSubmitting;
             _statusLabel.SetTextColor(Color.ForestGreen, ComponentState.Normal);
         }
@@ -316,10 +318,29 @@ namespace Intersect.Client.Interface.Game.Shops
 
         private void ResetBuyingState()
         {
+            _hasPendingPurchase = false;
             foreach (var row in _rows)
             {
                 row.SetBuying(false);
             }
+        }
+
+        internal void NotifyPurchaseFailed(string? message)
+        {
+            if (!_hasPendingPurchase)
+            {
+                return;
+            }
+
+            ResetBuyingState();
+
+            if (string.IsNullOrWhiteSpace(message))
+            {
+                return;
+            }
+
+            _statusLabel.Text = message;
+            _statusLabel.SetTextColor(Color.OrangeRed, ComponentState.Normal);
         }
     }
 }

--- a/Intersect.Client.Core/Networking/PacketHandler.cs
+++ b/Intersect.Client.Core/Networking/PacketHandler.cs
@@ -641,6 +641,13 @@ internal sealed partial class PacketHandler
                 packet.Target, packet.Items
             )
         );
+
+        if (packet.Type == ChatMessageType.Error && Interface.Interface.GameUi?.mPlayerShopBrowseWindow != null)
+        {
+            Interface.Interface.EnqueueInGame(
+                gameInterface => gameInterface.mPlayerShopBrowseWindow?.NotifyPurchaseFailed(packet.Message)
+            );
+        }
     }
 
     //AnnouncementPacket


### PR DESCRIPTION
## Summary
- track pending player shop purchases to avoid leaving controls disabled
- reset buying state and show error messaging when server returns validation errors

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e8fc07ea0832b9779a01f5335c6ff)