### PR TITLE
Handle null inventory slots in crafting window

### DIFF
--- a/Intersect.Client.Core/Interface/Game/Crafting/CraftingWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Crafting/CraftingWindow.cs
@@ -209,6 +209,11 @@ public partial class CraftingWindow : Window
         Dictionary<Guid, int> inventoryItemsByDescriptorId = [];
         foreach (var item in player.Inventory)
         {
+            if (item == null)
+            {
+                continue;
+            }
+
             var inventoryItemDescriptorId = item.ItemId;
             var currentQuantity = inventoryItemsByDescriptorId.GetValueOrDefault(inventoryItemDescriptorId, 0);
             inventoryItemsByDescriptorId[inventoryItemDescriptorId] = currentQuantity + item.Quantity;


### PR DESCRIPTION
## Summary
- prevent null inventory entries from causing crafting UI to crash while loading a recipe

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920a8a06034832b8ff92e801daad0ff)