### PR TITLE
Improve spell upgrade UI and effect scaling

### DIFF
--- a/Framework/Intersect.Framework.Core/GameObjects/Spells/SpellCombatDescriptor.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Spells/SpellCombatDescriptor.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel.DataAnnotations.Schema;
+using System;
+using System.ComponentModel.DataAnnotations.Schema;
 using Intersect.Enums;
 using Intersect.Utilities;
 using Microsoft.EntityFrameworkCore;
@@ -137,6 +138,20 @@ public partial class SpellCombatDescriptor
         if (TryGetUpgrade(props, SpellUpgradeKeys.Combat.CastRange, out var up))
         {
             value += up;
+        }
+
+        return value;
+    }
+
+    public SpellEffect GetEffectiveEffect(SpellProperties props)
+    {
+        var value = Effect;
+
+        if (props?.CustomUpgrades != null &&
+            props.CustomUpgrades.TryGetValue(SpellUpgradeKeys.Combat.EffectOverride, out var upgrade) &&
+            Enum.IsDefined(typeof(SpellEffect), upgrade))
+        {
+            value = (SpellEffect)upgrade;
         }
 
         return value;

--- a/Framework/Intersect.Framework.Core/GameObjects/Spells/SpellDescriptor.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Spells/SpellDescriptor.cs
@@ -217,7 +217,7 @@ public partial class SpellDescriptor : DatabaseObject<SpellDescriptor>, IFoldera
                         continue;
                     }
 
-                    if (IsOverride(key))
+                    if (SpellUpgradeKeys.IsOverride(key))
                     {
                         effective.CustomUpgrades[key] = val;
                     }
@@ -242,7 +242,7 @@ public partial class SpellDescriptor : DatabaseObject<SpellDescriptor>, IFoldera
                     continue;
                 }
 
-                if (IsOverride(key))
+                if (SpellUpgradeKeys.IsOverride(key))
                 {
                     effective.CustomUpgrades[key] = val;
                 }
@@ -257,40 +257,7 @@ public partial class SpellDescriptor : DatabaseObject<SpellDescriptor>, IFoldera
         return effective;
     }
 
-    private static bool IsOverride(string key) =>
-        key.EndsWith("Set", StringComparison.OrdinalIgnoreCase) ||
-        key.StartsWith("set.", StringComparison.OrdinalIgnoreCase);
-
-    public SpellProperties GetPropertiesForLevel(int level)
-    {
-        var result = new SpellProperties { Level = level };
-        if (LevelUpgrades == null)
-        {
-            return result;
-        }
-
-        for (var i = 1; i <= level; i++)
-        {
-            if (!LevelUpgrades.TryGetValue(i, out var upgrade) || upgrade?.CustomUpgrades == null)
-            {
-                continue;
-            }
-
-            foreach (var kv in upgrade.CustomUpgrades)
-            {
-                if (result.CustomUpgrades.TryGetValue(kv.Key, out var current))
-                {
-                    result.CustomUpgrades[kv.Key] = current + kv.Value;
-                }
-                else
-                {
-                    result.CustomUpgrades[kv.Key] = kv.Value;
-                }
-            }
-        }
-
-        return result;
-    }
+    public SpellProperties GetPropertiesForLevel(int level) => BuildEffectiveProperties(level);
 
     public int GetEffectiveCastDuration(SpellProperties props)
     {

--- a/Framework/Intersect.Framework.Core/GameObjects/Spells/SpellUpgradeKeys.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Spells/SpellUpgradeKeys.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Intersect.Enums;
 
@@ -19,6 +20,7 @@ public static class SpellUpgradeKeys
         public const string HotDotInterval = "Combat.HotDotInterval";
         public const string OnHitDuration = "Combat.OnHitDuration";
         public const string TrapDuration = "Combat.TrapDuration";
+        public const string EffectOverride = "Combat.Effect.Set";
 
         public static class StatDiff
         {
@@ -73,8 +75,8 @@ public static class SpellUpgradeKeys
         public const string Range = "Dash.Range";
     }
 
-    public static readonly HashSet<string> All =
-    [
+    public static readonly string[] Ordered =
+    {
         CastDuration,
         CooldownDuration,
         Combat.CritChance,
@@ -86,6 +88,7 @@ public static class SpellUpgradeKeys
         Combat.HotDotInterval,
         Combat.OnHitDuration,
         Combat.TrapDuration,
+        Combat.EffectOverride,
         Combat.StatDiff.Attack,
         Combat.StatDiff.Intelligence,
         Combat.StatDiff.Defense,
@@ -97,7 +100,13 @@ public static class SpellUpgradeKeys
         VitalCost.Health,
         VitalCost.Mana,
         Dash.Range,
-    ];
+    };
+
+    public static readonly HashSet<string> All = new(Ordered);
+
+    public static bool IsOverride(string key) =>
+        key.EndsWith("Set", StringComparison.OrdinalIgnoreCase) ||
+        key.StartsWith("set.", StringComparison.OrdinalIgnoreCase);
 
     public static bool IsValid(string key) => All.Contains(key);
 }

--- a/Intersect.Client.Core/Interface/Game/DescriptionWindows/SpellDescriptionWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/DescriptionWindows/SpellDescriptionWindow.cs
@@ -353,11 +353,12 @@ public partial class SpellDescriptionWindow() : DescriptionWindowBase(Interface.
         }
 
         // Handle effect display.
-        if (_spellDescriptor.Combat.Effect != SpellEffect.None)
+        var effectiveEffect = _spellDescriptor.Combat.GetEffectiveEffect(_effectiveProps);
+        if (effectiveEffect != SpellEffect.None)
         {
             showDuration = true;
             rows.AddKeyValueRow(string.Empty, string.Empty);
-            rows.AddKeyValueRow(Strings.SpellDescription.Effect, Strings.SpellDescription.Effects[(int)_spellDescriptor.Combat.Effect]);
+            rows.AddKeyValueRow(Strings.SpellDescription.Effect, Strings.SpellDescription.Effects[(int)effectiveEffect]);
         }
 
         // Show Stat Buff / Effect / HoT / DoT duration.
@@ -415,10 +416,6 @@ public partial class SpellDescriptionWindow() : DescriptionWindowBase(Interface.
     }
 
  
-
-    private static bool IsOverride(string key) =>
-        key.EndsWith("Set", StringComparison.OrdinalIgnoreCase) ||
-        key.StartsWith("set.", StringComparison.OrdinalIgnoreCase);
 
     protected void SetupExtraInfo()
     {

--- a/Intersect.Editor/Forms/Editors/frmSpell.cs
+++ b/Intersect.Editor/Forms/Editors/frmSpell.cs
@@ -14,9 +14,11 @@ using Intersect.Framework.Core.GameObjects.NPCs;
 using Intersect.Framework.Core.GameObjects.Spells;
 using Intersect.GameObjects;
 using Intersect.Utilities;
+using System;
 using System.Drawing;
 using System.Windows.Forms;
 using System.Collections.Generic;
+using System.Linq;
 using Graphics = System.Drawing.Graphics;
 
 namespace Intersect.Editor.Forms.Editors;
@@ -38,8 +40,9 @@ public partial class FrmSpell : EditorForm
     private int mUpgradeLevel = 1;
     private bool mLoadingLevels;
 
-    private readonly Dictionary<string, DarkNumericUpDown> mUpgradeControls = new();
+    private readonly Dictionary<string, Control> mUpgradeControls = new();
     private FlowLayoutPanel mUpgradePanel;
+    private const string DefaultEffectUpgradeText = "(Usar efecto base)";
 
     public FrmSpell()
     {
@@ -75,33 +78,135 @@ public partial class FrmSpell : EditorForm
         dgvUpgrades.Dispose();
         grpUpgrades.Controls.Add(mUpgradePanel);
 
-        foreach (var key in SpellUpgradeKeys.All)
+        foreach (var key in SpellUpgradeKeys.Ordered)
         {
             var row = new Panel
             {
                 Width = mUpgradePanel.ClientSize.Width - 25,
-                Height = 25
+                Height = 30
             };
 
             var lbl = new Label
             {
-                Text = key,
+                Text = GetUpgradeLabel(key),
                 AutoSize = true,
-                Location = new System.Drawing.Point(0, 5)
+                Location = new System.Drawing.Point(0, 7)
             };
 
-            var nud = new DarkNumericUpDown
-            {
-                Minimum = int.MinValue,
-                Maximum = int.MaxValue,
-                Width = 80,
-                Location = new System.Drawing.Point(row.Width - 85, 0)
-            };
+            var control = CreateUpgradeControl(key);
+            control.Location = new System.Drawing.Point(row.Width - control.Width - 5, (row.Height - control.Height) / 2);
 
             row.Controls.Add(lbl);
-            row.Controls.Add(nud);
+            row.Controls.Add(control);
             mUpgradePanel.Controls.Add(row);
-            mUpgradeControls[key] = nud;
+            mUpgradeControls[key] = control;
+        }
+    }
+
+    private Control CreateUpgradeControl(string key)
+    {
+        if (key == SpellUpgradeKeys.Combat.EffectOverride)
+        {
+            var combo = new DarkComboBox
+            {
+                Width = 160,
+                DropDownStyle = ComboBoxStyle.DropDownList,
+                DrawMode = DrawMode.OwnerDrawFixed,
+                ForeColor = Color.Gainsboro,
+                BackColor = Color.FromArgb(69, 73, 74)
+            };
+
+            combo.Items.Add(DefaultEffectUpgradeText);
+            foreach (var item in cmbExtraEffect.Items.Cast<object>())
+            {
+                combo.Items.Add(item);
+            }
+
+            combo.SelectedIndex = 0;
+            return combo;
+        }
+
+        return new DarkNumericUpDown
+        {
+            Minimum = int.MinValue,
+            Maximum = int.MaxValue,
+            Width = 100
+        };
+    }
+
+    private string GetUpgradeLabel(string key)
+    {
+        return key switch
+        {
+            SpellUpgradeKeys.CastDuration => Strings.SpellEditor.casttime.ToString(),
+            SpellUpgradeKeys.CooldownDuration => Strings.SpellEditor.cooldown.ToString(),
+            SpellUpgradeKeys.Combat.CritChance => Strings.SpellEditor.critchance.ToString(),
+            SpellUpgradeKeys.Combat.CritMultiplier => Strings.SpellEditor.critmultiplier.ToString(),
+            SpellUpgradeKeys.Combat.HitRadius => Strings.SpellEditor.hitradius.ToString(),
+            SpellUpgradeKeys.Combat.CastRange => Strings.SpellEditor.castrange.ToString(),
+            SpellUpgradeKeys.Combat.Scaling => Strings.SpellEditor.scalingamount.ToString(),
+            SpellUpgradeKeys.Combat.Duration => Strings.SpellEditor.boostduration.ToString(),
+            SpellUpgradeKeys.Combat.HotDotInterval => Strings.SpellEditor.hotdottick.ToString(),
+            SpellUpgradeKeys.Combat.OnHitDuration => "Duración de efecto On Hit:",
+            SpellUpgradeKeys.Combat.TrapDuration => "Duración de trampa:",
+            SpellUpgradeKeys.Combat.EffectOverride => "Efecto adicional:",
+            SpellUpgradeKeys.Combat.StatDiff.Attack => Globals.GetStatName((int)Stat.Attack),
+            SpellUpgradeKeys.Combat.StatDiff.Intelligence => Globals.GetStatName((int)Stat.Intelligence),
+            SpellUpgradeKeys.Combat.StatDiff.Defense => Globals.GetStatName((int)Stat.Defense),
+            SpellUpgradeKeys.Combat.StatDiff.Vitality => Globals.GetStatName((int)Stat.Vitality),
+            SpellUpgradeKeys.Combat.StatDiff.Speed => Globals.GetStatName((int)Stat.Speed),
+            SpellUpgradeKeys.Combat.StatDiff.Agility => Globals.GetStatName((int)Stat.Agility),
+            SpellUpgradeKeys.Combat.VitalDiff.Health => "Salud (daño/curación):",
+            SpellUpgradeKeys.Combat.VitalDiff.Mana => "Maná (daño/curación):",
+            SpellUpgradeKeys.VitalCost.Health => "Coste de salud:",
+            SpellUpgradeKeys.VitalCost.Mana => "Coste de maná:",
+            SpellUpgradeKeys.Dash.Range => "Alcance del dash:",
+            _ => key
+        };
+    }
+
+    private static void ResetUpgradeControl(string key, Control control)
+    {
+        switch (control)
+        {
+            case DarkNumericUpDown numeric:
+                numeric.Value = 0;
+                break;
+            case DarkComboBox combo when key == SpellUpgradeKeys.Combat.EffectOverride:
+                combo.SelectedIndex = 0;
+                break;
+        }
+    }
+
+    private static void ApplyUpgradeValue(string key, Control control, int value)
+    {
+        switch (control)
+        {
+            case DarkNumericUpDown numeric:
+                numeric.Value = value;
+                break;
+            case DarkComboBox combo when key == SpellUpgradeKeys.Combat.EffectOverride:
+                var index = Math.Max(0, Math.Min(value + 1, combo.Items.Count - 1));
+                combo.SelectedIndex = index;
+                break;
+        }
+    }
+
+    private static int? GetUpgradeValue(string key, Control control)
+    {
+        switch (control)
+        {
+            case DarkNumericUpDown numeric:
+                return (int)numeric.Value;
+            case DarkComboBox combo when key == SpellUpgradeKeys.Combat.EffectOverride:
+                if (combo.SelectedIndex <= 0)
+                {
+                    return null;
+                }
+
+                return combo.SelectedIndex - 1;
+            default:
+                return null;
         }
     }
     private void AssignEditorItem(Guid id)
@@ -433,10 +538,15 @@ public partial class FrmSpell : EditorForm
 
         foreach (var kv in mUpgradeControls)
         {
-            var value = (int)kv.Value.Value;
-            if (value != 0)
+            var value = GetUpgradeValue(kv.Key, kv.Value);
+            if (!value.HasValue)
             {
-                props.CustomUpgrades[kv.Key] = value;
+                continue;
+            }
+
+            if (value != 0 || SpellUpgradeKeys.IsOverride(kv.Key))
+            {
+                props.CustomUpgrades[kv.Key] = value.Value;
             }
         }
 
@@ -450,9 +560,9 @@ public partial class FrmSpell : EditorForm
             return;
         }
 
-        foreach (var control in mUpgradeControls.Values)
+        foreach (var kv in mUpgradeControls)
         {
-            control.Value = 0;
+            ResetUpgradeControl(kv.Key, kv.Value);
         }
 
         if (mUpgradeLevel < 1 || mUpgradeLevel > Options.Instance.Player.MaxSpellLevel)
@@ -468,7 +578,7 @@ public partial class FrmSpell : EditorForm
             {
                 if (mUpgradeControls.TryGetValue(kv.Key, out var control))
                 {
-                    control.Value = kv.Value;
+                    ApplyUpgradeValue(kv.Key, control, kv.Value);
                 }
             }
         }

--- a/Intersect.Server.Core/Entities/Entity.cs
+++ b/Intersect.Server.Core/Entities/Entity.cs
@@ -1802,13 +1802,14 @@ public abstract partial class Entity : IEntity
         var aliveAnimations = new List<KeyValuePair<Guid, Direction>>();
 
         spellProperties = SpellMath.Scale(spellDescriptor, spellProperties);
+        var effectiveEffect = spellDescriptor.Combat.GetEffectiveEffect(spellProperties);
 
         //Only count safe zones and friendly fire if its a dangerous spell! (If one has been used)
         if (!spellDescriptor.Combat.Friendly &&
             (spellDescriptor.Combat.TargetType != (int)SpellTargetType.Self || onHitTrigger))
         {
             //If about to hit self with an unfriendly spell (maybe aoe?) return
-            if (target == this && spellDescriptor.Combat.Effect != SpellEffect.OnHit)
+            if (target == this && effectiveEffect != SpellEffect.OnHit)
             {
                 return;
             }
@@ -1864,7 +1865,7 @@ public abstract partial class Entity : IEntity
         }
 
         if (spellDescriptor.HitAnimationId != Guid.Empty &&
-            (spellDescriptor.Combat.Effect != SpellEffect.OnHit || onHitTrigger))
+            (effectiveEffect != SpellEffect.OnHit || onHitTrigger))
         {
             deadAnimations.Add(new KeyValuePair<Guid, Direction>(spellDescriptor.HitAnimationId, Direction.Up));
             aliveAnimations.Add(new KeyValuePair<Guid, Direction>(spellDescriptor.HitAnimationId, Direction.Up));
@@ -1900,8 +1901,8 @@ public abstract partial class Entity : IEntity
         var damageHealth = spellDescriptor.Combat.GetEffectiveVitalDiff(Vital.Health, spellProperties);
         var damageMana = spellDescriptor.Combat.GetEffectiveVitalDiff(Vital.Mana, spellProperties);
 
-        if ((spellDescriptor.Combat.Effect != SpellEffect.OnHit || onHitTrigger) &&
-            spellDescriptor.Combat.Effect != SpellEffect.Shield)
+        if ((effectiveEffect != SpellEffect.OnHit || onHitTrigger) &&
+            effectiveEffect != SpellEffect.Shield)
         {
             Attack(
                 target, damageHealth, damageMana, (DamageType)spellDescriptor.Combat.DamageType,
@@ -1912,13 +1913,13 @@ public abstract partial class Entity : IEntity
             );
         }
 
-        if (spellDescriptor.Combat.Effect > 0) //Handle status effects
+        if (effectiveEffect > 0) //Handle status effects
         {
             //Check for onhit effect to avoid the onhit effect recycling.
-            if (!(onHitTrigger && spellDescriptor.Combat.Effect == SpellEffect.OnHit))
+            if (!(onHitTrigger && effectiveEffect == SpellEffect.OnHit))
             {
                 // If the entity is immune to some status, then just inform the client of such
-                if (target.Immunities.Contains(spellDescriptor.Combat.Effect))
+                if (target.Immunities.Contains(effectiveEffect))
                 {
                     PacketSender.SendActionMsg(
                         target, Strings.Combat.ImmuneToEffect, CustomColors.Combat.Status
@@ -1928,7 +1929,7 @@ public abstract partial class Entity : IEntity
                 {
                     // Else, apply the status
                     new Status(
-                        target, this, spellDescriptor, spellDescriptor.Combat.Effect, duration,
+                        target, this, spellDescriptor, effectiveEffect, duration,
                         spellDescriptor.Combat.TransformSprite
                     );
 
@@ -1938,11 +1939,11 @@ public abstract partial class Entity : IEntity
                     }
 
                     PacketSender.SendActionMsg(
-                        target, Strings.Combat.Status[(int)spellDescriptor.Combat.Effect], CustomColors.Combat.Status
+                        target, Strings.Combat.Status[(int)effectiveEffect], CustomColors.Combat.Status
                     );
 
                     //If an onhit or shield status bail out as we don't want to do any damage.
-                    if (spellDescriptor.Combat.Effect == SpellEffect.OnHit || spellDescriptor.Combat.Effect == SpellEffect.Shield)
+                    if (effectiveEffect == SpellEffect.OnHit || effectiveEffect == SpellEffect.Shield)
                     {
                         Animate(target, aliveAnimations);
 
@@ -1955,9 +1956,9 @@ public abstract partial class Entity : IEntity
         {
             if (statBuffTime > -1)
             {
-                if (!target.Immunities.Contains(spellDescriptor.Combat.Effect))
+                if (!target.Immunities.Contains(effectiveEffect))
                 {
-                    new Status(target, this, spellDescriptor, spellDescriptor.Combat.Effect, statBuffTime, "");
+                    new Status(target, this, spellDescriptor, effectiveEffect, statBuffTime, "");
 
                     if (target is Npc npc)
                     {
@@ -2512,17 +2513,18 @@ public abstract partial class Entity : IEntity
         }
 
         var spellProperties = (this as Player)?.GetSpellProperties(spell.Id);
+        var scaledSpellProperties = SpellMath.Scale(spell, spellProperties);
 
         // Do we meet the vital requirements?
         if (checkVitalReqs)
         {
-            if (spell.GetEffectiveVitalCost(Vital.Mana, spellProperties) > GetVital(Vital.Mana))
+            if (spell.GetEffectiveVitalCost(Vital.Mana, scaledSpellProperties) > GetVital(Vital.Mana))
             {
                 reason = SpellCastFailureReason.InsufficientMP;
                 return false;
             }
 
-            if (spell.GetEffectiveVitalCost(Vital.Health, spellProperties) >= GetVital(Vital.Health))
+            if (spell.GetEffectiveVitalCost(Vital.Health, scaledSpellProperties) >= GetVital(Vital.Health))
             {
                 reason = SpellCastFailureReason.InsufficientHP;
                 return false;
@@ -2531,7 +2533,8 @@ public abstract partial class Entity : IEntity
 
         // Check if the caster has any status effects that need to apply.
         // Ignore if the current spell is a Cleanse, this will ignore any and all status effects.
-        if (spell.Combat.Effect != SpellEffect.Cleanse)
+        var effectiveEffect = spell.Combat.GetEffectiveEffect(scaledSpellProperties);
+        if (effectiveEffect != SpellEffect.Cleanse)
         {
             foreach (var status in CachedStatuses)
             {
@@ -2591,7 +2594,7 @@ public abstract partial class Entity : IEntity
         //Check for range of a single target spell
         if (singleTargetSpell && target != this)
         {
-            var castRange = spell.Combat.GetEffectiveCastRange(spellProperties);
+            var castRange = spell.Combat.GetEffectiveCastRange(scaledSpellProperties);
             if (!InRangeOf(target, castRange))
             {
                 reason = SpellCastFailureReason.OutOfRange;
@@ -2618,6 +2621,7 @@ public abstract partial class Entity : IEntity
 
         var spellProperties = CastSpellProperties ?? (this as Player)?.GetSpellProperties(spellId);
         var scaledProperties = SpellMath.Scale(spellBase, spellProperties);
+        var effectiveEffect = spellBase.Combat.GetEffectiveEffect(scaledProperties);
 
         var manaCost = spellBase.GetEffectiveVitalCost(Vital.Mana, scaledProperties);
         if (manaCost > 0)
@@ -2650,7 +2654,7 @@ public abstract partial class Entity : IEntity
                     {
                         case SpellTargetType.Self:
                             if (spellBase.HitAnimationId != Guid.Empty &&
-                                spellBase.Combat.Effect != SpellEffect.OnHit)
+                                effectiveEffect != SpellEffect.OnHit)
                             {
                                 PacketSender.SendAnimationToProximity(
                                     spellBase.HitAnimationId,
@@ -2727,7 +2731,7 @@ public abstract partial class Entity : IEntity
 
                             break;
                         case SpellTargetType.OnHit:
-                            if (spellBase.Combat.Effect == SpellEffect.OnHit)
+                            if (effectiveEffect == SpellEffect.OnHit)
                             {
                                 new Status(
                                     this,
@@ -2737,10 +2741,10 @@ public abstract partial class Entity : IEntity
                                     spellBase.Combat.GetEffectiveOnHitDuration(scaledProperties),
                                     spellBase.Combat.TransformSprite
                                 );
-                                
+
                                 PacketSender.SendActionMsg(
                                     this,
-                                    Strings.Combat.Status[(int)spellBase.Combat.Effect],
+                                    Strings.Combat.Status[(int)effectiveEffect],
                                     CustomColors.Combat.Status
                                 );
                             }

--- a/Intersect.Server.Core/General/SpellMath.cs
+++ b/Intersect.Server.Core/General/SpellMath.cs
@@ -6,23 +6,6 @@ public static class SpellMath
 {
     public static SpellProperties Scale(SpellDescriptor descriptor, SpellProperties? properties = null)
     {
-        var scaled = descriptor.GetPropertiesForLevel(properties?.Level ?? 1);
-
-        if (properties?.CustomUpgrades?.Count > 0)
-        {
-            foreach (var kv in properties.CustomUpgrades)
-            {
-                if (scaled.CustomUpgrades.ContainsKey(kv.Key))
-                {
-                    scaled.CustomUpgrades[kv.Key] += kv.Value;
-                }
-                else
-                {
-                    scaled.CustomUpgrades[kv.Key] = kv.Value;
-                }
-            }
-        }
-
-        return scaled;
+        return descriptor.BuildEffectiveProperties(properties?.Level ?? 1, properties);
     }
 }


### PR DESCRIPTION
## Summary
- add a level-based effect override key and honor it when building spell properties
- show effective spell effects in descriptions and combat handling based on upgraded properties
- replace the spell upgrade grid with labeled controls, including an effect override picker, for clearer editor usability

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939f3126088832b8ddb84d5db256c61)