### PR TITLE
Guard item stats arrays in editor

### DIFF
--- a/Intersect.Editor/Forms/Editors/frmItem.cs
+++ b/Intersect.Editor/Forms/Editors/frmItem.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Drawing.Imaging;
+using System.Windows.Forms;
 using DarkUI.Forms;
 using Intersect.Editor.Content;
 using Intersect.Editor.Core;
@@ -176,6 +177,43 @@ public partial class FrmItem : EditorForm
         PopulateRuneCombos();
         InitLocalization();
         UpdateEditor();
+    }
+
+    private static decimal ClampToControlRange(decimal value, NumericUpDown control)
+    {
+        if (value < control.Minimum)
+        {
+            return control.Minimum;
+        }
+
+        if (value > control.Maximum)
+        {
+            return control.Maximum;
+        }
+
+        return value;
+    }
+
+    private static void SetNumericValue(NumericUpDown control, int[] values, int index)
+    {
+        if (values != null && index < values.Length)
+        {
+            control.Enabled = true;
+            control.Value = ClampToControlRange(values[index], control);
+        }
+        else
+        {
+            control.Enabled = false;
+            control.Value = 0;
+        }
+    }
+
+    private static void UpdateStatValue(int[] array, int index, int value)
+    {
+        if (array != null && index < array.Length)
+        {
+            array[index] = value;
+        }
     }
 
     private void InitLocalization()
@@ -371,24 +409,24 @@ public partial class FrmItem : EditorForm
             }
 
             // Stats fijos
-            nudStr.Value = mEditorItem.StatsGiven[0];
-            nudMag.Value = mEditorItem.StatsGiven[1];
-            nudDef.Value = mEditorItem.StatsGiven[2];
-            nudMR.Value = mEditorItem.StatsGiven[3];
-            nudSpd.Value = mEditorItem.StatsGiven[4];
-            nudAgi.Value = mEditorItem.StatsGiven[5];
-            nudDmg.Value = mEditorItem.StatsGiven[6];
-            nudCur.Value = mEditorItem.StatsGiven[7];
+            SetNumericValue(nudStr, mEditorItem.StatsGiven, 0);
+            SetNumericValue(nudMag, mEditorItem.StatsGiven, 1);
+            SetNumericValue(nudDef, mEditorItem.StatsGiven, 2);
+            SetNumericValue(nudMR, mEditorItem.StatsGiven, 3);
+            SetNumericValue(nudSpd, mEditorItem.StatsGiven, 4);
+            SetNumericValue(nudAgi, mEditorItem.StatsGiven, 5);
+            SetNumericValue(nudDmg, mEditorItem.StatsGiven, 6);
+            SetNumericValue(nudCur, mEditorItem.StatsGiven, 7);
 
             // Stats porcentuales
-            nudStrPercentage.Value = mEditorItem.PercentageStatsGiven[0];
-            nudMagPercentage.Value = mEditorItem.PercentageStatsGiven[1];
-            nudDefPercentage.Value = mEditorItem.PercentageStatsGiven[2];
-            nudMRPercentage.Value = mEditorItem.PercentageStatsGiven[3];
-            nudSpdPercentage.Value = mEditorItem.PercentageStatsGiven[4];
-            nudAgiPercentage.Value = mEditorItem.PercentageStatsGiven[5];
-            nudDmgPercentage.Value = mEditorItem.PercentageStatsGiven[6];
-            nudCurPercentage.Value = mEditorItem.PercentageStatsGiven[7];
+            SetNumericValue(nudStrPercentage, mEditorItem.PercentageStatsGiven, 0);
+            SetNumericValue(nudMagPercentage, mEditorItem.PercentageStatsGiven, 1);
+            SetNumericValue(nudDefPercentage, mEditorItem.PercentageStatsGiven, 2);
+            SetNumericValue(nudMRPercentage, mEditorItem.PercentageStatsGiven, 3);
+            SetNumericValue(nudSpdPercentage, mEditorItem.PercentageStatsGiven, 4);
+            SetNumericValue(nudAgiPercentage, mEditorItem.PercentageStatsGiven, 5);
+            SetNumericValue(nudDmgPercentage, mEditorItem.PercentageStatsGiven, 6);
+            SetNumericValue(nudCurPercentage, mEditorItem.PercentageStatsGiven, 7);
 
             // Vitals
             nudHealthBonus.Value = mEditorItem.VitalsGiven[0];
@@ -1044,52 +1082,52 @@ public partial class FrmItem : EditorForm
 
     private void nudStr_ValueChanged(object sender, EventArgs e)
     {
-        mEditorItem.StatsGiven[0] = (int)nudStr.Value;
+        UpdateStatValue(mEditorItem.StatsGiven, 0, (int)nudStr.Value);
     }
 
     private void nudMag_ValueChanged(object sender, EventArgs e)
     {
-        mEditorItem.StatsGiven[1] = (int)nudMag.Value;
+        UpdateStatValue(mEditorItem.StatsGiven, 1, (int)nudMag.Value);
     }
 
     private void nudDef_ValueChanged(object sender, EventArgs e)
     {
-        mEditorItem.StatsGiven[2] = (int)nudDef.Value;
+        UpdateStatValue(mEditorItem.StatsGiven, 2, (int)nudDef.Value);
     }
 
     private void nudMR_ValueChanged(object sender, EventArgs e)
     {
-        mEditorItem.StatsGiven[3] = (int)nudMR.Value;
+        UpdateStatValue(mEditorItem.StatsGiven, 3, (int)nudMR.Value);
     }
 
     private void nudSpd_ValueChanged(object sender, EventArgs e)
     {
-        mEditorItem.StatsGiven[4] = (int)nudSpd.Value;
+        UpdateStatValue(mEditorItem.StatsGiven, 4, (int)nudSpd.Value);
     }
 
     private void nudStrPercentage_ValueChanged(object sender, EventArgs e)
     {
-        mEditorItem.PercentageStatsGiven[0] = (int)nudStrPercentage.Value;
+        UpdateStatValue(mEditorItem.PercentageStatsGiven, 0, (int)nudStrPercentage.Value);
     }
 
     private void nudMagPercentage_ValueChanged(object sender, EventArgs e)
     {
-        mEditorItem.PercentageStatsGiven[1] = (int)nudMagPercentage.Value;
+        UpdateStatValue(mEditorItem.PercentageStatsGiven, 1, (int)nudMagPercentage.Value);
     }
 
     private void nudDefPercentage_ValueChanged(object sender, EventArgs e)
     {
-        mEditorItem.PercentageStatsGiven[2] = (int)nudDefPercentage.Value;
+        UpdateStatValue(mEditorItem.PercentageStatsGiven, 2, (int)nudDefPercentage.Value);
     }
 
     private void nudMRPercentage_ValueChanged(object sender, EventArgs e)
     {
-        mEditorItem.PercentageStatsGiven[3] = (int)nudMRPercentage.Value;
+        UpdateStatValue(mEditorItem.PercentageStatsGiven, 3, (int)nudMRPercentage.Value);
     }
 
     private void nudSpdPercentage_ValueChanged(object sender, EventArgs e)
     {
-        mEditorItem.PercentageStatsGiven[4] = (int)nudSpdPercentage.Value;
+        UpdateStatValue(mEditorItem.PercentageStatsGiven, 4, (int)nudSpdPercentage.Value);
     }
 
     private void nudBag_ValueChanged(object sender, EventArgs e)
@@ -1819,31 +1857,31 @@ public partial class FrmItem : EditorForm
 
     private void nudAgi_ValueChanged(object sender, EventArgs e)
     {
-        mEditorItem.StatsGiven[5] = (int)nudAgi.Value;
+        UpdateStatValue(mEditorItem.StatsGiven, 5, (int)nudAgi.Value);
     }
 
     private void nudDmg_ValueChanged(object sender, EventArgs e)
     {
-        mEditorItem.StatsGiven[6] = (int)nudDmg.Value;
+        UpdateStatValue(mEditorItem.StatsGiven, 6, (int)nudDmg.Value);
     }
 
     private void nudCur_ValueChanged(object sender, EventArgs e)
     {
-        mEditorItem.StatsGiven[7] = (int)nudCur.Value;
+        UpdateStatValue(mEditorItem.StatsGiven, 7, (int)nudCur.Value);
     }
 
     private void nudAgiPercentage_ValueChanged(object sender, EventArgs e)
     {
-        mEditorItem.PercentageStatsGiven[5] = (int)nudAgiPercentage.Value;
+        UpdateStatValue(mEditorItem.PercentageStatsGiven, 5, (int)nudAgiPercentage.Value);
     }
 
     private void nudDmgPercentage_ValueChanged(object sender, EventArgs e)
     {
-        mEditorItem.PercentageStatsGiven[6] = (int)nudDmgPercentage.Value;
+        UpdateStatValue(mEditorItem.PercentageStatsGiven, 6, (int)nudDmgPercentage.Value);
     }
 
     private void nudCurPercentage_ValueChanged(object sender, EventArgs e)
     {
-        mEditorItem.PercentageStatsGiven[7] = (int)nudCurPercentage.Value;
+        UpdateStatValue(mEditorItem.PercentageStatsGiven, 7, (int)nudCurPercentage.Value);
     }
 }


### PR DESCRIPTION
## Summary
- add helper methods to clamp numeric inputs and guard against missing stat indices
- disable stat controls when the backing arrays are shorter to prevent crashes while loading items
- update stat change handlers to safely write values only when indices exist

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b8a168bf4832bb38707b55be5276a)