### PR TITLE
Add critical chance scaling and display improvements

### DIFF
--- a/Framework/Intersect.Framework.Core/Config/CombatOptions.cs
+++ b/Framework/Intersect.Framework.Core/Config/CombatOptions.cs
@@ -11,6 +11,11 @@ public partial class CombatOptions
     public int MaxDashSpeed { get; set; } = 200;
 
     /// <summary>
+    /// Number of agility points required to gain 1% critical chance.
+    /// </summary>
+    public int AgilityPerCritChance { get; set; } = 10;
+
+    /// <summary>
     /// Allowed distance to target party members when using quick target keys.
     /// </summary>
     public int PartyTargetDistance { get; set; } = 20;

--- a/Framework/Intersect.Framework.Core/GameObjects/Items/ItemEffect.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Items/ItemEffect.cs
@@ -19,4 +19,6 @@ public enum ItemEffect : byte
     Accuracy = 7,
 
     Evasion = 8,
+
+    CriticalChance = 9,
 }

--- a/Intersect.Client.Core/Entities/Player.cs
+++ b/Intersect.Client.Core/Entities/Player.cs
@@ -34,6 +34,7 @@ using Intersect.GameObjects;
 using Intersect.Network.Packets.Server;
 using Intersect.Utilities;
 using Microsoft.Extensions.Logging;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Intersect.Client.Entities;
@@ -2623,6 +2624,99 @@ public partial class Player : Entity, IPlayer
         }
 
         return attackTime;
+    }
+
+    public ItemDescriptor? GetEquippedWeaponDescriptor()
+    {
+        ItemDescriptor? weapon = null;
+        var weaponSlotId = Options.Instance.Equipment.Slots.IndexOf("Weapon");
+
+        if (this == Globals.Me)
+        {
+            if (MyEquipment.TryGetValue(weaponSlotId, out var weaponSlots) && weaponSlots.Count > 0)
+            {
+                var invItem = Inventory.ElementAtOrDefault(weaponSlots[0]);
+                if (invItem != null)
+                {
+                    weapon = ItemDescriptor.Get(invItem.ItemId);
+                }
+            }
+        }
+        else if (Equipment.TryGetValue(weaponSlotId, out var weaponItems) && weaponItems.Count > 0)
+        {
+            weapon = ItemDescriptor.Get(weaponItems[0]);
+        }
+
+        return weapon;
+    }
+
+    public int GetEquipmentEffect(ItemEffect effect)
+    {
+        var effects = new Dictionary<ItemEffect, int>();
+
+        void ApplyEffects(ItemDescriptor? descriptor)
+        {
+            if (descriptor == null)
+            {
+                return;
+            }
+
+            foreach (var effectData in descriptor.Effects)
+            {
+                effects.ApplyEffect(effectData);
+            }
+        }
+
+        if (this == Globals.Me)
+        {
+            foreach (var (_, equipmentSlots) in MyEquipment)
+            {
+                foreach (var slotIndex in equipmentSlots)
+                {
+                    var invItem = Inventory.ElementAtOrDefault(slotIndex);
+                    if (invItem == null)
+                    {
+                        continue;
+                    }
+
+                    ApplyEffects(ItemDescriptor.Get(invItem.ItemId));
+                }
+            }
+        }
+        else
+        {
+            foreach (var (_, equippedItems) in Equipment)
+            {
+                foreach (var descriptorId in equippedItems)
+                {
+                    ApplyEffects(ItemDescriptor.Get(descriptorId));
+                }
+            }
+        }
+
+        return effects.TryGetValue(effect, out var value) ? value : 0;
+    }
+
+    public int GetBaseCriticalChance()
+    {
+        var weapon = GetEquippedWeaponDescriptor();
+        if (weapon != null)
+        {
+            return weapon.CritChance;
+        }
+
+        var cls = ClassDescriptor.Get(Class);
+        return cls?.CritChance ?? 0;
+    }
+
+    public int CalculateCriticalChance(int baseCritChance)
+    {
+        var agilityPerCrit = Math.Max(1, Options.Instance.Combat.AgilityPerCritChance);
+        var agilityContribution = Stat[(int)Stat.Agility] / agilityPerCrit;
+        var equipmentBonus = GetEquipmentEffect(ItemEffect.CriticalChance);
+
+        var total = baseCritChance + agilityContribution + equipmentBonus;
+        return Math.Max(0, total);
     }
 
 

--- a/Intersect.Client.Core/Interface/Game/Character/CharacterWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Character/CharacterWindow.cs
@@ -64,6 +64,7 @@ public partial class CharacterWindow:Window
     Label mAgilityLabel;
     Label mDamageLabel;
     Label mCureLabel;
+    Label mCritChanceLabel;
     public ImagePanel[] PaperdollPanels;
 
     public string[] PaperdollTextures;
@@ -246,37 +247,40 @@ public partial class CharacterWindow:Window
         mCureLabel = new Label(this, "CureLabel");
         mCureLabel.SetPosition(statsX, statsY + statSpacing * 7);
 
+        mCritChanceLabel = new Label(this, "CritLabel");
+        mCritChanceLabel.SetPosition(statsX, statsY + statSpacing * 8);
+
         mPointsLabel = new Label(this, "PointsLabel");
-        mPointsLabel.SetPosition(statsX, statsY + statSpacing * 8);
+        mPointsLabel.SetPosition(statsX, statsY + statSpacing * 9);
 
         var extraBuffsLabel = new Label(this, "ExtraBuffsLabel");
         extraBuffsLabel.SetText(Strings.Character.ExtraBuffs);
-        extraBuffsLabel.SetPosition(statsX, statsY + statSpacing * 9);
+        extraBuffsLabel.SetPosition(statsX, statsY + statSpacing * 10);
 
         mHpRegen = new Label(this, "HpRegen");
-        mHpRegen.SetPosition(statsX, statsY + statSpacing * 10);
+        mHpRegen.SetPosition(statsX, statsY + statSpacing * 11);
         mManaRegen = new Label(this, "ManaRegen");
-        mManaRegen.SetPosition(statsX, statsY + statSpacing * 11);
+        mManaRegen.SetPosition(statsX, statsY + statSpacing * 12);
         mLifeSteal = new Label(this, "Lifesteal");
-        mLifeSteal.SetPosition(statsX, statsY + statSpacing * 12);
+        mLifeSteal.SetPosition(statsX, statsY + statSpacing * 13);
         mAttackSpeed = new Label(this, "AttackSpeed");
-        mAttackSpeed.SetPosition(statsX, statsY + statSpacing * 13);
+        mAttackSpeed.SetPosition(statsX, statsY + statSpacing * 14);
         mSpeedBuff = new Label(this, "SpeedBuff");
-        mSpeedBuff.SetPosition(statsX, statsY + statSpacing * 14);
+        mSpeedBuff.SetPosition(statsX, statsY + statSpacing * 15);
         mDamageBuff = new Label(this, "DamageBuff");
-        mDamageBuff.SetPosition(statsX, statsY + statSpacing * 15);
+        mDamageBuff.SetPosition(statsX, statsY + statSpacing * 16);
         mCureBuff = new Label(this, "CureBuff");
-        mCureBuff.SetPosition(statsX, statsY + statSpacing * 16);
+        mCureBuff.SetPosition(statsX, statsY + statSpacing * 17);
         mExtraExp = new Label(this, "ExtraExp");
-        mExtraExp.SetPosition(statsX, statsY + statSpacing * 17);
+        mExtraExp.SetPosition(statsX, statsY + statSpacing * 18);
         mLuck = new Label(this, "Luck");
-        mLuck.SetPosition(statsX, statsY + statSpacing * 18);
+        mLuck.SetPosition(statsX, statsY + statSpacing * 19);
         mTenacity = new Label(this, "Tenacity");
-        mTenacity.SetPosition(statsX, statsY + statSpacing * 19);
+        mTenacity.SetPosition(statsX, statsY + statSpacing * 20);
         mCooldownReduction = new Label(this, "CooldownReduction");
-        mCooldownReduction.SetPosition(statsX, statsY + statSpacing * 20);
+        mCooldownReduction.SetPosition(statsX, statsY + statSpacing * 21);
         mManaSteal = new Label(this, "Manasteal");
-        mManaSteal.SetPosition(statsX, statsY + statSpacing * 21);
+        mManaSteal.SetPosition(statsX, statsY + statSpacing * 22);
 
         UpdateExtraBuffs();
 
@@ -475,6 +479,8 @@ public partial class CharacterWindow:Window
                 player.Stat[(int)Stat.Cures]
             )
         );
+        var critChance = player.CalculateCriticalChance(player.GetBaseCriticalChance());
+        mCritChanceLabel.SetText(Strings.Character.CriticalChance.ToString(critChance));
         mPointsLabel.SetText(Strings.Character.Points.ToString(player.StatPoints));
         mAddAbilityPwrBtn.IsHidden = player.StatPoints == 0 ||
                                      player.Stat[(int) Stat.Intelligence] == Options.Instance.Player.MaxStat;
@@ -633,11 +639,12 @@ public partial class CharacterWindow:Window
         }
 
         //Getting extra buffs from items
-        if (item.Effects.Find(effect => effect.Type != ItemEffect.None && effect.Percentage > 0) != default)
+        if (item.Effects.Find(effect => effect.Type != ItemEffect.None && effect.GetValue() > 0) != default)
         {
             foreach (var effect in item.Effects)
             {
-                if (effect.Percentage <= 0)
+                var effectAmount = effect.GetValue();
+                if (effectAmount <= 0)
                 {
                     continue;
                 }
@@ -645,22 +652,22 @@ public partial class CharacterWindow:Window
                 switch (effect.Type)
                 {
                     case ItemEffect.CooldownReduction:
-                        CooldownAmount += effect.Percentage;
+                        CooldownAmount += effectAmount;
                         break;
                     case ItemEffect.Lifesteal:
-                        LifeStealAmount += effect.Percentage;
+                        LifeStealAmount += effectAmount;
                         break;
                     case ItemEffect.Tenacity:
-                        TenacityAmount += effect.Percentage;
+                        TenacityAmount += effectAmount;
                         break;
                     case ItemEffect.Luck:
-                        LuckAmount += effect.Percentage;
+                        LuckAmount += effectAmount;
                         break;
                     case ItemEffect.EXP:
-                        ExtraExpAmount += effect.Percentage;
+                        ExtraExpAmount += effectAmount;
                         break;
                     case ItemEffect.Manasteal:
-                        ManaStealAmount += effect.Percentage;
+                        ManaStealAmount += effectAmount;
                         break;
                 }
             }

--- a/Intersect.Client.Core/Interface/Game/DescriptionWindows/ItemDescriptionWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/DescriptionWindows/ItemDescriptionWindow.cs
@@ -677,9 +677,15 @@ public partial class ItemDescriptionWindow() : DescriptionWindowBase(Interface.G
             }
 
             // Crit Chance
-            if (_itemDescriptor.CritChance > 0)
+            var critChance = _itemDescriptor.CritChance;
+            if (Globals.Me != null)
             {
-                rows.AddKeyValueRow(Strings.ItemDescription.CritChance, Strings.ItemDescription.Percentage.ToString(_itemDescriptor.CritChance));
+                critChance = Globals.Me.CalculateCriticalChance(critChance);
+            }
+
+            if (critChance > 0)
+            {
+                rows.AddKeyValueRow(Strings.ItemDescription.CritChance, Strings.ItemDescription.Percentage.ToString(critChance));
                 rows.AddKeyValueRow(Strings.ItemDescription.CritMultiplier, Strings.ItemDescription.Multiplier.ToString(_itemDescriptor.CritMultiplier));
             }
 

--- a/Intersect.Client.Core/Interface/Game/DescriptionWindows/SpellDescriptionWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/DescriptionWindows/SpellDescriptionWindow.cs
@@ -291,6 +291,10 @@ public partial class SpellDescriptionWindow() : DescriptionWindowBase(Interface.
 
         // Crit Chance
         var critChance = _spellDescriptor.Combat.GetEffectiveCritChance(_effectiveProps);
+        if (Globals.Me != null)
+        {
+            critChance = Globals.Me.CalculateCriticalChance(critChance);
+        }
         if (critChance > 0)
         {
             rows.AddKeyValueRow(Strings.SpellDescription.CritChance, Strings.SpellDescription.Percentage.ToString(critChance));

--- a/Intersect.Client.Core/Localization/Strings.cs
+++ b/Intersect.Client.Core/Localization/Strings.cs
@@ -1139,6 +1139,9 @@ public static partial class Strings
         public static LocalizedString HealthRegen = @"Health Regen: {00}%";
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString CriticalChance = @"Critical Chance: {00}%";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public static LocalizedString LevelAndClass = @"Level: {00}, Class: {01}";
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]

--- a/Intersect.Editor/Localization/Strings.cs
+++ b/Intersect.Editor/Localization/Strings.cs
@@ -3899,6 +3899,9 @@ Tick timer saved in server config.json.";
             {4, @"Luck"},
             {5, @"EXP"},
             {6, @"Mana Steal"},
+            {7, @"Accuracy"},
+            {8, @"Evasion"},
+            {9, @"Critical Chance"},
         };
 
         public static LocalizedString bonuses = @"Stat Bonuses";

--- a/Intersect.Server.Core/Entities/Entity.cs
+++ b/Intersect.Server.Core/Entities/Entity.cs
@@ -2110,6 +2110,18 @@ public abstract partial class Entity : IEntity
             return entity is Player player ? player.GetEquipmentBonusEffect(effect) : 0;
         }
 
+        static int CalculateCriticalChance(Entity attacker, int baseCritChance)
+        {
+            var critChance = baseCritChance;
+
+            var agilityPerCrit = Math.Max(1, Options.Instance.Combat.AgilityPerCritChance);
+            critChance += attacker.Stat[(int)Stat.Agility].Value() / agilityPerCrit;
+
+            critChance += GetItemEffectBonus(attacker, ItemEffect.CriticalChance);
+
+            return Math.Max(0, critChance);
+        }
+
         static double CalculateHitChance(Entity attacker, Entity defender)
         {
             const double minChance = 0.05d;
@@ -2161,9 +2173,10 @@ public abstract partial class Entity : IEntity
         var enemyVitals = enemy.GetVitals();
         var invulnerable = enemy.CachedStatuses.Any(status => status.Type == SpellEffect.Invulnerable);
 
+        var finalCritChance = CalculateCriticalChance(this, critChance);
         bool isCrit = false;
         //Is this a critical hit?
-        if (Randomization.Next(1, 101) > critChance)
+        if (Randomization.Next(1, 101) > finalCritChance)
         {
             critMultiplier = 1;
         }


### PR DESCRIPTION
## Summary
- add a critical chance item effect and configuration for agility-to-crit conversion
- include agility and equipment bonuses when calculating critical hits and showing crit chance in UIs
- extend character, spell, and item displays plus editor strings to surface the resulting critical chance

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938d5f9f444832bba0e1f2e380f350a)