### PR TITLE
Add support for consumables applying spell effects

### DIFF
--- a/Framework/Intersect.Framework.Core/GameObjects/Items/ConsumableType.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Items/ConsumableType.cs
@@ -7,4 +7,6 @@ public enum ConsumableType : byte
     Mana = 1,
 
     Experience = 2,
+
+    Effect = 3,
 }

--- a/Intersect.Client.Core/Interface/Game/DescriptionWindows/ItemDescriptionWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/DescriptionWindows/ItemDescriptionWindow.cs
@@ -850,7 +850,16 @@ public partial class ItemDescriptionWindow() : DescriptionWindowBase(Interface.G
         // Consumable data.
         if (_itemDescriptor.Consumable != null)
         {
-            if (_itemDescriptor.Consumable.Value > 0 && _itemDescriptor.Consumable.Percentage > 0)
+            if (_itemDescriptor.Consumable.Type == ConsumableType.Effect)
+            {
+                if (_itemDescriptor.Spell != null)
+                {
+                    rows.AddKeyValueRow(
+                        Strings.ItemDescription.ConsumableTypes[(int)_itemDescriptor.Consumable.Type], _itemDescriptor.Spell.Name
+                    );
+                }
+            }
+            else if (_itemDescriptor.Consumable.Value > 0 && _itemDescriptor.Consumable.Percentage > 0)
             {
                 rows.AddKeyValueRow(Strings.ItemDescription.ConsumableTypes[(int)_itemDescriptor.Consumable.Type], Strings.ItemDescription.RegularAndPercentage.ToString(_itemDescriptor.Consumable.Value, _itemDescriptor.Consumable.Percentage));
             }

--- a/Intersect.Client.Core/Localization/Strings.cs
+++ b/Intersect.Client.Core/Localization/Strings.cs
@@ -2273,6 +2273,7 @@ If you are sure you want to hand over your guild enter '\c{{#ff8080}}{02}\c{{}}'
             {0, "Restores HP:"},
             {1, "Restores MP:"},
             {2, "Grants Experience:"},
+            {3, "Applies Effect:"},
         };
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]

--- a/Intersect.Editor/Forms/Editors/frmItem.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/frmItem.Designer.cs
@@ -1537,7 +1537,7 @@ namespace Intersect.Editor.Forms.Editors
             cmbConsume.FlatStyle = FlatStyle.Flat;
             cmbConsume.ForeColor = System.Drawing.Color.Gainsboro;
             cmbConsume.FormattingEnabled = true;
-            cmbConsume.Items.AddRange(new object[] { "Health", "Mana", "Experience" });
+            cmbConsume.Items.AddRange(new object[] { "Health", "Mana", "Experience", "Effect" });
             cmbConsume.Location = new System.Drawing.Point(22, 43);
             cmbConsume.Margin = new Padding(4, 3, 4, 3);
             cmbConsume.Name = "cmbConsume";

--- a/Intersect.Editor/Forms/Editors/frmItem.cs
+++ b/Intersect.Editor/Forms/Editors/frmItem.cs
@@ -554,6 +554,8 @@ public partial class FrmItem : EditorForm
         grpBags.Visible = false;
         chkStackable.Enabled = true;
         grpEnchanting.Visible = false;
+        chkQuickCast.Enabled = true;
+        chkSingleUseSpell.Enabled = true;
         var selectedType = (ItemType)cmbType.SelectedIndex;
         var selectedSubType = cmbSubType.SelectedItem?.ToString();
         if ((int)mEditorItem.ItemType != cmbType.SelectedIndex)
@@ -579,6 +581,16 @@ public partial class FrmItem : EditorForm
             nudInterval.Value = mEditorItem.Consumable.Value;
             nudIntervalPercentage.Value = mEditorItem.Consumable.Percentage;
             grpConsumable.Visible = true;
+
+            if (mEditorItem.Consumable.Type == ConsumableType.Effect)
+            {
+                cmbTeachSpell.SelectedIndex = SpellDescriptor.ListIndex(mEditorItem.SpellId) + 1;
+                chkQuickCast.Checked = true;
+                chkQuickCast.Enabled = false;
+                chkSingleUseSpell.Checked = mEditorItem.SingleUse;
+                chkSingleUseSpell.Enabled = false;
+                grpSpell.Visible = true;
+            }
         }
         else if (cmbType.SelectedIndex == (int)ItemType.Spell)
         {
@@ -745,6 +757,7 @@ public partial class FrmItem : EditorForm
     private void cmbConsume_SelectedIndexChanged(object sender, EventArgs e)
     {
         mEditorItem.Consumable.Type = (ConsumableType)cmbConsume.SelectedIndex;
+        RefreshExtendedData();
     }
 
     private void cmbPaperdoll_SelectedIndexChanged(object sender, EventArgs e)

--- a/Intersect.Server.Core/Entities/Player.cs
+++ b/Intersect.Server.Core/Entities/Player.cs
@@ -3656,6 +3656,26 @@ public partial class Player : Entity
                     var die = false;
                     long value;
 
+                    if (itemBase.Consumable.Type == ConsumableType.Effect)
+                    {
+                        var effectSpell = itemBase.Spell;
+                        if (effectSpell == null)
+                        {
+                            PacketSender.SendChatMsg(this, Strings.Items.CannotUse, ChatMessageType.Error);
+
+                            return;
+                        }
+
+                        TryAttack(this, effectSpell, new SpellProperties { Level = 1 });
+
+                        if (TryTakeItem(Items[slot], 1) && useEvent != default)
+                        {
+                            EnqueueStartCommonEvent(useEvent);
+                        }
+
+                        return;
+                    }
+
                     switch (itemBase.Consumable.Type)
                     {
                         case ConsumableType.Health:


### PR DESCRIPTION
## Summary
- add a new consumable effect type that triggers an associated spell on use
- show consumable effect spell info in item descriptions and the editor
- extend item editor options to pick spells for consumable effects

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692911948f44832bb5a4452b7a77ccb9)