### PR TITLE
Handle remote fishing visuals

### DIFF
--- a/Intersect.Client.Core/Entities/Entity.cs
+++ b/Intersect.Client.Core/Entities/Entity.cs
@@ -48,6 +48,17 @@ public partial class Entity : IEntity
 
     public long CastTime { get; set; } = 0;
 
+    //Fishing
+    public bool IsFishing { get; set; }
+
+    public int FishingStageIndex { get; set; }
+
+    public bool IsFishingRodPressed { get; set; }
+
+    public long FishingStageTimer { get; set; }
+
+    public long FishingStageDuration { get; set; }
+
     //Combat Status
     public bool IsAttacking => AttackTimer > Timing.Global.Milliseconds;
 
@@ -178,6 +189,8 @@ public partial class Entity : IEntity
     public HashSet<Entity>? RenderList { get; set; }
 
     private Guid _spellCast;
+
+    private int _lastFishingStage;
 
     public Guid SpellCast
     {
@@ -2160,6 +2173,122 @@ public partial class Entity : IEntity
         Status = [.. Status.OrderByDescending(x => x.RemainingMs)];
     }
 
+    private bool UpdateFishingSpriteAnimation(long timingMilliseconds)
+    {
+        if (!IsFishing && _lastFishingStage == 0)
+        {
+            return false;
+        }
+
+        if (!IsFishing)
+        {
+            FishingStageIndex = 0;
+        }
+
+        if (SpriteFrameTimer + Options.Instance.Sprites.IdleFrameDuration >= timingMilliseconds)
+        {
+            return true;
+        }
+
+        switch (FishingStageIndex)
+        {
+            case 0:
+                if (_lastFishingStage == 1)
+                {
+                    if (AnimatedTextures.TryGetValue(SpriteAnimations.Weapon, out _))
+                    {
+                        SpriteAnimation = SpriteAnimations.Weapon;
+                        SpriteFrame = Math.Max(0, SpriteFrames - 1);
+                    }
+
+                    _lastFishingStage = 0;
+                }
+                else if (_lastFishingStage == 0)
+                {
+                    SpriteFrame = Math.Max(0, SpriteFrame - 1);
+                    if (SpriteFrame == 0 && AnimatedTextures.TryGetValue(SpriteAnimations.Idle, out _))
+                    {
+                        SpriteAnimation = SpriteAnimations.Idle;
+                    }
+                }
+                else
+                {
+                    _lastFishingStage = FishingStageIndex;
+                }
+
+                break;
+
+            case 1:
+                if (_lastFishingStage == 0)
+                {
+                    if (AnimatedTextures.TryGetValue(SpriteAnimations.Weapon, out _))
+                    {
+                        SpriteAnimation = SpriteAnimations.Weapon;
+                        SpriteFrame = 0;
+                    }
+
+                    _lastFishingStage = FishingStageIndex;
+                }
+                else if (_lastFishingStage == 1)
+                {
+                    SpriteFrame = Math.Min(SpriteFrames - 1, SpriteFrame + 1);
+                    if (SpriteFrame >= SpriteFrames - 1 && AnimatedTextures.TryGetValue(SpriteAnimations.Idle, out _))
+                    {
+                        SpriteAnimation = SpriteAnimations.Idle;
+                    }
+                }
+
+                break;
+
+            case 2:
+                if (_lastFishingStage == 1)
+                {
+                    if (AnimatedTextures.TryGetValue(SpriteAnimations.Weapon, out _))
+                    {
+                        SpriteAnimation = SpriteAnimations.Weapon;
+                    }
+
+                    _lastFishingStage = FishingStageIndex;
+                }
+
+                SpriteFrame = IsFishingRodPressed ? 0 : Math.Min(1, SpriteFrames - 1);
+
+                break;
+
+            case 3:
+                if (_lastFishingStage == 2)
+                {
+                    if (AnimatedTextures.TryGetValue(SpriteAnimations.Weapon, out _))
+                    {
+                        SpriteAnimation = SpriteAnimations.Weapon;
+                        SpriteFrame = Math.Max(0, SpriteFrames - 1);
+                    }
+
+                    _lastFishingStage = FishingStageIndex;
+                }
+                else if (_lastFishingStage == 3)
+                {
+                    SpriteFrame--;
+                    if (SpriteFrame < 0)
+                    {
+                        if (AnimatedTextures.TryGetValue(SpriteAnimations.Idle, out _))
+                        {
+                            SpriteAnimation = SpriteAnimations.Idle;
+                        }
+
+                        SpriteFrame = 0;
+                        _lastFishingStage = 0;
+                    }
+                }
+
+                break;
+        }
+
+        SpriteFrameTimer = timingMilliseconds;
+
+        return IsFishing || _lastFishingStage != 0;
+    }
+
     private void UpdateSpriteAnimation()
     {
         // Exit if textures haven't been loaded yet
@@ -2170,6 +2299,11 @@ public partial class Entity : IEntity
 
         var timingMilliseconds = Timing.Global.Milliseconds;
         var isNotBlockingAndCasting = !IsBlocking && !IsCasting;
+
+        if (this != Globals.Me && UpdateFishingSpriteAnimation(timingMilliseconds))
+        {
+            return;
+        }
 
         SpriteAnimation = SpriteAnimations.Normal;
         if (AnimatedTextures.TryGetValue(SpriteAnimations.Idle, out _) &&

--- a/Intersect.Client.Core/Networking/PacketHandler.cs
+++ b/Intersect.Client.Core/Networking/PacketHandler.cs
@@ -1200,6 +1200,50 @@ internal sealed partial class PacketHandler
         }
     }
 
+    public void HandlePacket(IPacketSender packetSender, EntityFishingPacket packet)
+    {
+        var id = packet.Id;
+        var type = packet.Type;
+        var mapId = packet.MapId;
+
+        Entity en = null;
+        if (type < EntityType.Event)
+        {
+            if (!Globals.Entities.ContainsKey(id))
+            {
+                return;
+            }
+
+            en = Globals.Entities[id];
+        }
+        else
+        {
+            var entityMap = MapInstance.Get(mapId);
+            if (entityMap == null)
+            {
+                return;
+            }
+
+            if (!entityMap.LocalEntities.ContainsKey(id))
+            {
+                return;
+            }
+
+            en = entityMap.LocalEntities[id];
+        }
+
+        if (en == null)
+        {
+            return;
+        }
+
+        en.IsFishing = packet.IsFishing;
+        en.FishingStageIndex = packet.Stage;
+        en.IsFishingRodPressed = packet.IsPressed;
+        en.FishingStageTimer = Timing.Global.Milliseconds;
+        en.FishingStageDuration = Options.Instance.Sprites.IdleFrameDuration;
+    }
+
     //EntityDiePacket
     public void HandlePacket(IPacketSender packetSender, EntityDiePacket packet)
     {


### PR DESCRIPTION
## Summary
- add fishing visual state tracking to the base Entity class
- handle EntityFishingPacket updates to keep remote fishing state in sync
- drive sprite animation selection for non-local entities using fishing stages and rod presses

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69434eeed1b8832ba1fdb3100c2649a2)