### PR TITLE
Refactor character UI to move equipment into inventory

### DIFF
--- a/Intersect.Client.Core/Interface/Game/Character/CharacterWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Character/CharacterWindow.cs
@@ -20,9 +20,12 @@ namespace Intersect.Client.Interface.Game.Character;
 
 public partial class CharacterWindow : Window
 {
-    private const int WindowWidth = 700;
+    private const int WindowWidth = 560;
     private const int WindowHeight = 520;
     private const int Margin = 16;
+
+    private const int InfoHeight = 120;
+    private const int StatsHeight = 220;
 
     private const int StatRowHeight = 24;
     private const int StatLabelWidth = 230;
@@ -32,30 +35,18 @@ public partial class CharacterWindow : Window
     private const string TitleFont = "sourcesansproblack";
     private const string BodyFont = "source-sans-pro";
 
-    //Equipment List
-    public List<EquipmentItem> Items = new List<EquipmentItem>();
-
     // Containers
     private Base mCharacterInfoContainer;
     private Base mStatsContainer;
-    private Base mEquipmentContainer;
     private Base mExtraBuffsContainer;
 
     private ScrollControl mExtraBuffsScroll;
     private Base mExtraBuffsList;
 
     // Character UI
-    private ImagePanel mCharacterContainer;
     private Label mCharacterLevelAndClass;
     private Label mCharacterName;
     private Button mFactionButton;
-
-    private ImagePanel mCharacterPortrait; // (si lo usas después)
-    private string mCharacterPortraitImg = string.Empty;
-    private string mCurrentSprite = string.Empty;
-
-    public ImagePanel[] PaperdollPanels;
-    public string[] PaperdollTextures;
 
     // Stats UI
     private Label mAttackLabel;
@@ -229,19 +220,21 @@ public partial class CharacterWindow : Window
         var contentX = Margin;
         var contentY = Margin;
 
-        var leftW = 420;
-        var rightW = WindowWidth - (Margin * 2) - leftW;
-        var topH = 250;
-        var bottomH = WindowHeight - (Margin * 2) - topH;
+        var contentW = WindowWidth - (Margin * 2);
+        var contentH = WindowHeight - (Margin * 2);
 
         // Containers
-        mCharacterInfoContainer = CreateContainer("CharacterInfoContainer", contentX, contentY, leftW, 150);
-        mStatsContainer = CreateContainer("StatsContainer", contentX, contentY + 150, leftW, topH - 150);
-        mEquipmentContainer = CreateContainer("EquipmentContainer", contentX + leftW, contentY, rightW, topH);
-        mExtraBuffsContainer = CreateContainer("ExtraBuffsContainer", contentX, contentY + topH, WindowWidth - (Margin * 2), bottomH);
+        mCharacterInfoContainer = CreateContainer("CharacterInfoContainer", contentX, contentY, contentW, InfoHeight);
+        mStatsContainer = CreateContainer("StatsContainer", contentX, contentY + InfoHeight, contentW, StatsHeight);
+        mExtraBuffsContainer = CreateContainer(
+            "ExtraBuffsContainer",
+            contentX,
+            contentY + InfoHeight + StatsHeight,
+            contentW,
+            contentH - InfoHeight - StatsHeight
+        );
 
         BuildCharacterInfoSection();
-        BuildEquipmentSection();
         BuildStatsSection();
         BuildExtraBuffsSection();
 
@@ -281,79 +274,6 @@ public partial class CharacterWindow : Window
         mFactionButton.SetStateTexture(ComponentState.Hovered, "factionicon_hovered.png");
         mFactionButton.SetToolTipText("Faction");
         mFactionButton.Clicked += (s, e) => Interface.GameUi.GameMenu?.ToggleFactionWindow();
-
-        mCharacterContainer = new ImagePanel(mCharacterInfoContainer, "CharacterContainer");
-        mCharacterContainer.SetSize(120, 120);
-        mCharacterContainer.SetPosition(0, y);
-
-        mCharacterPortrait = new ImagePanel(mCharacterContainer);
-        mCharacterPortrait.SetSize(80, 80);
-        mCharacterPortrait.SetPosition(
-            (mCharacterContainer.Width - mCharacterPortrait.Width) / 2,
-            (mCharacterContainer.Height - mCharacterPortrait.Height) / 2
-        );
-
-        PaperdollPanels = new ImagePanel[Options.Instance.Equipment.Slots.Count + 1];
-        PaperdollTextures = new string[Options.Instance.Equipment.Slots.Count + 1];
-        for (var i = 0; i <= Options.Instance.Equipment.Slots.Count; i++)
-        {
-            PaperdollPanels[i] = new ImagePanel(mCharacterContainer);
-            PaperdollTextures[i] = string.Empty;
-            PaperdollPanels[i].Hide();
-        }
-    }
-
-    private void BuildEquipmentSection()
-    {
-        var header = CreateSectionTitle(mEquipmentContainer, "EquipmentHeader", 0, 0, "Equipo");
-
-        var columns = 4;
-        var slotW = 36;
-        var slotH = 36;
-        var spacingX = 8;
-        var spacingY = 8;
-
-        var startX = 0;
-        var startY = header.Height + 8;
-
-        int itemIndex = 0;
-        var multiSlotTracker = new Dictionary<string, int>();
-
-        for (int slotIndex = 0; slotIndex < Options.Instance.Equipment.EquipmentSlots.Count; slotIndex++)
-        {
-            var slot = Options.Instance.Equipment.EquipmentSlots[slotIndex];
-
-            for (int j = 0; j < slot.MaxItems; j++)
-            {
-                var item = new EquipmentItem(slotIndex, this);
-                Items.Add(item);
-
-                var slotName = slot.Name;
-
-                if (slot.MaxItems <= 1)
-                {
-                    item.Pnl = new ImagePanel(mEquipmentContainer, slotName);
-                }
-                else
-                {
-                    if (!multiSlotTracker.ContainsKey(slotName))
-                        multiSlotTracker[slotName] = 0;
-
-                    var currentIndex = multiSlotTracker[slotName];
-                    item.Pnl = new ImagePanel(mEquipmentContainer, $"{slotName}_{currentIndex}");
-                    multiSlotTracker[slotName]++;
-                }
-
-                int row = itemIndex / columns;
-                int col = itemIndex % columns;
-
-                item.Pnl.SetSize(slotW, slotH);
-                item.Pnl.SetPosition(startX + col * (slotW + spacingX), startY + row * (slotH + spacingY));
-                item.Setup();
-
-                itemIndex++;
-            }
-        }
     }
 
     private void BuildStatsSection()
@@ -527,79 +447,6 @@ public partial class CharacterWindow : Window
         mCharacterName.Text = player.Name;
         mCharacterLevelAndClass.Text = Strings.Character.LevelAndClass.ToString(player.Level, ClassDescriptor.GetName(player.Class));
 
-        // Portrait/paperdoll
-        var entityTex = Globals.ContentManager.GetTexture(Framework.Content.TextureType.Entity, player.Sprite);
-
-        if (!string.IsNullOrWhiteSpace(player.Sprite) && player.Sprite != mCurrentSprite && entityTex != null)
-        {
-            for (var z = 0; z < Options.Instance.Equipment.Paperdoll.Directions[1].Count; z++)
-            {
-                var paperdoll = string.Empty;
-                var slotName = Options.Instance.Equipment.Paperdoll.Directions[1][z];
-                var slotIndex = Options.Instance.Equipment.Slots.IndexOf(slotName);
-
-                if (slotIndex > -1)
-                {
-                    var equipment = player.MyEquipment;
-
-                    if (equipment.TryGetValue(slotIndex, out var equippedList) && equippedList.Count > 0)
-                    {
-                        var inventoryIndex = equippedList[0];
-                        if (inventoryIndex >= 0 && inventoryIndex < Options.Instance.Player.MaxInventory)
-                        {
-                            var itemNum = player.Inventory[inventoryIndex].ItemId;
-
-                            if (ItemDescriptor.TryGet(itemNum, out var itemDescriptor))
-                            {
-                                paperdoll = player.Gender == 0 ? itemDescriptor.MalePaperdoll : itemDescriptor.FemalePaperdoll;
-                                PaperdollPanels[z].RenderColor = itemDescriptor.Color;
-                            }
-                        }
-                    }
-                }
-                else if (slotName == "Player")
-                {
-                    PaperdollPanels[z].Show();
-                    PaperdollPanels[z].Texture = entityTex;
-                    PaperdollPanels[z].SetTextureRect(0, 0, entityTex.Width / Options.Instance.Sprites.NormalFrames, entityTex.Height / Options.Instance.Sprites.Directions);
-                    PaperdollPanels[z].SizeToContents();
-                    PaperdollPanels[z].RenderColor = player.Color;
-                    Align.Center(PaperdollPanels[z]);
-                }
-
-                if (string.IsNullOrWhiteSpace(paperdoll) && !string.IsNullOrWhiteSpace(PaperdollTextures[z]) && slotName != "Player")
-                {
-                    PaperdollPanels[z].Texture = null;
-                    PaperdollPanels[z].Hide();
-                    PaperdollTextures[z] = string.Empty;
-                }
-                else if (!string.IsNullOrWhiteSpace(paperdoll) && paperdoll != PaperdollTextures[z])
-                {
-                    var paperdollTex = Globals.ContentManager.GetTexture(Framework.Content.TextureType.Paperdoll, paperdoll);
-
-                    PaperdollPanels[z].Texture = paperdollTex;
-                    if (paperdollTex != null)
-                    {
-                        PaperdollPanels[z].SetTextureRect(0, 0, paperdollTex.Width / Options.Instance.Sprites.NormalFrames, paperdollTex.Height / Options.Instance.Sprites.Directions);
-                        PaperdollPanels[z].SetSize(paperdollTex.Width / Options.Instance.Sprites.NormalFrames, paperdollTex.Height / Options.Instance.Sprites.Directions);
-                        PaperdollPanels[z].SetPosition(
-                            mCharacterContainer.Width / 2 - PaperdollPanels[z].Width / 2,
-                            mCharacterContainer.Height / 2 - PaperdollPanels[z].Height / 2
-                        );
-                    }
-
-                    PaperdollPanels[z].Show();
-                    PaperdollTextures[z] = paperdoll;
-                }
-            }
-        }
-        else if (player.Sprite != mCurrentSprite && player.Face != mCurrentSprite)
-        {
-            mCharacterPortrait.IsHidden = true;
-            for (var i = 0; i < Options.Instance.Equipment.Slots.Count; i++)
-                PaperdollPanels[i].Hide();
-        }
-
         // Stats text
         mAttackLabel.SetText(Strings.Character.StatLabelValue.ToString(Strings.Combat.Stats[Stat.Attack], player.Stat[(int)Stat.Attack]));
         mAbilityPwrLabel.SetText(Strings.Character.StatLabelValue.ToString(Strings.Combat.Stats[Stat.Intelligence], player.Stat[(int)Stat.Intelligence]));
@@ -624,63 +471,6 @@ public partial class CharacterWindow : Window
         UpdateExtraBuffs();
         mDamageLabel.SetText(Strings.Character.FlatDamage.ToString(FormatEffectValue(_flatDamage)));
         mCureLabel.SetText(Strings.Character.FlatCures.ToString(FormatEffectValue(_flatCures)));
-
-        UpdateEquippedItems(true);
-    }
-
-    private void UpdateEquippedItems(bool updateExtraBuffs = false)
-    {
-        var player = DisplayedPlayer;
-        if (player is null)
-            return;
-
-        int itemIndex = 0;
-        for (var slotIndex = 0; slotIndex < Options.Instance.Equipment.EquipmentSlots.Count; slotIndex++)
-        {
-            var slot = Options.Instance.Equipment.EquipmentSlots[slotIndex];
-
-            if (player == Globals.Me)
-            {
-                var itemSlots = player.MyEquipment.GetValueOrDefault(slotIndex) ?? new List<int>();
-                for (var i = 0; i < slot.MaxItems; i++)
-                {
-                    if (itemIndex >= Items.Count)
-                        break;
-
-                    var itemIds = new List<Guid>();
-                    var props = new List<ItemProperties>();
-
-                    if (i < itemSlots.Count && itemSlots[i] >= 0 && itemSlots[i] < Options.Instance.Player.MaxInventory)
-                    {
-                        var invItem = player.Inventory[itemSlots[i]];
-                        if (invItem.ItemId != Guid.Empty)
-                        {
-                            itemIds.Add(invItem.ItemId);
-                            props.Add(invItem.ItemProperties);
-                        }
-                    }
-
-                    Items[itemIndex].Update(itemIds, props);
-                    itemIndex++;
-                }
-            }
-            else
-            {
-                var equippedIds = player.Equipment.GetValueOrDefault(slotIndex) ?? new List<Guid>();
-                for (var i = 0; i < slot.MaxItems; i++)
-                {
-                    if (itemIndex >= Items.Count)
-                        break;
-
-                    var itemIds = new List<Guid>();
-                    if (i < equippedIds.Count && equippedIds[i] != Guid.Empty)
-                        itemIds.Add(equippedIds[i]);
-
-                    Items[itemIndex].Update(itemIds, new List<ItemProperties>());
-                    itemIndex++;
-                }
-            }
-        }
     }
 
     public void UpdateExtraBuffs()

--- a/Intersect.Client.Core/Interface/Game/Character/EquipmentItem.cs
+++ b/Intersect.Client.Core/Interface/Game/Character/EquipmentItem.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Diagnostics;
 using Intersect.Client.Framework.File_Management;
 using Intersect.Client.Framework.GenericClasses;
@@ -17,7 +18,7 @@ public partial class EquipmentItem
 {
     public List<ImagePanel> ContentPanels = new();
 
-    private WindowControl mCharacterWindow;
+    private readonly Func<Player?> _playerProvider;
 
     private List<Guid> mCurrentItemIds = new();
 
@@ -29,10 +30,10 @@ public partial class EquipmentItem
 
     public ImagePanel Pnl;
 
-    public EquipmentItem(int index, WindowControl characterWindow)
+    public EquipmentItem(int index, Func<Player?> playerProvider)
     {
         mYindex = index;
-        mCharacterWindow = characterWindow;
+        _playerProvider = playerProvider;
     }
 
     public void Setup()
@@ -77,7 +78,7 @@ public partial class EquipmentItem
             return;
         }
 
-        var player = (mCharacterWindow as CharacterWindow)?.DisplayedPlayer;
+        var player = _playerProvider?.Invoke();
         if (player == null || player != Globals.Me)
         {
             return;

--- a/Intersect.Client.Core/Interface/Game/Inventory/InventoryWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Inventory/InventoryWindow.cs
@@ -9,11 +9,14 @@ using Intersect.Client.Framework.File_Management;
 using Intersect.Client.Framework.Gwen;
 using Intersect.Client.Framework.Gwen.Control;
 using Intersect.Client.Framework.Gwen.Control.EventArguments;
+using Intersect.Client.Interface.Game.Character;
 using Intersect.Client.General;
 using Intersect.Client.Localization;
 using Intersect.Client.Utilities;
 using Intersect.Client.Framework.Items;
+using Intersect.Client.Framework.Content;
 using Intersect.Framework.Core.GameObjects.Items;
+using Intersect.Framework.Core.GameObjects.PlayerClass;
 
 namespace Intersect.Client.Interface.Game.Inventory;
 
@@ -21,6 +24,8 @@ public partial class InventoryWindow : Window
 {
     public List<SlotItem> Items { get; set; } = [];
 
+    private readonly Base _characterPanel;
+    private readonly Base _equipmentPanel;
     private readonly Base _headerPanel;
     private readonly ScrollControl _slotContainer;
     private readonly ContextMenu _contextMenu;
@@ -28,6 +33,15 @@ public partial class InventoryWindow : Window
     private readonly Button _sortButton;
     private readonly ComboBox _typeBox;
     private readonly ComboBox _subtypeBox;
+
+    private readonly ImagePanel _paperdollContainer;
+    private readonly Label _characterName;
+    private readonly Label _characterLevelAndClass;
+    private readonly List<EquipmentItem> _equipmentItems = [];
+    private readonly ImagePanel[] _paperdollLayers;
+    private readonly string[] _paperdollTextures;
+    private readonly Label _equipmentHeader;
+    private string _currentSprite = string.Empty;
 
  
     private readonly Dictionary<int, HashSet<string>> _subtypesByType = new();
@@ -50,6 +64,11 @@ public partial class InventoryWindow : Window
     private const int CTRL_H = 24;   // alto de controles
     private const int CTRL_W_SMALL = 140;
     private const int CTRL_W_MED = 150;
+    private const int LEFT_COL_WIDTH = 240;
+    private const int PAPERDOLL_SIZE = 160;
+    private const int EQUIP_COLUMNS = 3;
+    private const int EQUIP_SLOT_SIZE = 36;
+    private const int EQUIP_SPACING = 8;
 
     private int _lastW, _lastH;
 
@@ -63,12 +82,71 @@ public partial class InventoryWindow : Window
         IsClosable = true;
 
         // Tamaño/posición explícitos
-        SetSize(380, 460);
+        SetSize(760, 520);
+
+        // Columna izquierda: info de personaje y equipo
+        _characterPanel = new Base(this, "CharacterPanel");
+        _characterPanel.SetPosition(PAD, PAD);
+        _characterPanel.SetSize(LEFT_COL_WIDTH, Height - PAD * 2);
+
+        _characterName = new Label(_characterPanel, "CharacterName")
+        {
+            FontName = "sourcesansproblack",
+            FontSize = 14,
+            AutoSizeToContents = true,
+            TextColorOverride = Color.White,
+        };
+        _characterName.SetPosition(0, 0);
+
+        _characterLevelAndClass = new Label(_characterPanel, "CharacterLevelAndClass")
+        {
+            FontName = "source-sans-pro",
+            FontSize = 12,
+            AutoSizeToContents = true,
+            TextColorOverride = Color.White,
+        };
+        _characterLevelAndClass.SetPosition(0, _characterName.Height + 2);
+
+        _paperdollContainer = new ImagePanel(_characterPanel, "PaperdollContainer");
+        _paperdollContainer.SetSize(PAPERDOLL_SIZE, PAPERDOLL_SIZE);
+        _paperdollContainer.SetPosition((LEFT_COL_WIDTH - PAPERDOLL_SIZE) / 2, _characterLevelAndClass.Bottom + GAP);
+
+        _paperdollLayers = new ImagePanel[Options.Instance.Equipment.Slots.Count + 1];
+        _paperdollTextures = new string[_paperdollLayers.Length];
+        for (var i = 0; i < _paperdollLayers.Length; i++)
+        {
+            _paperdollLayers[i] = new ImagePanel(_paperdollContainer)
+            {
+                IsVisibleInTree = false
+            };
+            _paperdollLayers[i].Hide();
+            _paperdollTextures[i] = string.Empty;
+        }
+
+        _equipmentPanel = new Base(_characterPanel, "EquipmentPanel");
+        _equipmentPanel.SetPosition(0, _paperdollContainer.Bottom + GAP);
+        _equipmentPanel.SetSize(_characterPanel.Width, _characterPanel.Height - _equipmentPanel.Y);
+
+        _equipmentHeader = new Label(_equipmentPanel, "EquipmentHeader")
+        {
+            FontName = "sourcesansproblack",
+            FontSize = 12,
+            AutoSizeToContents = true,
+            Text = "Equipo",
+            TextColorOverride = Color.White,
+        };
+        _equipmentHeader.SetPosition(0, 0);
+        _equipmentHeader.SizeToContents();
+
+        BuildEquipmentSlots();
+
+        var rightX = PAD + LEFT_COL_WIDTH + GAP;
+        var rightW = Width - rightX - PAD;
 
         // --------- Header (contenedor de filtros) ----------
         _headerPanel = new Base(this, "HeaderPanel");
-        _headerPanel.SetPosition(PAD, PAD);
-        _headerPanel.SetSize(Width - PAD * 2, HEADER_H);
+        _headerPanel.SetPosition(rightX, PAD);
+        _headerPanel.SetSize(rightW, HEADER_H);
 
         // Campo de búsqueda
         _searchBox = new TextBox(_headerPanel, "SearchBox")
@@ -129,7 +207,8 @@ public partial class InventoryWindow : Window
             OverflowX = OverflowBehavior.Auto,
             OverflowY = OverflowBehavior.Scroll,
         };
-        _slotContainer.SetPosition(PAD, _headerPanel.Y + _headerPanel.Height + GAP);
+        _slotContainer.SetPosition(rightX, _headerPanel.Y + _headerPanel.Height + GAP);
+        _slotContainer.SetSize(rightW, Height - (_slotContainer.Y + PAD));
         
 
         // Context menu
@@ -159,16 +238,203 @@ public partial class InventoryWindow : Window
     // Recalcula posiciones/tamaños si cambia el tamaño de la ventana
     private void RecomputeLayout()
     {
-        _headerPanel.SetPosition(PAD, PAD);
-        _headerPanel.SetSize(Width - PAD * 2, HEADER_H);
+        _characterPanel.SetPosition(PAD, PAD);
+        _characterPanel.SetSize(LEFT_COL_WIDTH, Height - PAD * 2);
+
+        _characterName.SetPosition(0, 0);
+        _characterLevelAndClass.SetPosition(0, _characterName.Height + 2);
+
+        _paperdollContainer.SetPosition((LEFT_COL_WIDTH - PAPERDOLL_SIZE) / 2, _characterLevelAndClass.Bottom + GAP);
+
+        _equipmentPanel.SetPosition(0, _paperdollContainer.Bottom + GAP);
+        _equipmentPanel.SetSize(_characterPanel.Width, _characterPanel.Height - _equipmentPanel.Y);
+
+        var rightX = PAD + LEFT_COL_WIDTH + GAP;
+        var rightW = Width - rightX - PAD;
+
+        _headerPanel.SetPosition(rightX, PAD);
+        _headerPanel.SetSize(rightW, HEADER_H);
 
         _searchBox.SetPosition(0, 0);
         _sortButton.SetPosition(_searchBox.X + _searchBox.Width + GAP, 0);
         _typeBox.SetPosition(0, _searchBox.Y + _searchBox.Height + GAP);
         _subtypeBox.SetPosition(_typeBox.X + _typeBox.Width + GAP, _typeBox.Y);
 
-        _slotContainer.SetPosition(PAD, _headerPanel.Y + _headerPanel.Height + GAP);
-  
+        _slotContainer.SetPosition(rightX, _headerPanel.Y + _headerPanel.Height + GAP);
+        _slotContainer.SetSize(rightW, Height - (_slotContainer.Y + PAD));
+
+        LayoutEquipmentSlots();
+    }
+
+    private void BuildEquipmentSlots()
+    {
+        _equipmentItems.Clear();
+
+        var multiSlotTracker = new Dictionary<string, int>();
+        for (var slotIndex = 0; slotIndex < Options.Instance.Equipment.EquipmentSlots.Count; slotIndex++)
+        {
+            var slot = Options.Instance.Equipment.EquipmentSlots[slotIndex];
+
+            for (var j = 0; j < slot.MaxItems; j++)
+            {
+                var item = new EquipmentItem(slotIndex, () => Globals.Me);
+                _equipmentItems.Add(item);
+
+                var slotName = slot.Name;
+                var panelName = slotName;
+
+                if (slot.MaxItems > 1)
+                {
+                    var currentIndex = multiSlotTracker.GetValueOrDefault(slotName);
+                    panelName = $"{slotName}_{currentIndex}";
+                    multiSlotTracker[slotName] = currentIndex + 1;
+                }
+
+                item.Pnl = new ImagePanel(_equipmentPanel, panelName);
+                item.Setup();
+            }
+        }
+
+        LayoutEquipmentSlots();
+    }
+
+    private void LayoutEquipmentSlots()
+    {
+        if (_equipmentItems.Count == 0)
+            return;
+
+        var totalWidth = (EQUIP_COLUMNS * EQUIP_SLOT_SIZE) + ((EQUIP_COLUMNS - 1) * EQUIP_SPACING);
+        var startX = Math.Max(0, (_equipmentPanel.Width - totalWidth) / 2);
+        var startY = _equipmentHeader.Bottom + GAP;
+
+        for (var index = 0; index < _equipmentItems.Count; index++)
+        {
+            var row = index / EQUIP_COLUMNS;
+            var col = index % EQUIP_COLUMNS;
+
+            var panel = _equipmentItems[index].Pnl;
+            panel.SetSize(EQUIP_SLOT_SIZE, EQUIP_SLOT_SIZE);
+            panel.SetPosition(
+                startX + col * (EQUIP_SLOT_SIZE + EQUIP_SPACING),
+                startY + row * (EQUIP_SLOT_SIZE + EQUIP_SPACING)
+            );
+        }
+    }
+
+    private void UpdatePaperdoll(Player player)
+    {
+        var entityTex = Globals.ContentManager.GetTexture(TextureType.Entity, player.Sprite);
+
+        if (!string.IsNullOrWhiteSpace(player.Sprite) && entityTex != null)
+        {
+            for (var z = 0; z < Options.Instance.Equipment.Paperdoll.Directions[1].Count && z < _paperdollLayers.Length; z++)
+            {
+                var paperdoll = string.Empty;
+                var slotName = Options.Instance.Equipment.Paperdoll.Directions[1][z];
+                var slotIndex = Options.Instance.Equipment.Slots.IndexOf(slotName);
+
+                if (slotIndex > -1)
+                {
+                    var equipment = player.MyEquipment;
+
+                    if (equipment.TryGetValue(slotIndex, out var equippedList) && equippedList.Count > 0)
+                    {
+                        var inventoryIndex = equippedList[0];
+                        if (inventoryIndex >= 0 && inventoryIndex < Options.Instance.Player.MaxInventory)
+                        {
+                            var itemNum = player.Inventory[inventoryIndex].ItemId;
+
+                            if (ItemDescriptor.TryGet(itemNum, out var itemDescriptor))
+                            {
+                                paperdoll = player.Gender == 0 ? itemDescriptor.MalePaperdoll : itemDescriptor.FemalePaperdoll;
+                                _paperdollLayers[z].RenderColor = itemDescriptor.Color;
+                            }
+                        }
+                    }
+                }
+                else if (slotName == "Player")
+                {
+                    _paperdollLayers[z].Show();
+                    _paperdollLayers[z].Texture = entityTex;
+                    _paperdollLayers[z].SetTextureRect(0, 0, entityTex.Width / Options.Instance.Sprites.NormalFrames, entityTex.Height / Options.Instance.Sprites.Directions);
+                    _paperdollLayers[z].SizeToContents();
+                    _paperdollLayers[z].RenderColor = player.Color;
+                    _paperdollLayers[z].SetPosition(
+                        _paperdollContainer.Width / 2 - _paperdollLayers[z].Width / 2,
+                        _paperdollContainer.Height / 2 - _paperdollLayers[z].Height / 2
+                    );
+                }
+
+                if (string.IsNullOrWhiteSpace(paperdoll) && !string.IsNullOrWhiteSpace(_paperdollTextures[z]) && slotName != "Player")
+                {
+                    _paperdollLayers[z].Texture = null;
+                    _paperdollLayers[z].Hide();
+                    _paperdollTextures[z] = string.Empty;
+                }
+                else if (!string.IsNullOrWhiteSpace(paperdoll) && paperdoll != _paperdollTextures[z])
+                {
+                    var paperdollTex = Globals.ContentManager.GetTexture(TextureType.Paperdoll, paperdoll);
+
+                    _paperdollLayers[z].Texture = paperdollTex;
+                    if (paperdollTex != null)
+                    {
+                        _paperdollLayers[z].SetTextureRect(0, 0, paperdollTex.Width / Options.Instance.Sprites.NormalFrames, paperdollTex.Height / Options.Instance.Sprites.Directions);
+                        _paperdollLayers[z].SetSize(paperdollTex.Width / Options.Instance.Sprites.NormalFrames, paperdollTex.Height / Options.Instance.Sprites.Directions);
+                        _paperdollLayers[z].SetPosition(
+                            _paperdollContainer.Width / 2 - _paperdollLayers[z].Width / 2,
+                            _paperdollContainer.Height / 2 - _paperdollLayers[z].Height / 2
+                        );
+                    }
+
+                    _paperdollLayers[z].Show();
+                    _paperdollTextures[z] = paperdoll;
+                }
+            }
+
+            _currentSprite = player.Sprite ?? string.Empty;
+        }
+        else if (player.Sprite != _currentSprite && player.Face != _currentSprite)
+        {
+            foreach (var layer in _paperdollLayers)
+            {
+                layer.Hide();
+                layer.Texture = null;
+            }
+
+            _currentSprite = string.Empty;
+        }
+    }
+
+    private void UpdateEquipmentSlots(Player player)
+    {
+        int itemIndex = 0;
+        for (var slotIndex = 0; slotIndex < Options.Instance.Equipment.EquipmentSlots.Count; slotIndex++)
+        {
+            var slot = Options.Instance.Equipment.EquipmentSlots[slotIndex];
+            var itemSlots = player.MyEquipment.GetValueOrDefault(slotIndex) ?? new List<int>();
+
+            for (var i = 0; i < slot.MaxItems; i++)
+            {
+                if (itemIndex >= _equipmentItems.Count)
+                    break;
+
+                var itemIds = new List<Guid>();
+                var props = new List<ItemProperties>();
+
+                if (i < itemSlots.Count && itemSlots[i] >= 0 && itemSlots[i] < Options.Instance.Player.MaxInventory)
+                {
+                    var invItem = player.Inventory[itemSlots[i]];
+                    if (invItem.ItemId != Guid.Empty)
+                    {
+                        itemIds.Add(invItem.ItemId);
+                        props.Add(invItem.ItemProperties);
+                    }
+                }
+
+                _equipmentItems[itemIndex].Update(itemIds, props);
+                itemIndex++;
+            }
+        }
     }
 
     private void SortButton_Clicked(Base sender, MouseButtonState arguments)
@@ -379,6 +645,18 @@ public partial class InventoryWindow : Window
             _lastH = Height;
             RecomputeLayout();
         }
+
+        var player = Globals.Me;
+        if (player == null)
+        {
+            return;
+        }
+
+        _characterName.SetText(player.Name ?? string.Empty);
+        _characterLevelAndClass.SetText(Strings.Character.LevelAndClass.ToString(player.Level, ClassDescriptor.GetName(player.Class)));
+
+        UpdatePaperdoll(player);
+        UpdateEquipmentSlots(player);
 
         var query = _searchBox.Text;
         var asc = _sortAscending;


### PR DESCRIPTION
## Summary
- Simplify the character window to focus on player info, stats, and buffs
- Expand the inventory window with character paperdoll rendering and equipment slots
- Update equipment slot handling so it can be driven from the inventory UI

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694245a781e8832ba79d2fa874fafa32)