### PR TITLE
Fix chat description window close button

### DIFF
--- a/Intersect.Client.Core/Interface/Game/DescriptionWindows/ChatItemDescriptionWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/DescriptionWindows/ChatItemDescriptionWindow.cs
@@ -6,15 +6,11 @@ namespace Intersect.Client.Interface.Game.DescriptionWindows;
 
 public partial class ChatItemDescriptionWindow() : ItemDescriptionWindow()
 {
-    private readonly Button _closeButton;
+    private Button? _closeButton;
 
     public ChatItemDescriptionWindow()
     {
-        _closeButton = new Button(this, "ChatDescriptionCloseButton");
-        _closeButton.SetText("X");
-        _closeButton.SizeToContents();
-        _closeButton.Clicked += CloseButtonOnClicked;
-        _closeButton.IsTabable = false;
+        CreateCloseButton();
     }
 
     public new void Show(
@@ -25,8 +21,9 @@ public partial class ChatItemDescriptionWindow() : ItemDescriptionWindow()
     )
     {
         base.Show(item, amount, itemProperties, valueLabel);
+        CreateCloseButton();
         PositionCloseButton();
-        _closeButton.Show();
+        _closeButton?.Show();
     }
 
     public override void Hide()
@@ -42,6 +39,15 @@ public partial class ChatItemDescriptionWindow() : ItemDescriptionWindow()
             Interface.GameUi.GameCanvas.RemoveChild(Interface.GameUi.SpellDescriptionWindow, true);
             Interface.GameUi.SpellDescriptionWindow = default;
         }
+    }
+
+    private void CreateCloseButton()
+    {
+        _closeButton = new Button(this, "ChatDescriptionCloseButton");
+        _closeButton.SetText("X");
+        _closeButton.SizeToContents();
+        _closeButton.Clicked += CloseButtonOnClicked;
+        _closeButton.IsTabable = false;
     }
 
     private void PositionCloseButton()


### PR DESCRIPTION
## Summary
- recreate the chat description close button after the window rebuilds so it remains visible
- ensure the close button is positioned and shown whenever the chat item description window is displayed

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69228927c498832bb9c294aac83d6008)