### PR TITLE
Show equipment effects in item descriptions

### DIFF
--- a/Intersect.Client.Core/Interface/Game/DescriptionWindows/ItemDescriptionWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/DescriptionWindows/ItemDescriptionWindow.cs
@@ -825,17 +825,16 @@ public partial class ItemDescriptionWindow() : DescriptionWindowBase(Interface.G
 
                 rows.AddKeyValueRow(statLabel, statMessage);
 
-
-                // ====== Bonus Effects ======
-                foreach (var effect in _itemDescriptor.Effects)
-                {
-                    if (effect.Type != ItemEffect.None && effect.Percentage != 0)
-                    {
-                        rows.AddKeyValueRow(Strings.ItemDescription.BonusEffects[(int)effect.Type], Strings.ItemDescription.Percentage.ToString(effect.Percentage));
-                    }
-                }
-
                 rows.SizeToChildren(true, true);
+            }
+        }
+
+        // ====== Bonus Effects ======
+        foreach (var effect in _itemDescriptor.Effects)
+        {
+            if (effect.Type != ItemEffect.None && effect.Percentage != 0)
+            {
+                rows.AddKeyValueRow(Strings.ItemDescription.BonusEffects[(int)effect.Type], Strings.ItemDescription.Percentage.ToString(effect.Percentage));
             }
         }
         rows.SizeToChildren(true, true);


### PR DESCRIPTION
## Summary
- ensure equipment bonus effects always render in the item description
- move effect rendering out of stat range-only branch to display consistently

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a1c1e9b04832bb37ff8c51463a15b)