### PR TITLE
Handle null inventory items in attack animation

### DIFF
--- a/Intersect.Client.Core/Entities/Entity.cs
+++ b/Intersect.Client.Core/Entities/Entity.cs
@@ -2206,7 +2206,11 @@ public partial class Entity : IEntity
                         myList[0] >= 0 &&
                         myList[0] < Inventory.Length)
                     {
-                        itemId = Inventory[myList[0]].ItemId;
+                        var inventoryItem = Inventory[myList[0]];
+                        if (inventoryItem != null)
+                        {
+                            itemId = inventoryItem.ItemId;
+                        }
                     }
                 }
                 else


### PR DESCRIPTION
## Summary
- prevent null reference when resolving weapon item during attack animation

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6927b85d50bc832b9cf1fa0d1af3719f)