### PR TITLE
Show quest offer rewards like quest window

### DIFF
--- a/Intersect.Client.Core/Interface/Game/QuestOfferWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/QuestOfferWindow.cs
@@ -32,8 +32,19 @@ namespace Intersect.Client.Interface.Game
         private Label mQuestTitle;
 
         // Contenedores ya definidos en el JSON de UI
+        private readonly ScrollControl _rewardContainer;
         private readonly ScrollControl _rewardItemContainer;
         private readonly ScrollControl _rewardExpContainer;
+
+        // Helpers de layout de recompensas
+        private const int RewardPaddingX = 10;
+        private const int RewardPaddingY = 10;
+        private const int RewardSpacing = 3;
+        private const int RewardExpHeight = 44;
+
+        // Cache de widgets creados para medir/ubicar
+        private readonly List<Base> _rewardItemWidgets = new();
+        private readonly List<Base> _rewardExpWidgets = new();
 
         public QuestOfferWindow(Canvas gameCanvas)
         {
@@ -49,9 +60,11 @@ namespace Intersect.Client.Interface.Game
             mQuestPromptTemplate = new Label(mQuestPromptArea, "QuestOfferTemplate");
             mQuestPromptLabel = new RichLabel(mQuestPromptArea);
 
+            _rewardContainer = new ScrollControl(mQuestOfferWindow, "QuestRewardContainer");
+
             // Contenedores de recompensas (deben existir en el JSON)
-            _rewardItemContainer = new ScrollControl(mQuestOfferWindow, "QuestRewardItemContainer");
-            _rewardExpContainer = new ScrollControl(mQuestOfferWindow, "QuestRewardExpContainer");
+            _rewardExpContainer = TryGetOrCreate(_rewardContainer, "QuestRewardExpContainer", 10, 10, 380, RewardExpHeight);
+            _rewardItemContainer = TryGetOrCreate(_rewardContainer, "QuestRewardItemContainer", 10, 60, 380, 50);
 
             // Botones
             mAcceptButton = new Button(mQuestOfferWindow, "AcceptButton");
@@ -67,6 +80,10 @@ namespace Intersect.Client.Interface.Game
 
             // Bloqueo de input
             Interface.InputBlockingComponents.Add(mQuestOfferWindow);
+
+            _rewardExpContainer.IsHidden = true;
+            _rewardItemContainer.IsHidden = true;
+            _rewardContainer.IsHidden = true;
         }
 
         public void AddRewardWidget(Base widget)
@@ -77,9 +94,21 @@ namespace Intersect.Client.Interface.Game
             }
 
             var widgetName = widget.Name ?? string.Empty;
-            var goesToExp = widgetName.IndexOf("RewardExp", StringComparison.OrdinalIgnoreCase) >= 0;
+            var goesToExp =
+                widgetName.Contains("RewardExp", StringComparison.OrdinalIgnoreCase) ||
+                widgetName.Equals("ExpChip", StringComparison.OrdinalIgnoreCase) ||
+                widgetName.Equals("QuestRewardExpChip", StringComparison.OrdinalIgnoreCase);
 
             widget.Parent = goesToExp ? _rewardExpContainer : _rewardItemContainer;
+            if (goesToExp)
+            {
+                _rewardExpWidgets.Add(widget);
+            }
+            else
+            {
+                _rewardItemWidgets.Add(widget);
+            }
+
             widget.Show();
         }
 
@@ -87,6 +116,13 @@ namespace Intersect.Client.Interface.Game
         {
             ClearChildren(_rewardItemContainer);
             ClearChildren(_rewardExpContainer);
+
+            _rewardItemWidgets.Clear();
+            _rewardExpWidgets.Clear();
+
+            _rewardItemContainer.IsHidden = true;
+            _rewardExpContainer.IsHidden = true;
+            _rewardContainer.IsHidden = true;
         }
 
         private static void ClearChildren(Base container)
@@ -113,6 +149,20 @@ namespace Intersect.Client.Interface.Game
                 Globals.RemoveQuestRewards(questId);
                 ClearRewardWidgets();
             }
+        }
+
+        private static ScrollControl TryGetOrCreate(ScrollControl parent, string name, int x, int y, int w, int h)
+        {
+            var child = parent.FindChildByName(name) as ScrollControl;
+            if (child == null)
+            {
+                child = new ScrollControl(parent, name);
+                child.SetPosition(x, y);
+                child.SetSize(w, h);
+                child.EnableScroll(false, true);
+            }
+
+            return child;
         }
 
         private void _acceptButton_Clicked(Base sender, MouseButtonState arguments)
@@ -147,30 +197,142 @@ namespace Intersect.Client.Interface.Game
                 mQuestPromptLabel.AddText(quest.StartDescription, mQuestPromptTemplate);
                 mQuestPromptLabel.SizeToChildren(false, true);
                 mQuestOfferText = quest.StartDescription;
-
-                ClearRewardWidgets();
-
-                if (Globals.QuestRewards.TryGetValue(quest.Id, out var rewards))
-                {
-                    foreach (var reward in rewards)
-                    {
-                        _ = new QuestRewardItem(this, reward.Key, reward.Value);
-                    }
-                }
-
-                Globals.QuestExperience.TryGetValue(quest.Id, out var playerExp);
-                Globals.QuestJobExperience.TryGetValue(quest.Id, out Dictionary<JobType, long>? jobExp);
-                Globals.QuestGuildExperience.TryGetValue(quest.Id, out var guildExp);
-                Globals.QuestFactionHonor.TryGetValue(quest.Id, out Dictionary<Factions, int>? factionHonor);
-
-                if (playerExp > 0 || (jobExp != null && jobExp.Count > 0) || guildExp > 0 ||
-                    (factionHonor != null && factionHonor.Count > 0))
-                {
-                    _ = new QuestRewardExp(this, playerExp, jobExp, guildExp, factionHonor);
-                }
+                LoadRewardWidgets(quest.Id);
 
                 mLastQuestId = quest.Id;
             }
+        }
+
+        private void LoadRewardWidgets(Guid questId)
+        {
+            ClearRewardWidgets();
+
+            Globals.QuestExperience.TryGetValue(questId, out var playerExp);
+            Globals.QuestJobExperience.TryGetValue(questId, out Dictionary<JobType, long>? jobExp);
+            Globals.QuestGuildExperience.TryGetValue(questId, out var guildExp);
+            Globals.QuestFactionHonor.TryGetValue(questId, out Dictionary<Factions, int>? factionHonor);
+
+            var anyExp =
+                (playerExp > 0) ||
+                (jobExp != null && jobExp.Count > 0) ||
+                (guildExp > 0) ||
+                (factionHonor != null && factionHonor.Count > 0);
+
+            _rewardExpContainer.SetPosition(RewardPaddingX, RewardPaddingY);
+
+            var availableWidth = Math.Max(_rewardContainer.Width - 2 * RewardPaddingX, 1);
+            var expHeight = 0;
+
+            if (anyExp)
+            {
+                _ = new QuestRewardExp(this, playerExp, jobExp, guildExp, factionHonor);
+
+                const int minWidth = 80;
+                const int spacing = 4;
+                var x = 0;
+                var y = 0;
+                var rowHeight = RewardExpHeight;
+
+                foreach (var chip in _rewardExpWidgets)
+                {
+                    var width = Math.Max(chip.Width, minWidth);
+
+                    if (x > 0 && x + width > availableWidth)
+                    {
+                        x = 0;
+                        y += rowHeight + spacing;
+                    }
+
+                    chip.SetPosition(x, y);
+                    x += width + spacing;
+                }
+
+                expHeight = _rewardExpWidgets.Count > 0 ? y + rowHeight : 0;
+
+                _rewardExpContainer.SetSize(availableWidth, Math.Max(expHeight, 1));
+                _rewardExpContainer.IsHidden = _rewardExpWidgets.Count == 0;
+            }
+            else
+            {
+                _rewardExpContainer.IsHidden = true;
+                _rewardExpContainer.SetSize(1, 1);
+            }
+
+            if (Globals.QuestRewards.TryGetValue(questId, out var rewards) && rewards.Count > 0)
+            {
+                foreach (var kv in rewards)
+                {
+                    _ = new QuestRewardItem(this, kv.Key, kv.Value);
+                }
+
+                _rewardItemContainer.IsHidden = _rewardItemWidgets.Count == 0;
+            }
+            else
+            {
+                _rewardItemContainer.IsHidden = true;
+            }
+
+            _rewardContainer.IsHidden = _rewardExpContainer.IsHidden && _rewardItemContainer.IsHidden;
+            if (_rewardContainer.IsHidden)
+            {
+                return;
+            }
+
+            var itemsY = _rewardExpContainer.IsHidden
+                ? RewardPaddingY
+                : RewardPaddingY + _rewardExpContainer.Height + RewardSpacing;
+
+            _rewardItemContainer.SetPosition(RewardPaddingX, itemsY);
+
+            var itemsHeight = 0;
+
+            if (!_rewardItemContainer.IsHidden && _rewardItemWidgets.Count > 0)
+            {
+                const int paddingX = 10;
+                const int paddingY = 10;
+                var insideWidth = Math.Max(availableWidth - 2 * paddingX, 1);
+
+                _rewardItemContainer.SetSize(availableWidth, _rewardItemContainer.Height);
+
+                var first = _rewardItemWidgets[0];
+                var itemWidth = Math.Max(first.Width + first.Margin.Left + first.Margin.Right, 40);
+                var itemHeight = Math.Max(first.Height + first.Margin.Top + first.Margin.Bottom, 40);
+
+                var itemsPerRow = Math.Max(insideWidth / Math.Max(itemWidth, 1), 1);
+
+                for (var i = 0; i < _rewardItemWidgets.Count; i++)
+                {
+                    var column = i % itemsPerRow;
+                    var row = i / itemsPerRow;
+
+                    var x = paddingX + column * itemWidth;
+                    var y = paddingY + row * itemHeight;
+
+                    _rewardItemWidgets[i].SetPosition(x, y);
+                    _rewardItemWidgets[i].Show();
+                }
+
+                var rows = (int)Math.Ceiling(_rewardItemWidgets.Count / (double)itemsPerRow);
+                itemsHeight = paddingY * 2 + rows * itemHeight;
+
+                _rewardItemContainer.SetSize(availableWidth, itemsHeight);
+            }
+
+            var totalHeight = RewardPaddingY;
+            if (!_rewardExpContainer.IsHidden)
+            {
+                totalHeight += _rewardExpContainer.Height + RewardSpacing;
+            }
+
+            if (!_rewardItemContainer.IsHidden)
+            {
+                totalHeight += _rewardItemContainer.Height;
+            }
+
+            totalHeight += RewardPaddingY;
+
+            _rewardContainer.EnableScroll(false, true);
+            _rewardContainer.SetSize(_rewardContainer.Width, totalHeight);
         }
 
         public void Show() => mQuestOfferWindow.IsHidden = false;


### PR DESCRIPTION
## Summary
- align quest offer reward containers and layout with the quest log window
- ensure quest offer windows render experience chips and reward items consistently

## Testing
- Not run (dotnet CLI not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a11cf4cd0832b942b57047b81f421)