### PR TITLE
Add fishing enums and map attribute handling

### DIFF
--- a/Framework/Intersect.Framework.Core/Descriptors/GameObjectType.cs
+++ b/Framework/Intersect.Framework.Core/Descriptors/GameObjectType.cs
@@ -74,5 +74,9 @@ public enum GameObjectType
     UserVariable,
 
     [GameObjectInfo(typeof(SetDescriptor), "sets")]
-    Sets,
+    Sets = 19,
+
+    Fish = 20,
+
+    FishingSpot,
 }

--- a/Framework/Intersect.Framework.Core/GameObjects/Maps/Attributes/MapFishingSpotAttribute.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Maps/Attributes/MapFishingSpotAttribute.cs
@@ -1,0 +1,6 @@
+namespace Intersect.Framework.Core.GameObjects.Maps.Attributes;
+
+public partial class MapFishingSpotAttribute : MapAttribute
+{
+    public override MapAttributeType Type => MapAttributeType.FishingSpot;
+}

--- a/Framework/Intersect.Framework.Core/GameObjects/Maps/MapAttribute.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Maps/MapAttribute.cs
@@ -38,6 +38,8 @@ public abstract partial class MapAttribute
                 return new MapSlideAttribute();
             case MapAttributeType.Critter:
                 return new MapCritterAttribute();
+            case MapAttributeType.FishingSpot:
+                return new MapFishingSpotAttribute();
         }
 
         return null;

--- a/Framework/Intersect.Framework.Core/GameObjects/Maps/MapAttributeType.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Maps/MapAttributeType.cs
@@ -25,4 +25,6 @@ public enum MapAttributeType : byte
     Slide,
 
     Critter,
+
+    FishingSpot,
 }


### PR DESCRIPTION
## Summary
- add upstream fish and fishing spot game object type slots
- include fishing spot in map attribute types and creation
- introduce a fishing spot map attribute stub

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942fe15daac832b82ecbabb29315e01)