### PR TITLE
Add fishing packet types for client and server

### DIFF
--- a/Framework/Intersect.Framework.Core/Network/Packets/Client/FishingPacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Client/FishingPacket.cs
@@ -1,0 +1,12 @@
+using Intersect.Network;
+using MessagePack;
+
+namespace Intersect.Network.Packets.Client;
+
+[MessagePackObject]
+public partial class FishingPacket : IntersectPacket
+{
+    public FishingPacket()
+    {
+    }
+}

--- a/Framework/Intersect.Framework.Core/Network/Packets/Client/SendCancelFishing.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Client/SendCancelFishing.cs
@@ -1,0 +1,12 @@
+using Intersect.Network;
+using MessagePack;
+
+namespace Intersect.Network.Packets.Client;
+
+[MessagePackObject]
+public partial class SendCancelFishing : IntersectPacket
+{
+    public SendCancelFishing()
+    {
+    }
+}

--- a/Framework/Intersect.Framework.Core/Network/Packets/Client/SendFailedFishing.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Client/SendFailedFishing.cs
@@ -1,0 +1,12 @@
+using Intersect.Network;
+using MessagePack;
+
+namespace Intersect.Network.Packets.Client;
+
+[MessagePackObject]
+public partial class SendFailedFishing : IntersectPacket
+{
+    public SendFailedFishing()
+    {
+    }
+}

--- a/Framework/Intersect.Framework.Core/Network/Packets/Client/SendFishingSpot.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Client/SendFishingSpot.cs
@@ -1,0 +1,12 @@
+using Intersect.Network;
+using MessagePack;
+
+namespace Intersect.Network.Packets.Client;
+
+[MessagePackObject]
+public partial class SendFishingSpot : IntersectPacket
+{
+    public SendFishingSpot()
+    {
+    }
+}

--- a/Framework/Intersect.Framework.Core/Network/Packets/Client/SendSuccessFishing.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Client/SendSuccessFishing.cs
@@ -1,0 +1,12 @@
+using Intersect.Network;
+using MessagePack;
+
+namespace Intersect.Network.Packets.Client;
+
+[MessagePackObject]
+public partial class SendSuccessFishing : IntersectPacket
+{
+    public SendSuccessFishing()
+    {
+    }
+}

--- a/Framework/Intersect.Framework.Core/Network/Packets/Server/EntityFishingPacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Server/EntityFishingPacket.cs
@@ -1,0 +1,12 @@
+using Intersect.Network;
+using MessagePack;
+
+namespace Intersect.Network.Packets.Server;
+
+[MessagePackObject]
+public partial class EntityFishingPacket : IntersectPacket
+{
+    public EntityFishingPacket()
+    {
+    }
+}

--- a/Framework/Intersect.Framework.Core/Network/Packets/Server/SendClientFish.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Server/SendClientFish.cs
@@ -1,0 +1,12 @@
+using Intersect.Network;
+using MessagePack;
+
+namespace Intersect.Network.Packets.Server;
+
+[MessagePackObject]
+public partial class SendClientFish : IntersectPacket
+{
+    public SendClientFish()
+    {
+    }
+}

--- a/Framework/Intersect.Framework.Core/Network/Packets/Server/SendClientResultCastFishingRod.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Server/SendClientResultCastFishingRod.cs
@@ -1,0 +1,12 @@
+using Intersect.Network;
+using MessagePack;
+
+namespace Intersect.Network.Packets.Server;
+
+[MessagePackObject]
+public partial class SendClientResultCastFishingRod : IntersectPacket
+{
+    public SendClientResultCastFishingRod()
+    {
+    }
+}


### PR DESCRIPTION
## Summary
- add fishing-related client packet definitions
- add server packet definitions for fishing interactions
- ensure packet types are available for registration via existing bootstrapper flow

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694302f659d0832bbef7ca7dde992247)