### PR TITLE
Fix NullReference by instantiating flat effect controls

### DIFF
--- a/Intersect.Editor/Forms/Editors/frmItem.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/frmItem.Designer.cs
@@ -151,7 +151,9 @@ namespace Intersect.Editor.Forms.Editors
             chkEffectIsFlat = new DarkCheckBox();
             lstBonusEffects = new ListBox();
             lblEffectPercent = new Label();
+            lblEffectFlat = new Label();
             nudEffectPercent = new DarkNumericUpDown();
+            nudEffectFlat = new DarkNumericUpDown();
             grpRegen = new DarkGroupBox();
             nudMpRegen = new DarkNumericUpDown();
             nudHPRegen = new DarkNumericUpDown();


### PR DESCRIPTION
## Summary
- instantiate the flat effect label and numeric control in the item editor designer

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693903c1844c832b8eed5ace6182d4d5)