### PR TITLE
Broadcast fishing state updates to nearby players

### DIFF
--- a/Framework/Intersect.Framework.Core/Config/SpriteOptions.cs
+++ b/Framework/Intersect.Framework.Core/Config/SpriteOptions.cs
@@ -78,6 +78,11 @@ public partial class SpriteOptions
     public int WeaponFrames { get; set; } = 4;
 
     /// <summary>
+    /// Defines the number of frames there will be in fishing sprite sheets.
+    /// </summary>
+    public int FishingFrames { get; set; } = 4;
+
+    /// <summary>
     /// The number of rows in the sprite sheet that correspond to the number of directions supported in the game.
     /// Currently, Intersect only supports 4 rows of frames for directions.
     /// </summary>

--- a/Framework/Intersect.Framework.Core/Descriptors/GameObjectType.cs
+++ b/Framework/Intersect.Framework.Core/Descriptors/GameObjectType.cs
@@ -2,6 +2,7 @@ using Intersect.Extensions;
 using Intersect.Framework.Core.GameObjects.Animations;
 using Intersect.Framework.Core.GameObjects.Crafting;
 using Intersect.Framework.Core.GameObjects.Events;
+using Intersect.Framework.Core.GameObjects.Fishing;
 using Intersect.Framework.Core.GameObjects.Items;
 using Intersect.Framework.Core.GameObjects;
 using Intersect.Framework.Core.GameObjects.Mapping.Tilesets;
@@ -74,5 +75,11 @@ public enum GameObjectType
     UserVariable,
 
     [GameObjectInfo(typeof(SetDescriptor), "sets")]
-    Sets,
+    Sets = 19,
+
+    [GameObjectInfo(typeof(FishBase), "fish")]
+    Fish = 20,
+
+    [GameObjectInfo(typeof(FishingSpotBase), "fishing_spots")]
+    FishingSpot,
 }

--- a/Framework/Intersect.Framework.Core/FishingStage.cs
+++ b/Framework/Intersect.Framework.Core/FishingStage.cs
@@ -1,0 +1,9 @@
+namespace Intersect.Enums;
+
+public enum FishingStage
+{
+    None,
+    WaitingForBite,
+    Hooked,
+    Resolving
+}

--- a/Framework/Intersect.Framework.Core/GameObjects/Fishing/FishBase.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Fishing/FishBase.cs
@@ -1,0 +1,96 @@
+using System.ComponentModel.DataAnnotations.Schema;
+using Intersect.Framework.Core.GameObjects.Conditions;
+using Intersect.Framework.Core.GameObjects.Events;
+using Intersect.Models;
+using Newtonsoft.Json;
+
+namespace Intersect.Framework.Core.GameObjects.Fishing;
+
+public partial class FishBase : DatabaseObject<FishBase>, IFolderable
+{
+    [JsonConstructor]
+    public FishBase(Guid id) : base(id)
+    {
+        Name = "New Fish";
+    }
+
+    //Parameterless constructor for EF
+    public FishBase()
+    {
+        Name = "New Fish";
+    }
+
+    //{ get; set; }
+    //Øàíñ ïîéìàòü ðûáêó
+    [JsonProperty(Order = -13)]
+    public int chance { get; set; } = 100;
+    //Êàê ÷àñòî ïðèä¸òñÿ äîëáèòü êíîïêó
+    [JsonProperty(Order = -12)]
+    public int weight { get; set; } = 20;
+    //Äåðçîñòü ðûâêà êðþ÷êà â íà÷àëå ðûáàëêè
+    [JsonProperty(Order = -11)]
+    public int pushStrength { get; set; } = 0;
+    //ñèëà âûðûâàíèå êðþ÷êà â ïðîöåññå ðûáàëêè
+    [JsonProperty(Order = -10)]
+    public int strength { get; set; } = 20;
+    //Ïîçèöèÿ íà ïîëçóíêå â íà÷àëå ðûáàëêè
+    [JsonProperty(Order = -9)]
+    public int position { get; set; } = 0;
+
+    //Ðàçìåð äèàïàçîíà ëîâëè ðûáû
+    [JsonProperty(Order = -8)]
+    public int rangeSize { get; set; } = 33;
+    //Ñêîðîñòü ðûáû
+    [JsonProperty(Order = -7)]
+    public int speedMove { get; set; } = 20;
+    //Ìàí¸âðåííîñòü ðûáû. Òî, íàñêîëüêî áûñòðî áóäåò ìåíÿòüñÿ äèàïàçîí íà íîâûé ðàçìåð
+    [JsonProperty(Order = -6)]
+    public int speedChangeRangeSize { get; set; } = 50;
+
+
+    //Êîýôôèöèåíò íåïðåäñêàçóåìîñòè. Íàñêîëüêî ìîãóò îòëè÷àòüñÿ ïàðàìåòðû ðûáû îò çàÿâëåííûõ.
+    //Íå äà¸ò òî÷íî ïðåäñêàçàòü ïîâåäåíèå ðûáû. Òî, íàñêîëüêî ÷àñòî ìåíÿåòñÿ å¸ ïîâåäåíèå è íàñêîëüêî.
+    //Ïðè 100 ïîâåäåíèå ðûáû áóäåò ìåíÿòüñÿ ÷àùå ñ îãðîìíûìè îòëè÷èÿìè äðóã îò äðóãà
+    //Ïðè 0 îíà áóäåò âåñòè ñåáÿ ñòðîãî ñ ïàðàìåòðàìè
+    [JsonProperty(Order = -5)]
+    public int coeffUnpredictability { get; set; } = 0;
+    //Âðåìÿ ñìåíû íàïðàâëåíèÿ ðûáû
+    [JsonProperty(Order = -4)]
+    public int timeChangeSpeed { get; set; } = 2000;
+    //Âðåìÿ ñìåíû äèàïàçîíà ðûáû
+    [JsonProperty(Order = -3)]
+    public int timeChangeRangeSize { get; set; } = 5000;
+
+    //Ïðåäìåò ðûáêè
+    [JsonProperty(Order = -2)]
+    public Guid ItemId { get; set; }
+
+    /// <inheritdoc />
+    public string Folder { get; set; } = "";
+
+    //Èâåíò ðûáêè
+    [Column("Event")]
+    [JsonProperty]
+    public Guid EventId { get; set; }
+
+    [NotMapped]
+    [JsonIgnore]
+    public EventDescriptor Event
+    {
+        get => EventDescriptor.Get(EventId);
+        set => EventId = value?.Id ?? Guid.Empty;
+    }
+
+    [NotMapped]
+    public ConditionLists FishingRequirements = new ConditionLists();
+
+    //Òðåáîâàíèÿ äëÿ ëîâëè ýòîé ðûáêè
+    [Column("FishingRequirements")]
+    [JsonIgnore]
+    public string JsonFishingRequirements
+    {
+        get => FishingRequirements.Data();
+        set => FishingRequirements.Load(value ?? "[]");
+    }
+}
+

--- a/Framework/Intersect.Framework.Core/GameObjects/Fishing/FishingSpotBase.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Fishing/FishingSpotBase.cs
@@ -1,0 +1,105 @@
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Linq;
+using System.Xml.Linq;
+using Intersect.Framework.Core.GameObjects.Conditions;
+using Intersect.Framework.Core.GameObjects.Fishing;
+using Intersect.Models;
+using Newtonsoft.Json;
+
+
+namespace Intersect.Framework.Core.GameObjects.Fishing;
+
+    public partial class FishingSpotBase : DatabaseObject<FishingSpotBase>, IFolderable
+    {
+        [NotMapped]
+        public DbList<FishBase> Fishes = new DbList<FishBase>();
+
+
+        [JsonConstructor]
+        public FishingSpotBase(Guid id) : base(id)
+        {
+            Name = "New Fishing Spot";
+        }
+
+        //Parameterless constructor for EF
+        public FishingSpotBase()
+        {
+            Name = "New Fishing Spot";
+        }
+
+        [JsonIgnore]
+        [Column("Fishes")]
+        public string FishesJson
+        {
+            get => JsonConvert.SerializeObject(Fishes, Formatting.None);
+            protected set => Fishes = JsonConvert.DeserializeObject<DbList<FishBase>>(value);
+        }
+
+        public int FishingTimeMin { get; set; } = 7000;
+
+        public int FishingTimeMax { get; set; } = 30000;
+
+        public string Folder { get; set; } = "";
+
+        [NotMapped]
+        public ConditionLists FishingRequirements = new ConditionLists();
+
+        //Òðåáîâàíèÿ äëÿ ëîâëè ýòîé ðûáêè
+        [Column("FishingRequirements")]
+        [JsonIgnore]
+        public string JsonFishingRequirements
+        {
+            get => FishingRequirements.Data();
+            set => FishingRequirements.Load(value ?? "[]");
+        }
+
+        public static Guid IdFromList(int listIndex)
+        {
+            if (listIndex < 0 || listIndex >= Lookup.KeyList.Count)
+            {
+                return Guid.Empty;
+            }
+
+            return Lookup.KeyList.OrderBy(pairs => Lookup[pairs]?.Name).ToArray()[listIndex];
+        }
+
+        private SortByType sortBy;
+        public List<Guid> SortingFishByRarity(SortByType sortBy)
+        {
+            this.sortBy = sortBy;
+            List<Guid> result = new List<Guid>();
+            result.AddRange(Fishes.ToArray());
+            result.Sort(SortByRarity);
+            return result;
+        }
+        public enum SortByType
+        {
+            INCREASING,
+            DECREASING
+        }
+        private int SortByRarity(Guid fishID1, Guid fishId2)
+        {
+            int act1 = 1, act2 = -1;
+            if (sortBy == SortByType.DECREASING)
+            {
+                act1 = -1;
+                act2 = 1;
+            }
+            FishBase fish1 = FishBase.Get(fishID1);
+            FishBase fish2 = FishBase.Get(fishId2);
+
+            if (fish1 != null && fish2 == null) return act1;
+            else if (fish1 == null && fish2 != null) return act2;
+            else if (fish1 == null && fish2 == null) return 0;
+            else if (fish1 != null && fish2 != null)
+            {
+                if (fish1.chance > fish2.chance) return act1;
+                else if (fish1.chance < fish2.chance) return act2;
+                else if (fish1.chance == fish2.chance) return 0;
+                else return 0;
+            }
+            else return 0;
+        }
+
+
+    }

--- a/Framework/Intersect.Framework.Core/GameObjects/Maps/Attributes/MapFishingSpotAttribute.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Maps/Attributes/MapFishingSpotAttribute.cs
@@ -1,0 +1,26 @@
+﻿using Intersect.Framework.Core.GameObjects.Fishing;
+using Intersect.GameObjects.Annotations;
+using Intersect.Localization;
+
+namespace Intersect.Framework.Core.GameObjects.Maps.Attributes;
+
+public partial class MapFishingSpotAttribute : MapAttribute
+{
+    public override MapAttributeType Type => MapAttributeType.FishingSpot;
+
+    [EditorLabel("Attributes", "FishingSpotType")]
+    [EditorReference(typeof(FishingSpotBase), nameof(FishingSpotBase.Name))]
+    public Guid FishingSpotType { get; set; }
+
+    [EditorLabel("Attributes", "Blocked"), EditorBoolean(Style = BooleanStyle.YesNo)]
+    public bool IsBlocked { get; set; }
+
+    public override MapAttribute Clone()
+    {
+        var attribute = (MapFishingSpotAttribute) base.Clone();
+        attribute.FishingSpotType = FishingSpotType;
+        attribute.IsBlocked = IsBlocked;
+
+        return attribute;
+    }
+}

--- a/Framework/Intersect.Framework.Core/GameObjects/Maps/MapAttribute.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Maps/MapAttribute.cs
@@ -38,6 +38,8 @@ public abstract partial class MapAttribute
                 return new MapSlideAttribute();
             case MapAttributeType.Critter:
                 return new MapCritterAttribute();
+            case MapAttributeType.FishingSpot:
+                return new MapFishingSpotAttribute();
         }
 
         return null;

--- a/Framework/Intersect.Framework.Core/GameObjects/Maps/MapAttributeType.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Maps/MapAttributeType.cs
@@ -25,4 +25,6 @@ public enum MapAttributeType : byte
     Slide,
 
     Critter,
+
+    FishingSpot,
 }

--- a/Framework/Intersect.Framework.Core/Network/PacketHandlerRegistry.cs
+++ b/Framework/Intersect.Framework.Core/Network/PacketHandlerRegistry.cs
@@ -587,6 +587,12 @@ public partial class PacketHandlerRegistry : IDisposable
                 Handlers.Remove(disposableHandler.PacketType);
                 disposableHandler.Dispose();
             }
+
+            Handlers.Clear();
+            Preprocessors.Clear();
+            PreHooks.Clear();
+            PostHooks.Clear();
+            DisposableHandlers.Clear();
         }
     }
 

--- a/Framework/Intersect.Framework.Core/Network/Packets/Client/FishingPacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Client/FishingPacket.cs
@@ -1,0 +1,12 @@
+using Intersect.Network;
+using MessagePack;
+
+namespace Intersect.Network.Packets.Client;
+
+[MessagePackObject]
+public partial class FishingPacket : IntersectPacket
+{
+    public FishingPacket()
+    {
+    }
+}

--- a/Framework/Intersect.Framework.Core/Network/Packets/Client/SendCancelFishing.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Client/SendCancelFishing.cs
@@ -1,0 +1,12 @@
+using Intersect.Network;
+using MessagePack;
+
+namespace Intersect.Network.Packets.Client;
+
+[MessagePackObject]
+public partial class SendCancelFishing : IntersectPacket
+{
+    public SendCancelFishing()
+    {
+    }
+}

--- a/Framework/Intersect.Framework.Core/Network/Packets/Client/SendFailedFishing.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Client/SendFailedFishing.cs
@@ -1,0 +1,12 @@
+using Intersect.Network;
+using MessagePack;
+
+namespace Intersect.Network.Packets.Client;
+
+[MessagePackObject]
+public partial class SendFailedFishing : IntersectPacket
+{
+    public SendFailedFishing()
+    {
+    }
+}

--- a/Framework/Intersect.Framework.Core/Network/Packets/Client/SendFishingSpot.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Client/SendFishingSpot.cs
@@ -1,0 +1,12 @@
+using Intersect.Network;
+using MessagePack;
+
+namespace Intersect.Network.Packets.Client;
+
+[MessagePackObject]
+public partial class SendFishingSpot : IntersectPacket
+{
+    public SendFishingSpot()
+    {
+    }
+}

--- a/Framework/Intersect.Framework.Core/Network/Packets/Client/SendSuccessFishing.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Client/SendSuccessFishing.cs
@@ -1,0 +1,12 @@
+using Intersect.Network;
+using MessagePack;
+
+namespace Intersect.Network.Packets.Client;
+
+[MessagePackObject]
+public partial class SendSuccessFishing : IntersectPacket
+{
+    public SendSuccessFishing()
+    {
+    }
+}

--- a/Framework/Intersect.Framework.Core/Network/Packets/Server/EntityFishingPacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Server/EntityFishingPacket.cs
@@ -1,0 +1,42 @@
+using System;
+using Intersect.Enums;
+using Intersect.Network;
+using MessagePack;
+
+namespace Intersect.Network.Packets.Server;
+
+[MessagePackObject]
+public partial class EntityFishingPacket : IntersectPacket
+{
+    public EntityFishingPacket()
+    {
+    }
+
+    public EntityFishingPacket(Guid id, EntityType type, Guid mapId, bool isFishing, int stage, bool isPressed)
+    {
+        Id = id;
+        Type = type;
+        MapId = mapId;
+        IsFishing = isFishing;
+        Stage = stage;
+        IsPressed = isPressed;
+    }
+
+    [Key(0)]
+    public Guid Id { get; set; }
+
+    [Key(1)]
+    public EntityType Type { get; set; }
+
+    [Key(2)]
+    public Guid MapId { get; set; }
+
+    [Key(3)]
+    public bool IsFishing { get; set; }
+
+    [Key(4)]
+    public int Stage { get; set; }
+
+    [Key(5)]
+    public bool IsPressed { get; set; }
+}

--- a/Framework/Intersect.Framework.Core/Network/Packets/Server/EntityPacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Server/EntityPacket.cs
@@ -82,4 +82,19 @@ public abstract partial class EntityPacket : IntersectPacket
     [Key(23)]
     public Color Color { get; set; }
 
+    [Key(47)]
+    public bool IsFishing { get; set; }
+
+    [Key(48)]
+    public int FishingStageIndex { get; set; }
+
+    [Key(49)]
+    public bool IsFishingRodPressed { get; set; }
+
+    [Key(50)]
+    public long FishingStageTimer { get; set; }
+
+    [Key(51)]
+    public long FishingStageDuration { get; set; }
+
 }

--- a/Framework/Intersect.Framework.Core/Network/Packets/Server/FishingPackets.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Server/FishingPackets.cs
@@ -1,0 +1,84 @@
+using System;
+using Intersect.Enums;
+using MessagePack;
+
+namespace Intersect.Network.Packets.Server;
+
+[MessagePackObject]
+public sealed class StartFishingPacket : IntersectPacket
+{
+    //Parameterless Constructor for MessagePack
+    public StartFishingPacket()
+    {
+    }
+
+    public StartFishingPacket(Guid fishId, long stageTimer, long resolveTimer, FishingStage stage, bool cancelRequested)
+    {
+        FishId = fishId;
+        StageTimer = stageTimer;
+        ResolveTimer = resolveTimer;
+        Stage = stage;
+        CancelRequested = cancelRequested;
+    }
+
+    [Key(0)]
+    public Guid FishId { get; set; }
+
+    [Key(1)]
+    public long StageTimer { get; set; }
+
+    [Key(2)]
+    public long ResolveTimer { get; set; }
+
+    [Key(3)]
+    public FishingStage Stage { get; set; }
+
+    [Key(4)]
+    public bool CancelRequested { get; set; }
+}
+
+[MessagePackObject]
+public sealed class ResolveFishingPacket : IntersectPacket
+{
+    //Parameterless Constructor for MessagePack
+    public ResolveFishingPacket()
+    {
+    }
+
+    public ResolveFishingPacket(Guid fishId, long resolveTimer, bool cancelRequested, bool canceled)
+    {
+        FishId = fishId;
+        ResolveTimer = resolveTimer;
+        CancelRequested = cancelRequested;
+        Canceled = canceled;
+    }
+
+    [Key(0)]
+    public Guid FishId { get; set; }
+
+    [Key(1)]
+    public long ResolveTimer { get; set; }
+
+    [Key(2)]
+    public bool CancelRequested { get; set; }
+
+    [Key(3)]
+    public bool Canceled { get; set; }
+}
+
+[MessagePackObject]
+public sealed class StopFishingPacket : IntersectPacket
+{
+    //Parameterless Constructor for MessagePack
+    public StopFishingPacket()
+    {
+    }
+
+    public StopFishingPacket(bool canceled)
+    {
+        Canceled = canceled;
+    }
+
+    [Key(0)]
+    public bool Canceled { get; set; }
+}

--- a/Framework/Intersect.Framework.Core/Network/Packets/Server/SendClientFish.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Server/SendClientFish.cs
@@ -1,0 +1,21 @@
+using System;
+using Intersect.Network;
+using MessagePack;
+
+namespace Intersect.Network.Packets.Server;
+
+[MessagePackObject]
+public partial class SendClientFish : IntersectPacket
+{
+    public SendClientFish()
+    {
+    }
+
+    public SendClientFish(Guid fishId)
+    {
+        FishId = fishId;
+    }
+
+    [Key(0)]
+    public Guid FishId { get; set; }
+}

--- a/Framework/Intersect.Framework.Core/Network/Packets/Server/SendClientResultCastFishingRod.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Server/SendClientResultCastFishingRod.cs
@@ -1,0 +1,20 @@
+using Intersect.Network;
+using MessagePack;
+
+namespace Intersect.Network.Packets.Server;
+
+[MessagePackObject]
+public partial class SendClientResultCastFishingRod : IntersectPacket
+{
+    public SendClientResultCastFishingRod()
+    {
+    }
+
+    public SendClientResultCastFishingRod(bool success)
+    {
+        Success = success;
+    }
+
+    [Key(0)]
+    public bool Success { get; set; }
+}

--- a/Intersect.Client.Core/CustomChanges/FishEventClient.cs
+++ b/Intersect.Client.Core/CustomChanges/FishEventClient.cs
@@ -1,0 +1,859 @@
+using Intersect.Client.Core;
+using Intersect.Client.Core.Controls;
+using Intersect.Client.Core.Sounds;
+using Intersect.Client.Framework.Entities;
+using Intersect.Client.Framework.Graphics;
+using Intersect.Client.Framework.Input;
+using Intersect.Client.General;
+using Intersect.Client.Interface.Game.Fishing;
+using Intersect.Client.Networking;
+using Intersect.Enums;
+using Intersect.Framework.Core;
+using Intersect.Framework.Core.GameObjects.Fishing;
+using Intersect.Framework.Core.GameObjects.Items;
+using Intersect.Framework.Core.GameObjects.Maps;
+using Intersect.Framework.Core.GameObjects.Maps.Attributes;
+using Intersect.GameObjects;
+using Intersect.Utilities;
+using Serilog;
+
+namespace Intersect.Client.Entities.Events;
+public partial class FishEventClient
+{
+
+    #region FuncVars
+    private Player? player;
+    private long lastUpdateTime;//Время последнего обновления для deltaTime
+    private float deltaTime;//Дельта времени
+    private bool isPressed = false;//Зажатие кнопки
+    private FishingWindow? eventUI;
+    private int timerFishingRod = 1000;
+    private long timeFishingRod;
+    private ItemDescriptor? currentFishingRod { get; set; }
+    private Sound[]? sounds;
+    private FishBase? fish;
+    #endregion
+
+    #region EventVars
+
+    private int stage { get; set; } = 0;
+
+    private float currentValue = 0; //Текущий прогресс в ловли рыбы
+    //С какого значения начинается рыбалка
+    //Более дерзкая рыба уменьшает это значение
+    //Более качественная удочка увеличивает это значение
+    private float beginValue = 0.5f;
+
+
+    //Диапазон, в котором игрок удерживает удочку
+    private float currentRangeSize;
+    private float targetRangeSize;
+    private float currentMoveSpeed;
+
+    private int timeChangeSpeed;
+    private int timeChangeRangeSize;
+
+    private long lastUpdateTimeRangeSize;
+    private long lastUpdateTimeSpeed;
+    //Текущая позиция диапазона
+    private float currentFishPosition;
+
+    private float playerPosition = 0;
+    private float playerStrength = 0.15f;
+    private float hookSize = 0.15f;
+
+
+    private int[]? mapPosition { get; set; }
+    private Direction? playerDirection { get; set; }
+    private void ResetData()
+    {
+        currentValue = 0;
+        beginValue = 0.5f;
+        currentRangeSize = 0;
+        targetRangeSize = 0;
+        currentMoveSpeed = 0;
+
+        timeChangeSpeed = 0;
+        timeChangeRangeSize = 0;
+
+        lastUpdateTimeRangeSize = 0;
+        lastUpdateTimeSpeed = 0;
+        currentFishPosition = 0;
+
+        playerPosition = 0;
+        isPullingRod = 0;
+    }
+
+    private void SetData()
+    {
+        currentFishPosition = fish.position / 100f;
+        currentMoveSpeed = fish.speedMove / 100f;
+        timeChangeSpeed = fish.timeChangeSpeed;
+        timeChangeRangeSize = fish.timeChangeRangeSize;
+        currentRangeSize = fish.rangeSize / 100f;
+        targetRangeSize = fish.rangeSize / 100f;
+    }
+
+    #endregion
+
+
+    public FishEventClient()
+    {
+        if (Interface.Interface.GameUi == null) return;
+        if (eventUI == null)
+            eventUI = new FishingWindow(Interface.Interface.GameUi.GameCanvas);
+        player = Globals.Me;
+        sounds = new Sound[10];
+    }
+
+    bool isDebaging = true;
+    bool isFishing = false;//Если игрок ловит рыбу
+    bool isFishingForAnimation = false;//Если игрок ловит рыбу
+    bool isFishingEvent = false;//Если игрок в ивенте ловли
+
+    #region Stage 0 Игрок закидывает удочку.
+
+
+    public bool TryFishing()
+    {
+        if (isFishingEvent)
+        {
+            if (isDebaging)
+                Log.Information("На текущий момент на крючке рыба.");
+            return true;//true потому, что рыбалка выполняется, а значит удары не должны отправится на сервер
+        }
+        if (!IsFishingRod())
+        {
+            if (isDebaging)
+                Log.Information("Это не удочка.");
+            return false;
+        }
+        if (Timing.Global.Milliseconds < timeFishingRod)
+        {
+            if (isDebaging)
+            {
+                float reqsec = (int)timerFishingRod / 1000f;
+                float cursec = (int)(timeFishingRod - Timing.Global.Milliseconds) / 1000f;
+                Log.Information($"Таймер еще не прошёл. {cursec.ToString("0.0sec.")} < {reqsec.ToString("0.0sec.")}");
+            }
+            return false;
+        }
+
+        MapAttribute mapAttribute;
+        mapAttribute = GetAttribute(MapAttributeType.FishingSpot);
+        if (mapAttribute != null)
+        {
+            MapFishingSpotAttribute attribute = (MapFishingSpotAttribute)mapAttribute;
+
+            Guid fishingSpotID = attribute.FishingSpotType;
+            FishingSpotBase spot = FishingSpotBase.Get(fishingSpotID);
+
+            if (isDebaging)
+                Log.Information("Удочка успешно кастанулась.");
+
+            if (stage == 0)
+            {
+                PacketSender.SendFishingSpot();
+            }
+            else
+            {
+                Freeze(timerFishingRod, true);
+                PacketSender.SendCancelFishing();
+                isFishing = false;
+                stage = 0;
+                if (isDebaging)
+                    Log.Information("Удочку забрали.");
+            }
+            timeFishingRod = Timing.Global.Milliseconds + timerFishingRod;
+
+        }
+        else
+        {
+            if (isDebaging)
+                Log.Information("Атрибут не найден.");
+            return false;
+        }
+
+        return true;
+    }
+
+    public void FishingRodCastHundler(bool isSuccess)
+    {
+        if (isSuccess)
+        {
+            if (stage == 0)
+            {
+                mapPosition = new int[] { player.X, player.Y };
+                playerDirection = player.DirectionFacing;
+                stage = 1;
+                isFishing = true;
+                isFishingForAnimation = true;
+                Freeze(timerFishingRod);
+                if (isDebaging)
+                    Log.Information("Удочку закинули.");
+            }
+        }
+    }
+
+    #region Функции
+    private bool IsFishingRod()
+    {
+        var weaponSlotIndex = Options.Instance.Equipment.WeaponSlot;
+        if (weaponSlotIndex > -1 && weaponSlotIndex < player.Equipment.Count)
+        {
+            // Corrección: player.MyEquipment[weaponSlotIndex] es una lista de ints, no un int.
+            // Debemos iterar sobre los índices de equipo en ese slot.
+            var equipmentIndices = player.MyEquipment[weaponSlotIndex];
+            foreach (var slot in equipmentIndices)
+            {
+                if (slot < Options.Instance.Player.MaxInventory)
+                {
+                    var itemId = Guid.Empty;
+                    if (slot > -1)
+                        itemId = player.Inventory[slot].ItemId;
+
+                    var item = ItemDescriptor.Get(itemId);
+
+                    if (item != null)
+                    {
+                        List<string> tools = [.. Options.Instance.Equipment.ToolTypes.ToArray()];
+                        int toolID = -1;
+                        toolID = tools.FindIndex(x => x == "Fishing Rod");
+                        if (toolID == -1)
+                            toolID = tools.FindIndex(x => x == "FishingRod");
+                        if (toolID == -1)
+                            toolID = tools.FindIndex(x => x == "fishing Rod");
+                        if (toolID == -1)
+                            toolID = tools.FindIndex(x => x == "fishingRod");
+                        if (toolID == -1)
+                            toolID = tools.FindIndex(x => x == "Удочка");
+                        if (toolID == -1)
+                            toolID = tools.FindIndex(x => x == "удочка");
+
+                        if (item.Tool == toolID && toolID != -1)
+                        {
+                            currentFishingRod = item;
+                            return true;
+                        }
+                    }
+                }
+            }
+            return false;
+        }
+        else return false;
+    }
+
+    private Direction GetDirection(int _x, int _y)
+    {
+        switch (_x)
+        {
+            case 0:
+                switch (_y)
+                {
+                    case 0:
+                        return Direction.None;
+                    case -1:
+                        return Direction.Up;
+                    case 1:
+                        return Direction.Down;
+                    default: return Direction.None;
+                }
+            case 1:
+                switch (_y)
+                {
+                    case 0:
+                        return Direction.Right;
+                    case -1:
+                        return Direction.UpRight;
+                    case 1:
+                        return Direction.DownRight;
+                    default: return Direction.Right;
+                }
+            case -1:
+                switch (_y)
+                {
+                    case 0:
+                        return Direction.Left;
+                    case -1:
+                        return Direction.UpLeft;
+                    case 1:
+                        return Direction.DownLeft;
+                    default: return Direction.Left;
+                }
+            default: return Direction.None;
+        }
+    }
+
+    public class Vector2Int
+    {
+        private int m_X;
+        private int m_Y;
+
+        public int X
+        {
+            get { return m_X; }
+
+            set { m_X = value; }
+        }
+        public int Y
+        {
+            get { return m_Y; }
+
+            set { m_Y = value; }
+        }
+
+        public Vector2Int()
+        {
+
+        }
+
+        public Vector2Int(int X, int Y)
+        {
+            this.m_X = X;
+            this.m_Y = Y;
+        }
+
+        public int this[int index]
+        {
+            get
+            {
+                switch (index)
+                {
+                    case 0: return X;
+                    case 1: return Y;
+                    default:
+                        throw new IndexOutOfRangeException(String.Format("Invalid Vector2Int index addressed: {0}!", index));
+                }
+            }
+
+            set
+            {
+                switch (index)
+                {
+                    case 0: X = value; break;
+                    case 1: Y = value; break;
+                    default:
+                        throw new IndexOutOfRangeException(String.Format("Invalid Vector2Int index addressed: {0}!", index));
+                }
+            }
+        }
+
+        public static Vector2Int operator -(Vector2Int v)
+        {
+            return new Vector2Int(-v.X, -v.Y);
+        }
+        public static Vector2Int operator -(Vector2Int a, Vector2Int b)
+        {
+            return new Vector2Int(a.X - b.X, a.Y - b.Y);
+        }
+    }
+
+    private MapAttribute GetAttribute(MapAttributeType requireType)
+    {
+        if (Maps.MapInstance.Get(player.MapId) == null) return null;
+        if ((player.X < Options.Instance.Map.MapWidth && player.X >= 0) &&
+            (player.Y < Options.Instance.Map.MapHeight && player.Y >= 0))
+        {
+
+            MapAttribute result = null;
+            int radarRadius = 3;//значения 3\5\7
+            for (int radarX = player.X - (radarRadius - 2); radarX < player.X + 2; radarX++)
+                for (int radarY = player.Y - 1; radarY < player.Y + 2; radarY++)
+                {
+                    Maps.MapInstance mapInstance = Maps.MapInstance.Get(player.MapId);
+                    if (radarX >= Options.Instance.Map.MapWidth || radarX < 0 ||
+                        radarY >= Options.Instance.Map.MapHeight || radarY < 0)
+                        continue;
+                    MapAttribute attribute = Maps.MapInstance.Get(player.MapId).Attributes[radarX, radarY];
+                    if (attribute == null || attribute.Type != requireType) continue;
+                    Vector2Int playerPos = new Vector2Int(player.X, player.Y);
+                    Vector2Int attributePos = new Vector2Int(radarX, radarY);
+                    Vector2Int direction = attributePos - playerPos;
+                    Direction requiredDirection = GetDirection(direction.X, direction.Y);
+
+                    if (requiredDirection == player.DirectionFacing)
+                    {
+                        result = attribute;
+                        break;
+                    }
+                }
+            return result;
+        }
+        else return null;
+    }
+    #endregion
+
+    #endregion
+
+    #region Stage 1 Рыба поймана на крючок. 
+
+    public void TheFishWasCaught(Guid fishID)
+    {
+        if (!isFishing) return;
+        ResetData();
+        fish = FishBase.Get(fishID);
+        SetData();
+
+        eventUI.Show();
+
+        lastUpdateTime = Timing.Global.MillisecondsUtc;
+        lastUpdateTimeSpeed = Timing.Global.MillisecondsUtc + fish.timeChangeSpeed;
+        lastUpdateTimeRangeSize = Timing.Global.MillisecondsUtc + fish.timeChangeRangeSize;
+
+        stage = 2;
+        //Проверяем силу рыбы, не сорвалась-ли она раньше, чем игрок может среагировать на это
+        currentValue = beginValue - fish.pushStrength / 100f;
+        if (currentValue <= 0)
+        {
+            FishingFailed();
+            return;
+        }
+    }
+
+    #endregion
+
+    public void Update()
+    {
+        LoadSounds();
+        FreezenUpdate();
+        SoundUpdate();
+        UpdateAnimation();
+
+        switch (stage)
+        {
+            case 1:
+                if (Controls.IsControlPressed(Control.MoveDown) ||
+                    Controls.IsControlPressed(Control.MoveLeft) ||
+                    Controls.IsControlPressed(Control.MoveRight) ||
+                    Controls.IsControlPressed(Control.MoveUp) ||
+                    Controls.IsControlPressed(Control.TurnAround))
+                {
+                    Freeze(timerFishingRod, true);
+                    stage = 0;
+                }
+                break;
+            case 2:
+                if (eventUI == null) return;
+                Globals.InFishing = true;
+                isFishingEvent = true;
+                deltaTime = (Timing.Global.MillisecondsUtc - lastUpdateTime) / 1000f;
+                lastUpdateTime = Timing.Global.MillisecondsUtc;
+
+                FishMove(deltaTime);
+                PlayerPressKey(deltaTime);
+                Progress(deltaTime);
+                eventUI.RangeMoveResize(currentFishPosition, currentRangeSize);
+                eventUI.PlayerForceMoved(playerPosition, hookSize);
+                eventUI.Progress(currentValue);
+                break;
+            case 3:
+                if (Timing.Global.MillisecondsUtc >= timerResultUI)
+                {
+                    HideResultUI();
+                }
+                break;
+        }
+    }
+
+    #region Stage 2 Борьба с рыбой
+
+    private void FishMove(float _deltaTime)
+    {
+        if (fish == null) return;
+        currentFishPosition += currentMoveSpeed * _deltaTime;
+        currentFishPosition = Math.Clamp(currentFishPosition, 0f + (currentRangeSize / 2f), 1f - (currentRangeSize / 2f));
+
+        float leftRange = currentFishPosition - (currentRangeSize / 2f);
+        float rightRange = currentFishPosition + (currentRangeSize / 2f);
+
+        if (leftRange == 0f || rightRange == 1f)
+            currentMoveSpeed = currentMoveSpeed * -1f;
+
+        //Смена скорости, а иногда и направления по окончанию таймера
+        if (Timing.Global.MillisecondsUtc > lastUpdateTimeSpeed)
+        {
+            currentMoveSpeed = ChaosRange(fish.speedMove / 100f, 0, fish.coeffUnpredictability, 1, 2) * Math.Sign(currentMoveSpeed);
+            int rand = RandomRange(1, 201);
+            if (rand < fish.coeffUnpredictability)
+                currentMoveSpeed *= -1f;
+            timeChangeSpeed = (int)ChaosRange(fish.timeChangeSpeed, 0, fish.coeffUnpredictability);
+            lastUpdateTimeSpeed = Timing.Global.MillisecondsUtc + timeChangeSpeed;
+        }
+        //Смена целевого размера диапазона по окончанию таймера
+        if (Timing.Global.MillisecondsUtc > lastUpdateTimeRangeSize)
+        {
+            targetRangeSize = ChaosRange(fish.rangeSize / 100f, 0, fish.coeffUnpredictability);
+            timeChangeRangeSize = (int)ChaosRange(fish.timeChangeRangeSize, 0, fish.coeffUnpredictability);
+            lastUpdateTimeRangeSize = Timing.Global.MillisecondsUtc + timeChangeRangeSize;
+        }
+        //Подгонка текущего диапазона к целевому
+        if (currentRangeSize != targetRangeSize)
+        {
+            int sign = Math.Sign(targetRangeSize - currentRangeSize);
+            currentRangeSize += fish.speedChangeRangeSize / 100f * _deltaTime * sign;
+            if (Math.Abs(targetRangeSize - currentRangeSize) < 0.01f) currentRangeSize = targetRangeSize;
+        }
+        currentFishPosition = Math.Clamp(currentFishPosition, 0f + (currentRangeSize / 2f), 1f - (currentRangeSize / 2f));
+
+    }
+
+
+    private float isPullingRod = 0;
+    private void PlayerPressKey(float _deltaTime)
+    {
+        if (fish == null) return;
+        float volumePressEMultiple = 10;
+        if (Controls.IsControlPressed(Control.AttackInteract))
+        {
+            if (!isPressed)
+            {
+                isPullingRod += playerStrength * volumePressEMultiple;
+                playerPosition += playerStrength;
+                isPressed = true;
+            }
+        }
+        else
+        {
+            isPressed = false;
+        }
+        playerPosition -= fish.weight / 100f * _deltaTime;
+        isPullingRod -= fish.weight / 100f * _deltaTime * (volumePressEMultiple * 0.5f);
+        playerPosition = Math.Clamp(playerPosition, 0f + (hookSize / 2f), 1f - (hookSize / 2f));
+        isPullingRod = Math.Clamp(isPullingRod, 0f, 1f);
+        IsFishingRodPressed = isPullingRod > 0.2f ? true : false;
+
+    }
+
+    private void Progress(float _deltaTime)
+    {
+        if (fish == null) return;
+        //Если крючок в диапазоне рыбы
+        if (isHookInFish())
+        {
+            currentValue += playerStrength * _deltaTime;
+            currentValue = Math.Clamp(currentValue, 0, 1);
+        }
+        else
+        {
+            currentValue -= (fish.strength / 100f) * _deltaTime;
+            currentValue = Math.Clamp(currentValue, 0, 1);
+        }
+        bool isHookInFish()
+        {
+            float leftHook = playerPosition - hookSize / 2f;
+            float rightHook = playerPosition + hookSize / 2f;
+            float leftFish = currentFishPosition - currentRangeSize / 2f;
+            float rightFish = currentFishPosition + currentRangeSize / 2f;
+
+            if (leftFish < rightHook && rightHook < rightFish)
+                return true;
+            else if (leftFish < leftHook && leftHook < rightFish)
+                return true;
+            else return false;
+        }
+
+        if (currentValue == 0f)
+            FishingFailed();
+        if (currentValue == 1f)
+            FishingSuccess();
+    }
+
+    float ChaosRange(float defaultValue, int min, int max, int sign = 0, int multiply = 1)
+    {
+        Random random = new Random();
+        int scale = random.Next(min, max);
+        sign = MathF.Sign(sign);
+        float result = 0;
+        switch (sign)
+        {
+            case 1:
+                result = scale / 100f;
+                break;
+            case -1:
+                result = -scale / 100f;
+                break;
+            default:
+                int res = random.Next(1, 101);
+                if (res > 50) result = scale / 100f;
+                else result = -scale / 100f;
+                break;
+        }
+        if (scale == 0) result = 0;
+        return defaultValue + defaultValue * (result * multiply);
+    }
+
+    int RandomRange(int min, int max)
+    {
+        Random random = new Random();
+        return random.Next(min, max);
+    }
+
+    #endregion
+
+    #region Stage 3 Отправка результата ивента
+
+    private long timerResultUI = 0;
+
+    private void FishingFailed()
+    {
+        stage = 3;
+        isFishingEvent = false;
+        PacketSender.SendFailedFishing();
+        timeFishingRod = Timing.Global.Milliseconds + timerFishingRod;
+        if (eventUI != null)
+            eventUI.HideBars();
+        timerResultUI = Timing.Global.MillisecondsUtc + timerFishingRod;
+        isSuccess = false;
+    }
+    private void FishingSuccess()
+    {
+        stage = 3;
+        isFishingEvent = false;
+        PacketSender.SendSuccessFishing();
+        timeFishingRod = Timing.Global.Milliseconds + timerFishingRod;
+        if (eventUI != null && fish != null)
+        {
+            eventUI.RedrawIcon(ItemDescriptor.Get(fish.ItemId));
+            eventUI.HideBars();
+            eventUI.ShowSuccess();
+        }
+        timerResultUI = Timing.Global.MillisecondsUtc + timerFishingRod;
+        isSuccess = true;
+    }
+
+    private void HideResultUI()
+    {
+        if (eventUI == null) return;
+        stage = 0;
+        timerResultUI = 0;
+        eventUI.HideFailed();
+        eventUI.HideSuccess();
+        eventUI.Hide();
+        isFishingForAnimation = false;
+        Globals.InFishing = false;
+    }
+
+    #endregion
+
+    #region Звуки
+
+    List<SoundData> soundsData = new List<SoundData>();
+
+    public class SoundData
+    {
+        public string name = "";
+        public int index = 0;
+        public SoundData(string name, int index)
+        {
+            this.name = name;
+            this.index = index;
+        }
+    }
+
+    private bool isSoundLoaded = false;
+    private bool isSuccess = false;//Для звука
+    private void LoadSounds()//Зарузить списки звуков
+    {
+        if (isSoundLoaded) return;
+        LoadSoundList("fishingUse");
+        LoadSoundList("isFish");
+        LoadSoundList("fishingFightOnLoad");
+        LoadSoundList("fishingFightOffLoad");
+        LoadSoundList("fishingFailed");
+        LoadSoundList("fishingSuccess");
+        isSoundLoaded = true;
+    }
+
+    private void LoadSoundList(string _name)//Поиск циклом файлов с названием _name(номер)
+    {
+        for (int i = 0; i < 10; i++)
+        {
+            string row = $"{_name}_{i}";
+            Sound? audioInstance = Audio.AddGameSound(row, false);
+            if (audioInstance != null && audioInstance.Loaded)
+            {
+                soundsData.Add(new SoundData(_name, i));
+          
+                audioInstance.Stop();
+                audioInstance = null;
+            }
+        }
+    }
+    private Sound GetRandomSound(string _name, bool loop)//Получить случайное название файла по имени
+    {
+        Random randomSound = new Random();
+
+        List<SoundData> find = soundsData.FindAll(x => x.name == _name);
+
+        if (find.Count > 0)
+        {
+            int random = randomSound.Next(0, find.Count);
+            string row = $"{find[random].name}_{find[random].index}";
+            //Log.Debug(row);
+            Sound result = Audio.AddGameSound(row, loop);
+            return result;
+        }
+        else return null;
+    }
+    private void PlaySound(int index)//Играть звук по индексу действия
+    {
+        if (sounds == null) return;
+        if (sounds[index] != null) return;
+        switch (index)
+        {
+            case 0:
+                sounds[index] = GetRandomSound("fishingUse", false);
+                break;
+            case 1:
+                sounds[1] = GetRandomSound("fishingFightOnLoad", true);
+                break;
+            case 2:
+                sounds[2] = GetRandomSound("isFish", false);
+                break;
+            case 3:
+                sounds[3] = GetRandomSound("fishingFightOffLoad", true);
+                break;
+            case 4://Не помню за что отвечает 4й номер, но он нигде не встречается.
+                sounds[4] = GetRandomSound("fishingUse", false);
+                break;
+            case 5:
+                sounds[5] = GetRandomSound("fishingFailed", false);
+                break;
+            case 6:
+                sounds[6] = GetRandomSound("fishingSuccess", false);
+                break;
+            default:
+                break;
+        }
+    }
+    private void StopSound(int index)//Остановить звук
+    {
+        if (sounds == null) return;
+        if (sounds[index] == null) return;
+        sounds[index].Stop();
+        sounds[index] = null;
+    }
+    private void StopAllSounds()//Остановить все звуки
+    {
+        if (sounds == null) return;
+        for (int soundID = 0; soundID < sounds.Length; soundID++)
+        {
+            if (sounds[soundID] == null) continue;
+            sounds[soundID].Stop();
+            sounds[soundID] = null;
+        }
+    }
+    private void SoundUpdate()
+    {
+        if (player == null) return;
+        switch (stage)
+        {
+            case 0:
+                if (oldStageForSound == 1)
+                {
+                    StopAllSounds();
+                    oldStageForSound = 0;
+                    PlaySound(5);
+                }
+                else if (oldStageForSound == 3)
+                {
+                    StopAllSounds();
+                    oldStageForSound = 0;
+                }
+                break;
+            case 1:
+                if (oldStageForSound == 0)
+                {
+                    oldStageForSound = stage;
+                    PlaySound(0);
+                }
+                break;
+            case 2:
+                if (oldStageForSound == 1)
+                {
+                    oldStageForSound = stage;
+                    StopAllSounds();
+                    PlaySound(2);
+                }
+                else if (oldStageForSound == 2)
+                {
+                    if (IsFishingRodPressed)
+                    {
+                        StopSound(3);
+                        PlaySound(1);
+                    }
+                    else
+                    {
+                        PlaySound(3);
+                        StopSound(1);
+                    }
+
+                }
+                break;
+            case 3:
+                if (oldStageForSound == 2)
+                {
+                    oldStageForSound = stage;
+                    StopAllSounds();
+                    if (isSuccess)
+                    {
+                        PlaySound(6);
+                    }
+                    else PlaySound(5);
+                }
+                break;
+        }
+    }
+
+    #endregion
+
+    #region Заморозка
+    private bool isFreezen = false;
+    private bool isFreezenQuit = false;
+    private long timeUnFreeze;
+    void FreezenUpdate()
+    {
+        if (!isFreezen || timeUnFreeze > Timing.Global.Milliseconds) return;
+        if (isFreezenQuit)
+        {
+            isFishingForAnimation = false;
+        }
+        Globals.InFishing = false;
+        isFreezen = false;
+        isFreezenQuit = false;
+    }
+
+    void Freeze(int timerFreeze, bool isFreezenQuit = false)
+    {
+        timeUnFreeze = Timing.Global.Milliseconds + timerFreeze;
+        Globals.InFishing = true;
+        isFreezen = true;
+        this.isFreezenQuit = isFreezenQuit;
+    }
+
+    #endregion
+
+    #region Пакет анимации
+
+    private int oldStageForSound = 0;
+    private int oldStageForAnimation = 0;
+    private bool oldStatusFishing = false;
+    private bool oldPressed = false;
+    private bool IsFishingRodPressed = false;
+
+    private void UpdateAnimation()
+    {
+        if (player == null) return;
+
+        if (isFishingForAnimation != oldStatusFishing ||
+            stage != oldStageForAnimation ||
+            IsFishingRodPressed != oldPressed)
+        {
+            oldStageForAnimation = stage;
+            oldStatusFishing = isFishingForAnimation;
+            oldPressed = IsFishingRodPressed;
+        }
+    }
+
+    #endregion
+}

--- a/Intersect.Client.Core/Entities/Entity.cs
+++ b/Intersect.Client.Core/Entities/Entity.cs
@@ -48,6 +48,17 @@ public partial class Entity : IEntity
 
     public long CastTime { get; set; } = 0;
 
+    //Fishing
+    public bool IsFishing { get; set; }
+
+    public int FishingStageIndex { get; set; }
+
+    public bool IsFishingRodPressed { get; set; }
+
+    public long FishingStageTimer { get; set; }
+
+    public long FishingStageDuration { get; set; }
+
     //Combat Status
     public bool IsAttacking => AttackTimer > Timing.Global.Milliseconds;
 
@@ -178,6 +189,8 @@ public partial class Entity : IEntity
     public HashSet<Entity>? RenderList { get; set; }
 
     private Guid _spellCast;
+
+    private int _lastFishingStage;
 
     public Guid SpellCast
     {
@@ -394,6 +407,7 @@ public partial class Entity : IEntity
                 SpriteAnimations.Shoot => Options.Instance.Sprites.ShootFrames,
                 SpriteAnimations.Cast => Options.Instance.Sprites.CastFrames,
                 SpriteAnimations.Weapon => Options.Instance.Sprites.WeaponFrames,
+                SpriteAnimations.Fishing => Options.Instance.Sprites.FishingFrames,
                 _ => Options.Instance.Sprites.NormalFrames,
             };
         }
@@ -2160,6 +2174,122 @@ public partial class Entity : IEntity
         Status = [.. Status.OrderByDescending(x => x.RemainingMs)];
     }
 
+    private bool UpdateFishingSpriteAnimation(long timingMilliseconds)
+    {
+        if (!IsFishing && _lastFishingStage == 0)
+        {
+            return false;
+        }
+
+        if (!IsFishing)
+        {
+            FishingStageIndex = 0;
+        }
+
+        if (SpriteFrameTimer + Options.Instance.Sprites.IdleFrameDuration >= timingMilliseconds)
+        {
+            return true;
+        }
+
+        switch (FishingStageIndex)
+        {
+            case 0:
+                if (_lastFishingStage == 1)
+                {
+                    if (AnimatedTextures.TryGetValue(SpriteAnimations.Weapon, out _))
+                    {
+                        SpriteAnimation = SpriteAnimations.Weapon;
+                        SpriteFrame = Math.Max(0, SpriteFrames - 1);
+                    }
+
+                    _lastFishingStage = 0;
+                }
+                else if (_lastFishingStage == 0)
+                {
+                    SpriteFrame = Math.Max(0, SpriteFrame - 1);
+                    if (SpriteFrame == 0 && AnimatedTextures.TryGetValue(SpriteAnimations.Idle, out _))
+                    {
+                        SpriteAnimation = SpriteAnimations.Idle;
+                    }
+                }
+                else
+                {
+                    _lastFishingStage = FishingStageIndex;
+                }
+
+                break;
+
+            case 1:
+                if (_lastFishingStage == 0)
+                {
+                    if (AnimatedTextures.TryGetValue(SpriteAnimations.Weapon, out _))
+                    {
+                        SpriteAnimation = SpriteAnimations.Weapon;
+                        SpriteFrame = 0;
+                    }
+
+                    _lastFishingStage = FishingStageIndex;
+                }
+                else if (_lastFishingStage == 1)
+                {
+                    SpriteFrame = Math.Min(SpriteFrames - 1, SpriteFrame + 1);
+                    if (SpriteFrame >= SpriteFrames - 1 && AnimatedTextures.TryGetValue(SpriteAnimations.Idle, out _))
+                    {
+                        SpriteAnimation = SpriteAnimations.Idle;
+                    }
+                }
+
+                break;
+
+            case 2:
+                if (_lastFishingStage == 1)
+                {
+                    if (AnimatedTextures.TryGetValue(SpriteAnimations.Weapon, out _))
+                    {
+                        SpriteAnimation = SpriteAnimations.Weapon;
+                    }
+
+                    _lastFishingStage = FishingStageIndex;
+                }
+
+                SpriteFrame = IsFishingRodPressed ? 0 : Math.Min(1, SpriteFrames - 1);
+
+                break;
+
+            case 3:
+                if (_lastFishingStage == 2)
+                {
+                    if (AnimatedTextures.TryGetValue(SpriteAnimations.Weapon, out _))
+                    {
+                        SpriteAnimation = SpriteAnimations.Weapon;
+                        SpriteFrame = Math.Max(0, SpriteFrames - 1);
+                    }
+
+                    _lastFishingStage = FishingStageIndex;
+                }
+                else if (_lastFishingStage == 3)
+                {
+                    SpriteFrame--;
+                    if (SpriteFrame < 0)
+                    {
+                        if (AnimatedTextures.TryGetValue(SpriteAnimations.Idle, out _))
+                        {
+                            SpriteAnimation = SpriteAnimations.Idle;
+                        }
+
+                        SpriteFrame = 0;
+                        _lastFishingStage = 0;
+                    }
+                }
+
+                break;
+        }
+
+        SpriteFrameTimer = timingMilliseconds;
+
+        return IsFishing || _lastFishingStage != 0;
+    }
+
     private void UpdateSpriteAnimation()
     {
         // Exit if textures haven't been loaded yet
@@ -2170,6 +2300,13 @@ public partial class Entity : IEntity
 
         var timingMilliseconds = Timing.Global.Milliseconds;
         var isNotBlockingAndCasting = !IsBlocking && !IsCasting;
+        var isFishing = this is Player { FishingStage: not FishingStage.None };
+        var hasFishingAnimation = AnimatedTextures.TryGetValue(SpriteAnimations.Fishing, out _);
+
+        if (this != Globals.Me && UpdateFishingSpriteAnimation(timingMilliseconds))
+        {
+            return;
+        }
 
         SpriteAnimation = SpriteAnimations.Normal;
         if (AnimatedTextures.TryGetValue(SpriteAnimations.Idle, out _) &&
@@ -2179,13 +2316,18 @@ public partial class Entity : IEntity
             SpriteAnimation = SpriteAnimations.Idle;
         }
 
+        if (isFishing && hasFishingAnimation && isNotBlockingAndCasting && !IsAttacking)
+        {
+            SpriteAnimation = SpriteAnimations.Fishing;
+        }
+
         if (IsMoving && !IsAttacking && isNotBlockingAndCasting)
         {
             SpriteAnimation = SpriteAnimations.Normal;
             LastActionTime = timingMilliseconds;
         }
 
-        if (IsAttacking && isNotBlockingAndCasting)
+        if (IsAttacking && isNotBlockingAndCasting && SpriteAnimation != SpriteAnimations.Fishing)
         {
             // Normal sprite-sheets have their own handler for attacking frames.
             if (AnimatedTextures.TryGetValue(SpriteAnimations.Normal, out _))
@@ -2261,7 +2403,7 @@ public partial class Entity : IEntity
             }
         }
 
-        if (IsCasting)
+        if (IsCasting && SpriteAnimation != SpriteAnimations.Fishing)
         {
             var spell = SpellDescriptor.Get(SpellCast);
             if (spell != null)
@@ -2313,6 +2455,19 @@ public partial class Entity : IEntity
                 SpriteFrameTimer = timingMilliseconds;
             }
         }
+        else if (SpriteAnimation == SpriteAnimations.Fishing)
+        {
+            if (SpriteFrameTimer + Options.Instance.Sprites.IdleFrameDuration < timingMilliseconds)
+            {
+                SpriteFrame++;
+                if (SpriteFrame >= SpriteFrames)
+                {
+                    SpriteFrame = 0;
+                }
+
+                SpriteFrameTimer = timingMilliseconds;
+            }
+        }
     }
 
 
@@ -2350,6 +2505,7 @@ public partial class Entity : IEntity
         {
             case SpriteAnimations.Normal:
             case SpriteAnimations.Idle:
+            case SpriteAnimations.Fishing:
                 break;
 
             case SpriteAnimations.Attack:

--- a/Intersect.Client.Core/Entities/Entity.cs
+++ b/Intersect.Client.Core/Entities/Entity.cs
@@ -439,6 +439,11 @@ public partial class Entity : IEntity
         NameColor = packet.NameColor;
         HeaderLabel = new Label(packet.HeaderLabel.Label, packet.HeaderLabel.Color);
         FooterLabel = new Label(packet.FooterLabel.Label, packet.FooterLabel.Color);
+        IsFishing = packet.IsFishing;
+        FishingStageIndex = packet.FishingStageIndex;
+        IsFishingRodPressed = packet.IsFishingRodPressed;
+        FishingStageTimer = packet.FishingStageTimer;
+        FishingStageDuration = packet.FishingStageDuration;
 
         var animsToClear = new List<Animation>();
         var animsToAdd = new List<AnimationDescriptor>();

--- a/Intersect.Client.Core/Entities/Player.cs
+++ b/Intersect.Client.Core/Entities/Player.cs
@@ -186,6 +186,56 @@ public partial class Player : Entity, IPlayer
 
     public long GlobalCooldown { get; set; }
 
+    public Guid? FishingFishId { get; private set; }
+
+    public long FishingStageTimer { get; private set; }
+
+    public long FishingResolveTimer { get; private set; }
+
+    public long FishingStageDuration { get; private set; }
+
+    public long FishingResolveDuration { get; private set; }
+
+    public FishingStage FishingStage { get; private set; } = FishingStage.None;
+
+    public bool IsFishingCancellationRequested { get; private set; }
+
+    public bool FishingCanceled { get; private set; }
+
+    public void StartFishing(Guid fishId, long stageTimer, long resolveTimer, FishingStage stage, bool cancelRequested)
+    {
+        FishingFishId = fishId;
+        FishingStageTimer = stageTimer;
+        FishingResolveTimer = resolveTimer;
+        FishingStageDuration = stageTimer - Timing.Global.Milliseconds;
+        FishingResolveDuration = resolveTimer - Timing.Global.Milliseconds;
+        FishingStage = stage;
+        IsFishingCancellationRequested = cancelRequested;
+        FishingCanceled = false;
+    }
+
+    public void ResolveFishing(Guid fishId, long resolveTimer, bool cancelRequested, bool canceled)
+    {
+        FishingFishId = fishId;
+        FishingResolveTimer = resolveTimer;
+        FishingResolveDuration = resolveTimer - Timing.Global.Milliseconds;
+        FishingStage = FishingStage.Resolving;
+        IsFishingCancellationRequested = cancelRequested;
+        FishingCanceled = canceled;
+    }
+
+    public void StopFishing(bool canceled)
+    {
+        FishingCanceled = canceled;
+        FishingStage = FishingStage.None;
+        FishingFishId = null;
+        FishingStageTimer = 0;
+        FishingResolveTimer = 0;
+        FishingStageDuration = 0;
+        FishingResolveDuration = 0;
+        IsFishingCancellationRequested = false;
+    }
+
     // Target data
     private long mlastTargetScanTime;
 

--- a/Intersect.Client.Core/General/Globals.cs
+++ b/Intersect.Client.Core/General/Globals.cs
@@ -176,6 +176,7 @@ public static partial class Globals
         HoldToSoftRetargetOnSelfCast || Database.AutoSoftRetargetOnSelfCast;
 
     public static bool WaitingOnServer { get; set; }
+    public static bool InFishing = false;
 
     internal static void EmitLifecycleChangingState()
     {

--- a/Intersect.Client.Core/Interface/Game/Character/CharacterWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Character/CharacterWindow.cs
@@ -166,7 +166,7 @@ public partial class CharacterWindow : Window
             FontSize = 11,
             TextColorOverride = Color.White,
             AutoSizeToContents = false,
-            Alignment = [Alignments.Left, Alignments.CenterV]
+        
         };
 
         label.SetSize(width, height);
@@ -514,6 +514,66 @@ public partial class CharacterWindow : Window
         }
     }
 
+    private bool TryGetEquippedWeaponProfile(
+        Player player,
+        out int baseDamage,
+        out Stat scalingStat,
+        out int scalingPercent
+    )
+    {
+        baseDamage = 0;
+        scalingStat = Stat.Attack;
+        scalingPercent = 0;
+
+        var weaponSlotIndex = Options.Instance.Equipment.Slots.IndexOf("Weapon");
+        if (weaponSlotIndex < 0)
+        {
+            weaponSlotIndex = Options.Instance.Equipment.Slots.IndexOf("MainHand");
+        }
+
+        if (weaponSlotIndex < 0)
+        {
+            return false;
+        }
+
+        Guid weaponId = Guid.Empty;
+
+        if (player == Globals.Me)
+        {
+            if (player.MyEquipment.TryGetValue(weaponSlotIndex, out var list) && list.Count > 0)
+            {
+                var invIndex = list[0];
+                if (invIndex >= 0 && invIndex < Options.Instance.Player.MaxInventory)
+                {
+                    weaponId = player.Inventory[invIndex].ItemId;
+                }
+            }
+        }
+        else
+        {
+            if (player.Equipment.TryGetValue(weaponSlotIndex, out var list) && list.Count > 0)
+            {
+                weaponId = list[0];
+            }
+        }
+
+        if (weaponId == Guid.Empty)
+        {
+            return false;
+        }
+
+        if (!ItemDescriptor.TryGet(weaponId, out var weapon))
+        {
+            return false;
+        }
+
+        baseDamage = weapon.Damage;
+        scalingStat = (Stat)weapon.ScalingStat;
+        scalingPercent = weapon.Scaling;
+
+        return true;
+    }
+
     // -------------------------
     // Update Loop
     // -------------------------
@@ -750,19 +810,27 @@ public partial class CharacterWindow : Window
                 player.Stat[(int)Stat.Speed]
             ));
 
-            var baseDamage = mClassDescriptor?.Damage ?? 0;
-            var scalingStat = (Stat)(mClassDescriptor?.ScalingStat ?? (int)Stat.Attack);
-            var scalingPercent = mClassDescriptor?.Scaling ?? 0;
-            var critMultiplier = mClassDescriptor?.CritMultiplier ?? 1f;
+            int sourceBaseDamage;
+            Stat sourceScalingStat;
+            int sourceScalingPercent;
 
-            var scalingStatValue = player.Stat[(int)scalingStat];
-            var scaledBase = baseDamage + scalingStatValue * (scalingPercent / 100f);
-            var minTrueDamage = scaledBase * 0.975 * critMultiplier;
-            var maxTrueDamage = scaledBase * 1.025 * critMultiplier;
+            if (!TryGetEquippedWeaponProfile(player, out sourceBaseDamage, out sourceScalingStat, out sourceScalingPercent))
+            {
+                sourceBaseDamage = mClassDescriptor?.Damage ?? 0;
+                sourceScalingStat = (Stat)(mClassDescriptor?.ScalingStat ?? (int)Stat.Attack);
+                sourceScalingPercent = mClassDescriptor?.Scaling ?? 0;
+            }
+
+            var statValue = player.Stat[(int)sourceScalingStat];
+            var scaledBase = sourceBaseDamage + statValue * (sourceScalingPercent / 100f);
+            var afterBonuses = (scaledBase + _flatDamage.Flat) * (1f + _flatDamage.Percentage / 100f);
+
+            var minTrueDamage = afterBonuses * 0.975f;
+            var maxTrueDamage = afterBonuses * 1.025f;
 
             mBasicAttackDamageLabel.SetText(
                 Strings.Character.BasicAttackDamage.ToString(
-                    baseDamage,
+                    sourceBaseDamage,
                     (int)Math.Round(minTrueDamage),
                     (int)Math.Round(maxTrueDamage)
                 )

--- a/Intersect.Client.Core/Interface/Game/Character/CharacterWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Character/CharacterWindow.cs
@@ -20,9 +20,12 @@ namespace Intersect.Client.Interface.Game.Character;
 
 public partial class CharacterWindow : Window
 {
-    private const int WindowWidth = 700;
+    private const int WindowWidth = 560;
     private const int WindowHeight = 520;
     private const int Margin = 16;
+
+    private const int InfoHeight = 120;
+    private const int StatsHeight = 220;
 
     private const int StatRowHeight = 24;
     private const int StatLabelWidth = 230;
@@ -32,30 +35,18 @@ public partial class CharacterWindow : Window
     private const string TitleFont = "sourcesansproblack";
     private const string BodyFont = "source-sans-pro";
 
-    //Equipment List
-    public List<EquipmentItem> Items = new List<EquipmentItem>();
-
     // Containers
     private Base mCharacterInfoContainer;
     private Base mStatsContainer;
-    private Base mEquipmentContainer;
     private Base mExtraBuffsContainer;
 
     private ScrollControl mExtraBuffsScroll;
     private Base mExtraBuffsList;
 
     // Character UI
-    private ImagePanel mCharacterContainer;
     private Label mCharacterLevelAndClass;
     private Label mCharacterName;
     private Button mFactionButton;
-
-    private ImagePanel mCharacterPortrait; // (si lo usas después)
-    private string mCharacterPortraitImg = string.Empty;
-    private string mCurrentSprite = string.Empty;
-
-    public ImagePanel[] PaperdollPanels;
-    public string[] PaperdollTextures;
 
     // Stats UI
     private Label mAttackLabel;
@@ -229,19 +220,21 @@ public partial class CharacterWindow : Window
         var contentX = Margin;
         var contentY = Margin;
 
-        var leftW = 420;
-        var rightW = WindowWidth - (Margin * 2) - leftW;
-        var topH = 250;
-        var bottomH = WindowHeight - (Margin * 2) - topH;
+        var contentW = WindowWidth - (Margin * 2);
+        var contentH = WindowHeight - (Margin * 2);
 
         // Containers
-        mCharacterInfoContainer = CreateContainer("CharacterInfoContainer", contentX, contentY, leftW, 150);
-        mStatsContainer = CreateContainer("StatsContainer", contentX, contentY + 150, leftW, topH - 150);
-        mEquipmentContainer = CreateContainer("EquipmentContainer", contentX + leftW, contentY, rightW, topH);
-        mExtraBuffsContainer = CreateContainer("ExtraBuffsContainer", contentX, contentY + topH, WindowWidth - (Margin * 2), bottomH);
+        mCharacterInfoContainer = CreateContainer("CharacterInfoContainer", contentX, contentY, contentW, InfoHeight);
+        mStatsContainer = CreateContainer("StatsContainer", contentX, contentY + InfoHeight, contentW, StatsHeight);
+        mExtraBuffsContainer = CreateContainer(
+            "ExtraBuffsContainer",
+            contentX,
+            contentY + InfoHeight + StatsHeight,
+            contentW,
+            contentH - InfoHeight - StatsHeight
+        );
 
         BuildCharacterInfoSection();
-        BuildEquipmentSection();
         BuildStatsSection();
         BuildExtraBuffsSection();
 
@@ -281,79 +274,6 @@ public partial class CharacterWindow : Window
         mFactionButton.SetStateTexture(ComponentState.Hovered, "factionicon_hovered.png");
         mFactionButton.SetToolTipText("Faction");
         mFactionButton.Clicked += (s, e) => Interface.GameUi.GameMenu?.ToggleFactionWindow();
-
-        mCharacterContainer = new ImagePanel(mCharacterInfoContainer, "CharacterContainer");
-        mCharacterContainer.SetSize(120, 120);
-        mCharacterContainer.SetPosition(0, y);
-
-        mCharacterPortrait = new ImagePanel(mCharacterContainer);
-        mCharacterPortrait.SetSize(80, 80);
-        mCharacterPortrait.SetPosition(
-            (mCharacterContainer.Width - mCharacterPortrait.Width) / 2,
-            (mCharacterContainer.Height - mCharacterPortrait.Height) / 2
-        );
-
-        PaperdollPanels = new ImagePanel[Options.Instance.Equipment.Slots.Count + 1];
-        PaperdollTextures = new string[Options.Instance.Equipment.Slots.Count + 1];
-        for (var i = 0; i <= Options.Instance.Equipment.Slots.Count; i++)
-        {
-            PaperdollPanels[i] = new ImagePanel(mCharacterContainer);
-            PaperdollTextures[i] = string.Empty;
-            PaperdollPanels[i].Hide();
-        }
-    }
-
-    private void BuildEquipmentSection()
-    {
-        var header = CreateSectionTitle(mEquipmentContainer, "EquipmentHeader", 0, 0, "Equipo");
-
-        var columns = 4;
-        var slotW = 36;
-        var slotH = 36;
-        var spacingX = 8;
-        var spacingY = 8;
-
-        var startX = 0;
-        var startY = header.Height + 8;
-
-        int itemIndex = 0;
-        var multiSlotTracker = new Dictionary<string, int>();
-
-        for (int slotIndex = 0; slotIndex < Options.Instance.Equipment.EquipmentSlots.Count; slotIndex++)
-        {
-            var slot = Options.Instance.Equipment.EquipmentSlots[slotIndex];
-
-            for (int j = 0; j < slot.MaxItems; j++)
-            {
-                var item = new EquipmentItem(slotIndex, this);
-                Items.Add(item);
-
-                var slotName = slot.Name;
-
-                if (slot.MaxItems <= 1)
-                {
-                    item.Pnl = new ImagePanel(mEquipmentContainer, slotName);
-                }
-                else
-                {
-                    if (!multiSlotTracker.ContainsKey(slotName))
-                        multiSlotTracker[slotName] = 0;
-
-                    var currentIndex = multiSlotTracker[slotName];
-                    item.Pnl = new ImagePanel(mEquipmentContainer, $"{slotName}_{currentIndex}");
-                    multiSlotTracker[slotName]++;
-                }
-
-                int row = itemIndex / columns;
-                int col = itemIndex % columns;
-
-                item.Pnl.SetSize(slotW, slotH);
-                item.Pnl.SetPosition(startX + col * (slotW + spacingX), startY + row * (slotH + spacingY));
-                item.Setup();
-
-                itemIndex++;
-            }
-        }
     }
 
     private void BuildStatsSection()
@@ -540,18 +460,22 @@ public partial class CharacterWindow : Window
 
         if (player == Globals.Me)
         {
-            if (player.MyEquipment.TryGetValue(weaponSlotIndex, out var list) && list.Count > 0)
+            if (player.MyEquipment.TryGetValue(weaponSlotIndex, out var list) && list?.Count > 0)
             {
                 var invIndex = list[0];
                 if (invIndex >= 0 && invIndex < Options.Instance.Player.MaxInventory)
                 {
-                    weaponId = player.Inventory[invIndex].ItemId;
+                    var inventorySlot = player.Inventory?[invIndex];
+                    if (inventorySlot != null)
+                    {
+                        weaponId = inventorySlot.ItemId;
+                    }
                 }
             }
         }
         else
         {
-            if (player.Equipment.TryGetValue(weaponSlotIndex, out var list) && list.Count > 0)
+            if (player.Equipment.TryGetValue(weaponSlotIndex, out var list) && list?.Count > 0)
             {
                 weaponId = list[0];
             }
@@ -587,79 +511,6 @@ public partial class CharacterWindow : Window
         mCharacterName.Text = player.Name;
         mCharacterLevelAndClass.Text = Strings.Character.LevelAndClass.ToString(player.Level, ClassDescriptor.GetName(player.Class));
 
-        // Portrait/paperdoll
-        var entityTex = Globals.ContentManager.GetTexture(Framework.Content.TextureType.Entity, player.Sprite);
-
-        if (!string.IsNullOrWhiteSpace(player.Sprite) && player.Sprite != mCurrentSprite && entityTex != null)
-        {
-            for (var z = 0; z < Options.Instance.Equipment.Paperdoll.Directions[1].Count; z++)
-            {
-                var paperdoll = string.Empty;
-                var slotName = Options.Instance.Equipment.Paperdoll.Directions[1][z];
-                var slotIndex = Options.Instance.Equipment.Slots.IndexOf(slotName);
-
-                if (slotIndex > -1)
-                {
-                    var equipment = player.MyEquipment;
-
-                    if (equipment.TryGetValue(slotIndex, out var equippedList) && equippedList.Count > 0)
-                    {
-                        var inventoryIndex = equippedList[0];
-                        if (inventoryIndex >= 0 && inventoryIndex < Options.Instance.Player.MaxInventory)
-                        {
-                            var itemNum = player.Inventory[inventoryIndex].ItemId;
-
-                            if (ItemDescriptor.TryGet(itemNum, out var itemDescriptor))
-                            {
-                                paperdoll = player.Gender == 0 ? itemDescriptor.MalePaperdoll : itemDescriptor.FemalePaperdoll;
-                                PaperdollPanels[z].RenderColor = itemDescriptor.Color;
-                            }
-                        }
-                    }
-                }
-                else if (slotName == "Player")
-                {
-                    PaperdollPanels[z].Show();
-                    PaperdollPanels[z].Texture = entityTex;
-                    PaperdollPanels[z].SetTextureRect(0, 0, entityTex.Width / Options.Instance.Sprites.NormalFrames, entityTex.Height / Options.Instance.Sprites.Directions);
-                    PaperdollPanels[z].SizeToContents();
-                    PaperdollPanels[z].RenderColor = player.Color;
-                    Align.Center(PaperdollPanels[z]);
-                }
-
-                if (string.IsNullOrWhiteSpace(paperdoll) && !string.IsNullOrWhiteSpace(PaperdollTextures[z]) && slotName != "Player")
-                {
-                    PaperdollPanels[z].Texture = null;
-                    PaperdollPanels[z].Hide();
-                    PaperdollTextures[z] = string.Empty;
-                }
-                else if (!string.IsNullOrWhiteSpace(paperdoll) && paperdoll != PaperdollTextures[z])
-                {
-                    var paperdollTex = Globals.ContentManager.GetTexture(Framework.Content.TextureType.Paperdoll, paperdoll);
-
-                    PaperdollPanels[z].Texture = paperdollTex;
-                    if (paperdollTex != null)
-                    {
-                        PaperdollPanels[z].SetTextureRect(0, 0, paperdollTex.Width / Options.Instance.Sprites.NormalFrames, paperdollTex.Height / Options.Instance.Sprites.Directions);
-                        PaperdollPanels[z].SetSize(paperdollTex.Width / Options.Instance.Sprites.NormalFrames, paperdollTex.Height / Options.Instance.Sprites.Directions);
-                        PaperdollPanels[z].SetPosition(
-                            mCharacterContainer.Width / 2 - PaperdollPanels[z].Width / 2,
-                            mCharacterContainer.Height / 2 - PaperdollPanels[z].Height / 2
-                        );
-                    }
-
-                    PaperdollPanels[z].Show();
-                    PaperdollTextures[z] = paperdoll;
-                }
-            }
-        }
-        else if (player.Sprite != mCurrentSprite && player.Face != mCurrentSprite)
-        {
-            mCharacterPortrait.IsHidden = true;
-            for (var i = 0; i < Options.Instance.Equipment.Slots.Count; i++)
-                PaperdollPanels[i].Hide();
-        }
-
         // Stats text
         mAttackLabel.SetText(Strings.Character.StatLabelValue.ToString(Strings.Combat.Stats[Stat.Attack], player.Stat[(int)Stat.Attack]));
         mAbilityPwrLabel.SetText(Strings.Character.StatLabelValue.ToString(Strings.Combat.Stats[Stat.Intelligence], player.Stat[(int)Stat.Intelligence]));
@@ -684,63 +535,6 @@ public partial class CharacterWindow : Window
         UpdateExtraBuffs();
         mDamageLabel.SetText(Strings.Character.FlatDamage.ToString(FormatEffectValue(_flatDamage)));
         mCureLabel.SetText(Strings.Character.FlatCures.ToString(FormatEffectValue(_flatCures)));
-
-        UpdateEquippedItems(true);
-    }
-
-    private void UpdateEquippedItems(bool updateExtraBuffs = false)
-    {
-        var player = DisplayedPlayer;
-        if (player is null)
-            return;
-
-        int itemIndex = 0;
-        for (var slotIndex = 0; slotIndex < Options.Instance.Equipment.EquipmentSlots.Count; slotIndex++)
-        {
-            var slot = Options.Instance.Equipment.EquipmentSlots[slotIndex];
-
-            if (player == Globals.Me)
-            {
-                var itemSlots = player.MyEquipment.GetValueOrDefault(slotIndex) ?? new List<int>();
-                for (var i = 0; i < slot.MaxItems; i++)
-                {
-                    if (itemIndex >= Items.Count)
-                        break;
-
-                    var itemIds = new List<Guid>();
-                    var props = new List<ItemProperties>();
-
-                    if (i < itemSlots.Count && itemSlots[i] >= 0 && itemSlots[i] < Options.Instance.Player.MaxInventory)
-                    {
-                        var invItem = player.Inventory[itemSlots[i]];
-                        if (invItem.ItemId != Guid.Empty)
-                        {
-                            itemIds.Add(invItem.ItemId);
-                            props.Add(invItem.ItemProperties);
-                        }
-                    }
-
-                    Items[itemIndex].Update(itemIds, props);
-                    itemIndex++;
-                }
-            }
-            else
-            {
-                var equippedIds = player.Equipment.GetValueOrDefault(slotIndex) ?? new List<Guid>();
-                for (var i = 0; i < slot.MaxItems; i++)
-                {
-                    if (itemIndex >= Items.Count)
-                        break;
-
-                    var itemIds = new List<Guid>();
-                    if (i < equippedIds.Count && equippedIds[i] != Guid.Empty)
-                        itemIds.Add(equippedIds[i]);
-
-                    Items[itemIndex].Update(itemIds, new List<ItemProperties>());
-                    itemIndex++;
-                }
-            }
-        }
     }
 
     public void UpdateExtraBuffs()

--- a/Intersect.Client.Core/Interface/Game/Character/CharacterWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Character/CharacterWindow.cs
@@ -2,6 +2,7 @@ using Intersect.Client.Core;
 using Intersect.Client.Entities;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Intersect.Client.Framework.File_Management;
 using Intersect.Client.Framework.Gwen;
 using Intersect.Client.Framework.Gwen.Control;
@@ -20,6 +21,22 @@ namespace Intersect.Client.Interface.Game.Character;
 
 public partial class CharacterWindow:Window
 {
+
+    private const int WindowWidth = 700;
+
+    private const int WindowHeight = 520;
+
+    private const int Margin = 16;
+
+    private const int StatRowHeight = 24;
+
+    private const int StatLabelWidth = 230;
+
+    private const int EffectLabelWidth = 220;
+
+    private const string TitleFont = "sourcesansproblack";
+
+    private const string BodyFont = "source-sans-pro";
 
     //Equipment List
     public List<EquipmentItem> Items = new List<EquipmentItem>();
@@ -65,6 +82,7 @@ public partial class CharacterWindow:Window
     Label mDamageLabel;
     Label mCureLabel;
     Label mCritChanceLabel;
+    Label mBasicAttackDamageLabel;
     public ImagePanel[] PaperdollPanels;
 
     public string[] PaperdollTextures;
@@ -87,6 +105,15 @@ public partial class CharacterWindow:Window
     Label mSpeedBuff;
     Label mDamageBuff;
     Label mCureBuff;
+    Label mAccuracy;
+    Label mEvasion;
+    Label mCritBonus;
+    Label mAntiCrit;
+    Label mArmorPenetration;
+    Label mDamageReduction;
+    Label mDamageReflect;
+    Label mFlatDamage;
+    Label mFlatCures;
     
     private Player? _player;
 
@@ -110,40 +137,132 @@ public partial class CharacterWindow:Window
 
     int ManaStealAmount = 0;
 
+    private EffectValue _accuracy = default;
+
+    private EffectValue _evasion = default;
+
+    private EffectValue _critBonus = default;
+
+    private EffectValue _antiCrit = default;
+
+    private EffectValue _armorPenetration = default;
+
+    private EffectValue _damageReduction = default;
+
+    private EffectValue _damageReflect = default;
+
+    private EffectValue _flatDamage = default;
+
+    private EffectValue _flatCures = default;
+
+    private Label CreateSectionTitle(string name, int x, int y, string text)
+    {
+        var label = new Label(this, name)
+        {
+            FontName = TitleFont,
+            FontSize = 14,
+            Text = text,
+            TextColorOverride = Color.White,
+            AutoSizeToContents = true
+        };
+
+        label.SetPosition(x, y);
+
+        return label;
+    }
+
+    private Label CreateBodyLabel(string name, int x, int y, int width, int height = StatRowHeight)
+    {
+        var label = new Label(this, name)
+        {
+            FontName = BodyFont,
+            FontSize = 11,
+            TextColorOverride = Color.White,
+            AutoSizeToContents = false,
+            Alignment = [Alignments.Left, Alignments.CenterV]
+        };
+
+        label.SetSize(width, height);
+        label.SetPosition(x, y);
+
+        return label;
+    }
+
+    private Button CreateStatButton(string name, int x, int y)
+    {
+        var button = new Button(this, name)
+        {
+            Width = 28,
+            Height = 22,
+            TextColorOverride = Color.White,
+            FontName = TitleFont,
+            FontSize = 11,
+            Text = "+"
+        };
+
+        button.SetPosition(x, y);
+
+        return button;
+    }
+
     //Init
     public CharacterWindow(Canvas gameCanvas) : base(gameCanvas, Strings.Character.Title, false, nameof(CharacterWindow))
     {
        
-       SetSize(520, 340);
+        SetSize(WindowWidth, WindowHeight);
 
-      IsResizable = false;
+        IsResizable = false;
 
-        // 📌 Nombre, Nivel y Clase
-        mCharacterName = new Label(this, "CharacterNameLabel");
-        mCharacterName.SetTextColor(Color.White, ComponentState.Normal);
-        mCharacterName.SetPosition(16, 16);
+        TitleLabel.FontName = TitleFont;
+        TitleLabel.FontSize = 14;
+        TitleLabel.TextColorOverride = Color.White;
 
-        mCharacterLevelAndClass = new Label(this, "ChatacterInfoLabel");
-        mCharacterLevelAndClass.SetPosition(16, 40);
+        var headerX = Margin;
+        var headerY = Margin;
 
-        mFactionButton = new Button(this, "FactionInfoButton");
-        mFactionButton.SetSize(32, 32);
-        mFactionButton.SetPosition(470, 16);
+        mCharacterName = new Label(this, "CharacterNameLabel")
+        {
+            FontName = TitleFont,
+            FontSize = 18,
+            TextColorOverride = Color.White,
+            AutoSizeToContents = true
+        };
+
+        mCharacterName.SetPosition(headerX, headerY);
+
+        mCharacterLevelAndClass = new Label(this, "ChatacterInfoLabel")
+        {
+            FontName = BodyFont,
+            FontSize = 12,
+            TextColorOverride = Color.White,
+            AutoSizeToContents = true
+        };
+
+        mCharacterLevelAndClass.SetPosition(headerX, headerY + 24);
+
+        mFactionButton = new Button(this, "FactionInfoButton")
+        {
+            Width = 32,
+            Height = 32
+        };
+
+        mFactionButton.SetPosition(WindowWidth - Margin - mFactionButton.Width, headerY);
         mFactionButton.SetStateTexture(ComponentState.Normal, "factionicon.png");
         mFactionButton.SetStateTexture(ComponentState.Hovered, "factionicon_hovered.png");
         mFactionButton.SetToolTipText("Faction");
         mFactionButton.Clicked += (s, e) => Interface.GameUi.GameMenu?.ToggleFactionWindow();
 
-        // 🖼️ Contenedor y retrato
         mCharacterContainer = new ImagePanel(this, "CharacterContainer");
-        mCharacterContainer.SetSize(96, 96);
-        mCharacterContainer.SetPosition(16, 70);
+        mCharacterContainer.SetSize(120, 120);
+        mCharacterContainer.SetPosition(headerX, headerY + 48);
 
         mCharacterPortrait = new ImagePanel(mCharacterContainer);
-        mCharacterPortrait.SetSize(64, 64);
-        mCharacterPortrait.SetPosition(16, 16);
+        mCharacterPortrait.SetSize(80, 80);
+        mCharacterPortrait.SetPosition(
+            (mCharacterContainer.Width - mCharacterPortrait.Width) / 2,
+            (mCharacterContainer.Height - mCharacterPortrait.Height) / 2
+        );
 
-        // 🧩 Slots visuales Paperdoll
         PaperdollPanels = new ImagePanel[Options.Instance.Equipment.Slots.Count + 1];
         PaperdollTextures = new string[Options.Instance.Equipment.Slots.Count + 1];
         for (var i = 0; i <= Options.Instance.Equipment.Slots.Count; i++)
@@ -153,14 +272,15 @@ public partial class CharacterWindow:Window
             PaperdollPanels[i].Hide();
         }
 
-        // 🧱 Equipamiento en grilla modular (4x4)
-        var startX = 300;
-        var startY = 40;
-        var slotW = 32;
-        var slotH = 32;
-        var spacingX = 5;
-        var spacingY = 5;
         var columns = 4;
+        var slotW = 36;
+        var slotH = 36;
+        var spacingX = 8;
+        var spacingY = 8;
+        var equipmentHeaderX = WindowWidth - Margin - (columns * slotW + spacingX * (columns - 1));
+        var equipmentHeader = CreateSectionTitle("EquipmentHeader", equipmentHeaderX, headerY, "Equipo");
+        var startX = equipmentHeader.X;
+        var startY = equipmentHeader.Y + equipmentHeader.Height + 8;
 
         int itemIndex = 0;
         var multiSlotTracker = new Dictionary<string, int>();
@@ -190,9 +310,8 @@ public partial class CharacterWindow:Window
                     multiSlotTracker[slotName]++;
                 }
 
-                // 📐 Ubicación provisional
-                int row = itemIndex / 4;
-                int col = itemIndex % 4;
+                int row = itemIndex / columns;
+                int col = itemIndex % columns;
 
                 item.Pnl.SetSize(slotW, slotH);
                 item.Pnl.SetPosition(startX + col * (slotW + spacingX), startY + row * (slotH + spacingY));
@@ -203,88 +322,101 @@ public partial class CharacterWindow:Window
         }
 
 
-        // 📊 Etiquetas y botones de stats
-        int statsX = 16;
-        int statsY = 180;
-        int statSpacing = 22;
+        var statsHeader = CreateSectionTitle("StatsHeader", mCharacterContainer.X + mCharacterContainer.Width + 20, headerY, "Atributos");
+        var statsX = statsHeader.X;
+        var statsY = statsHeader.Y + statsHeader.Height + 6;
 
-        mAttackLabel = new Label(this, "AttackLabel");
-        mAttackLabel.SetPosition(statsX, statsY);
-        mAddAttackBtn = new Button(this, "IncreaseAttackButton");
-        mAddAttackBtn.SetPosition(statsX + 130, statsY);
+        mAttackLabel = CreateBodyLabel("AttackLabel", statsX, statsY, StatLabelWidth);
+        mAddAttackBtn = CreateStatButton("IncreaseAttackButton", statsX + StatLabelWidth + 8, statsY);
         mAddAttackBtn.Clicked += _addAttackBtn_Clicked;
 
-        mDefenseLabel = new Label(this, "DefenseLabel");
-        mDefenseLabel.SetPosition(statsX, statsY + statSpacing);
-        mAddDefenseBtn = new Button(this, "IncreaseDefenseButton");
-        mAddDefenseBtn.SetPosition(statsX + 130, statsY + statSpacing);
-        mAddDefenseBtn.Clicked += _addDefenseBtn_Clicked;
-
-        mSpeedLabel = new Label(this, "SpeedLabel");
-        mSpeedLabel.SetPosition(statsX, statsY + statSpacing * 2);
-        mAddAgilityBtn = new Button(this, "IncreaseSpeedButton");
-        mAddAgilityBtn.SetPosition(statsX + 130, statsY + statSpacing * 2);
-        mAddAgilityBtn.Clicked += _addSpeedBtn_Clicked;
-
-        mAbilityPwrLabel = new Label(this, "AbilityPowerLabel");
-        mAbilityPwrLabel.SetPosition(statsX, statsY + statSpacing * 3);
-        mAddAbilityPwrBtn = new Button(this, "IncreaseAbilityPowerButton");
-        mAddAbilityPwrBtn.SetPosition(statsX + 130, statsY + statSpacing * 3);
+        mAbilityPwrLabel = CreateBodyLabel("AbilityPowerLabel", statsX, statsY + StatRowHeight, StatLabelWidth);
+        mAddAbilityPwrBtn = CreateStatButton("IncreaseAbilityPowerButton", statsX + StatLabelWidth + 8, statsY + StatRowHeight);
         mAddAbilityPwrBtn.Clicked += _addAbilityPwrBtn_Clicked;
 
-        mMagicRstLabel = new Label(this, "MagicResistLabel");
-        mMagicRstLabel.SetPosition(statsX, statsY + statSpacing * 4);
-        mAddMagicResistBtn = new Button(    this, "IncreaseMagicResistButton");
-        mAddMagicResistBtn.SetPosition(statsX + 130, statsY + statSpacing * 4);
+        mDefenseLabel = CreateBodyLabel("DefenseLabel", statsX, statsY + StatRowHeight * 2, StatLabelWidth);
+        mAddDefenseBtn = CreateStatButton("IncreaseDefenseButton", statsX + StatLabelWidth + 8, statsY + StatRowHeight * 2);
+        mAddDefenseBtn.Clicked += _addDefenseBtn_Clicked;
+
+        mMagicRstLabel = CreateBodyLabel("MagicResistLabel", statsX, statsY + StatRowHeight * 3, StatLabelWidth);
+        mAddMagicResistBtn = CreateStatButton("IncreaseMagicResistButton", statsX + StatLabelWidth + 8, statsY + StatRowHeight * 3);
         mAddMagicResistBtn.Clicked += _addMagicResistBtn_Clicked;
 
-        mAgilityLabel = new Label(this, "AgilityLabel");
-        mAgilityLabel.SetPosition(statsX, statsY + statSpacing * 5);
+        mSpeedLabel = CreateBodyLabel("SpeedLabel", statsX, statsY + StatRowHeight * 4, StatLabelWidth);
+        mAddAgilityBtn = CreateStatButton("IncreaseSpeedButton", statsX + StatLabelWidth + 8, statsY + StatRowHeight * 4);
+        mAddAgilityBtn.Clicked += _addSpeedBtn_Clicked;
 
-        mDamageLabel = new Label(this, "DamageLabel");
-        mDamageLabel.SetPosition(statsX, statsY + statSpacing * 6);
+        mAgilityLabel = CreateBodyLabel("AgilityLabel", statsX, statsY + StatRowHeight * 5, StatLabelWidth);
+        mDamageLabel = CreateBodyLabel("DamageLabel", statsX, statsY + StatRowHeight * 6, StatLabelWidth);
+        mCureLabel = CreateBodyLabel("CureLabel", statsX, statsY + StatRowHeight * 7, StatLabelWidth);
+        mCritChanceLabel = CreateBodyLabel("CritLabel", statsX, statsY + StatRowHeight * 8, StatLabelWidth);
+        mPointsLabel = CreateBodyLabel("PointsLabel", statsX, statsY + StatRowHeight * 9, StatLabelWidth + 40);
 
-        mCureLabel = new Label(this, "CureLabel");
-        mCureLabel.SetPosition(statsX, statsY + statSpacing * 7);
+        mBasicAttackDamageLabel = CreateBodyLabel(
+            "BasicAttackDamageLabel",
+            statsX,
+            statsY + StatRowHeight * 10,
+            StatLabelWidth + 60,
+            StatRowHeight + 4
+        );
 
-        mCritChanceLabel = new Label(this, "CritLabel");
-        mCritChanceLabel.SetPosition(statsX, statsY + statSpacing * 8);
+        var effectsHeader = CreateSectionTitle(
+            "ExtraBuffsLabel",
+            statsX,
+            statsY + StatRowHeight * 10 + mBasicAttackDamageLabel.Height + 12,
+            Strings.Character.ExtraBuffs
+        );
+        var effectsY = effectsHeader.Y + effectsHeader.Height + 4;
+        var effectsX = effectsHeader.X;
+        var secondColumnX = effectsX + EffectLabelWidth + 20;
+        var thirdColumnX = secondColumnX + EffectLabelWidth + 20;
+        const int effectSpacing = 20;
 
-        mPointsLabel = new Label(this, "PointsLabel");
-        mPointsLabel.SetPosition(statsX, statsY + statSpacing * 9);
+        mHpRegen = CreateBodyLabel("HpRegen", effectsX, effectsY, EffectLabelWidth, effectSpacing);
+        mManaRegen = CreateBodyLabel("ManaRegen", effectsX, effectsY + effectSpacing, EffectLabelWidth, effectSpacing);
+        mLifeSteal = CreateBodyLabel("Lifesteal", effectsX, effectsY + effectSpacing * 2, EffectLabelWidth, effectSpacing);
+        mAttackSpeed = CreateBodyLabel("AttackSpeed", effectsX, effectsY + effectSpacing * 3, EffectLabelWidth, effectSpacing);
+        mSpeedBuff = CreateBodyLabel("SpeedBuff", effectsX, effectsY + effectSpacing * 4, EffectLabelWidth, effectSpacing);
+        mDamageBuff = CreateBodyLabel("DamageBuff", effectsX, effectsY + effectSpacing * 5, EffectLabelWidth, effectSpacing);
+        mAccuracy = CreateBodyLabel("Accuracy", effectsX, effectsY + effectSpacing * 6, EffectLabelWidth, effectSpacing);
+        mEvasion = CreateBodyLabel("Evasion", effectsX, effectsY + effectSpacing * 7, EffectLabelWidth, effectSpacing);
+        mArmorPenetration = CreateBodyLabel(
+            "ArmorPenetration",
+            effectsX,
+            effectsY + effectSpacing * 8,
+            EffectLabelWidth,
+            effectSpacing
+        );
 
-        var extraBuffsLabel = new Label(this, "ExtraBuffsLabel");
-        extraBuffsLabel.SetText(Strings.Character.ExtraBuffs);
-        extraBuffsLabel.SetPosition(statsX, statsY + statSpacing * 10);
+        mCureBuff = CreateBodyLabel("CureBuff", secondColumnX, effectsY, EffectLabelWidth, effectSpacing);
+        mExtraExp = CreateBodyLabel("ExtraExp", secondColumnX, effectsY + effectSpacing, EffectLabelWidth, effectSpacing);
+        mLuck = CreateBodyLabel("Luck", secondColumnX, effectsY + effectSpacing * 2, EffectLabelWidth, effectSpacing);
+        mTenacity = CreateBodyLabel("Tenacity", secondColumnX, effectsY + effectSpacing * 3, EffectLabelWidth, effectSpacing);
+        mCooldownReduction = CreateBodyLabel(
+            "CooldownReduction",
+            secondColumnX,
+            effectsY + effectSpacing * 4,
+            EffectLabelWidth,
+            effectSpacing
+        );
+        mManaSteal = CreateBodyLabel("Manasteal", secondColumnX, effectsY + effectSpacing * 5, EffectLabelWidth, effectSpacing);
+        mCritBonus = CreateBodyLabel("CriticalBonus", secondColumnX, effectsY + effectSpacing * 6, EffectLabelWidth, effectSpacing);
+        mAntiCrit = CreateBodyLabel("AntiCritical", secondColumnX, effectsY + effectSpacing * 7, EffectLabelWidth, effectSpacing);
+        mDamageReduction = CreateBodyLabel(
+            "DamageReduction",
+            secondColumnX,
+            effectsY + effectSpacing * 8,
+            EffectLabelWidth,
+            effectSpacing
+        );
 
-        mHpRegen = new Label(this, "HpRegen");
-        mHpRegen.SetPosition(statsX, statsY + statSpacing * 11);
-        mManaRegen = new Label(this, "ManaRegen");
-        mManaRegen.SetPosition(statsX, statsY + statSpacing * 12);
-        mLifeSteal = new Label(this, "Lifesteal");
-        mLifeSteal.SetPosition(statsX, statsY + statSpacing * 13);
-        mAttackSpeed = new Label(this, "AttackSpeed");
-        mAttackSpeed.SetPosition(statsX, statsY + statSpacing * 14);
-        mSpeedBuff = new Label(this, "SpeedBuff");
-        mSpeedBuff.SetPosition(statsX, statsY + statSpacing * 15);
-        mDamageBuff = new Label(this, "DamageBuff");
-        mDamageBuff.SetPosition(statsX, statsY + statSpacing * 16);
-        mCureBuff = new Label(this, "CureBuff");
-        mCureBuff.SetPosition(statsX, statsY + statSpacing * 17);
-        mExtraExp = new Label(this, "ExtraExp");
-        mExtraExp.SetPosition(statsX, statsY + statSpacing * 18);
-        mLuck = new Label(this, "Luck");
-        mLuck.SetPosition(statsX, statsY + statSpacing * 19);
-        mTenacity = new Label(this, "Tenacity");
-        mTenacity.SetPosition(statsX, statsY + statSpacing * 20);
-        mCooldownReduction = new Label(this, "CooldownReduction");
-        mCooldownReduction.SetPosition(statsX, statsY + statSpacing * 21);
-        mManaSteal = new Label(this, "Manasteal");
-        mManaSteal.SetPosition(statsX, statsY + statSpacing * 22);
+        mDamageReflect = CreateBodyLabel("DamageReflect", thirdColumnX, effectsY, EffectLabelWidth, effectSpacing);
+        mFlatDamage = CreateBodyLabel("FlatDamage", thirdColumnX, effectsY + effectSpacing, EffectLabelWidth, effectSpacing);
+        mFlatCures = CreateBodyLabel("FlatCures", thirdColumnX, effectsY + effectSpacing * 2, EffectLabelWidth, effectSpacing);
 
         UpdateExtraBuffs();
 
-       LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
+        LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
     }
 
     public void SetPlayer(Player? player)
@@ -316,6 +448,65 @@ public partial class CharacterWindow:Window
     void _addAttackBtn_Clicked(Base sender, MouseButtonState arguments)
     {
         PacketSender.SendUpgradeStat((int) Stat.Attack);
+    }
+
+    private IEnumerable<ItemDescriptor> GetEquippedDescriptors(Player player)
+    {
+        if (player == Globals.Me)
+        {
+            foreach (var (_, equipmentSlots) in player.MyEquipment)
+            {
+                foreach (var slotIndex in equipmentSlots)
+                {
+                    var invItem = player.Inventory.ElementAtOrDefault(slotIndex);
+                    if (invItem?.ItemId == null || invItem.ItemId == Guid.Empty)
+                    {
+                        continue;
+                    }
+
+                    var descriptor = ItemDescriptor.Get(invItem.ItemId);
+                    if (descriptor != null)
+                    {
+                        yield return descriptor;
+                    }
+                }
+            }
+        }
+        else
+        {
+            foreach (var (_, equippedItems) in player.Equipment)
+            {
+                foreach (var id in equippedItems)
+                {
+                    if (id == Guid.Empty)
+                    {
+                        continue;
+                    }
+
+                    var descriptor = ItemDescriptor.Get(id);
+                    if (descriptor != null)
+                    {
+                        yield return descriptor;
+                    }
+                }
+            }
+        }
+    }
+
+    private string FormatEffectValue(EffectValue value)
+    {
+        var segments = new List<string>();
+        if (value.Percentage != 0)
+        {
+            segments.Add($"{value.Percentage}%");
+        }
+
+        if (value.Flat != 0)
+        {
+            segments.Add($"+{value.Flat}");
+        }
+
+        return segments.Count == 0 ? "0" : string.Join(" / ", segments);
     }
 
     //Methods
@@ -484,6 +675,8 @@ public partial class CharacterWindow:Window
             player.StatPoints == 0 || player.Stat[(int) Stat.Agility] == Options.Instance.Player.MaxStat;
 
         UpdateExtraBuffs();
+        mDamageLabel.SetText(Strings.Character.FlatDamage.ToString(FormatEffectValue(_flatDamage)));
+        mCureLabel.SetText(Strings.Character.FlatCures.ToString(FormatEffectValue(_flatCures)));
         UpdateEquippedItems(true);
     }
 
@@ -518,10 +711,6 @@ public partial class CharacterWindow:Window
                         {
                             itemIds.Add(invItem.ItemId);
                             props.Add(invItem.ItemProperties);
-                            if (updateExtraBuffs)
-                            {
-                                UpdateExtraBuffs(invItem.ItemId);
-                            }
                         }
                     }
 
@@ -541,10 +730,6 @@ public partial class CharacterWindow:Window
                     if (i < equippedIds.Count && equippedIds[i] != Guid.Empty)
                     {
                         itemIds.Add(equippedIds[i]);
-                        if (updateExtraBuffs)
-                        {
-                            UpdateExtraBuffs(equippedIds[i]);
-                        }
                     }
 
                     Items[itemIndex].Update(itemIds, new List<ItemProperties>());
@@ -559,13 +744,8 @@ public partial class CharacterWindow:Window
         var player = DisplayedPlayer;
         mClassDescriptor = ClassDescriptor.Get(player?.Class ?? Guid.Empty);
 
-        if (mClassDescriptor != null)
-        {
-            HpRegenAmount = mClassDescriptor.VitalRegen[(int)Vital.Health];
-            mHpRegen.SetText(Strings.Character.HealthRegen.ToString(HpRegenAmount));
-            ManaRegenAmount = mClassDescriptor.VitalRegen[(int)Vital.Mana];
-            mManaRegen.SetText(Strings.Character.ManaRegen.ToString(ManaRegenAmount));
-        }
+        HpRegenAmount = mClassDescriptor?.VitalRegen[(int)Vital.Health] ?? 0;
+        ManaRegenAmount = mClassDescriptor?.VitalRegen[(int)Vital.Mana] ?? 0;
 
         CooldownAmount = 0;
         LifeStealAmount = 0;
@@ -574,22 +754,128 @@ public partial class CharacterWindow:Window
         ExtraExpAmount = 0;
         ManaStealAmount = 0;
 
-        mLifeSteal.SetText(Strings.Character.Lifesteal.ToString(0));
-        mExtraExp.SetText(Strings.Character.ExtraExp.ToString(0));
-        mLuck.SetText(Strings.Character.Luck.ToString(0));
-        mTenacity.SetText(Strings.Character.Tenacity.ToString(0));
-        mCooldownReduction.SetText(Strings.Character.CooldownReduction.ToString(0));
-        mManaSteal.SetText(Strings.Character.Manasteal.ToString(0));
+        _accuracy = default;
+        _evasion = default;
+        _critBonus = default;
+        _antiCrit = default;
+        _armorPenetration = default;
+        _damageReduction = default;
+        _damageReflect = default;
+        _flatDamage = default;
+        _flatCures = default;
 
         if (player != null)
         {
+            foreach (var descriptor in GetEquippedDescriptors(player))
+            {
+                HpRegenAmount += descriptor.VitalsRegen[(int)Vital.Health];
+                ManaRegenAmount += descriptor.VitalsRegen[(int)Vital.Mana];
+
+                foreach (var effect in descriptor.Effects)
+                {
+                    var effectValue = effect.GetValues();
+                    if (effectValue.GetPrimaryValue() == 0)
+                    {
+                        continue;
+                    }
+
+                    switch (effect.Type)
+                    {
+                        case ItemEffect.CooldownReduction:
+                            CooldownAmount += effectValue.GetPrimaryValue();
+                            break;
+                        case ItemEffect.Lifesteal:
+                            LifeStealAmount += effectValue.GetPrimaryValue();
+                            break;
+                        case ItemEffect.Tenacity:
+                            TenacityAmount += effectValue.GetPrimaryValue();
+                            break;
+                        case ItemEffect.Luck:
+                            LuckAmount += effectValue.GetPrimaryValue();
+                            break;
+                        case ItemEffect.EXP:
+                            ExtraExpAmount += effectValue.GetPrimaryValue();
+                            break;
+                        case ItemEffect.Manasteal:
+                            ManaStealAmount += effectValue.GetPrimaryValue();
+                            break;
+                        case ItemEffect.Accuracy:
+                            _accuracy = _accuracy.Add(effectValue);
+                            break;
+                        case ItemEffect.Evasion:
+                            _evasion = _evasion.Add(effectValue);
+                            break;
+                        case ItemEffect.CriticalChance:
+                            _critBonus = _critBonus.Add(effectValue);
+                            break;
+                        case ItemEffect.AntiCritChance:
+                            _antiCrit = _antiCrit.Add(effectValue);
+                            break;
+                        case ItemEffect.ArmorPenetration:
+                            _armorPenetration = _armorPenetration.Add(effectValue);
+                            break;
+                        case ItemEffect.DamageReduction:
+                            _damageReduction = _damageReduction.Add(effectValue);
+                            break;
+                        case ItemEffect.DamageReflect:
+                            _damageReflect = _damageReflect.Add(effectValue);
+                            break;
+                        case ItemEffect.Damages:
+                            _flatDamage = _flatDamage.Add(effectValue);
+                            break;
+                        case ItemEffect.Cures:
+                            _flatCures = _flatCures.Add(effectValue);
+                            break;
+                    }
+                }
+            }
+
             mAttackSpeed.SetText(Strings.Character.AttackSpeed.ToString(player.CalculateAttackTime() / 1000f));
 
             mSpeedBuff.SetText(Strings.Character.StatLabelValue.ToString(
                 Strings.Combat.Stats[Stat.Speed],
                 player.Stat[(int)Stat.Speed]
             ));
+
+            var baseDamage = mClassDescriptor?.Damage ?? 0;
+            var scalingStat = (Stat)(mClassDescriptor?.ScalingStat ?? (int)Stat.Attack);
+            var scalingPercent = mClassDescriptor?.Scaling ?? 0;
+            var critMultiplier = mClassDescriptor?.CritMultiplier ?? 1f;
+
+            var scalingStatValue = player.Stat[(int)scalingStat];
+            var scaledBase = baseDamage + scalingStatValue * (scalingPercent / 100f);
+            var minTrueDamage = scaledBase * 0.975 * critMultiplier;
+            var maxTrueDamage = scaledBase * 1.025 * critMultiplier;
+
+            mBasicAttackDamageLabel.SetText(
+                Strings.Character.BasicAttackDamage.ToString(
+                    baseDamage,
+                    (int)Math.Round(minTrueDamage),
+                    (int)Math.Round(maxTrueDamage)
+                )
+            );
         }
+
+        mHpRegen.SetText(Strings.Character.HealthRegen.ToString(HpRegenAmount));
+        mManaRegen.SetText(Strings.Character.ManaRegen.ToString(ManaRegenAmount));
+        mLifeSteal.SetText(Strings.Character.Lifesteal.ToString(LifeStealAmount));
+        mExtraExp.SetText(Strings.Character.ExtraExp.ToString(ExtraExpAmount));
+        mLuck.SetText(Strings.Character.Luck.ToString(LuckAmount));
+        mTenacity.SetText(Strings.Character.Tenacity.ToString(TenacityAmount));
+        mCooldownReduction.SetText(Strings.Character.CooldownReduction.ToString(CooldownAmount));
+        mManaSteal.SetText(Strings.Character.Manasteal.ToString(ManaStealAmount));
+
+        mDamageBuff.SetText(Strings.Character.FlatDamage.ToString(FormatEffectValue(_flatDamage)));
+        mCureBuff.SetText(Strings.Character.FlatCures.ToString(FormatEffectValue(_flatCures)));
+        mAccuracy.SetText($"{Strings.ItemDescription.BonusEffects[(int)ItemEffect.Accuracy]} {FormatEffectValue(_accuracy)}");
+        mEvasion.SetText($"{Strings.ItemDescription.BonusEffects[(int)ItemEffect.Evasion]} {FormatEffectValue(_evasion)}");
+        mCritBonus.SetText($"{Strings.ItemDescription.BonusEffects[(int)ItemEffect.CriticalChance]} {FormatEffectValue(_critBonus)}");
+        mAntiCrit.SetText($"{Strings.ItemDescription.BonusEffects[(int)ItemEffect.AntiCritChance]} {FormatEffectValue(_antiCrit)}");
+        mArmorPenetration.SetText($"{Strings.ItemDescription.BonusEffects[(int)ItemEffect.ArmorPenetration]} {FormatEffectValue(_armorPenetration)}");
+        mDamageReduction.SetText($"{Strings.ItemDescription.BonusEffects[(int)ItemEffect.DamageReduction]} {FormatEffectValue(_damageReduction)}");
+        mDamageReflect.SetText($"{Strings.ItemDescription.BonusEffects[(int)ItemEffect.DamageReflect]} {FormatEffectValue(_damageReflect)}");
+        mFlatDamage.SetText($"{Strings.ItemDescription.BonusEffects[(int)ItemEffect.Damages]} {FormatEffectValue(_flatDamage)}");
+        mFlatCures.SetText($"{Strings.ItemDescription.BonusEffects[(int)ItemEffect.Cures]} {FormatEffectValue(_flatCures)}");
     }
 
     /// <summary>

--- a/Intersect.Client.Core/Interface/Game/Character/CharacterWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Character/CharacterWindow.cs
@@ -18,146 +18,134 @@ using Intersect.Framework.Core.GameObjects.PlayerClass;
 
 namespace Intersect.Client.Interface.Game.Character;
 
-
-public partial class CharacterWindow:Window
+public partial class CharacterWindow : Window
 {
-
     private const int WindowWidth = 700;
-
     private const int WindowHeight = 520;
-
     private const int Margin = 16;
 
     private const int StatRowHeight = 24;
-
     private const int StatLabelWidth = 230;
-
-    private const int EffectLabelWidth = 220;
+    private const int EffectLabelWidth = 420; // más ancho porque ahora es 1 sola columna
+    private const int EffectRowHeight = 20;
 
     private const string TitleFont = "sourcesansproblack";
-
     private const string BodyFont = "source-sans-pro";
 
     //Equipment List
     public List<EquipmentItem> Items = new List<EquipmentItem>();
 
-    Label mAbilityPwrLabel;
+    // Containers
+    private Base mCharacterInfoContainer;
+    private Base mStatsContainer;
+    private Base mEquipmentContainer;
+    private Base mExtraBuffsContainer;
 
-    Button mAddAbilityPwrBtn;
+    private ScrollControl mExtraBuffsScroll;
+    private Base mExtraBuffsList;
 
-    Button mAddAttackBtn;
-
-    Button mAddDefenseBtn;
-
-    Button mAddMagicResistBtn;
-
-    Button mAddAgilityBtn;
-    Button mFactionButton;
-
-    //Stats
-    Label mAttackLabel;
-
+    // Character UI
     private ImagePanel mCharacterContainer;
-
     private Label mCharacterLevelAndClass;
-
     private Label mCharacterName;
+    private Button mFactionButton;
 
-    private ImagePanel mCharacterPortrait;
-
+    private ImagePanel mCharacterPortrait; // (si lo usas después)
     private string mCharacterPortraitImg = string.Empty;
-
     private string mCurrentSprite = string.Empty;
 
-    Label mDefenseLabel;
-
-    private ItemProperties mItemProperties = null;
-
-    Label mMagicRstLabel;
-
-    Label mPointsLabel;
-
-    Label mSpeedLabel;
-    Label mAgilityLabel;
-    Label mDamageLabel;
-    Label mCureLabel;
-    Label mCritChanceLabel;
-    Label mBasicAttackDamageLabel;
     public ImagePanel[] PaperdollPanels;
-
     public string[] PaperdollTextures;
+
+    // Stats UI
+    private Label mAttackLabel;
+    private Label mAbilityPwrLabel;
+    private Label mDefenseLabel;
+    private Label mMagicRstLabel;
+    private Label mSpeedLabel;
+    private Label mAgilityLabel;
+    private Label mDamageLabel;
+    private Label mCureLabel;
+    private Label mCritChanceLabel;
+    private Label mBasicAttackDamageLabel;
+    private Label mPointsLabel;
+
+    private Button mAddAttackBtn;
+    private Button mAddAbilityPwrBtn;
+    private Button mAddDefenseBtn;
+    private Button mAddMagicResistBtn;
+    private Button mAddAgilityBtn; // (ojo: en tu código estaba “IncreaseSpeedButton” pero variable “AgilityBtn”)
+
+    // Extra Buffs UI
+    private Label mHpRegen;
+    private Label mManaRegen;
+    private Label mLifeSteal;
+    private Label mAttackSpeed;
+    private Label mExtraExp;
+    private Label mLuck;
+    private Label mTenacity;
+    private Label mCooldownReduction;
+    private Label mManaSteal;
+    private Label mSpeedBuff;
+    private Label mDamageBuff;
+    private Label mCureBuff;
+
+    private Label mAccuracy;
+    private Label mEvasion;
+    private Label mCritBonus;
+    private Label mAntiCrit;
+    private Label mArmorPenetration;
+    private Label mDamageReduction;
+    private Label mDamageReflect;
+    private Label mFlatDamage;
+    private Label mFlatCures;
 
     //Location
     public int X;
-
     public int Y;
 
-    //Extra Buffs
-    Label mHpRegen;
-    Label mManaRegen;
-    Label mLifeSteal;
-    Label mAttackSpeed;
-    Label mExtraExp;
-    Label mLuck;
-    Label mTenacity;
-    Label mCooldownReduction;
-    Label mManaSteal;
-    Label mSpeedBuff;
-    Label mDamageBuff;
-    Label mCureBuff;
-    Label mAccuracy;
-    Label mEvasion;
-    Label mCritBonus;
-    Label mAntiCrit;
-    Label mArmorPenetration;
-    Label mDamageReduction;
-    Label mDamageReflect;
-    Label mFlatDamage;
-    Label mFlatCures;
-    
     private Player? _player;
-
-    ClassDescriptor mClassDescriptor;
+    private ItemProperties mItemProperties = null;
+    private ClassDescriptor mClassDescriptor;
 
     public Player? DisplayedPlayer => _player ?? Globals.Me;
 
     long HpRegenAmount;
-
     long ManaRegenAmount;
 
     int LifeStealAmount = 0;
-
     int ExtraExpAmount = 0;
-
     int LuckAmount = 0;
-
     int TenacityAmount = 0;
-
     int CooldownAmount = 0;
-
     int ManaStealAmount = 0;
 
     private EffectValue _accuracy = default;
-
     private EffectValue _evasion = default;
-
     private EffectValue _critBonus = default;
-
     private EffectValue _antiCrit = default;
-
     private EffectValue _armorPenetration = default;
-
     private EffectValue _damageReduction = default;
-
     private EffectValue _damageReflect = default;
-
     private EffectValue _flatDamage = default;
-
     private EffectValue _flatCures = default;
 
-    private Label CreateSectionTitle(string name, int x, int y, string text)
+    // -------------------------
+    // Helpers
+    // -------------------------
+
+    private Base CreateContainer(string name, int x, int y, int w, int h, bool drawBg = false)
     {
-        var label = new Label(this, name)
+        var panel = new Base(this, name);
+        panel.SetPosition(x, y);
+        panel.SetSize(w, h);
+        panel.ShouldDrawBackground = drawBg;
+        return panel;
+    }
+
+    private Label CreateSectionTitle(Base parent, string name, int x, int y, string text)
+    {
+        var label = new Label(parent, name)
         {
             FontName = TitleFont,
             FontSize = 14,
@@ -167,13 +155,12 @@ public partial class CharacterWindow:Window
         };
 
         label.SetPosition(x, y);
-
         return label;
     }
 
-    private Label CreateBodyLabel(string name, int x, int y, int width, int height = StatRowHeight)
+    private Label CreateBodyLabel(Base parent, string name, int x, int y, int width, int height = StatRowHeight)
     {
-        var label = new Label(this, name)
+        var label = new Label(parent, name)
         {
             FontName = BodyFont,
             FontSize = 11,
@@ -184,13 +171,12 @@ public partial class CharacterWindow:Window
 
         label.SetSize(width, height);
         label.SetPosition(x, y);
-
         return label;
     }
 
-    private Button CreateStatButton(string name, int x, int y)
+    private Button CreateStatButton(Base parent, string name, int x, int y)
     {
-        var button = new Button(this, name)
+        var button = new Button(parent, name)
         {
             Width = 28,
             Height = 22,
@@ -201,296 +187,13 @@ public partial class CharacterWindow:Window
         };
 
         button.SetPosition(x, y);
-
         return button;
     }
 
-    //Init
-    public CharacterWindow(Canvas gameCanvas) : base(gameCanvas, Strings.Character.Title, false, nameof(CharacterWindow))
+    private int Stack(Base ctrl, int x, int y, int spacing = 4)
     {
-       
-        SetSize(WindowWidth, WindowHeight);
-
-        IsResizable = false;
-
-        TitleLabel.FontName = TitleFont;
-        TitleLabel.FontSize = 14;
-        TitleLabel.TextColorOverride = Color.White;
-
-        var headerX = Margin;
-        var headerY = Margin;
-
-        mCharacterName = new Label(this, "CharacterNameLabel")
-        {
-            FontName = TitleFont,
-            FontSize = 18,
-            TextColorOverride = Color.White,
-            AutoSizeToContents = true
-        };
-
-        mCharacterName.SetPosition(headerX, headerY);
-
-        mCharacterLevelAndClass = new Label(this, "ChatacterInfoLabel")
-        {
-            FontName = BodyFont,
-            FontSize = 12,
-            TextColorOverride = Color.White,
-            AutoSizeToContents = true
-        };
-
-        mCharacterLevelAndClass.SetPosition(headerX, headerY + 24);
-
-        mFactionButton = new Button(this, "FactionInfoButton")
-        {
-            Width = 32,
-            Height = 32
-        };
-
-        mFactionButton.SetPosition(WindowWidth - Margin - mFactionButton.Width, headerY);
-        mFactionButton.SetStateTexture(ComponentState.Normal, "factionicon.png");
-        mFactionButton.SetStateTexture(ComponentState.Hovered, "factionicon_hovered.png");
-        mFactionButton.SetToolTipText("Faction");
-        mFactionButton.Clicked += (s, e) => Interface.GameUi.GameMenu?.ToggleFactionWindow();
-
-        mCharacterContainer = new ImagePanel(this, "CharacterContainer");
-        mCharacterContainer.SetSize(120, 120);
-        mCharacterContainer.SetPosition(headerX, headerY + 48);
-
-        mCharacterPortrait = new ImagePanel(mCharacterContainer);
-        mCharacterPortrait.SetSize(80, 80);
-        mCharacterPortrait.SetPosition(
-            (mCharacterContainer.Width - mCharacterPortrait.Width) / 2,
-            (mCharacterContainer.Height - mCharacterPortrait.Height) / 2
-        );
-
-        PaperdollPanels = new ImagePanel[Options.Instance.Equipment.Slots.Count + 1];
-        PaperdollTextures = new string[Options.Instance.Equipment.Slots.Count + 1];
-        for (var i = 0; i <= Options.Instance.Equipment.Slots.Count; i++)
-        {
-            PaperdollPanels[i] = new ImagePanel(mCharacterContainer);
-            PaperdollTextures[i] = string.Empty;
-            PaperdollPanels[i].Hide();
-        }
-
-        var columns = 4;
-        var slotW = 36;
-        var slotH = 36;
-        var spacingX = 8;
-        var spacingY = 8;
-        var equipmentHeaderX = WindowWidth - Margin - (columns * slotW + spacingX * (columns - 1));
-        var equipmentHeader = CreateSectionTitle("EquipmentHeader", equipmentHeaderX, headerY, "Equipo");
-        var startX = equipmentHeader.X;
-        var startY = equipmentHeader.Y + equipmentHeader.Height + 8;
-
-        int itemIndex = 0;
-        var multiSlotTracker = new Dictionary<string, int>();
-
-        for (int slotIndex = 0; slotIndex < Options.Instance.Equipment.EquipmentSlots.Count; slotIndex++)
-        {
-            var slot = Options.Instance.Equipment.EquipmentSlots[slotIndex];
-
-            for (int j = 0; j < slot.MaxItems; j++)
-            {
-                var item = new EquipmentItem(slotIndex, this);
-                Items.Add(item);
-
-                var slotName = slot.Name;
-
-                if (slot.MaxItems <= 1)
-                {
-                    item.Pnl = new ImagePanel(this, slotName);
-                }
-                else
-                {
-                    if (!multiSlotTracker.ContainsKey(slotName))
-                        multiSlotTracker[slotName] = 0;
-
-                    var currentIndex = multiSlotTracker[slotName];
-                    item.Pnl = new ImagePanel(this, $"{slotName}_{currentIndex}");
-                    multiSlotTracker[slotName]++;
-                }
-
-                int row = itemIndex / columns;
-                int col = itemIndex % columns;
-
-                item.Pnl.SetSize(slotW, slotH);
-                item.Pnl.SetPosition(startX + col * (slotW + spacingX), startY + row * (slotH + spacingY));
-                item.Setup();
-
-                itemIndex++;
-            }
-        }
-
-
-        var statsHeader = CreateSectionTitle("StatsHeader", mCharacterContainer.X + mCharacterContainer.Width + 20, headerY, "Atributos");
-        var statsX = statsHeader.X;
-        var statsY = statsHeader.Y + statsHeader.Height + 6;
-
-        mAttackLabel = CreateBodyLabel("AttackLabel", statsX, statsY, StatLabelWidth);
-        mAddAttackBtn = CreateStatButton("IncreaseAttackButton", statsX + StatLabelWidth + 8, statsY);
-        mAddAttackBtn.Clicked += _addAttackBtn_Clicked;
-
-        mAbilityPwrLabel = CreateBodyLabel("AbilityPowerLabel", statsX, statsY + StatRowHeight, StatLabelWidth);
-        mAddAbilityPwrBtn = CreateStatButton("IncreaseAbilityPowerButton", statsX + StatLabelWidth + 8, statsY + StatRowHeight);
-        mAddAbilityPwrBtn.Clicked += _addAbilityPwrBtn_Clicked;
-
-        mDefenseLabel = CreateBodyLabel("DefenseLabel", statsX, statsY + StatRowHeight * 2, StatLabelWidth);
-        mAddDefenseBtn = CreateStatButton("IncreaseDefenseButton", statsX + StatLabelWidth + 8, statsY + StatRowHeight * 2);
-        mAddDefenseBtn.Clicked += _addDefenseBtn_Clicked;
-
-        mMagicRstLabel = CreateBodyLabel("MagicResistLabel", statsX, statsY + StatRowHeight * 3, StatLabelWidth);
-        mAddMagicResistBtn = CreateStatButton("IncreaseMagicResistButton", statsX + StatLabelWidth + 8, statsY + StatRowHeight * 3);
-        mAddMagicResistBtn.Clicked += _addMagicResistBtn_Clicked;
-
-        mSpeedLabel = CreateBodyLabel("SpeedLabel", statsX, statsY + StatRowHeight * 4, StatLabelWidth);
-        mAddAgilityBtn = CreateStatButton("IncreaseSpeedButton", statsX + StatLabelWidth + 8, statsY + StatRowHeight * 4);
-        mAddAgilityBtn.Clicked += _addSpeedBtn_Clicked;
-
-        mAgilityLabel = CreateBodyLabel("AgilityLabel", statsX, statsY + StatRowHeight * 5, StatLabelWidth);
-        mDamageLabel = CreateBodyLabel("DamageLabel", statsX, statsY + StatRowHeight * 6, StatLabelWidth);
-        mCureLabel = CreateBodyLabel("CureLabel", statsX, statsY + StatRowHeight * 7, StatLabelWidth);
-        mCritChanceLabel = CreateBodyLabel("CritLabel", statsX, statsY + StatRowHeight * 8, StatLabelWidth);
-        mPointsLabel = CreateBodyLabel("PointsLabel", statsX, statsY + StatRowHeight * 9, StatLabelWidth + 40);
-
-        mBasicAttackDamageLabel = CreateBodyLabel(
-            "BasicAttackDamageLabel",
-            statsX,
-            statsY + StatRowHeight * 10,
-            StatLabelWidth + 60,
-            StatRowHeight + 4
-        );
-
-        var effectsHeader = CreateSectionTitle(
-            "ExtraBuffsLabel",
-            statsX,
-            statsY + StatRowHeight * 10 + mBasicAttackDamageLabel.Height + 12,
-            Strings.Character.ExtraBuffs
-        );
-        var effectsY = effectsHeader.Y + effectsHeader.Height + 4;
-        var effectsX = effectsHeader.X;
-        var secondColumnX = effectsX + EffectLabelWidth + 20;
-        var thirdColumnX = secondColumnX + EffectLabelWidth + 20;
-        const int effectSpacing = 20;
-
-        mHpRegen = CreateBodyLabel("HpRegen", effectsX, effectsY, EffectLabelWidth, effectSpacing);
-        mManaRegen = CreateBodyLabel("ManaRegen", effectsX, effectsY + effectSpacing, EffectLabelWidth, effectSpacing);
-        mLifeSteal = CreateBodyLabel("Lifesteal", effectsX, effectsY + effectSpacing * 2, EffectLabelWidth, effectSpacing);
-        mAttackSpeed = CreateBodyLabel("AttackSpeed", effectsX, effectsY + effectSpacing * 3, EffectLabelWidth, effectSpacing);
-        mSpeedBuff = CreateBodyLabel("SpeedBuff", effectsX, effectsY + effectSpacing * 4, EffectLabelWidth, effectSpacing);
-        mDamageBuff = CreateBodyLabel("DamageBuff", effectsX, effectsY + effectSpacing * 5, EffectLabelWidth, effectSpacing);
-        mAccuracy = CreateBodyLabel("Accuracy", effectsX, effectsY + effectSpacing * 6, EffectLabelWidth, effectSpacing);
-        mEvasion = CreateBodyLabel("Evasion", effectsX, effectsY + effectSpacing * 7, EffectLabelWidth, effectSpacing);
-        mArmorPenetration = CreateBodyLabel(
-            "ArmorPenetration",
-            effectsX,
-            effectsY + effectSpacing * 8,
-            EffectLabelWidth,
-            effectSpacing
-        );
-
-        mCureBuff = CreateBodyLabel("CureBuff", secondColumnX, effectsY, EffectLabelWidth, effectSpacing);
-        mExtraExp = CreateBodyLabel("ExtraExp", secondColumnX, effectsY + effectSpacing, EffectLabelWidth, effectSpacing);
-        mLuck = CreateBodyLabel("Luck", secondColumnX, effectsY + effectSpacing * 2, EffectLabelWidth, effectSpacing);
-        mTenacity = CreateBodyLabel("Tenacity", secondColumnX, effectsY + effectSpacing * 3, EffectLabelWidth, effectSpacing);
-        mCooldownReduction = CreateBodyLabel(
-            "CooldownReduction",
-            secondColumnX,
-            effectsY + effectSpacing * 4,
-            EffectLabelWidth,
-            effectSpacing
-        );
-        mManaSteal = CreateBodyLabel("Manasteal", secondColumnX, effectsY + effectSpacing * 5, EffectLabelWidth, effectSpacing);
-        mCritBonus = CreateBodyLabel("CriticalBonus", secondColumnX, effectsY + effectSpacing * 6, EffectLabelWidth, effectSpacing);
-        mAntiCrit = CreateBodyLabel("AntiCritical", secondColumnX, effectsY + effectSpacing * 7, EffectLabelWidth, effectSpacing);
-        mDamageReduction = CreateBodyLabel(
-            "DamageReduction",
-            secondColumnX,
-            effectsY + effectSpacing * 8,
-            EffectLabelWidth,
-            effectSpacing
-        );
-
-        mDamageReflect = CreateBodyLabel("DamageReflect", thirdColumnX, effectsY, EffectLabelWidth, effectSpacing);
-        mFlatDamage = CreateBodyLabel("FlatDamage", thirdColumnX, effectsY + effectSpacing, EffectLabelWidth, effectSpacing);
-        mFlatCures = CreateBodyLabel("FlatCures", thirdColumnX, effectsY + effectSpacing * 2, EffectLabelWidth, effectSpacing);
-
-        UpdateExtraBuffs();
-
-        LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
-    }
-
-    public void SetPlayer(Player? player)
-    {
-        _player = player;
-    }
-
-    //Update Button Event Handlers
-    void _addMagicResistBtn_Clicked(Base sender, MouseButtonState arguments)
-    {
-        PacketSender.SendUpgradeStat((int) Stat.Vitality);
-    }
-
-    void _addAbilityPwrBtn_Clicked(Base sender, MouseButtonState arguments)
-    {
-        PacketSender.SendUpgradeStat((int) Stat.Intelligence);
-    }
-
-    void _addSpeedBtn_Clicked(Base sender, MouseButtonState arguments)
-    {
-        PacketSender.SendUpgradeStat((int) Stat.Agility);
-    }
-
-    void _addDefenseBtn_Clicked(Base sender, MouseButtonState arguments)
-    {
-        PacketSender.SendUpgradeStat((int) Stat.Defense);
-    }
-
-    void _addAttackBtn_Clicked(Base sender, MouseButtonState arguments)
-    {
-        PacketSender.SendUpgradeStat((int) Stat.Attack);
-    }
-
-    private IEnumerable<ItemDescriptor> GetEquippedDescriptors(Player player)
-    {
-        if (player == Globals.Me)
-        {
-            foreach (var (_, equipmentSlots) in player.MyEquipment)
-            {
-                foreach (var slotIndex in equipmentSlots)
-                {
-                    var invItem = player.Inventory.ElementAtOrDefault(slotIndex);
-                    if (invItem?.ItemId == null || invItem.ItemId == Guid.Empty)
-                    {
-                        continue;
-                    }
-
-                    var descriptor = ItemDescriptor.Get(invItem.ItemId);
-                    if (descriptor != null)
-                    {
-                        yield return descriptor;
-                    }
-                }
-            }
-        }
-        else
-        {
-            foreach (var (_, equippedItems) in player.Equipment)
-            {
-                foreach (var id in equippedItems)
-                {
-                    if (id == Guid.Empty)
-                    {
-                        continue;
-                    }
-
-                    var descriptor = ItemDescriptor.Get(id);
-                    if (descriptor != null)
-                    {
-                        yield return descriptor;
-                    }
-                }
-            }
-        }
+        ctrl.SetPosition(x, y);
+        return y + ctrl.Height + spacing;
     }
 
     private string FormatEffectValue(EffectValue value)
@@ -509,39 +212,324 @@ public partial class CharacterWindow:Window
         return segments.Count == 0 ? "0" : string.Join(" / ", segments);
     }
 
-    //Methods
+    // -------------------------
+    // Init
+    // -------------------------
+
+    public CharacterWindow(Canvas gameCanvas) : base(gameCanvas, Strings.Character.Title, false, nameof(CharacterWindow))
+    {
+        SetSize(WindowWidth, WindowHeight);
+        IsResizable = false;
+
+        TitleLabel.FontName = TitleFont;
+        TitleLabel.FontSize = 14;
+        TitleLabel.TextColorOverride = Color.White;
+
+        // Macro layout
+        var contentX = Margin;
+        var contentY = Margin;
+
+        var leftW = 420;
+        var rightW = WindowWidth - (Margin * 2) - leftW;
+        var topH = 250;
+        var bottomH = WindowHeight - (Margin * 2) - topH;
+
+        // Containers
+        mCharacterInfoContainer = CreateContainer("CharacterInfoContainer", contentX, contentY, leftW, 150);
+        mStatsContainer = CreateContainer("StatsContainer", contentX, contentY + 150, leftW, topH - 150);
+        mEquipmentContainer = CreateContainer("EquipmentContainer", contentX + leftW, contentY, rightW, topH);
+        mExtraBuffsContainer = CreateContainer("ExtraBuffsContainer", contentX, contentY + topH, WindowWidth - (Margin * 2), bottomH);
+
+        BuildCharacterInfoSection();
+        BuildEquipmentSection();
+        BuildStatsSection();
+        BuildExtraBuffsSection();
+
+        UpdateExtraBuffs();
+        LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
+    }
+
+    private void BuildCharacterInfoSection()
+    {
+        int y = 0;
+
+        mCharacterName = new Label(mCharacterInfoContainer, "CharacterNameLabel")
+        {
+            FontName = TitleFont,
+            FontSize = 18,
+            TextColorOverride = Color.White,
+            AutoSizeToContents = true
+        };
+        y = Stack(mCharacterName, 0, y, 2);
+
+        mCharacterLevelAndClass = new Label(mCharacterInfoContainer, "ChatacterInfoLabel")
+        {
+            FontName = BodyFont,
+            FontSize = 12,
+            TextColorOverride = Color.White,
+            AutoSizeToContents = true
+        };
+        y = Stack(mCharacterLevelAndClass, 0, y, 10);
+
+        mFactionButton = new Button(mCharacterInfoContainer, "FactionInfoButton")
+        {
+            Width = 32,
+            Height = 32
+        };
+        mFactionButton.SetPosition(mCharacterInfoContainer.Width - mFactionButton.Width, 0);
+        mFactionButton.SetStateTexture(ComponentState.Normal, "factionicon.png");
+        mFactionButton.SetStateTexture(ComponentState.Hovered, "factionicon_hovered.png");
+        mFactionButton.SetToolTipText("Faction");
+        mFactionButton.Clicked += (s, e) => Interface.GameUi.GameMenu?.ToggleFactionWindow();
+
+        mCharacterContainer = new ImagePanel(mCharacterInfoContainer, "CharacterContainer");
+        mCharacterContainer.SetSize(120, 120);
+        mCharacterContainer.SetPosition(0, y);
+
+        mCharacterPortrait = new ImagePanel(mCharacterContainer);
+        mCharacterPortrait.SetSize(80, 80);
+        mCharacterPortrait.SetPosition(
+            (mCharacterContainer.Width - mCharacterPortrait.Width) / 2,
+            (mCharacterContainer.Height - mCharacterPortrait.Height) / 2
+        );
+
+        PaperdollPanels = new ImagePanel[Options.Instance.Equipment.Slots.Count + 1];
+        PaperdollTextures = new string[Options.Instance.Equipment.Slots.Count + 1];
+        for (var i = 0; i <= Options.Instance.Equipment.Slots.Count; i++)
+        {
+            PaperdollPanels[i] = new ImagePanel(mCharacterContainer);
+            PaperdollTextures[i] = string.Empty;
+            PaperdollPanels[i].Hide();
+        }
+    }
+
+    private void BuildEquipmentSection()
+    {
+        var header = CreateSectionTitle(mEquipmentContainer, "EquipmentHeader", 0, 0, "Equipo");
+
+        var columns = 4;
+        var slotW = 36;
+        var slotH = 36;
+        var spacingX = 8;
+        var spacingY = 8;
+
+        var startX = 0;
+        var startY = header.Height + 8;
+
+        int itemIndex = 0;
+        var multiSlotTracker = new Dictionary<string, int>();
+
+        for (int slotIndex = 0; slotIndex < Options.Instance.Equipment.EquipmentSlots.Count; slotIndex++)
+        {
+            var slot = Options.Instance.Equipment.EquipmentSlots[slotIndex];
+
+            for (int j = 0; j < slot.MaxItems; j++)
+            {
+                var item = new EquipmentItem(slotIndex, this);
+                Items.Add(item);
+
+                var slotName = slot.Name;
+
+                if (slot.MaxItems <= 1)
+                {
+                    item.Pnl = new ImagePanel(mEquipmentContainer, slotName);
+                }
+                else
+                {
+                    if (!multiSlotTracker.ContainsKey(slotName))
+                        multiSlotTracker[slotName] = 0;
+
+                    var currentIndex = multiSlotTracker[slotName];
+                    item.Pnl = new ImagePanel(mEquipmentContainer, $"{slotName}_{currentIndex}");
+                    multiSlotTracker[slotName]++;
+                }
+
+                int row = itemIndex / columns;
+                int col = itemIndex % columns;
+
+                item.Pnl.SetSize(slotW, slotH);
+                item.Pnl.SetPosition(startX + col * (slotW + spacingX), startY + row * (slotH + spacingY));
+                item.Setup();
+
+                itemIndex++;
+            }
+        }
+    }
+
+    private void BuildStatsSection()
+    {
+        var header = CreateSectionTitle(mStatsContainer, "StatsHeader", 0, 0, "Atributos");
+
+        var x = 0;
+        var y = header.Height + 6;
+
+        // Attack
+        mAttackLabel = CreateBodyLabel(mStatsContainer, "AttackLabel", x, y, StatLabelWidth);
+        mAddAttackBtn = CreateStatButton(mStatsContainer, "IncreaseAttackButton", x + StatLabelWidth + 8, y);
+        mAddAttackBtn.Clicked += _addAttackBtn_Clicked;
+        y += StatRowHeight;
+
+        // Ability Power
+        mAbilityPwrLabel = CreateBodyLabel(mStatsContainer, "AbilityPowerLabel", x, y, StatLabelWidth);
+        mAddAbilityPwrBtn = CreateStatButton(mStatsContainer, "IncreaseAbilityPowerButton", x + StatLabelWidth + 8, y);
+        mAddAbilityPwrBtn.Clicked += _addAbilityPwrBtn_Clicked;
+        y += StatRowHeight;
+
+        // Defense
+        mDefenseLabel = CreateBodyLabel(mStatsContainer, "DefenseLabel", x, y, StatLabelWidth);
+        mAddDefenseBtn = CreateStatButton(mStatsContainer, "IncreaseDefenseButton", x + StatLabelWidth + 8, y);
+        mAddDefenseBtn.Clicked += _addDefenseBtn_Clicked;
+        y += StatRowHeight;
+
+        // Vitality (Magic Resist label en tu UI, pero realmente es Vitality)
+        mMagicRstLabel = CreateBodyLabel(mStatsContainer, "MagicResistLabel", x, y, StatLabelWidth);
+        mAddMagicResistBtn = CreateStatButton(mStatsContainer, "IncreaseMagicResistButton", x + StatLabelWidth + 8, y);
+        mAddMagicResistBtn.Clicked += _addMagicResistBtn_Clicked;
+        y += StatRowHeight;
+
+        // Speed
+        mAgilityLabel = CreateBodyLabel(mStatsContainer, "AgilityLabel", x, y, StatLabelWidth);
+
+        mAddAgilityBtn = CreateStatButton(mStatsContainer, "IncreaseSpeedButton", x + StatLabelWidth + 8, y);
+        mAddAgilityBtn.Clicked += _addSpeedBtn_Clicked;
+        y += StatRowHeight;
+
+        // Read-only stats
+        mSpeedLabel = CreateBodyLabel(mStatsContainer, "SpeedLabel", x, y, StatLabelWidth); y += StatRowHeight;
+        mDamageLabel = CreateBodyLabel(mStatsContainer, "DamageLabel", x, y, StatLabelWidth); y += StatRowHeight;
+        mCureLabel = CreateBodyLabel(mStatsContainer, "CureLabel", x, y, StatLabelWidth); y += StatRowHeight;
+        mCritChanceLabel = CreateBodyLabel(mStatsContainer, "CritLabel", x, y, StatLabelWidth); y += StatRowHeight;
+        mPointsLabel = CreateBodyLabel(mStatsContainer, "PointsLabel", x, y, StatLabelWidth + 40); y += StatRowHeight;
+
+        mBasicAttackDamageLabel = CreateBodyLabel(
+            mStatsContainer,
+            "BasicAttackDamageLabel",
+            x,
+            y,
+            StatLabelWidth + 120,
+            StatRowHeight + 4
+        );
+    }
+
+    private void BuildExtraBuffsSection()
+    {
+        var header = CreateSectionTitle(mExtraBuffsContainer, "ExtraBuffsHeader", 0, 0, Strings.Character.ExtraBuffs);
+
+        mExtraBuffsScroll = new ScrollControl(mExtraBuffsContainer, "ExtraBuffsScroll");
+        mExtraBuffsScroll.SetPosition(0, header.Height + 6);
+        mExtraBuffsScroll.SetSize(mExtraBuffsContainer.Width, mExtraBuffsContainer.Height - (header.Height + 6));
+        mExtraBuffsScroll.AutoHideBars = true;
+
+        mExtraBuffsList = new Base(mExtraBuffsScroll, "ExtraBuffsList");
+        mExtraBuffsList.SetPosition(0, 0);
+        mExtraBuffsList.SetSize(mExtraBuffsScroll.Width - 20, 10);
+
+        int y = 0;
+
+        // Apilado 1 por 1 (una sola columna)
+        mHpRegen = CreateBodyLabel(mExtraBuffsList, "HpRegen", 0, y, EffectLabelWidth, EffectRowHeight); y += EffectRowHeight;
+        mManaRegen = CreateBodyLabel(mExtraBuffsList, "ManaRegen", 0, y, EffectLabelWidth, EffectRowHeight); y += EffectRowHeight;
+        mLifeSteal = CreateBodyLabel(mExtraBuffsList, "Lifesteal", 0, y, EffectLabelWidth, EffectRowHeight); y += EffectRowHeight;
+        mAttackSpeed = CreateBodyLabel(mExtraBuffsList, "AttackSpeed", 0, y, EffectLabelWidth, EffectRowHeight); y += EffectRowHeight;
+
+        mSpeedBuff = CreateBodyLabel(mExtraBuffsList, "SpeedBuff", 0, y, EffectLabelWidth, EffectRowHeight); y += EffectRowHeight;
+        mDamageBuff = CreateBodyLabel(mExtraBuffsList, "DamageBuff", 0, y, EffectLabelWidth, EffectRowHeight); y += EffectRowHeight;
+        mCureBuff = CreateBodyLabel(mExtraBuffsList, "CureBuff", 0, y, EffectLabelWidth, EffectRowHeight); y += EffectRowHeight;
+
+        mExtraExp = CreateBodyLabel(mExtraBuffsList, "ExtraExp", 0, y, EffectLabelWidth, EffectRowHeight); y += EffectRowHeight;
+        mLuck = CreateBodyLabel(mExtraBuffsList, "Luck", 0, y, EffectLabelWidth, EffectRowHeight); y += EffectRowHeight;
+        mTenacity = CreateBodyLabel(mExtraBuffsList, "Tenacity", 0, y, EffectLabelWidth, EffectRowHeight); y += EffectRowHeight;
+        mCooldownReduction = CreateBodyLabel(mExtraBuffsList, "CooldownReduction", 0, y, EffectLabelWidth, EffectRowHeight); y += EffectRowHeight;
+        mManaSteal = CreateBodyLabel(mExtraBuffsList, "Manasteal", 0, y, EffectLabelWidth, EffectRowHeight); y += EffectRowHeight;
+
+        mAccuracy = CreateBodyLabel(mExtraBuffsList, "Accuracy", 0, y, EffectLabelWidth, EffectRowHeight); y += EffectRowHeight;
+        mEvasion = CreateBodyLabel(mExtraBuffsList, "Evasion", 0, y, EffectLabelWidth, EffectRowHeight); y += EffectRowHeight;
+        mCritBonus = CreateBodyLabel(mExtraBuffsList, "CriticalBonus", 0, y, EffectLabelWidth, EffectRowHeight); y += EffectRowHeight;
+        mAntiCrit = CreateBodyLabel(mExtraBuffsList, "AntiCritical", 0, y, EffectLabelWidth, EffectRowHeight); y += EffectRowHeight;
+        mArmorPenetration = CreateBodyLabel(mExtraBuffsList, "ArmorPenetration", 0, y, EffectLabelWidth, EffectRowHeight); y += EffectRowHeight;
+        mDamageReduction = CreateBodyLabel(mExtraBuffsList, "DamageReduction", 0, y, EffectLabelWidth, EffectRowHeight); y += EffectRowHeight;
+        mDamageReflect = CreateBodyLabel(mExtraBuffsList, "DamageReflect", 0, y, EffectLabelWidth, EffectRowHeight); y += EffectRowHeight;
+
+        mFlatDamage = CreateBodyLabel(mExtraBuffsList, "FlatDamage", 0, y, EffectLabelWidth, EffectRowHeight); y += EffectRowHeight;
+        mFlatCures = CreateBodyLabel(mExtraBuffsList, "FlatCures", 0, y, EffectLabelWidth, EffectRowHeight); y += EffectRowHeight;
+
+        // Ajusta el alto del list para que el scroll funcione bien
+        mExtraBuffsList.SetSize(mExtraBuffsList.Width, y + 4);
+    }
+
+    // -------------------------
+    // Public
+    // -------------------------
+
+    public void SetPlayer(Player? player) => _player = player;
+
+    //Update Button Event Handlers
+    void _addMagicResistBtn_Clicked(Base sender, MouseButtonState arguments) =>
+        PacketSender.SendUpgradeStat((int)Stat.Vitality);
+
+    void _addAbilityPwrBtn_Clicked(Base sender, MouseButtonState arguments) =>
+        PacketSender.SendUpgradeStat((int)Stat.Intelligence);
+
+    void _addSpeedBtn_Clicked(Base sender, MouseButtonState arguments) =>
+        PacketSender.SendUpgradeStat((int)Stat.Agility);
+
+    void _addDefenseBtn_Clicked(Base sender, MouseButtonState arguments) =>
+        PacketSender.SendUpgradeStat((int)Stat.Defense);
+
+    void _addAttackBtn_Clicked(Base sender, MouseButtonState arguments) =>
+        PacketSender.SendUpgradeStat((int)Stat.Attack);
+
+    private IEnumerable<ItemDescriptor> GetEquippedDescriptors(Player player)
+    {
+        if (player == Globals.Me)
+        {
+            foreach (var (_, equipmentSlots) in player.MyEquipment)
+            {
+                foreach (var slotIndex in equipmentSlots)
+                {
+                    var invItem = player.Inventory.ElementAtOrDefault(slotIndex);
+                    if (invItem?.ItemId == null || invItem.ItemId == Guid.Empty)
+                        continue;
+
+                    var descriptor = ItemDescriptor.Get(invItem.ItemId);
+                    if (descriptor != null)
+                        yield return descriptor;
+                }
+            }
+        }
+        else
+        {
+            foreach (var (_, equippedItems) in player.Equipment)
+            {
+                foreach (var id in equippedItems)
+                {
+                    if (id == Guid.Empty)
+                        continue;
+
+                    var descriptor = ItemDescriptor.Get(id);
+                    if (descriptor != null)
+                        yield return descriptor;
+                }
+            }
+        }
+    }
+
+    // -------------------------
+    // Update Loop
+    // -------------------------
+
     public void Update()
     {
         var player = DisplayedPlayer;
         if (IsHidden || player is null)
-        {
             return;
-        }
 
         mCharacterName.Text = player.Name;
-        mCharacterLevelAndClass.Text = Strings.Character.LevelAndClass.ToString(
-            player.Level, ClassDescriptor.GetName(player.Class)
-        );
+        mCharacterLevelAndClass.Text = Strings.Character.LevelAndClass.ToString(player.Level, ClassDescriptor.GetName(player.Class));
 
-        //Load Portrait
-        //UNCOMMENT THIS LINE IF YOU'D RATHER HAVE A FACE HERE IGameTexture faceTex = Globals.ContentManager.GetTexture(Framework.Content.TextureType.Face, player.Face);
-        var entityTex = Globals.ContentManager.GetTexture(
-            Framework.Content.TextureType.Entity, player.Sprite
-        );
+        // Portrait/paperdoll
+        var entityTex = Globals.ContentManager.GetTexture(Framework.Content.TextureType.Entity, player.Sprite);
 
-        /* UNCOMMENT THIS BLOCK IF YOU"D RATHER HAVE A FACE HERE if (player.Face != "" && player.Face != _currentSprite && faceTex != null)
-         {
-             _characterPortrait.Texture = faceTex;
-             _characterPortrait.SetTextureRect(0, 0, faceTex.GetWidth(), faceTex.GetHeight());
-             _characterPortrait.SizeToContents();
-             Align.Center(_characterPortrait);
-             _characterPortrait.IsHidden = false;
-             for (int i = 0; i < Options.Instance.Equipment.Slots.Count; i++)
-             {
-                 _paperdollPanels[i].Hide();
-             }
-         }
-         else */
         if (!string.IsNullOrWhiteSpace(player.Sprite) && player.Sprite != mCurrentSprite && entityTex != null)
         {
             for (var z = 0; z < Options.Instance.Equipment.Paperdoll.Directions[1].Count; z++)
@@ -554,20 +542,16 @@ public partial class CharacterWindow:Window
                 {
                     var equipment = player.MyEquipment;
 
-                    // Intentar obtener la lista de ítems equipados en este slot
                     if (equipment.TryGetValue(slotIndex, out var equippedList) && equippedList.Count > 0)
                     {
-                        var inventoryIndex = equippedList[0]; // Tomamos el primero para mostrar
+                        var inventoryIndex = equippedList[0];
                         if (inventoryIndex >= 0 && inventoryIndex < Options.Instance.Player.MaxInventory)
                         {
                             var itemNum = player.Inventory[inventoryIndex].ItemId;
 
                             if (ItemDescriptor.TryGet(itemNum, out var itemDescriptor))
                             {
-                                paperdoll = player.Gender == 0
-                                    ? itemDescriptor.MalePaperdoll
-                                    : itemDescriptor.FemalePaperdoll;
-
+                                paperdoll = player.Gender == 0 ? itemDescriptor.MalePaperdoll : itemDescriptor.FemalePaperdoll;
                                 PaperdollPanels[z].RenderColor = itemDescriptor.Color;
                             }
                         }
@@ -598,7 +582,10 @@ public partial class CharacterWindow:Window
                     {
                         PaperdollPanels[z].SetTextureRect(0, 0, paperdollTex.Width / Options.Instance.Sprites.NormalFrames, paperdollTex.Height / Options.Instance.Sprites.Directions);
                         PaperdollPanels[z].SetSize(paperdollTex.Width / Options.Instance.Sprites.NormalFrames, paperdollTex.Height / Options.Instance.Sprites.Directions);
-                        PaperdollPanels[z].SetPosition(mCharacterContainer.Width / 2 - PaperdollPanels[z].Width / 2, mCharacterContainer.Height / 2 - PaperdollPanels[z].Height / 2);
+                        PaperdollPanels[z].SetPosition(
+                            mCharacterContainer.Width / 2 - PaperdollPanels[z].Width / 2,
+                            mCharacterContainer.Height / 2 - PaperdollPanels[z].Height / 2
+                        );
                     }
 
                     PaperdollPanels[z].Show();
@@ -606,77 +593,38 @@ public partial class CharacterWindow:Window
                 }
             }
         }
-
         else if (player.Sprite != mCurrentSprite && player.Face != mCurrentSprite)
         {
             mCharacterPortrait.IsHidden = true;
             for (var i = 0; i < Options.Instance.Equipment.Slots.Count; i++)
-            {
                 PaperdollPanels[i].Hide();
-            }
         }
 
-        mAttackLabel.SetText(
-            Strings.Character.StatLabelValue.ToString(
-                Strings.Combat.Stats[Stat.Attack],
-                player.Stat[(int)Stat.Attack]
-            )
-        );
+        // Stats text
+        mAttackLabel.SetText(Strings.Character.StatLabelValue.ToString(Strings.Combat.Stats[Stat.Attack], player.Stat[(int)Stat.Attack]));
+        mAbilityPwrLabel.SetText(Strings.Character.StatLabelValue.ToString(Strings.Combat.Stats[Stat.Intelligence], player.Stat[(int)Stat.Intelligence]));
+        mDefenseLabel.SetText(Strings.Character.StatLabelValue.ToString(Strings.Combat.Stats[Stat.Defense], player.Stat[(int)Stat.Defense]));
+        mMagicRstLabel.SetText(Strings.Character.StatLabelValue.ToString(Strings.Combat.Stats[Stat.Vitality], player.Stat[(int)Stat.Vitality]));
+        mSpeedLabel.SetText(Strings.Character.StatLabelValue.ToString(Strings.Combat.Stats[Stat.Speed], player.Stat[(int)Stat.Speed]));
+        mAgilityLabel.SetText(Strings.Character.StatLabelValue.ToString(Strings.Combat.Stats[Stat.Agility], player.Stat[(int)Stat.Agility]));
 
-        mAbilityPwrLabel.SetText(
-            Strings.Character.StatLabelValue.ToString(
-                Strings.Combat.Stats[Stat.Intelligence],
-                player.Stat[(int)Stat.Intelligence]
-            )
-        );
-
-        mDefenseLabel.SetText(
-            Strings.Character.StatLabelValue.ToString(
-                Strings.Combat.Stats[Stat.Defense],
-                player.Stat[(int)Stat.Defense]
-            )
-        );
-
-        mMagicRstLabel.SetText(
-            Strings.Character.StatLabelValue.ToString(
-                Strings.Combat.Stats[Stat.Vitality],
-                player.Stat[(int)Stat.Vitality]
-            )
-        );
-
-        mSpeedLabel.SetText(
-            Strings.Character.StatLabelValue.ToString(
-                Strings.Combat.Stats[Stat.Speed],
-                player.Stat[(int)Stat.Speed]
-            )
-        );
-        mAgilityLabel.SetText(
-            Strings.Character.StatLabelValue.ToString(
-                Strings.Combat.Stats[Stat.Agility],
-                player.Stat[(int)Stat.Agility]
-            )
-        );
         var critChance = player.CalculateCriticalChance(player.GetBaseCriticalChance());
         mCritChanceLabel.SetText(Strings.Character.CriticalChance.ToString(critChance));
+
         mPointsLabel.SetText(Strings.Character.Points.ToString(player.StatPoints));
-        mAddAbilityPwrBtn.IsHidden = player.StatPoints == 0 ||
-                                     player.Stat[(int) Stat.Intelligence] == Options.Instance.Player.MaxStat;
 
-        mAddAttackBtn.IsHidden =
-            player.StatPoints == 0 || player.Stat[(int) Stat.Attack] == Options.Instance.Player.MaxStat;
+        // Buttons visibility
+        mAddAbilityPwrBtn.IsHidden = player.StatPoints == 0 || player.Stat[(int)Stat.Intelligence] == Options.Instance.Player.MaxStat;
+        mAddAttackBtn.IsHidden = player.StatPoints == 0 || player.Stat[(int)Stat.Attack] == Options.Instance.Player.MaxStat;
+        mAddDefenseBtn.IsHidden = player.StatPoints == 0 || player.Stat[(int)Stat.Defense] == Options.Instance.Player.MaxStat;
+        mAddMagicResistBtn.IsHidden = player.StatPoints == 0 || player.Stat[(int)Stat.Vitality] == Options.Instance.Player.MaxStat;
+        mAddAgilityBtn.IsHidden = player.StatPoints == 0 || player.Stat[(int)Stat.Agility] == Options.Instance.Player.MaxStat;
 
-        mAddDefenseBtn.IsHidden = player.StatPoints == 0 ||
-                                  player.Stat[(int) Stat.Defense] == Options.Instance.Player.MaxStat;
-
-        mAddMagicResistBtn.IsHidden = player.StatPoints == 0 ||
-                                      player.Stat[(int) Stat.Vitality] == Options.Instance.Player.MaxStat;
-
-        mAddAgilityBtn.IsHidden =
-            player.StatPoints == 0 || player.Stat[(int) Stat.Agility] == Options.Instance.Player.MaxStat;
-
+        // Effects
         UpdateExtraBuffs();
         mDamageLabel.SetText(Strings.Character.FlatDamage.ToString(FormatEffectValue(_flatDamage)));
         mCureLabel.SetText(Strings.Character.FlatCures.ToString(FormatEffectValue(_flatCures)));
+
         UpdateEquippedItems(true);
     }
 
@@ -684,9 +632,7 @@ public partial class CharacterWindow:Window
     {
         var player = DisplayedPlayer;
         if (player is null)
-        {
             return;
-        }
 
         int itemIndex = 0;
         for (var slotIndex = 0; slotIndex < Options.Instance.Equipment.EquipmentSlots.Count; slotIndex++)
@@ -728,9 +674,7 @@ public partial class CharacterWindow:Window
 
                     var itemIds = new List<Guid>();
                     if (i < equippedIds.Count && equippedIds[i] != Guid.Empty)
-                    {
                         itemIds.Add(equippedIds[i]);
-                    }
 
                     Items[itemIndex].Update(itemIds, new List<ItemProperties>());
                     itemIndex++;
@@ -775,57 +719,26 @@ public partial class CharacterWindow:Window
                 {
                     var effectValue = effect.GetValues();
                     if (effectValue.GetPrimaryValue() == 0)
-                    {
                         continue;
-                    }
 
                     switch (effect.Type)
                     {
-                        case ItemEffect.CooldownReduction:
-                            CooldownAmount += effectValue.GetPrimaryValue();
-                            break;
-                        case ItemEffect.Lifesteal:
-                            LifeStealAmount += effectValue.GetPrimaryValue();
-                            break;
-                        case ItemEffect.Tenacity:
-                            TenacityAmount += effectValue.GetPrimaryValue();
-                            break;
-                        case ItemEffect.Luck:
-                            LuckAmount += effectValue.GetPrimaryValue();
-                            break;
-                        case ItemEffect.EXP:
-                            ExtraExpAmount += effectValue.GetPrimaryValue();
-                            break;
-                        case ItemEffect.Manasteal:
-                            ManaStealAmount += effectValue.GetPrimaryValue();
-                            break;
-                        case ItemEffect.Accuracy:
-                            _accuracy = _accuracy.Add(effectValue);
-                            break;
-                        case ItemEffect.Evasion:
-                            _evasion = _evasion.Add(effectValue);
-                            break;
-                        case ItemEffect.CriticalChance:
-                            _critBonus = _critBonus.Add(effectValue);
-                            break;
-                        case ItemEffect.AntiCritChance:
-                            _antiCrit = _antiCrit.Add(effectValue);
-                            break;
-                        case ItemEffect.ArmorPenetration:
-                            _armorPenetration = _armorPenetration.Add(effectValue);
-                            break;
-                        case ItemEffect.DamageReduction:
-                            _damageReduction = _damageReduction.Add(effectValue);
-                            break;
-                        case ItemEffect.DamageReflect:
-                            _damageReflect = _damageReflect.Add(effectValue);
-                            break;
-                        case ItemEffect.Damages:
-                            _flatDamage = _flatDamage.Add(effectValue);
-                            break;
-                        case ItemEffect.Cures:
-                            _flatCures = _flatCures.Add(effectValue);
-                            break;
+                        case ItemEffect.CooldownReduction: CooldownAmount += effectValue.GetPrimaryValue(); break;
+                        case ItemEffect.Lifesteal: LifeStealAmount += effectValue.GetPrimaryValue(); break;
+                        case ItemEffect.Tenacity: TenacityAmount += effectValue.GetPrimaryValue(); break;
+                        case ItemEffect.Luck: LuckAmount += effectValue.GetPrimaryValue(); break;
+                        case ItemEffect.EXP: ExtraExpAmount += effectValue.GetPrimaryValue(); break;
+                        case ItemEffect.Manasteal: ManaStealAmount += effectValue.GetPrimaryValue(); break;
+
+                        case ItemEffect.Accuracy: _accuracy = _accuracy.Add(effectValue); break;
+                        case ItemEffect.Evasion: _evasion = _evasion.Add(effectValue); break;
+                        case ItemEffect.CriticalChance: _critBonus = _critBonus.Add(effectValue); break;
+                        case ItemEffect.AntiCritChance: _antiCrit = _antiCrit.Add(effectValue); break;
+                        case ItemEffect.ArmorPenetration: _armorPenetration = _armorPenetration.Add(effectValue); break;
+                        case ItemEffect.DamageReduction: _damageReduction = _damageReduction.Add(effectValue); break;
+                        case ItemEffect.DamageReflect: _damageReflect = _damageReflect.Add(effectValue); break;
+                        case ItemEffect.Damages: _flatDamage = _flatDamage.Add(effectValue); break;
+                        case ItemEffect.Cures: _flatCures = _flatCures.Add(effectValue); break;
                     }
                 }
             }
@@ -867,6 +780,7 @@ public partial class CharacterWindow:Window
 
         mDamageBuff.SetText(Strings.Character.FlatDamage.ToString(FormatEffectValue(_flatDamage)));
         mCureBuff.SetText(Strings.Character.FlatCures.ToString(FormatEffectValue(_flatCures)));
+
         mAccuracy.SetText($"{Strings.ItemDescription.BonusEffects[(int)ItemEffect.Accuracy]} {FormatEffectValue(_accuracy)}");
         mEvasion.SetText($"{Strings.ItemDescription.BonusEffects[(int)ItemEffect.Evasion]} {FormatEffectValue(_evasion)}");
         mCritBonus.SetText($"{Strings.ItemDescription.BonusEffects[(int)ItemEffect.CriticalChance]} {FormatEffectValue(_critBonus)}");
@@ -874,98 +788,30 @@ public partial class CharacterWindow:Window
         mArmorPenetration.SetText($"{Strings.ItemDescription.BonusEffects[(int)ItemEffect.ArmorPenetration]} {FormatEffectValue(_armorPenetration)}");
         mDamageReduction.SetText($"{Strings.ItemDescription.BonusEffects[(int)ItemEffect.DamageReduction]} {FormatEffectValue(_damageReduction)}");
         mDamageReflect.SetText($"{Strings.ItemDescription.BonusEffects[(int)ItemEffect.DamageReflect]} {FormatEffectValue(_damageReflect)}");
+
+        // Estos dos son “flat” pero los estás mostrando también acá
         mFlatDamage.SetText($"{Strings.ItemDescription.BonusEffects[(int)ItemEffect.Damages]} {FormatEffectValue(_flatDamage)}");
         mFlatCures.SetText($"{Strings.ItemDescription.BonusEffects[(int)ItemEffect.Cures]} {FormatEffectValue(_flatCures)}");
-    }
 
-    /// <summary>
-    /// Update Extra Buffs Effects like hp/mana regen and items effect types
-    /// </summary>
-    /// <param name="itemId">Id of item to update extra buffs</param>
-    private void UpdateExtraBuffs(Guid itemId)
-    {
-        var item = ItemDescriptor.Get(itemId);
-
-        if (item == null)
+        // Reajusta alto del listado por si cambiaste fuentes/escala
+        if (mExtraBuffsList != null)
         {
-            return;
-        }
-
-        //Getting HP and Mana Regen from items
-        if (item.VitalsRegen[(int)Vital.Health] != 0)
-        {
-            HpRegenAmount += item.VitalsRegen[(int)Vital.Health];
-        }
-
-        if (item.VitalsRegen[(int)Vital.Mana] != 0)
-        {
-            ManaRegenAmount += item.VitalsRegen[(int)Vital.Mana];
-        }
-
-        //Getting extra buffs from items
-        if (item.Effects.Find(effect => effect.Type != ItemEffect.None && effect.GetValue() > 0) != default)
-        {
-            foreach (var effect in item.Effects)
-            {
-                var effectAmount = effect.GetValue();
-                if (effectAmount <= 0)
-                {
-                    continue;
-                }
-
-                switch (effect.Type)
-                {
-                    case ItemEffect.CooldownReduction:
-                        CooldownAmount += effectAmount;
-                        break;
-                    case ItemEffect.Lifesteal:
-                        LifeStealAmount += effectAmount;
-                        break;
-                    case ItemEffect.Tenacity:
-                        TenacityAmount += effectAmount;
-                        break;
-                    case ItemEffect.Luck:
-                        LuckAmount += effectAmount;
-                        break;
-                    case ItemEffect.EXP:
-                        ExtraExpAmount += effectAmount;
-                        break;
-                    case ItemEffect.Manasteal:
-                        ManaStealAmount += effectAmount;
-                        break;
-                }
-            }
+            // “básico”: deja el height tal cual lo seteamos en BuildExtraBuffsSection()
+            // Si luego haces hide/show dinámico, aquí recalculas el alto.
         }
     }
-
 
     /// <summary>
     /// Show the window
     /// </summary>
-    public void Show()
-    {
-        this.IsHidden = false;
-    }
+    public void Show() => IsHidden = false;
 
-    /// <summary>
-    /// </summary>
-    /// <returns>Returns if window is visible</returns>
-    public bool IsVisible()
-    {
-        return !this.IsHidden;
-    }
+    public bool IsVisible() => !IsHidden;
 
-    /// <summary>
-    /// Hide the window
-    /// </summary>
-    public void Hide()
-    {
-        this.IsHidden = true;
-    }
+    public void Hide() => IsHidden = true;
 
     protected override void EnsureInitialized()
     {
         LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
     }
-
 }

--- a/Intersect.Client.Core/Interface/Game/Character/EquipmentItem.cs
+++ b/Intersect.Client.Core/Interface/Game/Character/EquipmentItem.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Diagnostics;
+using Intersect.Client.Entities;
 using Intersect.Client.Framework.File_Management;
 using Intersect.Client.Framework.GenericClasses;
 using Intersect.Client.Framework.Gwen;
@@ -17,7 +19,7 @@ public partial class EquipmentItem
 {
     public List<ImagePanel> ContentPanels = new();
 
-    private WindowControl mCharacterWindow;
+    private readonly Func<Player?> _playerProvider;
 
     private List<Guid> mCurrentItemIds = new();
 
@@ -29,10 +31,10 @@ public partial class EquipmentItem
 
     public ImagePanel Pnl;
 
-    public EquipmentItem(int index, WindowControl characterWindow)
+    public EquipmentItem(int index, Func<Player?> playerProvider)
     {
         mYindex = index;
-        mCharacterWindow = characterWindow;
+        _playerProvider = playerProvider;
     }
 
     public void Setup()
@@ -77,7 +79,7 @@ public partial class EquipmentItem
             return;
         }
 
-        var player = (mCharacterWindow as CharacterWindow)?.DisplayedPlayer;
+        var player = _playerProvider?.Invoke();
         if (player == null || player != Globals.Me)
         {
             return;

--- a/Intersect.Client.Core/Interface/Game/Fishing/FishingWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Fishing/FishingWindow.cs
@@ -1,0 +1,331 @@
+using System;
+using Intersect.Client.Core;
+using Intersect.Client.Entities;
+using Intersect.Client.Framework.File_Management;
+using Intersect.Client.Framework.GenericClasses;
+using Intersect.Client.Framework.Graphics;
+using Intersect.Client.Framework.Gwen;
+using Intersect.Client.Framework.Gwen.Control;
+using Intersect.Client.General;
+using Intersect.Client.Interface;
+using Intersect.Client.Localization;
+using Intersect.Framework.Core.GameObjects.Items;
+using Intersect.GameObjects;
+
+namespace Intersect.Client.Interface.Game.Fishing;
+
+public partial class FishingWindow : Window
+{
+    private ImagePanel? _root;
+
+    private ImagePanel? _fishEventPanel;
+    private ImagePanel? _rangeMoveFrame;
+    private ImagePanel? _rangeMoveAnchorFiller;
+    private ImagePanel? _rangeMoveFiller;
+
+    private ImagePanel? _playerHook;
+
+    private ImagePanel? _progressBarFrame;
+    private ImagePanel? _progressBarAnchorFiller;
+    private ImagePanel? _progressBarFiller;
+
+    private ImagePanel? _success;
+    private ImagePanel? _itemViewer;
+    private ImagePanel? _failed;
+    private Label? _successText;
+
+    public FishingWindow(Canvas gameCanvas) : base(gameCanvas, Strings.Fishing.WindowTitle, false, nameof(FishingWindow))
+    {
+        DisableResizing();
+        IsClosable = false;
+        IsResizable = false;
+        SkipRender();
+
+        Alignment = [Alignments.Center];
+
+        Hide();
+    }
+
+    protected override void EnsureInitialized()
+    {
+        if (_root != null)
+        {
+            return;
+        }
+
+        BuildUi();
+        LoadJsonUi(GameContentManager.UI.InGame, Graphics.Renderer.GetResolutionString());
+    }
+
+    private void BuildUi()
+    {
+        _root = new ImagePanel(this, "FishEventUI")
+        {
+            RestrictToParent = false,
+            MouseInputEnabled = false,
+            ShouldDrawBackground = true,
+            Alignment = [Alignments.Center],
+            RenderColor = Color.FromArgb(255, 255, 255, 255),
+            MinimumSize = new Point(1, 1),
+            MaximumSize = new Point(4096, 4096),
+        };
+        _root.SetBounds(0, 0, 512, 168);
+
+        _fishEventPanel = new ImagePanel(_root, "MainPanel")
+        {
+            RestrictToParent = false,
+            MouseInputEnabled = false,
+            ShouldDrawBackground = true,
+            Alignment = [Alignments.Center],
+            TextureFilename = "fish_background.png",
+            RenderColor = Color.FromArgb(255, 255, 255, 255),
+            MinimumSize = new Point(1, 1),
+            MaximumSize = new Point(4096, 4096),
+        };
+        _fishEventPanel.SetBounds(0, 0, 512, 168);
+
+        _rangeMoveFrame = new ImagePanel(_fishEventPanel, "MoveRange")
+        {
+            RestrictToParent = true,
+            MouseInputEnabled = false,
+            ShouldDrawBackground = true,
+            Alignment = [Alignments.Center],
+            TextureFilename = "fish_backlayer.png",
+            RenderColor = Color.FromArgb(255, 255, 255, 255),
+            MinimumSize = new Point(1, 1),
+            MaximumSize = new Point(4096, 4096),
+        };
+        _rangeMoveFrame.SetBounds(24, 96, 464, 48);
+
+        _rangeMoveAnchorFiller = new ImagePanel(_rangeMoveFrame, "rangeMoveAnchorFiller")
+        {
+            RestrictToParent = true,
+            MouseInputEnabled = false,
+            ShouldDrawBackground = true,
+            Alignment = [Alignments.Center],
+            RenderColor = Color.FromArgb(255, 255, 255, 255),
+            MinimumSize = new Point(1, 1),
+            MaximumSize = new Point(4096, 4096),
+        };
+        _rangeMoveAnchorFiller.SetBounds(0, 0, 464, 48);
+
+        _rangeMoveFiller = new ImagePanel(_rangeMoveFrame, "MoveFiller")
+        {
+            RestrictToParent = true,
+            MouseInputEnabled = false,
+            ShouldDrawBackground = true,
+            Alignment = [Alignments.Center],
+            TextureFilename = "fish_filler.png",
+            RenderColor = Color.FromArgb(255, 255, 255, 255),
+            MinimumSize = new Point(1, 1),
+            MaximumSize = new Point(4096, 4096),
+        };
+        _rangeMoveFiller.SetBounds(198, 2, 68, 44);
+
+        _playerHook = new ImagePanel(_rangeMoveFrame, "MoveForce")
+        {
+            RestrictToParent = true,
+            MouseInputEnabled = false,
+            ShouldDrawBackground = true,
+            Alignment = [Alignments.Center],
+            TextureFilename = "fish_force.png",
+            RenderColor = Color.FromArgb(255, 255, 255, 255),
+            MinimumSize = new Point(1, 1),
+            MaximumSize = new Point(4096, 4096),
+        };
+        _playerHook.SetBounds(208, 0, 48, 48);
+
+        _progressBarFrame = new ImagePanel(_fishEventPanel, "ProgressBarFrame")
+        {
+            RestrictToParent = true,
+            MouseInputEnabled = false,
+            ShouldDrawBackground = true,
+            Alignment = [Alignments.Center],
+            TextureFilename = "fish_test1.png",
+            RenderColor = Color.FromArgb(255, 255, 255, 255),
+            MinimumSize = new Point(1, 1),
+            MaximumSize = new Point(4096, 4096),
+        };
+        _progressBarFrame.SetBounds(24, 24, 464, 48);
+
+        _progressBarAnchorFiller = new ImagePanel(_progressBarFrame, "ProgressBarAnchorFiller")
+        {
+            RestrictToParent = true,
+            MouseInputEnabled = false,
+            ShouldDrawBackground = true,
+            Alignment = [Alignments.Center],
+            RenderColor = Color.FromArgb(255, 255, 255, 255),
+            MinimumSize = new Point(1, 1),
+            MaximumSize = new Point(4096, 4096),
+        };
+        _progressBarAnchorFiller.SetBounds(0, 0, 464, 48);
+
+        _progressBarFiller = new ImagePanel(_progressBarFrame, "ProgressBarFiller")
+        {
+            RestrictToParent = true,
+            MouseInputEnabled = false,
+            ShouldDrawBackground = true,
+            Alignment = [Alignments.Center],
+            TextureFilename = "fish_test2.png",
+            RenderColor = Color.FromArgb(255, 255, 255, 255),
+            MinimumSize = new Point(1, 1),
+            MaximumSize = new Point(4096, 4096),
+        };
+        _progressBarFiller.SetBounds(0, 0, 464, 48);
+
+        _success = new ImagePanel(_root, "Success")
+        {
+            RestrictToParent = true,
+            MouseInputEnabled = false,
+            ShouldDrawBackground = true,
+            Alignment = [Alignments.Center],
+            TextureFilename = "fish_sussess.png",
+            RenderColor = Color.FromArgb(255, 255, 255, 255),
+            MinimumSize = new Point(1, 1),
+            MaximumSize = new Point(4096, 4096),
+        };
+        _success.SetBounds(160, 0, 192, 168);
+
+        _itemViewer = new ImagePanel(_success, "ItemViewer")
+        {
+            RestrictToParent = true,
+            MouseInputEnabled = false,
+            ShouldDrawBackground = true,
+            Alignment = [Alignments.Center],
+            RenderColor = Color.FromArgb(255, 255, 255, 255),
+            MinimumSize = new Point(1, 1),
+            MaximumSize = new Point(4096, 4096),
+        };
+        _itemViewer.SetBounds(72, 48, 48, 48);
+
+        _successText = new Label(_success, "SuccessText")
+        {
+            Text = "You got the fish!",
+            RenderColor = Color.FromArgb(255, 255, 255, 255),
+            Alignment = [Alignments.Center],
+            ShouldDrawBackground = true,
+            MinimumSize = new Point(1, 1),
+            MaximumSize = new Point(4096, 4096),
+            TextColor = new Color(255, 255, 255, 255),
+            FontName = "sourcesansproblack",
+            FontSize = 12,
+        };
+        _successText.SetBounds(37, 119, 117, 20);
+        _successText.SetTextScale(1f);
+
+        _failed = new ImagePanel(_root, "Failed")
+        {
+            RestrictToParent = true,
+            MouseInputEnabled = false,
+            ShouldDrawBackground = true,
+            Alignment = [Alignments.Center],
+            TextureFilename = "smallbutton_clicked.png",
+            RenderColor = Color.FromArgb(255, 255, 255, 255),
+            MinimumSize = new Point(1, 1),
+            MaximumSize = new Point(4096, 4096),
+        };
+        _failed.SetBounds(165, 65, 182, 38);
+    }
+
+    public bool IsVisible => IsVisibleInTree && _fishEventPanel?.IsHidden == false;
+
+    public override void Show()
+    {
+        EnsureInitialized();
+        base.Show();
+
+        _root?.Show();
+        _rangeMoveFrame?.Show();
+        _playerHook?.Show();
+        _progressBarFrame?.Show();
+        _fishEventPanel?.Show();
+    }
+
+    public override void Hide()
+    {
+        base.Hide();
+        _root?.Hide();
+    }
+
+    public void HideBars()
+    {
+        _rangeMoveFrame?.Hide();
+        _playerHook?.Hide();
+        _progressBarFrame?.Hide();
+        _fishEventPanel?.Hide();
+    }
+
+    public void ShowSuccess() => _success?.Show();
+
+    public void HideSuccess() => _success?.Hide();
+
+    public void ShowFailed() => _failed?.Show();
+
+    public void HideFailed() => _failed?.Hide();
+
+    public void RedrawIcon(ItemDescriptor item)
+    {
+        EnsureInitialized();
+        var itemTex = Globals.ContentManager.GetTexture(Framework.Content.TextureType.Item, item.Icon);
+        if (_itemViewer != null)
+        {
+            _itemViewer.Texture = itemTex;
+        }
+
+        if (_successText != null)
+        {
+            _successText.Text = $"{item.Name}";
+        }
+    }
+
+    public void RangeMoveResize(float valuePosition, float valueSize)
+    {
+        if (_rangeMoveAnchorFiller == null || _rangeMoveFiller == null)
+        {
+            return;
+        }
+
+        valuePosition = Math.Clamp(valuePosition, 0, 1);
+        valueSize = Math.Clamp(valueSize, 0, 1);
+
+        var width = (int)(_rangeMoveAnchorFiller.Width * valueSize);
+        var x = (int)(_rangeMoveAnchorFiller.Width * valuePosition - width / 2f);
+
+        _rangeMoveFiller.SetBounds(new Rectangle(_rangeMoveAnchorFiller.X + x, _rangeMoveAnchorFiller.Y, width, _rangeMoveFiller.Height));
+    }
+
+    public void PlayerForceMoved(float valuePosition, float valueSize)
+    {
+        if (_rangeMoveAnchorFiller == null || _playerHook == null)
+        {
+            return;
+        }
+
+        valuePosition = Math.Clamp(valuePosition, 0, 1);
+        valueSize = Math.Clamp(valueSize, 0, 1);
+
+        var width = (int)(_rangeMoveAnchorFiller.Width * valueSize);
+        var x = (int)(_rangeMoveAnchorFiller.Width * valuePosition - width / 2f);
+
+        _playerHook.SetBounds(new Rectangle(_rangeMoveAnchorFiller.X + x, _rangeMoveAnchorFiller.Y, width, _playerHook.Height));
+    }
+
+    public void Progress(float valueProgress)
+    {
+        if (_progressBarAnchorFiller == null || _progressBarFiller == null)
+        {
+            return;
+        }
+
+        valueProgress = Math.Clamp(valueProgress, 0, 1);
+
+        var width = (int)(_progressBarAnchorFiller.Width * valueProgress);
+
+        _progressBarFiller.SetBounds(new Rectangle(_progressBarFiller.X, _progressBarFiller.Y, width, _progressBarFiller.Height));
+    }
+
+    public void Update(Player player)
+    {
+        EnsureInitialized();
+    }
+}

--- a/Intersect.Client.Core/Interface/Game/GameInterface.cs
+++ b/Intersect.Client.Core/Interface/Game/GameInterface.cs
@@ -9,6 +9,7 @@ using Intersect.Client.Interface.Game.Chat;
 using Intersect.Client.Interface.Game.Crafting;
 using Intersect.Client.Interface.Game.DescriptionWindows;
 using Intersect.Client.Interface.Game.Enchanting;
+using Intersect.Client.Interface.Game.Fishing;
 using Intersect.Client.Interface.Game.EntityPanel;
 using Intersect.Client.Interface.Game.Guilds;
 using Intersect.Client.Interface.Game.Hotbar;
@@ -67,6 +68,7 @@ public partial class GameInterface : MutableInterface
     public EnchantItemWindow mEnchantItemWindow;
     private RuneEnchantWindow mRuneItemWindow;
     private BreakItemWindow mBreakItemWindow;
+    private FishingWindow? _fishingWindow;
     private MapItemWindow mMapItemWindow;
     private GuildCreationWindow mCreateGuildWindow;
     private SettingsWindow? _settingsWindow;
@@ -548,6 +550,7 @@ public partial class GameInterface : MutableInterface
         mBreakItemWindow?.Update();
         mEnchantItemWindow?.Update();
         mRuneItemWindow?.Update();
+        UpdateFishingWindow();
         _bestiaryWindow?.Update();
         mMailBoxWindow?.UpdateMail();
         mSellMarketWindow?.Update();
@@ -729,6 +732,18 @@ public partial class GameInterface : MutableInterface
             mChatBox.UnFocus();
             UnfocusChat = false;
         }
+    }
+
+    private void UpdateFishingWindow()
+    {
+        if (Globals.Me == null)
+        {
+            _fishingWindow?.Hide();
+            return;
+        }
+
+        _fishingWindow ??= new FishingWindow(GameCanvas);
+        _fishingWindow.Update(Globals.Me);
     }
 
     public void UpdateAdminWindowMapList()

--- a/Intersect.Client.Core/Interface/Game/Inventory/InventoryWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Inventory/InventoryWindow.cs
@@ -9,11 +9,14 @@ using Intersect.Client.Framework.File_Management;
 using Intersect.Client.Framework.Gwen;
 using Intersect.Client.Framework.Gwen.Control;
 using Intersect.Client.Framework.Gwen.Control.EventArguments;
+using Intersect.Client.Interface.Game.Character;
 using Intersect.Client.General;
 using Intersect.Client.Localization;
 using Intersect.Client.Utilities;
 using Intersect.Client.Framework.Items;
+using Intersect.Client.Framework.Content;
 using Intersect.Framework.Core.GameObjects.Items;
+using Intersect.Framework.Core.GameObjects.PlayerClass;
 
 namespace Intersect.Client.Interface.Game.Inventory;
 
@@ -21,6 +24,8 @@ public partial class InventoryWindow : Window
 {
     public List<SlotItem> Items { get; set; } = [];
 
+    private readonly Base _characterPanel;
+    private readonly Base _equipmentPanel;
     private readonly Base _headerPanel;
     private readonly ScrollControl _slotContainer;
     private readonly ContextMenu _contextMenu;
@@ -28,6 +33,15 @@ public partial class InventoryWindow : Window
     private readonly Button _sortButton;
     private readonly ComboBox _typeBox;
     private readonly ComboBox _subtypeBox;
+
+    private readonly ImagePanel _paperdollContainer;
+    private readonly Label _characterName;
+    private readonly Label _characterLevelAndClass;
+    private readonly List<EquipmentItem> _equipmentItems = [];
+    private readonly ImagePanel[] _paperdollLayers;
+    private readonly string[] _paperdollTextures;
+    private readonly Label _equipmentHeader;
+    private string _currentSprite = string.Empty;
 
  
     private readonly Dictionary<int, HashSet<string>> _subtypesByType = new();
@@ -50,6 +64,11 @@ public partial class InventoryWindow : Window
     private const int CTRL_H = 24;   // alto de controles
     private const int CTRL_W_SMALL = 140;
     private const int CTRL_W_MED = 150;
+    private const int LEFT_COL_WIDTH = 240;
+    private const int PAPERDOLL_SIZE = 160;
+    private const int EQUIP_COLUMNS = 3;
+    private const int EQUIP_SLOT_SIZE = 36;
+    private const int EQUIP_SPACING = 8;
 
     private int _lastW, _lastH;
 
@@ -63,12 +82,71 @@ public partial class InventoryWindow : Window
         IsClosable = true;
 
         // Tamaño/posición explícitos
-        SetSize(380, 460);
+        SetSize(760, 520);
+
+        // Columna izquierda: info de personaje y equipo
+        _characterPanel = new Base(this, "CharacterPanel");
+        _characterPanel.SetPosition(PAD, PAD);
+        _characterPanel.SetSize(LEFT_COL_WIDTH, Height - PAD * 2);
+
+        _characterName = new Label(_characterPanel, "CharacterName")
+        {
+            FontName = "sourcesansproblack",
+            FontSize = 14,
+            AutoSizeToContents = true,
+            TextColorOverride = Color.White,
+        };
+        _characterName.SetPosition(0, 0);
+
+        _characterLevelAndClass = new Label(_characterPanel, "CharacterLevelAndClass")
+        {
+            FontName = "source-sans-pro",
+            FontSize = 12,
+            AutoSizeToContents = true,
+            TextColorOverride = Color.White,
+        };
+        _characterLevelAndClass.SetPosition(0, _characterName.Height + 2);
+
+        _paperdollContainer = new ImagePanel(_characterPanel, "PaperdollContainer");
+        _paperdollContainer.SetSize(PAPERDOLL_SIZE, PAPERDOLL_SIZE);
+        _paperdollContainer.SetPosition((LEFT_COL_WIDTH - PAPERDOLL_SIZE) / 2, _characterLevelAndClass.Bottom + GAP);
+
+        _paperdollLayers = new ImagePanel[Options.Instance.Equipment.Slots.Count + 1];
+        _paperdollTextures = new string[_paperdollLayers.Length];
+        for (var i = 0; i < _paperdollLayers.Length; i++)
+        {
+            _paperdollLayers[i] = new ImagePanel(_paperdollContainer)
+            {
+                IsVisibleInTree = false
+            };
+            _paperdollLayers[i].Hide();
+            _paperdollTextures[i] = string.Empty;
+        }
+
+        _equipmentPanel = new Base(_characterPanel, "EquipmentPanel");
+        _equipmentPanel.SetPosition(0, _paperdollContainer.Bottom + GAP);
+        _equipmentPanel.SetSize(_characterPanel.Width, _characterPanel.Height - _equipmentPanel.Y);
+
+        _equipmentHeader = new Label(_equipmentPanel, "EquipmentHeader")
+        {
+            FontName = "sourcesansproblack",
+            FontSize = 12,
+            AutoSizeToContents = true,
+            Text = "Equipo",
+            TextColorOverride = Color.White,
+        };
+        _equipmentHeader.SetPosition(0, 0);
+        _equipmentHeader.SizeToContents();
+
+        BuildEquipmentSlots();
+
+        var rightX = PAD + LEFT_COL_WIDTH + GAP;
+        var rightW = Width - rightX - PAD;
 
         // --------- Header (contenedor de filtros) ----------
         _headerPanel = new Base(this, "HeaderPanel");
-        _headerPanel.SetPosition(PAD, PAD);
-        _headerPanel.SetSize(Width - PAD * 2, HEADER_H);
+        _headerPanel.SetPosition(rightX, PAD);
+        _headerPanel.SetSize(rightW, HEADER_H);
 
         // Campo de búsqueda
         _searchBox = new TextBox(_headerPanel, "SearchBox")
@@ -129,7 +207,8 @@ public partial class InventoryWindow : Window
             OverflowX = OverflowBehavior.Auto,
             OverflowY = OverflowBehavior.Scroll,
         };
-        _slotContainer.SetPosition(PAD, _headerPanel.Y + _headerPanel.Height + GAP);
+        _slotContainer.SetPosition(rightX, _headerPanel.Y + _headerPanel.Height + GAP);
+        _slotContainer.SetSize(rightW, Height - (_slotContainer.Y + PAD));
         
 
         // Context menu
@@ -159,16 +238,203 @@ public partial class InventoryWindow : Window
     // Recalcula posiciones/tamaños si cambia el tamaño de la ventana
     private void RecomputeLayout()
     {
-        _headerPanel.SetPosition(PAD, PAD);
-        _headerPanel.SetSize(Width - PAD * 2, HEADER_H);
+        _characterPanel.SetPosition(PAD, PAD);
+        _characterPanel.SetSize(LEFT_COL_WIDTH, Height - PAD * 2);
+
+        _characterName.SetPosition(0, 0);
+        _characterLevelAndClass.SetPosition(0, _characterName.Height + 2);
+
+        _paperdollContainer.SetPosition((LEFT_COL_WIDTH - PAPERDOLL_SIZE) / 2, _characterLevelAndClass.Bottom + GAP);
+
+        _equipmentPanel.SetPosition(0, _paperdollContainer.Bottom + GAP);
+        _equipmentPanel.SetSize(_characterPanel.Width, _characterPanel.Height - _equipmentPanel.Y);
+
+        var rightX = PAD + LEFT_COL_WIDTH + GAP;
+        var rightW = Width - rightX - PAD;
+
+        _headerPanel.SetPosition(rightX, PAD);
+        _headerPanel.SetSize(rightW, HEADER_H);
 
         _searchBox.SetPosition(0, 0);
         _sortButton.SetPosition(_searchBox.X + _searchBox.Width + GAP, 0);
         _typeBox.SetPosition(0, _searchBox.Y + _searchBox.Height + GAP);
         _subtypeBox.SetPosition(_typeBox.X + _typeBox.Width + GAP, _typeBox.Y);
 
-        _slotContainer.SetPosition(PAD, _headerPanel.Y + _headerPanel.Height + GAP);
-  
+        _slotContainer.SetPosition(rightX, _headerPanel.Y + _headerPanel.Height + GAP);
+        _slotContainer.SetSize(rightW, Height - (_slotContainer.Y + PAD));
+
+        LayoutEquipmentSlots();
+    }
+
+    private void BuildEquipmentSlots()
+    {
+        _equipmentItems.Clear();
+
+        var multiSlotTracker = new Dictionary<string, int>();
+        for (var slotIndex = 0; slotIndex < Options.Instance.Equipment.EquipmentSlots.Count; slotIndex++)
+        {
+            var slot = Options.Instance.Equipment.EquipmentSlots[slotIndex];
+
+            for (var j = 0; j < slot.MaxItems; j++)
+            {
+                var item = new EquipmentItem(slotIndex, () => Globals.Me);
+                _equipmentItems.Add(item);
+
+                var slotName = slot.Name;
+                var panelName = slotName;
+
+                if (slot.MaxItems > 1)
+                {
+                    var currentIndex = multiSlotTracker.GetValueOrDefault(slotName);
+                    panelName = $"{slotName}_{currentIndex}";
+                    multiSlotTracker[slotName] = currentIndex + 1;
+                }
+
+                item.Pnl = new ImagePanel(_equipmentPanel, panelName);
+                item.Setup();
+            }
+        }
+
+        LayoutEquipmentSlots();
+    }
+
+    private void LayoutEquipmentSlots()
+    {
+        if (_equipmentItems.Count == 0)
+            return;
+
+        var totalWidth = (EQUIP_COLUMNS * EQUIP_SLOT_SIZE) + ((EQUIP_COLUMNS - 1) * EQUIP_SPACING);
+        var startX = Math.Max(0, (_equipmentPanel.Width - totalWidth) / 2);
+        var startY = _equipmentHeader.Bottom + GAP;
+
+        for (var index = 0; index < _equipmentItems.Count; index++)
+        {
+            var row = index / EQUIP_COLUMNS;
+            var col = index % EQUIP_COLUMNS;
+
+            var panel = _equipmentItems[index].Pnl;
+            panel.SetSize(EQUIP_SLOT_SIZE, EQUIP_SLOT_SIZE);
+            panel.SetPosition(
+                startX + col * (EQUIP_SLOT_SIZE + EQUIP_SPACING),
+                startY + row * (EQUIP_SLOT_SIZE + EQUIP_SPACING)
+            );
+        }
+    }
+
+    private void UpdatePaperdoll(Player player)
+    {
+        var entityTex = Globals.ContentManager.GetTexture(TextureType.Entity, player.Sprite);
+
+        if (!string.IsNullOrWhiteSpace(player.Sprite) && entityTex != null)
+        {
+            for (var z = 0; z < Options.Instance.Equipment.Paperdoll.Directions[1].Count && z < _paperdollLayers.Length; z++)
+            {
+                var paperdoll = string.Empty;
+                var slotName = Options.Instance.Equipment.Paperdoll.Directions[1][z];
+                var slotIndex = Options.Instance.Equipment.Slots.IndexOf(slotName);
+
+                if (slotIndex > -1)
+                {
+                    var equipment = player.MyEquipment;
+
+                    if (equipment.TryGetValue(slotIndex, out var equippedList) && equippedList.Count > 0)
+                    {
+                        var inventoryIndex = equippedList[0];
+                        if (inventoryIndex >= 0 && inventoryIndex < Options.Instance.Player.MaxInventory)
+                        {
+                            var itemNum = player.Inventory[inventoryIndex].ItemId;
+
+                            if (ItemDescriptor.TryGet(itemNum, out var itemDescriptor))
+                            {
+                                paperdoll = player.Gender == 0 ? itemDescriptor.MalePaperdoll : itemDescriptor.FemalePaperdoll;
+                                _paperdollLayers[z].RenderColor = itemDescriptor.Color;
+                            }
+                        }
+                    }
+                }
+                else if (slotName == "Player")
+                {
+                    _paperdollLayers[z].Show();
+                    _paperdollLayers[z].Texture = entityTex;
+                    _paperdollLayers[z].SetTextureRect(0, 0, entityTex.Width / Options.Instance.Sprites.NormalFrames, entityTex.Height / Options.Instance.Sprites.Directions);
+                    _paperdollLayers[z].SizeToContents();
+                    _paperdollLayers[z].RenderColor = player.Color;
+                    _paperdollLayers[z].SetPosition(
+                        _paperdollContainer.Width / 2 - _paperdollLayers[z].Width / 2,
+                        _paperdollContainer.Height / 2 - _paperdollLayers[z].Height / 2
+                    );
+                }
+
+                if (string.IsNullOrWhiteSpace(paperdoll) && !string.IsNullOrWhiteSpace(_paperdollTextures[z]) && slotName != "Player")
+                {
+                    _paperdollLayers[z].Texture = null;
+                    _paperdollLayers[z].Hide();
+                    _paperdollTextures[z] = string.Empty;
+                }
+                else if (!string.IsNullOrWhiteSpace(paperdoll) && paperdoll != _paperdollTextures[z])
+                {
+                    var paperdollTex = Globals.ContentManager.GetTexture(TextureType.Paperdoll, paperdoll);
+
+                    _paperdollLayers[z].Texture = paperdollTex;
+                    if (paperdollTex != null)
+                    {
+                        _paperdollLayers[z].SetTextureRect(0, 0, paperdollTex.Width / Options.Instance.Sprites.NormalFrames, paperdollTex.Height / Options.Instance.Sprites.Directions);
+                        _paperdollLayers[z].SetSize(paperdollTex.Width / Options.Instance.Sprites.NormalFrames, paperdollTex.Height / Options.Instance.Sprites.Directions);
+                        _paperdollLayers[z].SetPosition(
+                            _paperdollContainer.Width / 2 - _paperdollLayers[z].Width / 2,
+                            _paperdollContainer.Height / 2 - _paperdollLayers[z].Height / 2
+                        );
+                    }
+
+                    _paperdollLayers[z].Show();
+                    _paperdollTextures[z] = paperdoll;
+                }
+            }
+
+            _currentSprite = player.Sprite ?? string.Empty;
+        }
+        else if (player.Sprite != _currentSprite && player.Face != _currentSprite)
+        {
+            foreach (var layer in _paperdollLayers)
+            {
+                layer.Hide();
+                layer.Texture = null;
+            }
+
+            _currentSprite = string.Empty;
+        }
+    }
+
+    private void UpdateEquipmentSlots(Player player)
+    {
+        int itemIndex = 0;
+        for (var slotIndex = 0; slotIndex < Options.Instance.Equipment.EquipmentSlots.Count; slotIndex++)
+        {
+            var slot = Options.Instance.Equipment.EquipmentSlots[slotIndex];
+            var itemSlots = player.MyEquipment.GetValueOrDefault(slotIndex) ?? new List<int>();
+
+            for (var i = 0; i < slot.MaxItems; i++)
+            {
+                if (itemIndex >= _equipmentItems.Count)
+                    break;
+
+                var itemIds = new List<Guid>();
+                var props = new List<ItemProperties>();
+
+                if (i < itemSlots.Count && itemSlots[i] >= 0 && itemSlots[i] < Options.Instance.Player.MaxInventory)
+                {
+                    var invItem = player.Inventory[itemSlots[i]];
+                    if (invItem.ItemId != Guid.Empty)
+                    {
+                        itemIds.Add(invItem.ItemId);
+                        props.Add(invItem.ItemProperties);
+                    }
+                }
+
+                _equipmentItems[itemIndex].Update(itemIds, props);
+                itemIndex++;
+            }
+        }
     }
 
     private void SortButton_Clicked(Base sender, MouseButtonState arguments)
@@ -379,6 +645,18 @@ public partial class InventoryWindow : Window
             _lastH = Height;
             RecomputeLayout();
         }
+
+        var player = Globals.Me;
+        if (player == null)
+        {
+            return;
+        }
+
+        _characterName.SetText(player.Name ?? string.Empty);
+        _characterLevelAndClass.SetText(Strings.Character.LevelAndClass.ToString(player.Level, ClassDescriptor.GetName(player.Class)));
+
+        UpdatePaperdoll(player);
+        UpdateEquipmentSlots(player);
 
         var query = _searchBox.Text;
         var asc = _sortAscending;

--- a/Intersect.Client.Core/Localization/Strings.cs
+++ b/Intersect.Client.Core/Localization/Strings.cs
@@ -585,6 +585,36 @@ public static partial class Strings
         public static LocalizedString NothingToGain = "Breaking this item yields no materials.";
     }
 
+    public partial struct Fishing
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString WindowTitle = "Fishing";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Hook = "Hook";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Cancel = "Cancel";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString StageWaiting = "Waiting for a bite...";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString StageHooked = "Fish hooked!";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString StageResolving = "Reeling in...";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString StageCanceled = "Fishing canceled";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString StageTimer = "Bite Timer: {00}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString ResolveTimer = "Catch Timer: {00}";
+    }
+
     public partial struct Enchanting
     {
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]

--- a/Intersect.Client.Core/Localization/Strings.cs
+++ b/Intersect.Client.Core/Localization/Strings.cs
@@ -1157,6 +1157,9 @@ public static partial class Strings
         public static LocalizedString Manasteal = @"Manasteal: {00}%";
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString BasicAttackDamage = @"Basic Damage: {00} | True: {01}-{02}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public static LocalizedString Points = @"Points: {00}";
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
@@ -1170,6 +1173,12 @@ public static partial class Strings
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public static LocalizedString Tenacity = @"Tenacity: {00}%";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString FlatDamage = @"Damage Bonus: {00}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString FlatCures = @"Healing Bonus: {00}";
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public static LocalizedString Title = @"Character Information";
@@ -1310,13 +1319,14 @@ public static partial class Strings
         public static LocalizedString AttackWhileCastingDeny = @"You cannot attack while casting a spell.";
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-        public static Dictionary<Stat, LocalizedString> Stats = new() {
+        public static Dictionary<Stat, LocalizedString> Stats = new()
+        {
             { Stat.Attack, @"Attack" },
             { Stat.Intelligence, @"Intelligence" },
             { Stat.Defense, @"Defense" },
             { Stat.Vitality, @"Vitality" },
-            { Stat.Agility, @"Agility" },
             { Stat.Speed, @"Speed" },
+            { Stat.Agility, @"Agility" },
         };
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
@@ -2267,6 +2277,8 @@ If you are sure you want to hand over your guild enter '\c{{#ff8080}}{02}\c{{}}'
             {11, @"Armor Penetration:"},
             {12, @"Damage Reduction:"},
             {13, @"Damage Reflect:"},
+            {14, @"Damage Bonus:"},
+            {15, @"Healing Bonus:"},
         };
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]

--- a/Intersect.Client.Core/Networking/PacketHandler.cs
+++ b/Intersect.Client.Core/Networking/PacketHandler.cs
@@ -1200,6 +1200,50 @@ internal sealed partial class PacketHandler
         }
     }
 
+    public void HandlePacket(IPacketSender packetSender, EntityFishingPacket packet)
+    {
+        var id = packet.Id;
+        var type = packet.Type;
+        var mapId = packet.MapId;
+
+        Entity en = null;
+        if (type < EntityType.Event)
+        {
+            if (!Globals.Entities.ContainsKey(id))
+            {
+                return;
+            }
+
+            en = Globals.Entities[id];
+        }
+        else
+        {
+            var entityMap = MapInstance.Get(mapId);
+            if (entityMap == null)
+            {
+                return;
+            }
+
+            if (!entityMap.LocalEntities.ContainsKey(id))
+            {
+                return;
+            }
+
+            en = entityMap.LocalEntities[id];
+        }
+
+        if (en == null)
+        {
+            return;
+        }
+
+        en.IsFishing = packet.IsFishing;
+        en.FishingStageIndex = packet.Stage;
+        en.IsFishingRodPressed = packet.IsPressed;
+        en.FishingStageTimer = Timing.Global.Milliseconds;
+        en.FishingStageDuration = Options.Instance.Sprites.IdleFrameDuration;
+    }
+
     //EntityDiePacket
     public void HandlePacket(IPacketSender packetSender, EntityDiePacket packet)
     {
@@ -1569,6 +1613,32 @@ internal sealed partial class PacketHandler
     public void HandlePacket(IPacketSender packetSender, GlobalCooldownPacket packet)
     {
         Globals.Me.GlobalCooldown = Timing.Global.Milliseconds + packet.GlobalCooldown;
+    }
+
+    public void HandlePacket(IPacketSender packetSender, StartFishingPacket packet)
+    {
+        Globals.Me?.StartFishing(
+            packet.FishId,
+            Timing.Global.Milliseconds + packet.StageTimer,
+            Timing.Global.Milliseconds + packet.ResolveTimer,
+            packet.Stage,
+            packet.CancelRequested
+        );
+    }
+
+    public void HandlePacket(IPacketSender packetSender, ResolveFishingPacket packet)
+    {
+        Globals.Me?.ResolveFishing(
+            packet.FishId,
+            Timing.Global.Milliseconds + packet.ResolveTimer,
+            packet.CancelRequested,
+            packet.Canceled
+        );
+    }
+
+    public void HandlePacket(IPacketSender packetSender, StopFishingPacket packet)
+    {
+        Globals.Me?.StopFishing(packet.Canceled);
     }
 
     //ExperiencePacket

--- a/Intersect.Client.Core/Networking/PacketSender.cs
+++ b/Intersect.Client.Core/Networking/PacketSender.cs
@@ -576,4 +576,29 @@ public static partial class PacketSender
         Network.SendPacket(new TargetPacket(targetId));
     }
 
+    public static void SendFishingCast()
+    {
+        Network.SendPacket(new FishingPacket());
+    }
+
+    public static void SendFishingSpot()
+    {
+        Network.SendPacket(new SendFishingSpot());
+    }
+
+    public static void SendSuccessFishing()
+    {
+        Network.SendPacket(new SendSuccessFishing());
+    }
+
+    public static void SendCancelFishing()
+    {
+        Network.SendPacket(new SendCancelFishing());
+    }
+
+    public static void SendFailedFishing()
+    {
+        Network.SendPacket(new SendFailedFishing());
+    }
+
 }

--- a/Intersect.Client.Framework/Entities/SpriteAnimations.cs
+++ b/Intersect.Client.Framework/Entities/SpriteAnimations.cs
@@ -8,4 +8,5 @@ public enum SpriteAnimations
     Shoot,
     Cast,
     Weapon,
+    Fishing,
 }

--- a/Intersect.Client.Framework/Gwen/Input/InputHandler.cs
+++ b/Intersect.Client.Framework/Gwen/Input/InputHandler.cs
@@ -420,7 +420,7 @@ public static partial class InputHandler
 
         if (KeyData.SetMouseButtonState(mouseButton, pressed))
         {
-            hoveredControl.InputMouseButtonState(MouseButton.Left, mousePosition, pressed);
+            hoveredControl.InputMouseButtonState(mouseButton, mousePosition, pressed);
         }
 
         // Double click.

--- a/Intersect.Editor/Forms/DockingElements/frmMapLayers.Designer.cs
+++ b/Intersect.Editor/Forms/DockingElements/frmMapLayers.Designer.cs
@@ -40,11 +40,15 @@ namespace Intersect.Editor.Forms.DockingElements
             this.cmbTilesets = new DarkUI.Controls.DarkComboBox();
             cmbAttributeType = new DarkUI.Controls.DarkComboBox();
             this.grpResource = new DarkUI.Controls.DarkGroupBox();
+            this.grpFishingSpot = new DarkUI.Controls.DarkGroupBox();
             this.grpZResource = new DarkUI.Controls.DarkGroupBox();
             this.rbLevel2 = new DarkUI.Controls.DarkRadioButton();
             this.rbLevel1 = new DarkUI.Controls.DarkRadioButton();
             this.cmbResourceAttribute = new DarkUI.Controls.DarkComboBox();
             this.lblResource = new System.Windows.Forms.Label();
+            this.cmbFishingSpot = new DarkUI.Controls.DarkComboBox();
+            this.lblFishingSpot = new System.Windows.Forms.Label();
+            this.chkFishingSpotBlocked = new DarkUI.Controls.DarkCheckBox();
             this.grpItem = new DarkUI.Controls.DarkGroupBox();
             this.nudItemQuantity = new DarkUI.Controls.DarkNumericUpDown();
             this.cmbItemAttribute = new DarkUI.Controls.DarkComboBox();
@@ -145,6 +149,7 @@ namespace Intersect.Editor.Forms.DockingElements
             this.lblItemRespawnTime = new System.Windows.Forms.Label();
             this.tooltips = new System.Windows.Forms.ToolTip(this.components);
             this.grpResource.SuspendLayout();
+            this.grpFishingSpot.SuspendLayout();
             this.grpZResource.SuspendLayout();
             this.grpItem.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.nudItemQuantity)).BeginInit();
@@ -299,6 +304,22 @@ namespace Intersect.Editor.Forms.DockingElements
             this.grpResource.Text = "Resource";
             this.grpResource.Visible = false;
             //
+            // grpFishingSpot
+            //
+            this.grpFishingSpot.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(45)))), ((int)(((byte)(48)))));
+            this.grpFishingSpot.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
+            this.grpFishingSpot.Controls.Add(this.chkFishingSpotBlocked);
+            this.grpFishingSpot.Controls.Add(this.cmbFishingSpot);
+            this.grpFishingSpot.Controls.Add(this.lblFishingSpot);
+            this.grpFishingSpot.ForeColor = System.Drawing.Color.Gainsboro;
+            this.grpFishingSpot.Location = new System.Drawing.Point(8, 42);
+            this.grpFishingSpot.Name = "grpFishingSpot";
+            this.grpFishingSpot.Size = new System.Drawing.Size(250, 90);
+            this.grpFishingSpot.TabIndex = 32;
+            this.grpFishingSpot.TabStop = false;
+            this.grpFishingSpot.Text = "Fishing Spot";
+            this.grpFishingSpot.Visible = false;
+            //
             // grpZResource
             //
             this.grpZResource.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(45)))), ((int)(((byte)(45)))), ((int)(((byte)(48)))));
@@ -363,6 +384,44 @@ namespace Intersect.Editor.Forms.DockingElements
             this.lblResource.Size = new System.Drawing.Size(56, 13);
             this.lblResource.TabIndex = 10;
             this.lblResource.Text = "Resource:";
+            //
+            // cmbFishingSpot
+            //
+            this.cmbFishingSpot.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
+            this.cmbFishingSpot.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(90)))), ((int)(((byte)(90)))), ((int)(((byte)(90)))));
+            this.cmbFishingSpot.BorderStyle = System.Windows.Forms.ButtonBorderStyle.Solid;
+            this.cmbFishingSpot.ButtonColor = System.Drawing.Color.FromArgb(((int)(((byte)(43)))), ((int)(((byte)(43)))), ((int)(((byte)(43)))));
+            this.cmbFishingSpot.DrawDropdownHoverOutline = false;
+            this.cmbFishingSpot.DrawFocusRectangle = false;
+            this.cmbFishingSpot.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
+            this.cmbFishingSpot.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmbFishingSpot.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.cmbFishingSpot.ForeColor = System.Drawing.Color.Gainsboro;
+            this.cmbFishingSpot.FormattingEnabled = true;
+            this.cmbFishingSpot.Location = new System.Drawing.Point(17, 36);
+            this.cmbFishingSpot.Name = "cmbFishingSpot";
+            this.cmbFishingSpot.Size = new System.Drawing.Size(222, 21);
+            this.cmbFishingSpot.TabIndex = 21;
+            this.cmbFishingSpot.Text = null;
+            this.cmbFishingSpot.TextPadding = new System.Windows.Forms.Padding(2);
+            //
+            // lblFishingSpot
+            //
+            this.lblFishingSpot.AutoSize = true;
+            this.lblFishingSpot.Location = new System.Drawing.Point(14, 16);
+            this.lblFishingSpot.Name = "lblFishingSpot";
+            this.lblFishingSpot.Size = new System.Drawing.Size(68, 13);
+            this.lblFishingSpot.TabIndex = 22;
+            this.lblFishingSpot.Text = "Fishing Spot";
+            //
+            // chkFishingSpotBlocked
+            //
+            this.chkFishingSpotBlocked.AutoSize = true;
+            this.chkFishingSpotBlocked.Location = new System.Drawing.Point(17, 65);
+            this.chkFishingSpotBlocked.Name = "chkFishingSpotBlocked";
+            this.chkFishingSpotBlocked.Size = new System.Drawing.Size(65, 17);
+            this.chkFishingSpotBlocked.TabIndex = 23;
+            this.chkFishingSpotBlocked.Text = "Blocked";
             //
             // grpItem
             //
@@ -1245,6 +1304,7 @@ namespace Intersect.Editor.Forms.DockingElements
             this.pnlAttributes.Controls.Add(this.grpSound);
             this.pnlAttributes.Controls.Add(this.grpZDimension);
             this.pnlAttributes.Controls.Add(this.grpItem);
+            this.pnlAttributes.Controls.Add(this.grpFishingSpot);
             this.pnlAttributes.Controls.Add(this.grpResource);
             this.pnlAttributes.Dock = System.Windows.Forms.DockStyle.Fill;
             this.pnlAttributes.Location = new System.Drawing.Point(0, 0);
@@ -1712,6 +1772,8 @@ namespace Intersect.Editor.Forms.DockingElements
             this.Load += new System.EventHandler(this.frmMapLayers_Load);
             this.grpResource.ResumeLayout(false);
             this.grpResource.PerformLayout();
+            this.grpFishingSpot.ResumeLayout(false);
+            this.grpFishingSpot.PerformLayout();
             this.grpZResource.ResumeLayout(false);
             this.grpZResource.PerformLayout();
             this.grpItem.ResumeLayout(false);
@@ -1814,6 +1876,10 @@ namespace Intersect.Editor.Forms.DockingElements
         public Controls.LightEditorCtrl lightEditor;
         private DarkComboBox cmbResourceAttribute;
         private System.Windows.Forms.Label lblResource;
+        private DarkGroupBox grpFishingSpot;
+        private DarkComboBox cmbFishingSpot;
+        private System.Windows.Forms.Label lblFishingSpot;
+        private DarkCheckBox chkFishingSpotBlocked;
         private DarkComboBox cmbItemAttribute;
         private DarkComboBox cmbWarpMap;
         private DarkButton btnVisualMapSelector;

--- a/Intersect.Editor/Forms/DockingElements/frmMapLayers.cs
+++ b/Intersect.Editor/Forms/DockingElements/frmMapLayers.cs
@@ -5,6 +5,7 @@ using Intersect.Editor.General;
 using Intersect.Editor.Localization;
 using Intersect.Enums;
 using Intersect.Framework.Core.GameObjects.Animations;
+using Intersect.Framework.Core.GameObjects.Fishing;
 using Intersect.Framework.Core.GameObjects.Items;
 using Intersect.Framework.Core.GameObjects.Mapping.Tilesets;
 using Intersect.Framework.Core.GameObjects.Maps;
@@ -462,6 +463,7 @@ public partial class FrmMapLayers : DockContent
         grpWarp.Visible = false;
         grpSound.Visible = false;
         grpResource.Visible = false;
+        grpFishingSpot.Visible = false;
         grpAnimation.Visible = false;
         grpSlide.Visible = false;
         grpCritter.Visible = false;
@@ -487,6 +489,7 @@ public partial class FrmMapLayers : DockContent
         {MapAttributeType.Item,Strings.Attributes.ItemSpawn},
         {MapAttributeType.NpcAvoid,Strings.Attributes.NpcAvoid},
         {MapAttributeType.Resource,Strings.Attributes.ResourceSpawn},
+        {MapAttributeType.FishingSpot,Strings.Attributes.FishingSpot},
         {MapAttributeType.Sound,Strings.Attributes.MapSound},
         {MapAttributeType.Slide,Strings.Attributes.Slide},
         {MapAttributeType.Warp,Strings.Attributes.Warp},
@@ -570,6 +573,17 @@ public partial class FrmMapLayers : DockContent
                     cmbResourceAttribute.SelectedIndex = 0;
                 }
 
+                break;
+            case MapAttributeType.FishingSpot:
+                grpFishingSpot.Visible = true;
+                cmbFishingSpot.Items.Clear();
+                cmbFishingSpot.Items.AddRange(FishingSpotBase.Names);
+                if (cmbFishingSpot.Items.Count > 0)
+                {
+                    cmbFishingSpot.SelectedIndex = 0;
+                }
+
+                chkFishingSpotBlocked.Checked = false;
                 break;
             case MapAttributeType.Animation:
                 grpAnimation.Visible = true;
@@ -659,6 +673,9 @@ public partial class FrmMapLayers : DockContent
             case MapAttributeType.Resource:
                 return CreateResourceAttribute();
 
+            case MapAttributeType.FishingSpot:
+                return CreateFishingSpotAttribute();
+
             case MapAttributeType.Animation:
                 return CreateAnimationAttribute();
 
@@ -721,6 +738,14 @@ public partial class FrmMapLayers : DockContent
         resourceAttribute.ResourceId = ResourceDescriptor.IdFromList(cmbResourceAttribute.SelectedIndex);
         resourceAttribute.SpawnLevel = (byte)(rbLevel1.Checked ? 0 : 1);
         return resourceAttribute;
+    }
+
+    private MapFishingSpotAttribute CreateFishingSpotAttribute()
+    {
+        var fishingSpotAttribute = (MapFishingSpotAttribute)MapAttribute.CreateAttribute(MapAttributeType.FishingSpot);
+        fishingSpotAttribute.FishingSpotType = FishingSpotBase.IdFromList(cmbFishingSpot.SelectedIndex);
+        fishingSpotAttribute.IsBlocked = chkFishingSpotBlocked.Checked;
+        return fishingSpotAttribute;
     }
 
     private MapAnimationAttribute CreateAnimationAttribute()

--- a/Intersect.Editor/Forms/Editors/frmDynamicRequirements.cs
+++ b/Intersect.Editor/Forms/Editors/frmDynamicRequirements.cs
@@ -1,4 +1,4 @@
-﻿using Intersect.Editor.Core;
+using Intersect.Editor.Core;
 using Intersect.Editor.Forms.Editors.Events.Event_Commands;
 using Intersect.Editor.Localization;
 using Intersect.Framework.Core.GameObjects.Conditions;
@@ -14,6 +14,8 @@ public enum RequirementType
 
     Resource,
 
+  
+
     Spell,
 
     Event,
@@ -28,7 +30,9 @@ public enum RequirementType
 
     NpcCanBeAttacked,
 
-    Craft
+    Craft,
+    Fish,
+    FishingSpot
 
 }
 
@@ -68,6 +72,10 @@ public partial class FrmDynamicRequirements : Form
                 lblInstructions.Text = Strings.DynamicRequirements.instructionsresource;
 
                 break;
+            case RequirementType.Fish:
+                lblInstructions.Text = Strings.DynamicRequirements.instructionsfish;
+
+                break;
             case RequirementType.Spell:
                 lblInstructions.Text = Strings.DynamicRequirements.instructionsspell;
 
@@ -98,6 +106,10 @@ public partial class FrmDynamicRequirements : Form
                 break;
             case RequirementType.Craft:
                 lblInstructions.Text = Strings.DynamicRequirements.instructionscraft;
+
+                break;
+            case RequirementType.FishingSpot:
+                lblInstructions.Text = Strings.DynamicRequirements.instructionsfishingspot;
 
                 break;
             default:

--- a/Intersect.Editor/Forms/Editors/frmFishes.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/frmFishes.Designer.cs
@@ -1,0 +1,891 @@
+using DarkUI.Controls;
+
+namespace Intersect.Editor.Forms.Editors
+{
+    partial class FrmFishes
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            components = new System.ComponentModel.Container();
+            var resources = new System.ComponentModel.ComponentResourceManager(typeof(FrmFishes));
+            btnCancel = new DarkButton();
+            btnSave = new DarkButton();
+            grpFishes = new DarkGroupBox();
+            btnClearSearch = new DarkButton();
+            txtSearch = new DarkTextBox();
+            lstGameObjects = new Controls.GameObjectList();
+            pnlContainer = new Panel();
+            grpGeneral = new DarkGroupBox();
+            lblName = new Label();
+            txtName = new DarkTextBox();
+            picFish = new PictureBox();
+            cmbEvent = new DarkComboBox();
+            btnAddFolder = new DarkButton();
+            lblCommonEvent = new Label();
+            lblFolder = new Label();
+            cmbFolder = new DarkComboBox();
+            nudChance = new DarkNumericUpDown();
+            cmbFishItem = new DarkComboBox();
+            lblFishItem = new Label();
+            lblChance = new Label();
+            grpParameters = new DarkGroupBox();
+            nudTimeChangeRangeSize = new DarkNumericUpDown();
+            lblTimeChangeRangeSize = new Label();
+            nudTimeChangeSpeed = new DarkNumericUpDown();
+            lblTimeChangeSpeed = new Label();
+            nudCoeffUnpredictability = new DarkNumericUpDown();
+            lblCoeffUnpredictability = new Label();
+            nudSpeedResize = new DarkNumericUpDown();
+            lblSpeedResize = new Label();
+            nudSpeedMove = new DarkNumericUpDown();
+            lblSpeedMove = new Label();
+            nudRangeSize = new DarkNumericUpDown();
+            lblRangeSize = new Label();
+            nudPosition = new DarkNumericUpDown();
+            lblPosition = new Label();
+            nudStrength = new DarkNumericUpDown();
+            lblStrength = new Label();
+            nudPushStrength = new DarkNumericUpDown();
+            lblPushStrength = new Label();
+            nudWeight = new DarkNumericUpDown();
+            lblWeight = new DarkLabel();
+            toolStrip = new DarkToolStrip();
+            toolStripItemNew = new ToolStripButton();
+            toolStripSeparator1 = new ToolStripSeparator();
+            toolStripItemDelete = new ToolStripButton();
+            toolStripSeparator2 = new ToolStripSeparator();
+            btnAlphabetical = new ToolStripButton();
+            toolStripSeparator4 = new ToolStripSeparator();
+            toolStripItemCopy = new ToolStripButton();
+            toolStripItemPaste = new ToolStripButton();
+            toolStripSeparator3 = new ToolStripSeparator();
+            toolStripItemUndo = new ToolStripButton();
+            btnFishRequirements = new DarkButton();
+            grpFishes.SuspendLayout();
+            pnlContainer.SuspendLayout();
+            grpGeneral.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)picFish).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)nudChance).BeginInit();
+            grpParameters.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)nudTimeChangeRangeSize).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)nudTimeChangeSpeed).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)nudCoeffUnpredictability).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)nudSpeedResize).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)nudSpeedMove).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)nudRangeSize).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)nudPosition).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)nudStrength).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)nudPushStrength).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)nudWeight).BeginInit();
+            toolStrip.SuspendLayout();
+            SuspendLayout();
+            // 
+            // btnCancel
+            // 
+            btnCancel.DialogResult = DialogResult.Cancel;
+            btnCancel.Location = new System.Drawing.Point(719, 487);
+            btnCancel.Margin = new Padding(4, 3, 4, 3);
+            btnCancel.Name = "btnCancel";
+            btnCancel.Padding = new Padding(6);
+            btnCancel.Size = new Size(201, 31);
+            btnCancel.TabIndex = 24;
+            btnCancel.Text = "Cancel";
+            btnCancel.Click += btnCancel_Click;
+            // 
+            // btnSave
+            // 
+            btnSave.Location = new System.Drawing.Point(514, 487);
+            btnSave.Margin = new Padding(4, 3, 4, 3);
+            btnSave.Name = "btnSave";
+            btnSave.Padding = new Padding(6);
+            btnSave.Size = new Size(197, 31);
+            btnSave.TabIndex = 23;
+            btnSave.Text = "Save";
+            btnSave.Click += btnSave_Click;
+            // 
+            // grpFishes
+            // 
+            grpFishes.BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
+            grpFishes.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            grpFishes.Controls.Add(btnClearSearch);
+            grpFishes.Controls.Add(txtSearch);
+            grpFishes.Controls.Add(lstGameObjects);
+            grpFishes.ForeColor = System.Drawing.Color.Gainsboro;
+            grpFishes.Location = new System.Drawing.Point(14, 42);
+            grpFishes.Margin = new Padding(4, 3, 4, 3);
+            grpFishes.Name = "grpFishes";
+            grpFishes.Padding = new Padding(4, 3, 4, 3);
+            grpFishes.Size = new Size(237, 435);
+            grpFishes.TabIndex = 22;
+            grpFishes.TabStop = false;
+            grpFishes.Text = "Fishes";
+            // 
+            // btnClearSearch
+            // 
+            btnClearSearch.Location = new System.Drawing.Point(209, 15);
+            btnClearSearch.Margin = new Padding(4, 3, 4, 3);
+            btnClearSearch.Name = "btnClearSearch";
+            btnClearSearch.Padding = new Padding(6);
+            btnClearSearch.Size = new Size(21, 23);
+            btnClearSearch.TabIndex = 28;
+            btnClearSearch.Text = "X";
+            btnClearSearch.Click += btnClearSearch_Click;
+            // 
+            // txtSearch
+            // 
+            txtSearch.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            txtSearch.BorderStyle = BorderStyle.FixedSingle;
+            txtSearch.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            txtSearch.Location = new System.Drawing.Point(7, 15);
+            txtSearch.Margin = new Padding(4, 3, 4, 3);
+            txtSearch.Name = "txtSearch";
+            txtSearch.Size = new Size(194, 23);
+            txtSearch.TabIndex = 27;
+            txtSearch.Text = "Search...";
+            txtSearch.Click += txtSearch_Click;
+            txtSearch.TextChanged += txtSearch_TextChanged;
+            txtSearch.Enter += txtSearch_Enter;
+            txtSearch.Leave += txtSearch_Leave;
+            // 
+            // lstGameObjects
+            // 
+            lstGameObjects.AllowDrop = true;
+            lstGameObjects.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            lstGameObjects.BorderStyle = BorderStyle.None;
+            lstGameObjects.ForeColor = System.Drawing.Color.Gainsboro;
+            lstGameObjects.HideSelection = false;
+            lstGameObjects.ImageIndex = 0;
+            lstGameObjects.LineColor = System.Drawing.Color.FromArgb(150, 150, 150);
+            lstGameObjects.Location = new System.Drawing.Point(7, 45);
+            lstGameObjects.Margin = new Padding(4, 3, 4, 3);
+            lstGameObjects.Name = "lstGameObjects";
+            lstGameObjects.SelectedImageIndex = 0;
+            lstGameObjects.Size = new Size(223, 377);
+            lstGameObjects.TabIndex = 26;
+            // 
+            // pnlContainer
+            // 
+            pnlContainer.Controls.Add(grpGeneral);
+            pnlContainer.Controls.Add(grpParameters);
+            pnlContainer.Location = new System.Drawing.Point(258, 42);
+            pnlContainer.Margin = new Padding(4, 3, 4, 3);
+            pnlContainer.Name = "pnlContainer";
+            pnlContainer.Size = new Size(662, 435);
+            pnlContainer.TabIndex = 31;
+            pnlContainer.Visible = false;
+            // 
+            // grpGeneral
+            // 
+            grpGeneral.BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
+            grpGeneral.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            grpGeneral.Controls.Add(btnFishRequirements);
+            grpGeneral.Controls.Add(lblName);
+            grpGeneral.Controls.Add(txtName);
+            grpGeneral.Controls.Add(picFish);
+            grpGeneral.Controls.Add(cmbEvent);
+            grpGeneral.Controls.Add(btnAddFolder);
+            grpGeneral.Controls.Add(lblCommonEvent);
+            grpGeneral.Controls.Add(lblFolder);
+            grpGeneral.Controls.Add(cmbFolder);
+            grpGeneral.Controls.Add(nudChance);
+            grpGeneral.Controls.Add(cmbFishItem);
+            grpGeneral.Controls.Add(lblFishItem);
+            grpGeneral.Controls.Add(lblChance);
+            grpGeneral.ForeColor = System.Drawing.Color.Gainsboro;
+            grpGeneral.Location = new System.Drawing.Point(6, 5);
+            grpGeneral.Margin = new Padding(4, 3, 4, 3);
+            grpGeneral.Name = "grpGeneral";
+            grpGeneral.Padding = new Padding(4, 3, 4, 3);
+            grpGeneral.Size = new Size(318, 418);
+            grpGeneral.TabIndex = 31;
+            grpGeneral.TabStop = false;
+            grpGeneral.Text = "General";
+            // 
+            // lblName
+            // 
+            lblName.AutoSize = true;
+            lblName.Location = new System.Drawing.Point(8, 25);
+            lblName.Margin = new Padding(4, 0, 4, 0);
+            lblName.Name = "lblName";
+            lblName.Size = new Size(42, 15);
+            lblName.TabIndex = 49;
+            lblName.Text = "Name:";
+            // 
+            // txtName
+            // 
+            txtName.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            txtName.BorderStyle = BorderStyle.FixedSingle;
+            txtName.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            txtName.Location = new System.Drawing.Point(116, 25);
+            txtName.Margin = new Padding(4, 3, 4, 3);
+            txtName.Name = "txtName";
+            txtName.Size = new Size(191, 23);
+            txtName.TabIndex = 48;
+            txtName.TextChanged += txtName_TextChanged;
+            // 
+            // picFish
+            // 
+            picFish.BackColor = System.Drawing.Color.Black;
+            picFish.Location = new System.Drawing.Point(200, 198);
+            picFish.Margin = new Padding(4, 3, 4, 3);
+            picFish.Name = "picFish";
+            picFish.Size = new Size(107, 106);
+            picFish.TabIndex = 47;
+            picFish.TabStop = false;
+            // 
+            // cmbEvent
+            // 
+            cmbEvent.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            cmbEvent.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            cmbEvent.BorderStyle = ButtonBorderStyle.Solid;
+            cmbEvent.ButtonColor = System.Drawing.Color.FromArgb(43, 43, 43);
+            cmbEvent.DrawDropdownHoverOutline = false;
+            cmbEvent.DrawFocusRectangle = false;
+            cmbEvent.DrawMode = DrawMode.OwnerDrawFixed;
+            cmbEvent.DropDownStyle = ComboBoxStyle.DropDownList;
+            cmbEvent.FlatStyle = FlatStyle.Flat;
+            cmbEvent.ForeColor = System.Drawing.Color.Gainsboro;
+            cmbEvent.FormattingEnabled = true;
+            cmbEvent.Location = new System.Drawing.Point(145, 128);
+            cmbEvent.Margin = new Padding(4, 3, 4, 3);
+            cmbEvent.Name = "cmbEvent";
+            cmbEvent.Size = new Size(162, 24);
+            cmbEvent.TabIndex = 43;
+            cmbEvent.Text = null;
+            cmbEvent.TextPadding = new Padding(2);
+            cmbEvent.SelectedIndexChanged += cmbEvent_SelectedIndexChanged;
+            // 
+            // btnAddFolder
+            // 
+            btnAddFolder.Location = new System.Drawing.Point(286, 58);
+            btnAddFolder.Margin = new Padding(4, 3, 4, 3);
+            btnAddFolder.Name = "btnAddFolder";
+            btnAddFolder.Padding = new Padding(6);
+            btnAddFolder.Size = new Size(21, 24);
+            btnAddFolder.TabIndex = 46;
+            btnAddFolder.Text = "+";
+            btnAddFolder.Click += btnAddFolder_Click;
+            // 
+            // lblCommonEvent
+            // 
+            lblCommonEvent.AutoSize = true;
+            lblCommonEvent.Location = new System.Drawing.Point(8, 130);
+            lblCommonEvent.Margin = new Padding(4, 0, 4, 0);
+            lblCommonEvent.Name = "lblCommonEvent";
+            lblCommonEvent.Size = new Size(93, 15);
+            lblCommonEvent.TabIndex = 42;
+            lblCommonEvent.Text = "Common Event:";
+            // 
+            // lblFolder
+            // 
+            lblFolder.AutoSize = true;
+            lblFolder.Location = new System.Drawing.Point(8, 60);
+            lblFolder.Margin = new Padding(4, 0, 4, 0);
+            lblFolder.Name = "lblFolder";
+            lblFolder.Size = new Size(43, 15);
+            lblFolder.TabIndex = 45;
+            lblFolder.Text = "Folder:";
+            // 
+            // cmbFolder
+            // 
+            cmbFolder.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            cmbFolder.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            cmbFolder.BorderStyle = ButtonBorderStyle.Solid;
+            cmbFolder.ButtonColor = System.Drawing.Color.FromArgb(43, 43, 43);
+            cmbFolder.DrawDropdownHoverOutline = false;
+            cmbFolder.DrawFocusRectangle = false;
+            cmbFolder.DrawMode = DrawMode.OwnerDrawFixed;
+            cmbFolder.DropDownStyle = ComboBoxStyle.DropDownList;
+            cmbFolder.FlatStyle = FlatStyle.Flat;
+            cmbFolder.ForeColor = System.Drawing.Color.Gainsboro;
+            cmbFolder.FormattingEnabled = true;
+            cmbFolder.Location = new System.Drawing.Point(116, 58);
+            cmbFolder.Margin = new Padding(4, 3, 4, 3);
+            cmbFolder.Name = "cmbFolder";
+            cmbFolder.Size = new Size(162, 24);
+            cmbFolder.TabIndex = 44;
+            cmbFolder.Text = null;
+            cmbFolder.TextPadding = new Padding(2);
+            cmbFolder.SelectedIndexChanged += cmbFolder_SelectedIndexChanged;
+            // 
+            // nudChance
+            // 
+            nudChance.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            nudChance.ForeColor = System.Drawing.Color.Gainsboro;
+            nudChance.Location = new System.Drawing.Point(116, 165);
+            nudChance.Margin = new Padding(4, 3, 4, 3);
+            nudChance.Name = "nudChance";
+            nudChance.Size = new Size(191, 23);
+            nudChance.TabIndex = 35;
+            nudChance.Value = new decimal(new int[] { 100, 0, 0, 0 });
+            nudChance.ValueChanged += ChangeValues;
+            // 
+            // cmbFishItem
+            // 
+            cmbFishItem.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            cmbFishItem.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            cmbFishItem.BorderStyle = ButtonBorderStyle.Solid;
+            cmbFishItem.ButtonColor = System.Drawing.Color.FromArgb(43, 43, 43);
+            cmbFishItem.DrawDropdownHoverOutline = false;
+            cmbFishItem.DrawFocusRectangle = false;
+            cmbFishItem.DrawMode = DrawMode.OwnerDrawFixed;
+            cmbFishItem.DropDownStyle = ComboBoxStyle.DropDownList;
+            cmbFishItem.FlatStyle = FlatStyle.Flat;
+            cmbFishItem.ForeColor = System.Drawing.Color.Gainsboro;
+            cmbFishItem.FormattingEnabled = true;
+            cmbFishItem.Location = new System.Drawing.Point(116, 93);
+            cmbFishItem.Margin = new Padding(4, 3, 4, 3);
+            cmbFishItem.Name = "cmbFishItem";
+            cmbFishItem.Size = new Size(191, 24);
+            cmbFishItem.TabIndex = 34;
+            cmbFishItem.Text = null;
+            cmbFishItem.TextPadding = new Padding(2);
+            cmbFishItem.SelectedIndexChanged += cmbResult_SelectedIndexChanged;
+            // 
+            // lblFishItem
+            // 
+            lblFishItem.AutoSize = true;
+            lblFishItem.Location = new System.Drawing.Point(8, 95);
+            lblFishItem.Margin = new Padding(4, 0, 4, 0);
+            lblFishItem.Name = "lblFishItem";
+            lblFishItem.Size = new Size(34, 15);
+            lblFishItem.TabIndex = 33;
+            lblFishItem.Text = "Item:";
+            // 
+            // lblChance
+            // 
+            lblChance.AutoSize = true;
+            lblChance.Location = new System.Drawing.Point(8, 165);
+            lblChance.Margin = new Padding(4, 0, 4, 0);
+            lblChance.Name = "lblChance";
+            lblChance.Size = new Size(68, 15);
+            lblChance.TabIndex = 3;
+            lblChance.Text = "Chance (%)";
+            // 
+            // grpParameters
+            // 
+            grpParameters.BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
+            grpParameters.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            grpParameters.Controls.Add(nudTimeChangeRangeSize);
+            grpParameters.Controls.Add(lblTimeChangeRangeSize);
+            grpParameters.Controls.Add(nudTimeChangeSpeed);
+            grpParameters.Controls.Add(lblTimeChangeSpeed);
+            grpParameters.Controls.Add(nudCoeffUnpredictability);
+            grpParameters.Controls.Add(lblCoeffUnpredictability);
+            grpParameters.Controls.Add(nudSpeedResize);
+            grpParameters.Controls.Add(lblSpeedResize);
+            grpParameters.Controls.Add(nudSpeedMove);
+            grpParameters.Controls.Add(lblSpeedMove);
+            grpParameters.Controls.Add(nudRangeSize);
+            grpParameters.Controls.Add(lblRangeSize);
+            grpParameters.Controls.Add(nudPosition);
+            grpParameters.Controls.Add(lblPosition);
+            grpParameters.Controls.Add(nudStrength);
+            grpParameters.Controls.Add(lblStrength);
+            grpParameters.Controls.Add(nudPushStrength);
+            grpParameters.Controls.Add(lblPushStrength);
+            grpParameters.Controls.Add(nudWeight);
+            grpParameters.Controls.Add(lblWeight);
+            grpParameters.ForeColor = System.Drawing.Color.Gainsboro;
+            grpParameters.Location = new System.Drawing.Point(331, 3);
+            grpParameters.Margin = new Padding(4, 3, 4, 3);
+            grpParameters.Name = "grpParameters";
+            grpParameters.Padding = new Padding(4, 3, 4, 3);
+            grpParameters.Size = new Size(318, 419);
+            grpParameters.TabIndex = 30;
+            grpParameters.TabStop = false;
+            grpParameters.Text = "Parameters";
+            // 
+            // nudTimeChangeRangeSize
+            // 
+            nudTimeChangeRangeSize.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            nudTimeChangeRangeSize.ForeColor = System.Drawing.Color.Gainsboro;
+            nudTimeChangeRangeSize.Location = new System.Drawing.Point(190, 340);
+            nudTimeChangeRangeSize.Margin = new Padding(4, 3, 4, 3);
+            nudTimeChangeRangeSize.Maximum = new decimal(new int[] { int.MaxValue, 0, 0, 0 });
+            nudTimeChangeRangeSize.Minimum = new decimal(new int[] { 100, 0, 0, 0 });
+            nudTimeChangeRangeSize.Name = "nudTimeChangeRangeSize";
+            nudTimeChangeRangeSize.Size = new Size(120, 23);
+            nudTimeChangeRangeSize.TabIndex = 66;
+            nudTimeChangeRangeSize.Value = new decimal(new int[] { 5000, 0, 0, 0 });
+            nudTimeChangeRangeSize.ValueChanged += ChangeValues;
+            // 
+            // lblTimeChangeRangeSize
+            // 
+            lblTimeChangeRangeSize.AutoSize = true;
+            lblTimeChangeRangeSize.Location = new System.Drawing.Point(16, 342);
+            lblTimeChangeRangeSize.Margin = new Padding(4, 0, 4, 0);
+            lblTimeChangeRangeSize.Name = "lblTimeChangeRangeSize";
+            lblTimeChangeRangeSize.Size = new Size(144, 15);
+            lblTimeChangeRangeSize.TabIndex = 65;
+            lblTimeChangeRangeSize.Text = "Timer Change Resize (MS)";
+            // 
+            // nudTimeChangeSpeed
+            // 
+            nudTimeChangeSpeed.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            nudTimeChangeSpeed.ForeColor = System.Drawing.Color.Gainsboro;
+            nudTimeChangeSpeed.Location = new System.Drawing.Point(190, 305);
+            nudTimeChangeSpeed.Margin = new Padding(4, 3, 4, 3);
+            nudTimeChangeSpeed.Maximum = new decimal(new int[] { int.MaxValue, 0, 0, 0 });
+            nudTimeChangeSpeed.Minimum = new decimal(new int[] { 100, 0, 0, 0 });
+            nudTimeChangeSpeed.Name = "nudTimeChangeSpeed";
+            nudTimeChangeSpeed.Size = new Size(120, 23);
+            nudTimeChangeSpeed.TabIndex = 64;
+            nudTimeChangeSpeed.Value = new decimal(new int[] { 2000, 0, 0, 0 });
+            nudTimeChangeSpeed.ValueChanged += ChangeValues;
+            // 
+            // lblTimeChangeSpeed
+            // 
+            lblTimeChangeSpeed.AutoSize = true;
+            lblTimeChangeSpeed.Location = new System.Drawing.Point(16, 307);
+            lblTimeChangeSpeed.Margin = new Padding(4, 0, 4, 0);
+            lblTimeChangeSpeed.Name = "lblTimeChangeSpeed";
+            lblTimeChangeSpeed.Size = new Size(144, 15);
+            lblTimeChangeSpeed.TabIndex = 63;
+            lblTimeChangeSpeed.Text = "Timer Change Speed (MS)";
+            // 
+            // nudCoeffUnpredictability
+            // 
+            nudCoeffUnpredictability.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            nudCoeffUnpredictability.ForeColor = System.Drawing.Color.Gainsboro;
+            nudCoeffUnpredictability.Location = new System.Drawing.Point(190, 270);
+            nudCoeffUnpredictability.Margin = new Padding(4, 3, 4, 3);
+            nudCoeffUnpredictability.Maximum = new decimal(new int[] { 200, 0, 0, 0 });
+            nudCoeffUnpredictability.Minimum = new decimal(new int[] { 200, 0, 0, int.MinValue });
+            nudCoeffUnpredictability.Name = "nudCoeffUnpredictability";
+            nudCoeffUnpredictability.Size = new Size(120, 23);
+            nudCoeffUnpredictability.TabIndex = 62;
+            nudCoeffUnpredictability.Value = new decimal(new int[] { 0, 0, 0, 0 });
+            nudCoeffUnpredictability.ValueChanged += ChangeValues;
+            // 
+            // lblCoeffUnpredictability
+            // 
+            lblCoeffUnpredictability.AutoSize = true;
+            lblCoeffUnpredictability.Location = new System.Drawing.Point(16, 272);
+            lblCoeffUnpredictability.Margin = new Padding(4, 0, 4, 0);
+            lblCoeffUnpredictability.Name = "lblCoeffUnpredictability";
+            lblCoeffUnpredictability.Size = new Size(144, 15);
+            lblCoeffUnpredictability.TabIndex = 61;
+            lblCoeffUnpredictability.Text = "Coeff Unpredictability (%)";
+            // 
+            // nudSpeedResize
+            // 
+            nudSpeedResize.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            nudSpeedResize.ForeColor = System.Drawing.Color.Gainsboro;
+            nudSpeedResize.Location = new System.Drawing.Point(148, 235);
+            nudSpeedResize.Margin = new Padding(4, 3, 4, 3);
+            nudSpeedResize.Maximum = new decimal(new int[] { 200, 0, 0, 0 });
+            nudSpeedResize.Minimum = new decimal(new int[] { 200, 0, 0, int.MinValue });
+            nudSpeedResize.Name = "nudSpeedResize";
+            nudSpeedResize.Size = new Size(162, 23);
+            nudSpeedResize.TabIndex = 60;
+            nudSpeedResize.Value = new decimal(new int[] { 20, 0, 0, 0 });
+            nudSpeedResize.ValueChanged += ChangeValues;
+            // 
+            // lblSpeedResize
+            // 
+            lblSpeedResize.AutoSize = true;
+            lblSpeedResize.Location = new System.Drawing.Point(16, 237);
+            lblSpeedResize.Margin = new Padding(4, 0, 4, 0);
+            lblSpeedResize.Name = "lblSpeedResize";
+            lblSpeedResize.Size = new Size(74, 15);
+            lblSpeedResize.TabIndex = 59;
+            lblSpeedResize.Text = "Speed Resize";
+            // 
+            // nudSpeedMove
+            // 
+            nudSpeedMove.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            nudSpeedMove.ForeColor = System.Drawing.Color.Gainsboro;
+            nudSpeedMove.Location = new System.Drawing.Point(148, 200);
+            nudSpeedMove.Margin = new Padding(4, 3, 4, 3);
+            nudSpeedMove.Maximum = new decimal(new int[] { 200, 0, 0, 0 });
+            nudSpeedMove.Minimum = new decimal(new int[] { 200, 0, 0, int.MinValue });
+            nudSpeedMove.Name = "nudSpeedMove";
+            nudSpeedMove.Size = new Size(162, 23);
+            nudSpeedMove.TabIndex = 58;
+            nudSpeedMove.Value = new decimal(new int[] { 20, 0, 0, 0 });
+            nudSpeedMove.ValueChanged += ChangeValues;
+            // 
+            // lblSpeedMove
+            // 
+            lblSpeedMove.AutoSize = true;
+            lblSpeedMove.Location = new System.Drawing.Point(16, 202);
+            lblSpeedMove.Margin = new Padding(4, 0, 4, 0);
+            lblSpeedMove.Name = "lblSpeedMove";
+            lblSpeedMove.Size = new Size(72, 15);
+            lblSpeedMove.TabIndex = 57;
+            lblSpeedMove.Text = "Speed Move";
+            // 
+            // nudRangeSize
+            // 
+            nudRangeSize.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            nudRangeSize.ForeColor = System.Drawing.Color.Gainsboro;
+            nudRangeSize.Location = new System.Drawing.Point(148, 165);
+            nudRangeSize.Margin = new Padding(4, 3, 4, 3);
+            nudRangeSize.Name = "nudRangeSize";
+            nudRangeSize.Size = new Size(162, 23);
+            nudRangeSize.TabIndex = 56;
+            nudRangeSize.Value = new decimal(new int[] { 30, 0, 0, 0 });
+            nudRangeSize.ValueChanged += ChangeValues;
+            // 
+            // lblRangeSize
+            // 
+            lblRangeSize.AutoSize = true;
+            lblRangeSize.Location = new System.Drawing.Point(16, 167);
+            lblRangeSize.Margin = new Padding(4, 0, 4, 0);
+            lblRangeSize.Name = "lblRangeSize";
+            lblRangeSize.Size = new Size(63, 15);
+            lblRangeSize.TabIndex = 55;
+            lblRangeSize.Text = "Range Size";
+            // 
+            // nudPosition
+            // 
+            nudPosition.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            nudPosition.ForeColor = System.Drawing.Color.Gainsboro;
+            nudPosition.Location = new System.Drawing.Point(148, 130);
+            nudPosition.Margin = new Padding(4, 3, 4, 3);
+            nudPosition.Name = "nudPosition";
+            nudPosition.Size = new Size(162, 23);
+            nudPosition.TabIndex = 54;
+            nudPosition.Value = new decimal(new int[] { 0, 0, 0, 0 });
+            nudPosition.ValueChanged += ChangeValues;
+            // 
+            // lblPosition
+            // 
+            lblPosition.AutoSize = true;
+            lblPosition.Location = new System.Drawing.Point(16, 132);
+            lblPosition.Margin = new Padding(4, 0, 4, 0);
+            lblPosition.Name = "lblPosition";
+            lblPosition.Size = new Size(50, 15);
+            lblPosition.TabIndex = 53;
+            lblPosition.Text = "Position";
+            // 
+            // nudStrength
+            // 
+            nudStrength.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            nudStrength.ForeColor = System.Drawing.Color.Gainsboro;
+            nudStrength.Location = new System.Drawing.Point(148, 95);
+            nudStrength.Margin = new Padding(4, 3, 4, 3);
+            nudStrength.Maximum = new decimal(new int[] { 200, 0, 0, 0 });
+            nudStrength.Minimum = new decimal(new int[] { 200, 0, 0, int.MinValue });
+            nudStrength.Name = "nudStrength";
+            nudStrength.Size = new Size(162, 23);
+            nudStrength.TabIndex = 52;
+            nudStrength.Value = new decimal(new int[] { 20, 0, 0, 0 });
+            nudStrength.ValueChanged += ChangeValues;
+            // 
+            // lblStrength
+            // 
+            lblStrength.AutoSize = true;
+            lblStrength.Location = new System.Drawing.Point(16, 97);
+            lblStrength.Margin = new Padding(4, 0, 4, 0);
+            lblStrength.Name = "lblStrength";
+            lblStrength.Size = new Size(52, 15);
+            lblStrength.TabIndex = 51;
+            lblStrength.Text = "Strength";
+            // 
+            // nudPushStrength
+            // 
+            nudPushStrength.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            nudPushStrength.ForeColor = System.Drawing.Color.Gainsboro;
+            nudPushStrength.Location = new System.Drawing.Point(148, 60);
+            nudPushStrength.Margin = new Padding(4, 3, 4, 3);
+            nudPushStrength.Maximum = new decimal(new int[] { 200, 0, 0, 0 });
+            nudPushStrength.Minimum = new decimal(new int[] { 200, 0, 0, int.MinValue });
+            nudPushStrength.Name = "nudPushStrength";
+            nudPushStrength.Size = new Size(162, 23);
+            nudPushStrength.TabIndex = 50;
+            nudPushStrength.Value = new decimal(new int[] { 10, 0, 0, 0 });
+            nudPushStrength.ValueChanged += ChangeValues;
+            // 
+            // lblPushStrength
+            // 
+            lblPushStrength.AutoSize = true;
+            lblPushStrength.Location = new System.Drawing.Point(16, 62);
+            lblPushStrength.Margin = new Padding(4, 0, 4, 0);
+            lblPushStrength.Name = "lblPushStrength";
+            lblPushStrength.Size = new Size(81, 15);
+            lblPushStrength.TabIndex = 49;
+            lblPushStrength.Text = "Push Strength";
+            // 
+            // nudWeight
+            // 
+            nudWeight.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            nudWeight.ForeColor = System.Drawing.Color.Gainsboro;
+            nudWeight.Location = new System.Drawing.Point(148, 25);
+            nudWeight.Margin = new Padding(4, 3, 4, 3);
+            nudWeight.Maximum = new decimal(new int[] { 200, 0, 0, 0 });
+            nudWeight.Minimum = new decimal(new int[] { 200, 0, 0, int.MinValue });
+            nudWeight.Name = "nudWeight";
+            nudWeight.Size = new Size(162, 23);
+            nudWeight.TabIndex = 48;
+            nudWeight.Value = new decimal(new int[] { 1, 0, 0, 0 });
+            nudWeight.ValueChanged += ChangeValues;
+            // 
+            // lblWeight
+            // 
+            lblWeight.AutoSize = true;
+            lblWeight.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            lblWeight.Location = new System.Drawing.Point(16, 27);
+            lblWeight.Margin = new Padding(4, 0, 4, 0);
+            lblWeight.Name = "lblWeight";
+            lblWeight.Size = new Size(45, 15);
+            lblWeight.TabIndex = 47;
+            lblWeight.Tag = "";
+            lblWeight.Text = "Weight";
+            // 
+            // toolStrip
+            // 
+            toolStrip.AutoSize = false;
+            toolStrip.BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
+            toolStrip.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStrip.Items.AddRange(new ToolStripItem[] { toolStripItemNew, toolStripSeparator1, toolStripItemDelete, toolStripSeparator2, btnAlphabetical, toolStripSeparator4, toolStripItemCopy, toolStripItemPaste, toolStripSeparator3, toolStripItemUndo });
+            toolStrip.Location = new System.Drawing.Point(0, 0);
+            toolStrip.Name = "toolStrip";
+            toolStrip.Padding = new Padding(6, 0, 1, 0);
+            toolStrip.Size = new Size(932, 29);
+            toolStrip.TabIndex = 43;
+            toolStrip.Text = "toolStrip1";
+            // 
+            // toolStripItemNew
+            // 
+            toolStripItemNew.DisplayStyle = ToolStripItemDisplayStyle.Image;
+            toolStripItemNew.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripItemNew.Image = (Image)resources.GetObject("toolStripItemNew.Image");
+            toolStripItemNew.ImageTransparentColor = System.Drawing.Color.Magenta;
+            toolStripItemNew.Name = "toolStripItemNew";
+            toolStripItemNew.Size = new Size(23, 26);
+            toolStripItemNew.Text = "New";
+            toolStripItemNew.Click += toolStripItemNew_Click;
+            // 
+            // toolStripSeparator1
+            // 
+            toolStripSeparator1.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripSeparator1.Margin = new Padding(0, 0, 2, 0);
+            toolStripSeparator1.Name = "toolStripSeparator1";
+            toolStripSeparator1.Size = new Size(6, 29);
+            // 
+            // toolStripItemDelete
+            // 
+            toolStripItemDelete.DisplayStyle = ToolStripItemDisplayStyle.Image;
+            toolStripItemDelete.Enabled = false;
+            toolStripItemDelete.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripItemDelete.Image = (Image)resources.GetObject("toolStripItemDelete.Image");
+            toolStripItemDelete.ImageTransparentColor = System.Drawing.Color.Magenta;
+            toolStripItemDelete.Name = "toolStripItemDelete";
+            toolStripItemDelete.Size = new Size(23, 26);
+            toolStripItemDelete.Text = "Delete";
+            toolStripItemDelete.Click += toolStripItemDelete_Click;
+            // 
+            // toolStripSeparator2
+            // 
+            toolStripSeparator2.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripSeparator2.Margin = new Padding(0, 0, 2, 0);
+            toolStripSeparator2.Name = "toolStripSeparator2";
+            toolStripSeparator2.Size = new Size(6, 29);
+            // 
+            // btnAlphabetical
+            // 
+            btnAlphabetical.DisplayStyle = ToolStripItemDisplayStyle.Image;
+            btnAlphabetical.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            btnAlphabetical.Image = (Image)resources.GetObject("btnAlphabetical.Image");
+            btnAlphabetical.ImageTransparentColor = System.Drawing.Color.Magenta;
+            btnAlphabetical.Name = "btnAlphabetical";
+            btnAlphabetical.Size = new Size(23, 26);
+            btnAlphabetical.Text = "Order Chronologically";
+            btnAlphabetical.Click += btnAlphabetical_Click;
+            // 
+            // toolStripSeparator4
+            // 
+            toolStripSeparator4.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripSeparator4.Margin = new Padding(0, 0, 2, 0);
+            toolStripSeparator4.Name = "toolStripSeparator4";
+            toolStripSeparator4.Size = new Size(6, 29);
+            // 
+            // toolStripItemCopy
+            // 
+            toolStripItemCopy.DisplayStyle = ToolStripItemDisplayStyle.Image;
+            toolStripItemCopy.Enabled = false;
+            toolStripItemCopy.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripItemCopy.Image = (Image)resources.GetObject("toolStripItemCopy.Image");
+            toolStripItemCopy.ImageTransparentColor = System.Drawing.Color.Magenta;
+            toolStripItemCopy.Name = "toolStripItemCopy";
+            toolStripItemCopy.Size = new Size(23, 26);
+            toolStripItemCopy.Text = "Copy";
+            toolStripItemCopy.Click += toolStripItemCopy_Click;
+            // 
+            // toolStripItemPaste
+            // 
+            toolStripItemPaste.DisplayStyle = ToolStripItemDisplayStyle.Image;
+            toolStripItemPaste.Enabled = false;
+            toolStripItemPaste.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripItemPaste.Image = (Image)resources.GetObject("toolStripItemPaste.Image");
+            toolStripItemPaste.ImageTransparentColor = System.Drawing.Color.Magenta;
+            toolStripItemPaste.Name = "toolStripItemPaste";
+            toolStripItemPaste.Size = new Size(23, 26);
+            toolStripItemPaste.Text = "Paste";
+            toolStripItemPaste.Click += toolStripItemPaste_Click;
+            // 
+            // toolStripSeparator3
+            // 
+            toolStripSeparator3.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripSeparator3.Margin = new Padding(0, 0, 2, 0);
+            toolStripSeparator3.Name = "toolStripSeparator3";
+            toolStripSeparator3.Size = new Size(6, 29);
+            // 
+            // toolStripItemUndo
+            // 
+            toolStripItemUndo.DisplayStyle = ToolStripItemDisplayStyle.Image;
+            toolStripItemUndo.Enabled = false;
+            toolStripItemUndo.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripItemUndo.Image = (Image)resources.GetObject("toolStripItemUndo.Image");
+            toolStripItemUndo.ImageTransparentColor = System.Drawing.Color.Magenta;
+            toolStripItemUndo.Name = "toolStripItemUndo";
+            toolStripItemUndo.Size = new Size(23, 26);
+            toolStripItemUndo.Text = "Undo";
+            toolStripItemUndo.Click += toolStripItemUndo_Click;
+            // 
+            // btnFishRequirements
+            // 
+            btnFishRequirements.Location = new System.Drawing.Point(11, 385);
+            btnFishRequirements.Margin = new Padding(4, 3, 4, 3);
+            btnFishRequirements.Name = "btnFishRequirements";
+            btnFishRequirements.Padding = new Padding(6);
+            btnFishRequirements.Size = new Size(296, 27);
+            btnFishRequirements.TabIndex = 50;
+            btnFishRequirements.Text = "Fishing Requirements";
+            btnFishRequirements.Click += btnFishRequirements_Click;
+            // 
+            // FrmFishes
+            // 
+            AutoScaleDimensions = new SizeF(7F, 15F);
+            AutoScaleMode = AutoScaleMode.Font;
+            AutoSize = true;
+            BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
+            ClientSize = new Size(932, 526);
+            ControlBox = false;
+            Controls.Add(toolStrip);
+            Controls.Add(pnlContainer);
+            Controls.Add(btnCancel);
+            Controls.Add(btnSave);
+            Controls.Add(grpFishes);
+            FormBorderStyle = FormBorderStyle.FixedSingle;
+            KeyPreview = true;
+            Margin = new Padding(4, 3, 4, 3);
+            MaximizeBox = false;
+            MinimizeBox = false;
+            Name = "FrmFishes";
+            StartPosition = FormStartPosition.CenterScreen;
+            Text = "Fishes Editor";
+            Load += frmFishes_Load;
+            KeyDown += form_KeyDown;
+            grpFishes.ResumeLayout(false);
+            grpFishes.PerformLayout();
+            pnlContainer.ResumeLayout(false);
+            grpGeneral.ResumeLayout(false);
+            grpGeneral.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)picFish).EndInit();
+            ((System.ComponentModel.ISupportInitialize)nudChance).EndInit();
+            grpParameters.ResumeLayout(false);
+            grpParameters.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)nudTimeChangeRangeSize).EndInit();
+            ((System.ComponentModel.ISupportInitialize)nudTimeChangeSpeed).EndInit();
+            ((System.ComponentModel.ISupportInitialize)nudCoeffUnpredictability).EndInit();
+            ((System.ComponentModel.ISupportInitialize)nudSpeedResize).EndInit();
+            ((System.ComponentModel.ISupportInitialize)nudSpeedMove).EndInit();
+            ((System.ComponentModel.ISupportInitialize)nudRangeSize).EndInit();
+            ((System.ComponentModel.ISupportInitialize)nudPosition).EndInit();
+            ((System.ComponentModel.ISupportInitialize)nudStrength).EndInit();
+            ((System.ComponentModel.ISupportInitialize)nudPushStrength).EndInit();
+            ((System.ComponentModel.ISupportInitialize)nudWeight).EndInit();
+            toolStrip.ResumeLayout(false);
+            toolStrip.PerformLayout();
+            ResumeLayout(false);
+        }
+
+        private string ConvexText(string text)
+        {
+            return text.Replace(@"\n", "\r\n");
+        }
+
+        #endregion
+
+        private DarkButton btnCancel;
+        private DarkButton btnSave;
+        private DarkGroupBox grpFishes;
+        private System.Windows.Forms.Panel pnlContainer;
+        private DarkGroupBox grpGeneral;
+        private System.Windows.Forms.Label lblFishItem;
+        private System.Windows.Forms.Label lblChance;
+        private DarkGroupBox grpParameters;
+        private DarkToolStrip toolStrip;
+        private System.Windows.Forms.ToolStripButton toolStripItemNew;
+        private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
+        private System.Windows.Forms.ToolStripButton toolStripItemDelete;
+        private System.Windows.Forms.ToolStripSeparator toolStripSeparator2;
+        public System.Windows.Forms.ToolStripButton toolStripItemCopy;
+        public System.Windows.Forms.ToolStripButton toolStripItemPaste;
+        private System.Windows.Forms.ToolStripSeparator toolStripSeparator3;
+        public System.Windows.Forms.ToolStripButton toolStripItemUndo;
+        private DarkComboBox cmbFishItem;
+        private DarkNumericUpDown nudChance;
+        private DarkButton btnClearSearch;
+        private DarkTextBox txtSearch;
+        private System.Windows.Forms.ToolStripButton btnAlphabetical;
+        private System.Windows.Forms.ToolStripSeparator toolStripSeparator4;
+        private DarkButton btnAddFolder;
+        private System.Windows.Forms.Label lblFolder;
+        private DarkComboBox cmbFolder;
+        private Controls.GameObjectList lstGameObjects;
+        private System.Windows.Forms.Label lblCommonEvent;
+        private DarkComboBox cmbEvent;
+        private DarkNumericUpDown nudWeight;
+        private DarkLabel lblWeight;
+        private DarkNumericUpDown nudPushStrength;
+        private Label lblPushStrength;
+        private DarkNumericUpDown nudPosition;
+        private Label lblPosition;
+        private DarkNumericUpDown nudStrength;
+        private Label lblStrength;
+        private DarkNumericUpDown nudCoeffUnpredictability;
+        private Label lblCoeffUnpredictability;
+        private DarkNumericUpDown nudSpeedResize;
+        private Label lblSpeedResize;
+        private DarkNumericUpDown nudSpeedMove;
+        private Label lblSpeedMove;
+        private DarkNumericUpDown nudRangeSize;
+        private Label lblRangeSize;
+        private DarkNumericUpDown nudTimeChangeRangeSize;
+        private Label lblTimeChangeRangeSize;
+        private DarkNumericUpDown nudTimeChangeSpeed;
+        private Label lblTimeChangeSpeed;
+        private PictureBox picFish;
+        private Label lblName;
+        private DarkTextBox txtName;
+        private DarkButton btnFishRequirements;
+    }
+}

--- a/Intersect.Editor/Forms/Editors/frmFishes.cs
+++ b/Intersect.Editor/Forms/Editors/frmFishes.cs
@@ -1,0 +1,525 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows.Forms;
+using DarkUI.Forms;
+using Intersect.Editor.General;
+using Intersect.Editor.Localization;
+using Intersect.Editor.Networking;
+using Intersect.Enums;
+using Intersect.Models;
+using System.Drawing.Imaging;
+using Intersect.Utilities;
+using System.Drawing.Drawing2D;
+using Intersect.Editor.Core;
+using Graphics = System.Drawing.Graphics;
+using Intersect.Framework.Core.GameObjects.Fishing;
+using Intersect.Framework.Core.GameObjects.Items;
+using Intersect.Framework.Core.GameObjects.Events;
+
+namespace Intersect.Editor.Forms.Editors
+{
+
+    public partial class FrmFishes : EditorForm
+    {
+
+        private List<FishBase> mChanged = new List<FishBase>();
+
+        private string mCopiedItem;
+
+        private FishBase currentFishEdit;
+
+        private List<string> mKnownFolders = new List<string>();
+
+        private bool isLoaded = false;
+
+        public FrmFishes()
+        {
+            ApplyHooks();
+            InitializeComponent();
+            Icon = Program.Icon;
+
+            lstGameObjects.LostFocus += itemList_FocusChanged;
+            lstGameObjects.GotFocus += itemList_FocusChanged;
+            cmbFishItem.Items.Clear();
+            cmbFishItem.Items.Add(Strings.General.None);
+            cmbFishItem.Items.AddRange(ItemDescriptor.Names);
+
+            cmbEvent.Items.Clear();
+            cmbEvent.Items.Add(Strings.General.None);
+            cmbEvent.Items.AddRange(EventDescriptor.Names);
+
+            lstGameObjects.Init(UpdateToolStripItems, AssignEditorItem, toolStripItemNew_Click, toolStripItemCopy_Click, toolStripItemUndo_Click, toolStripItemPaste_Click, toolStripItemDelete_Click);
+
+        }
+        private void AssignEditorItem(Guid id)
+        {
+            currentFishEdit = FishBase.Get(id);
+
+            UpdateEditor();
+        }
+
+        protected override void GameObjectUpdatedDelegate(GameObjectType type)
+        {
+            if (type == GameObjectType.Fish)
+            {
+                InitEditor();
+                if (currentFishEdit != null && !DatabaseObject<FishBase>.Lookup.Values.Contains(currentFishEdit))
+                {
+                    currentFishEdit = null;
+                    UpdateEditor();
+                }
+            }
+        }
+
+        private void UpdateEditor()
+        {
+
+            if (currentFishEdit != null)
+            {
+                isLoaded = false;
+                pnlContainer.Show();
+
+                txtName.Text = currentFishEdit.Name;
+
+                cmbFolder.Text = currentFishEdit.Folder;
+
+                nudChance.Value = currentFishEdit.chance;
+                nudCoeffUnpredictability.Value = currentFishEdit.coeffUnpredictability;
+                nudPosition.Value = currentFishEdit.position;
+                nudPushStrength.Value = currentFishEdit.pushStrength;
+                nudRangeSize.Value = currentFishEdit.rangeSize;
+                nudSpeedMove.Value = currentFishEdit.speedMove;
+                nudSpeedResize.Value = currentFishEdit.speedChangeRangeSize;
+                nudStrength.Value = currentFishEdit.strength;
+                nudWeight.Value = currentFishEdit.weight;
+                nudTimeChangeRangeSize.Value = currentFishEdit.timeChangeRangeSize;
+                nudTimeChangeSpeed.Value = currentFishEdit.timeChangeSpeed;
+
+                cmbFishItem.SelectedIndex = ItemDescriptor.ListIndex(currentFishEdit.ItemId) + 1;
+
+                picFish.BackgroundImage?.Dispose();
+                picFish.BackgroundImage = null;
+                if (cmbFishItem.SelectedIndex > 0)
+                {
+                    DrawItemIcon(ItemDescriptor.Get(currentFishEdit.ItemId));
+                }
+
+                if (mChanged.IndexOf(currentFishEdit) == -1)
+                {
+                    mChanged.Add(currentFishEdit);
+                    currentFishEdit.MakeBackup();
+                }
+
+                cmbEvent.SelectedIndex = EventDescriptor.ListIndex(currentFishEdit.EventId) + 1;
+                isLoaded = true;
+            }
+            else
+            {
+                pnlContainer.Hide();
+            }
+
+            UpdateToolStripItems();
+        }
+
+        #region Button Save&Cancel
+        private void btnCancel_Click(object sender, EventArgs e)
+        {
+            foreach (var item in mChanged)
+            {
+                item.RestoreBackup();
+                item.DeleteBackup();
+            }
+
+            Hide();
+            Globals.CurrentEditor = -1;
+            Dispose();
+        }
+
+        private void btnSave_Click(object sender, EventArgs e)
+        {
+            //Send Changed items
+            foreach (var item in mChanged)
+            {
+                PacketSender.SendSaveObject(item);
+                item.DeleteBackup();
+            }
+
+            Hide();
+            Globals.CurrentEditor = -1;
+            Dispose();
+        }
+        #endregion
+
+        #region Tools
+
+        private void toolStripItemNew_Click(object sender, EventArgs e)
+        {
+            PacketSender.SendCreateObject(GameObjectType.Fish);
+        }
+
+        private void toolStripItemDelete_Click(object sender, EventArgs e)
+        {
+            if (currentFishEdit != null && lstGameObjects.Focused)
+            {
+                if (DarkMessageBox.ShowWarning(
+                        Strings.FishesEditor.deleteprompt, Strings.FishesEditor.deletetitle, DarkDialogButton.YesNo,
+                        Icon
+                    ) ==
+                    DialogResult.Yes)
+                {
+                    PacketSender.SendDeleteObject(currentFishEdit);
+                }
+            }
+        }
+
+        private void toolStripItemCopy_Click(object sender, EventArgs e)
+        {
+            if (currentFishEdit != null && lstGameObjects.Focused)
+            {
+                mCopiedItem = currentFishEdit.JsonData;
+                toolStripItemPaste.Enabled = true;
+            }
+        }
+
+        private void toolStripItemPaste_Click(object sender, EventArgs e)
+        {
+            if (currentFishEdit != null && mCopiedItem != null && lstGameObjects.Focused)
+            {
+                currentFishEdit.Load(mCopiedItem, true);
+                UpdateEditor();
+            }
+        }
+
+        private void toolStripItemUndo_Click(object sender, EventArgs e)
+        {
+            if (mChanged.Contains(currentFishEdit) && currentFishEdit != null)
+            {
+                if (DarkMessageBox.ShowWarning(
+                        Strings.FishesEditor.undoprompt, Strings.FishesEditor.undotitle, DarkDialogButton.YesNo,
+                        Icon
+                    ) ==
+                    DialogResult.Yes)
+                {
+                    currentFishEdit.RestoreBackup();
+                    UpdateEditor();
+                }
+            }
+        }
+
+        #endregion
+
+        #region Fields
+
+        private void cmbEvent_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            currentFishEdit.Event = EventDescriptor.Get(EventDescriptor.IdFromList(cmbEvent.SelectedIndex - 1));
+        }
+
+        private void txtName_TextChanged(object sender, EventArgs e)
+        {
+            currentFishEdit.Name = txtName.Text;
+            lstGameObjects.UpdateText(txtName.Text);
+        }
+        private void ChangeValues(object sender, EventArgs e)
+        {
+            if (!isLoaded) return;
+            currentFishEdit.chance = (int)nudChance.Value;
+            currentFishEdit.coeffUnpredictability = (int)nudCoeffUnpredictability.Value;
+            currentFishEdit.position = (int)nudPosition.Value;
+            currentFishEdit.pushStrength = (int)nudPushStrength.Value;
+            currentFishEdit.rangeSize = (int)nudRangeSize.Value;
+            currentFishEdit.speedMove = (int)nudSpeedMove.Value;
+            currentFishEdit.speedChangeRangeSize = (int)nudSpeedResize.Value;
+            currentFishEdit.strength = (int)nudStrength.Value;
+            currentFishEdit.weight = (int)nudWeight.Value;
+            currentFishEdit.timeChangeRangeSize = (int)nudTimeChangeRangeSize.Value;
+            currentFishEdit.timeChangeSpeed = (int)nudTimeChangeSpeed.Value;
+
+        }
+        private void cmbResult_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            currentFishEdit.ItemId = ItemDescriptor     .IdFromList(cmbFishItem.SelectedIndex - 1);
+            var itm = ItemDescriptor.Get(currentFishEdit.ItemId);
+            picFish.BackgroundImage?.Dispose();
+            picFish.BackgroundImage = null;
+            if (cmbFishItem.SelectedIndex > 0)
+            {
+                DrawItemIcon(ItemDescriptor.Get(currentFishEdit.ItemId));
+            }
+        }
+        private void DrawItemIcon(ItemDescriptor item)
+        {
+            Bitmap picItemBmp = new Bitmap(picFish.Width, picFish.Height);
+            Graphics gfx = Graphics.FromImage(picItemBmp);
+            gfx.FillRectangle(Brushes.Black, new Rectangle(0, 0, picFish.Width, picFish.Height));
+            if (item != null)
+            {
+                Image img = Image.FromFile("resources/items/" + TextUtils.NullToNone(item.Icon));
+                if (img == null)
+                {
+                    picFish.BackgroundImage = null;
+                    return;
+                }
+                ImageAttributes imgAttributes = new ImageAttributes();
+
+                // Microsoft, what the heck is this crap?
+                imgAttributes.SetColorMatrix(
+                    new ColorMatrix(
+                        new float[][]
+                        {
+                            new float[] { (float)item.Color.R / 255,  0,  0,  0, 0},  // Modify the red space
+                            new float[] {0, (float)item.Color.G / 255,  0,  0, 0},    // Modify the green space
+                            new float[] {0,  0, (float)item.Color.B / 255,  0, 0},    // Modify the blue space
+                            new float[] {0,  0,  0, (float)item.Color.A / 255, 0},    // Modify the alpha space
+                            new float[] {0, 0, 0, 0, 1}                                 // We're not adding any non-linear changes. Value of 1 at the end is a dummy value!
+                        }
+                    )
+                );
+
+                int[] size = new int[] { picFish.Size.Width, picFish.Size.Height };
+
+                picItemBmp = new Bitmap(img, size[0], size[1]);
+                picItemBmp = resizeImage(img, size[0], size[1], imgAttributes);
+
+                img.Dispose();
+                imgAttributes.Dispose();
+            }
+
+
+            picFish.BackgroundImage = picItemBmp;
+        }
+
+        Bitmap resizeImage(Image image, int width, int height, ImageAttributes imgAttributes)
+        {
+            var destinationRect = new Rectangle(0, 0, width, height);
+            var destinationImage = new Bitmap(width, height);
+
+            destinationImage.SetResolution(image.HorizontalResolution, image.VerticalResolution);
+
+            using (var graphics = Graphics.FromImage(destinationImage))
+            {
+                graphics.CompositingMode = CompositingMode.SourceCopy;
+                graphics.CompositingQuality = CompositingQuality.HighQuality;
+
+                using (var wrapMode = imgAttributes)
+                {
+                    wrapMode.SetWrapMode(WrapMode.TileFlipXY);
+                    graphics.DrawImage(image, destinationRect, 0, 0, image.Width, image.Height,
+                                       GraphicsUnit.Pixel, wrapMode);
+                }
+            }
+            return destinationImage;
+        }
+        #endregion
+
+        #region HotKeys
+
+        private void itemList_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Control)
+            {
+                if (e.KeyCode == Keys.Z)
+                {
+                    toolStripItemUndo_Click(null, null);
+                }
+                else if (e.KeyCode == Keys.V)
+                {
+                    toolStripItemPaste_Click(null, null);
+                }
+                else if (e.KeyCode == Keys.C)
+                {
+                    toolStripItemCopy_Click(null, null);
+                }
+            }
+            else
+            {
+                if (e.KeyCode == Keys.Delete)
+                {
+                    toolStripItemDelete_Click(null, null);
+                }
+            }
+        }
+
+        private void UpdateToolStripItems()
+        {
+            toolStripItemCopy.Enabled = currentFishEdit != null && lstGameObjects.Focused;
+            toolStripItemPaste.Enabled = currentFishEdit != null && mCopiedItem != null && lstGameObjects.Focused;
+            toolStripItemDelete.Enabled = currentFishEdit != null && lstGameObjects.Focused;
+            toolStripItemUndo.Enabled = currentFishEdit != null && lstGameObjects.Focused;
+        }
+
+        private void itemList_FocusChanged(object sender, EventArgs e)
+        {
+            UpdateToolStripItems();
+        }
+
+        private void form_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Control)
+            {
+                if (e.KeyCode == Keys.N)
+                {
+                    toolStripItemNew_Click(null, null);
+                }
+            }
+        }
+
+        #endregion
+
+        #region Localization
+
+        private void frmFishes_Load(object sender, EventArgs e)
+        {
+            InitLocalization();
+        }
+
+        private void InitLocalization()
+        {
+            Text = Strings.FishEditor.Title;
+            toolStripItemNew.Text = Strings.FishEditor.New;
+            toolStripItemDelete.Text = Strings.FishEditor.delete;
+            toolStripItemCopy.Text = Strings.FishEditor.copy;
+            toolStripItemPaste.Text = Strings.FishEditor.paste;
+            toolStripItemUndo.Text = Strings.FishEditor.undo;
+
+            grpFishes.Text = Strings.FishEditor.fishes;
+
+            grpGeneral.Text = Strings.FishEditor.general;
+            lblName.Text = Strings.FishEditor.name;
+            lblFishItem.Text = Strings.FishEditor.item;
+
+            grpParameters.Text = Strings.FishEditor.parameters;
+            lblCommonEvent.Text = Strings.FishEditor.commonevent;
+
+            //Searching/Sorting
+            btnAlphabetical.ToolTipText = Strings.FishEditor.sortalphabetically;
+            txtSearch.Text = Strings.FishEditor.searchplaceholder;
+            lblFolder.Text = Strings.FishEditor.folderlabel;
+
+            btnSave.Text = Strings.FishEditor.save;
+            btnCancel.Text = Strings.FishEditor.cancel;
+            lblChance.Text = Strings.FishEditor.chance;
+            lblCoeffUnpredictability.Text = Strings.FishEditor.coeffUnpredictability;
+            lblPosition.Text = Strings.FishEditor.position;
+            lblPushStrength.Text = Strings.FishEditor.pushStrength;
+            lblRangeSize.Text = Strings.FishEditor.rangeSize;
+            lblSpeedMove.Text = Strings.FishEditor.speedMove;
+            lblSpeedResize.Text = Strings.FishEditor.speedResize;
+            lblStrength.Text = Strings.FishEditor.strength;
+            lblTimeChangeRangeSize.Text = Strings.FishEditor.timeChangeRangeSize;
+            lblTimeChangeSpeed.Text = Strings.FishEditor.nudTimeChangeSpeed;
+            lblWeight.Text = Strings.FishEditor.weight;
+        }
+
+        #endregion
+
+        #region "Item List - Folders, Searching, Sorting, Etc"
+        public void InitEditor()
+        {
+            //Collect folders
+            var mFolders = new List<string>();
+            foreach (var itm in FishBase.Lookup)
+            {
+                if (!string.IsNullOrEmpty(((FishBase)itm.Value).Folder) &&
+                    !mFolders.Contains(((FishBase)itm.Value).Folder))
+                {
+                    mFolders.Add(((FishBase)itm.Value).Folder);
+                    if (!mKnownFolders.Contains(((FishBase)itm.Value).Folder))
+                    {
+                        mKnownFolders.Add(((FishBase)itm.Value).Folder);
+                    }
+                }
+            }
+
+            mFolders.Sort();
+            mKnownFolders.Sort();
+            cmbFolder.Items.Clear();
+            cmbFolder.Items.Add("");
+            cmbFolder.Items.AddRange(mKnownFolders.ToArray());
+
+            var items = FishBase.Lookup.OrderBy(p => p.Value?.Name).Select(pair => new KeyValuePair<Guid, KeyValuePair<string, string>>(pair.Key,
+                new KeyValuePair<string, string>(((FishBase)pair.Value)?.Name ?? Models.DatabaseObject<FishBase>.Deleted, ((FishBase)pair.Value)?.Folder ?? ""))).ToArray();
+            lstGameObjects.Repopulate(items, mFolders, btnAlphabetical.Checked, CustomSearch(), txtSearch.Text);
+        }
+
+        private void btnAddFolder_Click(object sender, EventArgs e)
+        {
+            var folderName = "";
+            var result = DarkInputBox.ShowInformation(
+                Strings.FishesEditor.folderprompt, Strings.FishesEditor.foldertitle, ref folderName,
+                DarkDialogButton.OkCancel
+            );
+
+            if (result == DialogResult.OK && !string.IsNullOrEmpty(folderName))
+            {
+                if (!cmbFolder.Items.Contains(folderName))
+                {
+                    currentFishEdit.Folder = folderName;
+                    lstGameObjects.ExpandFolder(folderName);
+                    InitEditor();
+                    cmbFolder.Text = folderName;
+                }
+            }
+        }
+
+        private void cmbFolder_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            currentFishEdit.Folder = cmbFolder.Text;
+            InitEditor();
+        }
+
+        private void btnAlphabetical_Click(object sender, EventArgs e)
+        {
+            btnAlphabetical.Checked = !btnAlphabetical.Checked;
+            InitEditor();
+        }
+
+        private void txtSearch_TextChanged(object sender, EventArgs e)
+        {
+            InitEditor();
+        }
+
+        private void txtSearch_Leave(object sender, EventArgs e)
+        {
+            if (string.IsNullOrWhiteSpace(txtSearch.Text))
+            {
+                txtSearch.Text = Strings.FishesEditor.searchplaceholder;
+            }
+        }
+
+        private void txtSearch_Enter(object sender, EventArgs e)
+        {
+            txtSearch.SelectAll();
+            txtSearch.Focus();
+        }
+
+        private void btnClearSearch_Click(object sender, EventArgs e)
+        {
+            txtSearch.Text = Strings.FishesEditor.searchplaceholder;
+        }
+
+        private bool CustomSearch()
+        {
+            return !string.IsNullOrWhiteSpace(txtSearch.Text) &&
+                   txtSearch.Text != Strings.FishesEditor.searchplaceholder;
+        }
+
+        private void txtSearch_Click(object sender, EventArgs e)
+        {
+            if (txtSearch.Text == Strings.FishesEditor.searchplaceholder)
+            {
+                txtSearch.SelectAll();
+            }
+        }
+
+        #endregion
+
+        private void btnFishRequirements_Click(object sender, EventArgs e)
+        {
+            var frm = new FrmDynamicRequirements(currentFishEdit.FishingRequirements, RequirementType.Fish);
+            frm.ShowDialog();   
+        }
+    }
+
+}

--- a/Intersect.Editor/Forms/Editors/frmFishes.resx
+++ b/Intersect.Editor/Forms/Editors/frmFishes.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/Intersect.Editor/Forms/Editors/frmFishingSpots.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/frmFishingSpots.Designer.cs
@@ -1,0 +1,622 @@
+using DarkUI.Controls;
+
+namespace Intersect.Editor.Forms.Editors
+{
+    partial class FrmFishingSpots
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            components = new System.ComponentModel.Container();
+            var resources = new System.ComponentModel.ComponentResourceManager(typeof(FrmFishingSpots));
+            btnCancel = new DarkButton();
+            btnSave = new DarkButton();
+            grpSpots = new DarkGroupBox();
+            btnClearSearch = new DarkButton();
+            txtSearch = new DarkTextBox();
+            lstGameObjects = new Controls.GameObjectList();
+            pnlContainer = new Panel();
+            grpGeneral = new DarkGroupBox();
+            nudFishingTimeMax = new DarkNumericUpDown();
+            lblTimeMax = new DarkLabel();
+            nudFishingTimeMin = new DarkNumericUpDown();
+            lblTimeMin = new DarkLabel();
+            btnAddFolder = new DarkButton();
+            lblFolder = new Label();
+            cmbFolder = new DarkComboBox();
+            lblName = new Label();
+            txtName = new DarkTextBox();
+            grpFishes = new DarkGroupBox();
+            btnRemoveFish = new DarkButton();
+            btnFishDown = new DarkButton();
+            btnFishUp = new DarkButton();
+            btnAddFish = new DarkButton();
+            cmbFishes = new DarkComboBox();
+            lblAddFish = new Label();
+            lstFishes = new ListBox();
+            toolStrip = new DarkToolStrip();
+            toolStripItemNew = new ToolStripButton();
+            toolStripSeparator1 = new ToolStripSeparator();
+            toolStripItemDelete = new ToolStripButton();
+            toolStripSeparator2 = new ToolStripSeparator();
+            btnAlphabetical = new ToolStripButton();
+            toolStripSeparator4 = new ToolStripSeparator();
+            toolStripItemCopy = new ToolStripButton();
+            toolStripItemPaste = new ToolStripButton();
+            toolStripSeparator3 = new ToolStripSeparator();
+            toolStripItemUndo = new ToolStripButton();
+            btnFishRequirements = new DarkButton();
+            grpSpots.SuspendLayout();
+            pnlContainer.SuspendLayout();
+            grpGeneral.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)nudFishingTimeMax).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)nudFishingTimeMin).BeginInit();
+            grpFishes.SuspendLayout();
+            toolStrip.SuspendLayout();
+            SuspendLayout();
+            // 
+            // btnCancel
+            // 
+            btnCancel.DialogResult = DialogResult.Cancel;
+            btnCancel.Location = new System.Drawing.Point(657, 456);
+            btnCancel.Margin = new Padding(4, 3, 4, 3);
+            btnCancel.Name = "btnCancel";
+            btnCancel.Padding = new Padding(6);
+            btnCancel.Size = new Size(201, 31);
+            btnCancel.TabIndex = 24;
+            btnCancel.Text = "Cancel";
+            btnCancel.Click += btnCancel_Click;
+            // 
+            // btnSave
+            // 
+            btnSave.Location = new System.Drawing.Point(453, 456);
+            btnSave.Margin = new Padding(4, 3, 4, 3);
+            btnSave.Name = "btnSave";
+            btnSave.Padding = new Padding(6);
+            btnSave.Size = new Size(197, 31);
+            btnSave.TabIndex = 23;
+            btnSave.Text = "Save";
+            btnSave.Click += btnSave_Click;
+            // 
+            // grpSpots
+            // 
+            grpSpots.BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
+            grpSpots.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            grpSpots.Controls.Add(btnClearSearch);
+            grpSpots.Controls.Add(txtSearch);
+            grpSpots.Controls.Add(lstGameObjects);
+            grpSpots.ForeColor = System.Drawing.Color.Gainsboro;
+            grpSpots.Location = new System.Drawing.Point(14, 42);
+            grpSpots.Margin = new Padding(4, 3, 4, 3);
+            grpSpots.Name = "grpSpots";
+            grpSpots.Padding = new Padding(4, 3, 4, 3);
+            grpSpots.Size = new Size(237, 399);
+            grpSpots.TabIndex = 22;
+            grpSpots.TabStop = false;
+            grpSpots.Text = "Spots";
+            // 
+            // btnClearSearch
+            // 
+            btnClearSearch.Location = new System.Drawing.Point(209, 18);
+            btnClearSearch.Margin = new Padding(4, 3, 4, 3);
+            btnClearSearch.Name = "btnClearSearch";
+            btnClearSearch.Padding = new Padding(6);
+            btnClearSearch.Size = new Size(21, 23);
+            btnClearSearch.TabIndex = 25;
+            btnClearSearch.Text = "X";
+            btnClearSearch.Click += btnClearSearch_Click;
+            // 
+            // txtSearch
+            // 
+            txtSearch.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            txtSearch.BorderStyle = BorderStyle.FixedSingle;
+            txtSearch.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            txtSearch.Location = new System.Drawing.Point(7, 18);
+            txtSearch.Margin = new Padding(4, 3, 4, 3);
+            txtSearch.Name = "txtSearch";
+            txtSearch.Size = new Size(194, 23);
+            txtSearch.TabIndex = 24;
+            txtSearch.Text = "Search...";
+            txtSearch.Click += txtSearch_Click;
+            txtSearch.TextChanged += txtSearch_TextChanged;
+            txtSearch.Enter += txtSearch_Enter;
+            txtSearch.Leave += txtSearch_Leave;
+            // 
+            // lstGameObjects
+            // 
+            lstGameObjects.AllowDrop = true;
+            lstGameObjects.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            lstGameObjects.BorderStyle = BorderStyle.None;
+            lstGameObjects.ForeColor = System.Drawing.Color.Gainsboro;
+            lstGameObjects.HideSelection = false;
+            lstGameObjects.ImageIndex = 0;
+            lstGameObjects.LineColor = System.Drawing.Color.FromArgb(150, 150, 150);
+            lstGameObjects.Location = new System.Drawing.Point(7, 48);
+            lstGameObjects.Margin = new Padding(4, 3, 4, 3);
+            lstGameObjects.Name = "lstGameObjects";
+            lstGameObjects.SelectedImageIndex = 0;
+            lstGameObjects.Size = new Size(223, 342);
+            lstGameObjects.TabIndex = 23;
+            // 
+            // pnlContainer
+            // 
+            pnlContainer.Controls.Add(grpGeneral);
+            pnlContainer.Controls.Add(grpFishes);
+            pnlContainer.Location = new System.Drawing.Point(258, 42);
+            pnlContainer.Margin = new Padding(4, 3, 4, 3);
+            pnlContainer.Name = "pnlContainer";
+            pnlContainer.Size = new Size(609, 399);
+            pnlContainer.TabIndex = 31;
+            pnlContainer.Visible = false;
+            // 
+            // grpGeneral
+            // 
+            grpGeneral.BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
+            grpGeneral.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            grpGeneral.Controls.Add(btnFishRequirements);
+            grpGeneral.Controls.Add(nudFishingTimeMax);
+            grpGeneral.Controls.Add(lblTimeMax);
+            grpGeneral.Controls.Add(nudFishingTimeMin);
+            grpGeneral.Controls.Add(lblTimeMin);
+            grpGeneral.Controls.Add(btnAddFolder);
+            grpGeneral.Controls.Add(lblFolder);
+            grpGeneral.Controls.Add(cmbFolder);
+            grpGeneral.Controls.Add(lblName);
+            grpGeneral.Controls.Add(txtName);
+            grpGeneral.ForeColor = System.Drawing.Color.Gainsboro;
+            grpGeneral.Location = new System.Drawing.Point(8, 3);
+            grpGeneral.Margin = new Padding(4, 3, 4, 3);
+            grpGeneral.Name = "grpGeneral";
+            grpGeneral.Padding = new Padding(4, 3, 4, 3);
+            grpGeneral.Size = new Size(292, 387);
+            grpGeneral.TabIndex = 34;
+            grpGeneral.TabStop = false;
+            grpGeneral.Text = "General";
+            // 
+            // nudFishingTimeMax
+            // 
+            nudFishingTimeMax.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            nudFishingTimeMax.ForeColor = System.Drawing.Color.Gainsboro;
+            nudFishingTimeMax.Location = new System.Drawing.Point(123, 117);
+            nudFishingTimeMax.Margin = new Padding(4, 3, 4, 3);
+            nudFishingTimeMax.Maximum = new decimal(new int[] { 200000000, 0, 0, 0 });
+            nudFishingTimeMax.Name = "nudFishingTimeMax";
+            nudFishingTimeMax.Size = new Size(162, 23);
+            nudFishingTimeMax.TabIndex = 52;
+            nudFishingTimeMax.Value = new decimal(new int[] { 30000, 0, 0, 0 });
+            nudFishingTimeMax.ValueChanged += nud_ValueChanged;
+            // 
+            // lblTimeMax
+            // 
+            lblTimeMax.AutoSize = true;
+            lblTimeMax.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            lblTimeMax.Location = new System.Drawing.Point(5, 119);
+            lblTimeMax.Margin = new Padding(4, 0, 4, 0);
+            lblTimeMax.Name = "lblTimeMax";
+            lblTimeMax.Size = new Size(100, 15);
+            lblTimeMax.TabIndex = 51;
+            lblTimeMax.Tag = "";
+            lblTimeMax.Text = "Fishing Time Max";
+            // 
+            // nudFishingTimeMin
+            // 
+            nudFishingTimeMin.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            nudFishingTimeMin.ForeColor = System.Drawing.Color.Gainsboro;
+            nudFishingTimeMin.Location = new System.Drawing.Point(123, 88);
+            nudFishingTimeMin.Margin = new Padding(4, 3, 4, 3);
+            nudFishingTimeMin.Maximum = new decimal(new int[] { 200000000, 0, 0, 0 });
+            nudFishingTimeMin.Name = "nudFishingTimeMin";
+            nudFishingTimeMin.Size = new Size(162, 23);
+            nudFishingTimeMin.TabIndex = 50;
+            nudFishingTimeMin.Value = new decimal(new int[] { 7000, 0, 0, 0 });
+            nudFishingTimeMin.ValueChanged += nud_ValueChanged;
+            // 
+            // lblTimeMin
+            // 
+            lblTimeMin.AutoSize = true;
+            lblTimeMin.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            lblTimeMin.Location = new System.Drawing.Point(5, 90);
+            lblTimeMin.Margin = new Padding(4, 0, 4, 0);
+            lblTimeMin.Name = "lblTimeMin";
+            lblTimeMin.Size = new Size(98, 15);
+            lblTimeMin.TabIndex = 49;
+            lblTimeMin.Tag = "";
+            lblTimeMin.Text = "Fishing Time Min";
+            // 
+            // btnAddFolder
+            // 
+            btnAddFolder.Location = new System.Drawing.Point(264, 51);
+            btnAddFolder.Margin = new Padding(4, 3, 4, 3);
+            btnAddFolder.Name = "btnAddFolder";
+            btnAddFolder.Padding = new Padding(6);
+            btnAddFolder.Size = new Size(21, 24);
+            btnAddFolder.TabIndex = 23;
+            btnAddFolder.Text = "+";
+            btnAddFolder.Click += btnAddFolder_Click;
+            // 
+            // lblFolder
+            // 
+            lblFolder.AutoSize = true;
+            lblFolder.Location = new System.Drawing.Point(5, 55);
+            lblFolder.Margin = new Padding(4, 0, 4, 0);
+            lblFolder.Name = "lblFolder";
+            lblFolder.Size = new Size(43, 15);
+            lblFolder.TabIndex = 22;
+            lblFolder.Text = "Folder:";
+            // 
+            // cmbFolder
+            // 
+            cmbFolder.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            cmbFolder.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            cmbFolder.BorderStyle = ButtonBorderStyle.Solid;
+            cmbFolder.ButtonColor = System.Drawing.Color.FromArgb(43, 43, 43);
+            cmbFolder.DrawDropdownHoverOutline = false;
+            cmbFolder.DrawFocusRectangle = false;
+            cmbFolder.DrawMode = DrawMode.OwnerDrawFixed;
+            cmbFolder.DropDownStyle = ComboBoxStyle.DropDownList;
+            cmbFolder.FlatStyle = FlatStyle.Flat;
+            cmbFolder.ForeColor = System.Drawing.Color.Gainsboro;
+            cmbFolder.FormattingEnabled = true;
+            cmbFolder.Location = new System.Drawing.Point(66, 51);
+            cmbFolder.Margin = new Padding(4, 3, 4, 3);
+            cmbFolder.Name = "cmbFolder";
+            cmbFolder.Size = new Size(185, 24);
+            cmbFolder.TabIndex = 21;
+            cmbFolder.Text = null;
+            cmbFolder.TextPadding = new Padding(2);
+            cmbFolder.SelectedIndexChanged += cmbFolder_SelectedIndexChanged;
+            // 
+            // lblName
+            // 
+            lblName.AutoSize = true;
+            lblName.Location = new System.Drawing.Point(5, 23);
+            lblName.Margin = new Padding(4, 0, 4, 0);
+            lblName.Name = "lblName";
+            lblName.Size = new Size(42, 15);
+            lblName.TabIndex = 19;
+            lblName.Text = "Name:";
+            // 
+            // txtName
+            // 
+            txtName.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            txtName.BorderStyle = BorderStyle.FixedSingle;
+            txtName.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            txtName.Location = new System.Drawing.Point(66, 21);
+            txtName.Margin = new Padding(4, 3, 4, 3);
+            txtName.Name = "txtName";
+            txtName.Size = new Size(218, 23);
+            txtName.TabIndex = 18;
+            txtName.TextChanged += txtName_TextChanged;
+            // 
+            // grpFishes
+            // 
+            grpFishes.BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
+            grpFishes.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            grpFishes.Controls.Add(btnRemoveFish);
+            grpFishes.Controls.Add(btnFishDown);
+            grpFishes.Controls.Add(btnFishUp);
+            grpFishes.Controls.Add(btnAddFish);
+            grpFishes.Controls.Add(cmbFishes);
+            grpFishes.Controls.Add(lblAddFish);
+            grpFishes.Controls.Add(lstFishes);
+            grpFishes.ForeColor = System.Drawing.Color.Gainsboro;
+            grpFishes.Location = new System.Drawing.Point(308, 3);
+            grpFishes.Margin = new Padding(4, 3, 4, 3);
+            grpFishes.Name = "grpFishes";
+            grpFishes.Padding = new Padding(4, 3, 4, 3);
+            grpFishes.Size = new Size(292, 387);
+            grpFishes.TabIndex = 33;
+            grpFishes.TabStop = false;
+            grpFishes.Text = "Available Fishes";
+            // 
+            // btnRemoveFish
+            // 
+            btnRemoveFish.Location = new System.Drawing.Point(8, 347);
+            btnRemoveFish.Margin = new Padding(4, 3, 4, 3);
+            btnRemoveFish.Name = "btnRemoveFish";
+            btnRemoveFish.Padding = new Padding(6);
+            btnRemoveFish.Size = new Size(276, 27);
+            btnRemoveFish.TabIndex = 53;
+            btnRemoveFish.Text = "Remove Selected";
+            btnRemoveFish.Click += btnRemoveFish_Click;
+            // 
+            // btnFishDown
+            // 
+            btnFishDown.Location = new System.Drawing.Point(259, 203);
+            btnFishDown.Margin = new Padding(4, 3, 4, 3);
+            btnFishDown.Name = "btnFishDown";
+            btnFishDown.Padding = new Padding(6);
+            btnFishDown.Size = new Size(26, 46);
+            btnFishDown.TabIndex = 52;
+            btnFishDown.Text = "?";
+            btnFishDown.Click += btnFishDown_Click;
+            // 
+            // btnFishUp
+            // 
+            btnFishUp.Location = new System.Drawing.Point(259, 22);
+            btnFishUp.Margin = new Padding(4, 3, 4, 3);
+            btnFishUp.Name = "btnFishUp";
+            btnFishUp.Padding = new Padding(6);
+            btnFishUp.Size = new Size(26, 46);
+            btnFishUp.TabIndex = 51;
+            btnFishUp.Text = "?";
+            btnFishUp.Click += btnFishUp_Click;
+            // 
+            // btnAddFish
+            // 
+            btnAddFish.Location = new System.Drawing.Point(8, 314);
+            btnAddFish.Margin = new Padding(4, 3, 4, 3);
+            btnAddFish.Name = "btnAddFish";
+            btnAddFish.Padding = new Padding(6);
+            btnAddFish.Size = new Size(276, 27);
+            btnAddFish.TabIndex = 50;
+            btnAddFish.Text = "Add Selected";
+            btnAddFish.Click += btnAddFish_Click;
+            // 
+            // cmbFishes
+            // 
+            cmbFishes.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            cmbFishes.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            cmbFishes.BorderStyle = ButtonBorderStyle.Solid;
+            cmbFishes.ButtonColor = System.Drawing.Color.FromArgb(43, 43, 43);
+            cmbFishes.DrawDropdownHoverOutline = false;
+            cmbFishes.DrawFocusRectangle = false;
+            cmbFishes.DrawMode = DrawMode.OwnerDrawFixed;
+            cmbFishes.DropDownStyle = ComboBoxStyle.DropDownList;
+            cmbFishes.FlatStyle = FlatStyle.Flat;
+            cmbFishes.ForeColor = System.Drawing.Color.Gainsboro;
+            cmbFishes.FormattingEnabled = true;
+            cmbFishes.Location = new System.Drawing.Point(8, 283);
+            cmbFishes.Margin = new Padding(4, 3, 4, 3);
+            cmbFishes.Name = "cmbFishes";
+            cmbFishes.Size = new Size(276, 24);
+            cmbFishes.TabIndex = 49;
+            cmbFishes.Text = null;
+            cmbFishes.TextPadding = new Padding(2);
+            // 
+            // lblAddFish
+            // 
+            lblAddFish.AutoSize = true;
+            lblAddFish.Location = new System.Drawing.Point(7, 264);
+            lblAddFish.Margin = new Padding(4, 0, 4, 0);
+            lblAddFish.Name = "lblAddFish";
+            lblAddFish.Size = new Size(128, 15);
+            lblAddFish.TabIndex = 48;
+            lblAddFish.Text = "Add Fish To Be Fishing:";
+            // 
+            // lstFishes
+            // 
+            lstFishes.BackColor = System.Drawing.Color.FromArgb(60, 63, 65);
+            lstFishes.BorderStyle = BorderStyle.FixedSingle;
+            lstFishes.ForeColor = System.Drawing.Color.Gainsboro;
+            lstFishes.FormattingEnabled = true;
+            lstFishes.ItemHeight = 15;
+            lstFishes.Location = new System.Drawing.Point(7, 22);
+            lstFishes.Margin = new Padding(4, 3, 4, 3);
+            lstFishes.Name = "lstFishes";
+            lstFishes.Size = new Size(245, 227);
+            lstFishes.TabIndex = 47;
+            // 
+            // toolStrip
+            // 
+            toolStrip.AutoSize = false;
+            toolStrip.BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
+            toolStrip.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStrip.Items.AddRange(new ToolStripItem[] { toolStripItemNew, toolStripSeparator1, toolStripItemDelete, toolStripSeparator2, btnAlphabetical, toolStripSeparator4, toolStripItemCopy, toolStripItemPaste, toolStripSeparator3, toolStripItemUndo });
+            toolStrip.Location = new System.Drawing.Point(0, 0);
+            toolStrip.Name = "toolStrip";
+            toolStrip.Padding = new Padding(6, 0, 1, 0);
+            toolStrip.Size = new Size(878, 29);
+            toolStrip.TabIndex = 43;
+            toolStrip.Text = "toolStrip1";
+            // 
+            // toolStripItemNew
+            // 
+            toolStripItemNew.DisplayStyle = ToolStripItemDisplayStyle.Image;
+            toolStripItemNew.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripItemNew.Image = (Image)resources.GetObject("toolStripItemNew.Image");
+            toolStripItemNew.ImageTransparentColor = System.Drawing.Color.Magenta;
+            toolStripItemNew.Name = "toolStripItemNew";
+            toolStripItemNew.Size = new Size(23, 26);
+            toolStripItemNew.Text = "New";
+            toolStripItemNew.Click += toolStripItemNew_Click;
+            // 
+            // toolStripSeparator1
+            // 
+            toolStripSeparator1.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripSeparator1.Margin = new Padding(0, 0, 2, 0);
+            toolStripSeparator1.Name = "toolStripSeparator1";
+            toolStripSeparator1.Size = new Size(6, 29);
+            // 
+            // toolStripItemDelete
+            // 
+            toolStripItemDelete.DisplayStyle = ToolStripItemDisplayStyle.Image;
+            toolStripItemDelete.Enabled = false;
+            toolStripItemDelete.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripItemDelete.Image = (Image)resources.GetObject("toolStripItemDelete.Image");
+            toolStripItemDelete.ImageTransparentColor = System.Drawing.Color.Magenta;
+            toolStripItemDelete.Name = "toolStripItemDelete";
+            toolStripItemDelete.Size = new Size(23, 26);
+            toolStripItemDelete.Text = "Delete";
+            toolStripItemDelete.Click += toolStripItemDelete_Click;
+            // 
+            // toolStripSeparator2
+            // 
+            toolStripSeparator2.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripSeparator2.Margin = new Padding(0, 0, 2, 0);
+            toolStripSeparator2.Name = "toolStripSeparator2";
+            toolStripSeparator2.Size = new Size(6, 29);
+            // 
+            // btnAlphabetical
+            // 
+            btnAlphabetical.DisplayStyle = ToolStripItemDisplayStyle.Image;
+            btnAlphabetical.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            btnAlphabetical.Image = (Image)resources.GetObject("btnAlphabetical.Image");
+            btnAlphabetical.ImageTransparentColor = System.Drawing.Color.Magenta;
+            btnAlphabetical.Name = "btnAlphabetical";
+            btnAlphabetical.Size = new Size(23, 26);
+            btnAlphabetical.Text = "Order Chronologically";
+            btnAlphabetical.Click += btnAlphabetical_Click;
+            // 
+            // toolStripSeparator4
+            // 
+            toolStripSeparator4.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripSeparator4.Margin = new Padding(0, 0, 2, 0);
+            toolStripSeparator4.Name = "toolStripSeparator4";
+            toolStripSeparator4.Size = new Size(6, 29);
+            // 
+            // toolStripItemCopy
+            // 
+            toolStripItemCopy.DisplayStyle = ToolStripItemDisplayStyle.Image;
+            toolStripItemCopy.Enabled = false;
+            toolStripItemCopy.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripItemCopy.Image = (Image)resources.GetObject("toolStripItemCopy.Image");
+            toolStripItemCopy.ImageTransparentColor = System.Drawing.Color.Magenta;
+            toolStripItemCopy.Name = "toolStripItemCopy";
+            toolStripItemCopy.Size = new Size(23, 26);
+            toolStripItemCopy.Text = "Copy";
+            toolStripItemCopy.Click += toolStripItemCopy_Click;
+            // 
+            // toolStripItemPaste
+            // 
+            toolStripItemPaste.DisplayStyle = ToolStripItemDisplayStyle.Image;
+            toolStripItemPaste.Enabled = false;
+            toolStripItemPaste.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripItemPaste.Image = (Image)resources.GetObject("toolStripItemPaste.Image");
+            toolStripItemPaste.ImageTransparentColor = System.Drawing.Color.Magenta;
+            toolStripItemPaste.Name = "toolStripItemPaste";
+            toolStripItemPaste.Size = new Size(23, 26);
+            toolStripItemPaste.Text = "Paste";
+            toolStripItemPaste.Click += toolStripItemPaste_Click;
+            // 
+            // toolStripSeparator3
+            // 
+            toolStripSeparator3.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripSeparator3.Margin = new Padding(0, 0, 2, 0);
+            toolStripSeparator3.Name = "toolStripSeparator3";
+            toolStripSeparator3.Size = new Size(6, 29);
+            // 
+            // toolStripItemUndo
+            // 
+            toolStripItemUndo.DisplayStyle = ToolStripItemDisplayStyle.Image;
+            toolStripItemUndo.Enabled = false;
+            toolStripItemUndo.ForeColor = System.Drawing.Color.FromArgb(220, 220, 220);
+            toolStripItemUndo.Image = (Image)resources.GetObject("toolStripItemUndo.Image");
+            toolStripItemUndo.ImageTransparentColor = System.Drawing.Color.Magenta;
+            toolStripItemUndo.Name = "toolStripItemUndo";
+            toolStripItemUndo.Size = new Size(23, 26);
+            toolStripItemUndo.Text = "Undo";
+            toolStripItemUndo.Click += toolStripItemUndo_Click;
+            // 
+            // btnFishRequirements
+            // 
+            btnFishRequirements.Location = new System.Drawing.Point(8, 347);
+            btnFishRequirements.Margin = new Padding(4, 3, 4, 3);
+            btnFishRequirements.Name = "btnFishRequirements";
+            btnFishRequirements.Padding = new Padding(6);
+            btnFishRequirements.Size = new Size(277, 27);
+            btnFishRequirements.TabIndex = 53;
+            btnFishRequirements.Text = "Fishing Requirements";
+            btnFishRequirements.Click += btnFishRequirements_Click;
+            // 
+            // FrmFishingSpots
+            // 
+            AutoScaleDimensions = new SizeF(7F, 15F);
+            AutoScaleMode = AutoScaleMode.Font;
+            AutoSize = true;
+            BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
+            ClientSize = new Size(878, 498);
+            ControlBox = false;
+            Controls.Add(toolStrip);
+            Controls.Add(pnlContainer);
+            Controls.Add(btnCancel);
+            Controls.Add(btnSave);
+            Controls.Add(grpSpots);
+            FormBorderStyle = FormBorderStyle.FixedSingle;
+            KeyPreview = true;
+            Margin = new Padding(4, 3, 4, 3);
+            MaximizeBox = false;
+            MinimizeBox = false;
+            Name = "FrmFishingSpots";
+            StartPosition = FormStartPosition.CenterScreen;
+            Text = "Fishing Spots Editor";
+            Load += frmFishing_Load;
+            KeyDown += form_KeyDown;
+            grpSpots.ResumeLayout(false);
+            grpSpots.PerformLayout();
+            pnlContainer.ResumeLayout(false);
+            grpGeneral.ResumeLayout(false);
+            grpGeneral.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)nudFishingTimeMax).EndInit();
+            ((System.ComponentModel.ISupportInitialize)nudFishingTimeMin).EndInit();
+            grpFishes.ResumeLayout(false);
+            grpFishes.PerformLayout();
+            toolStrip.ResumeLayout(false);
+            toolStrip.PerformLayout();
+            ResumeLayout(false);
+        }
+
+        #endregion
+
+        private DarkButton btnCancel;
+        private DarkButton btnSave;
+        private DarkGroupBox grpSpots;
+        private System.Windows.Forms.Panel pnlContainer;
+        private DarkGroupBox grpFishes;
+        private DarkToolStrip toolStrip;
+        private System.Windows.Forms.ToolStripButton toolStripItemNew;
+        private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
+        private System.Windows.Forms.ToolStripButton toolStripItemDelete;
+        private System.Windows.Forms.ToolStripSeparator toolStripSeparator2;
+        public System.Windows.Forms.ToolStripButton toolStripItemCopy;
+        public System.Windows.Forms.ToolStripButton toolStripItemPaste;
+        private System.Windows.Forms.ToolStripSeparator toolStripSeparator3;
+        public System.Windows.Forms.ToolStripButton toolStripItemUndo;
+        private DarkGroupBox grpGeneral;
+        private System.Windows.Forms.Label lblName;
+        private DarkTextBox txtName;
+        private DarkButton btnClearSearch;
+        private DarkTextBox txtSearch;
+        private DarkButton btnAddFolder;
+        private System.Windows.Forms.Label lblFolder;
+        private DarkComboBox cmbFolder;
+        private System.Windows.Forms.ToolStripButton btnAlphabetical;
+        private System.Windows.Forms.ToolStripSeparator toolStripSeparator4;
+        private Controls.GameObjectList lstGameObjects;
+        private DarkButton btnFishDown;
+        private DarkButton btnFishUp;
+        private DarkButton btnAddFish;
+        private DarkComboBox cmbFishes;
+        private System.Windows.Forms.Label lblAddFish;
+        private System.Windows.Forms.ListBox lstFishes;
+        private DarkButton btnRemoveFish;
+        private DarkNumericUpDown nudFishingTimeMin;
+        private DarkLabel lblTimeMin;
+        private DarkNumericUpDown nudFishingTimeMax;
+        private DarkLabel lblTimeMax;
+        private DarkButton btnFishRequirements;
+    }
+}

--- a/Intersect.Editor/Forms/Editors/frmFishingSpots.cs
+++ b/Intersect.Editor/Forms/Editors/frmFishingSpots.cs
@@ -1,0 +1,409 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows.Forms;
+
+using DarkUI.Forms;
+using Intersect.Editor.Core;
+using Intersect.Editor.General;
+using Intersect.Editor.Localization;
+using Intersect.Editor.Networking;
+using Intersect.Enums;
+using Intersect.Framework.Core.GameObjects.Fishing;
+using Intersect.GameObjects;
+using Intersect.GameObjects;
+using Intersect.Models;
+
+namespace Intersect.Editor.Forms.Editors
+{
+
+    public partial class FrmFishingSpots : EditorForm
+    {
+
+        private List<FishingSpotBase> mChanged = new List<FishingSpotBase>();
+
+        private string mCopiedItem;
+
+        private FishingSpotBase currentSpotEdit;
+
+        private List<string> mKnownFolders = new List<string>();
+
+        private bool isLoaded = false;
+        public FrmFishingSpots()
+        {
+            ApplyHooks();
+            InitializeComponent();
+            Icon = Program.Icon;
+
+            lstGameObjects.Init(UpdateToolStripItems, AssignEditorItem, toolStripItemNew_Click, toolStripItemCopy_Click, toolStripItemUndo_Click, toolStripItemPaste_Click, toolStripItemDelete_Click);
+        }
+        private void AssignEditorItem(Guid id)
+        {
+            currentSpotEdit = FishingSpotBase.Get(id);
+            UpdateEditor();
+        }
+
+        protected override void GameObjectUpdatedDelegate(GameObjectType type)
+        {
+            if (type == GameObjectType.FishingSpot)
+            {
+                InitEditor();
+                if (currentSpotEdit != null && !DatabaseObject<FishingSpotBase>.Lookup.Values.Contains(currentSpotEdit))
+                {
+                    currentSpotEdit = null;
+                    UpdateEditor();
+                }
+            }
+        }
+
+        private void UpdateEditor()
+        {
+            if (currentSpotEdit != null)
+            {
+                isLoaded = false;
+                pnlContainer.Show();
+
+                txtName.Text = currentSpotEdit.Name;
+                nudFishingTimeMax.Value = currentSpotEdit.FishingTimeMax;
+                nudFishingTimeMin.Value = currentSpotEdit.FishingTimeMin;
+                cmbFolder.Text = currentSpotEdit.Folder;
+
+                UpdateList();
+
+                if (mChanged.IndexOf(currentSpotEdit) == -1)
+                {
+                    mChanged.Add(currentSpotEdit);
+                    currentSpotEdit.MakeBackup();
+                }
+                isLoaded = true;
+            }
+            else
+            {
+                pnlContainer.Hide();
+            }
+
+            UpdateToolStripItems();
+        }
+
+        private void nud_ValueChanged(object sender, EventArgs e)
+        {
+            if (!isLoaded) return;
+            currentSpotEdit.FishingTimeMin = (int)nudFishingTimeMin.Value;
+            currentSpotEdit.FishingTimeMax = (int)nudFishingTimeMax.Value;
+        }
+
+        private void txtName_TextChanged(object sender, EventArgs e)
+        {
+            currentSpotEdit.Name = txtName.Text;
+            lstGameObjects.UpdateText(txtName.Text);
+        }
+
+        private void btnCancel_Click(object sender, EventArgs e)
+        {
+            foreach (var item in mChanged)
+            {
+                item.RestoreBackup();
+                item.DeleteBackup();
+            }
+
+            Hide();
+            Globals.CurrentEditor = -1;
+            Dispose();
+        }
+
+        private void btnSave_Click(object sender, EventArgs e)
+        {
+            //Send Changed items
+            foreach (var item in mChanged)
+            {
+                PacketSender.SendSaveObject(item);
+                item.DeleteBackup();
+            }
+
+            Hide();
+            Globals.CurrentEditor = -1;
+            Dispose();
+        }
+
+        private void toolStripItemNew_Click(object sender, EventArgs e)
+        {
+            PacketSender.SendCreateObject(GameObjectType.FishingSpot);
+        }
+
+        private void toolStripItemDelete_Click(object sender, EventArgs e)
+        {
+            if (currentSpotEdit != null && lstGameObjects.Focused)
+            {
+                if (DarkMessageBox.ShowWarning(
+                        Strings.FishingSpotEditor.deleteprompt, Strings.FishingSpotEditor.delete,
+                        DarkDialogButton.YesNo, Icon
+                    ) ==
+                    DialogResult.Yes)
+                {
+                    PacketSender.SendDeleteObject(currentSpotEdit);
+                }
+            }
+        }
+
+        private void toolStripItemCopy_Click(object sender, EventArgs e)
+        {
+            if (currentSpotEdit != null && lstGameObjects.Focused)
+            {
+                mCopiedItem = currentSpotEdit.JsonData;
+                toolStripItemPaste.Enabled = true;
+            }
+        }
+
+        private void toolStripItemPaste_Click(object sender, EventArgs e)
+        {
+            if (currentSpotEdit != null && mCopiedItem != null && lstGameObjects.Focused)
+            {
+                currentSpotEdit.Load(mCopiedItem, true);
+                UpdateEditor();
+            }
+        }
+
+        private void toolStripItemUndo_Click(object sender, EventArgs e)
+        {
+            if (mChanged.Contains(currentSpotEdit) && currentSpotEdit != null)
+            {
+                if (DarkMessageBox.ShowWarning(
+                        Strings.FishingSpotEditor.undoprompt, Strings.FishingSpotEditor.undotitle,
+                        DarkDialogButton.YesNo, Icon
+                    ) ==
+                    DialogResult.Yes)
+                {
+                    currentSpotEdit.RestoreBackup();
+                    UpdateEditor();
+                }
+            }
+        }
+
+        private void UpdateToolStripItems()
+        {
+            toolStripItemCopy.Enabled = currentSpotEdit != null && lstGameObjects.Focused;
+            toolStripItemPaste.Enabled = currentSpotEdit != null && mCopiedItem != null && lstGameObjects.Focused;
+            toolStripItemDelete.Enabled = currentSpotEdit != null && lstGameObjects.Focused;
+            toolStripItemUndo.Enabled = currentSpotEdit != null && lstGameObjects.Focused;
+        }
+
+        private void lstGameObjects_FocusChanged(object sender, EventArgs e)
+        {
+            UpdateToolStripItems();
+        }
+
+        private void form_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Control)
+            {
+                if (e.KeyCode == Keys.N)
+                {
+                    toolStripItemNew_Click(null, null);
+                }
+            }
+        }
+
+        private void frmFishing_Load(object sender, EventArgs e)
+        {
+            cmbFishes.Items.Clear();
+            cmbFishes.Items.AddRange(FishBase.Names);
+
+            InitLocalization();
+        }
+
+        private void InitLocalization()
+        {
+            Text = Strings.FishingSpotEditor.title;
+            toolStripItemNew.Text = Strings.FishingSpotEditor.New;
+            toolStripItemDelete.Text = Strings.FishingSpotEditor.delete;
+            toolStripItemCopy.Text = Strings.FishingSpotEditor.copy;
+            toolStripItemPaste.Text = Strings.FishingSpotEditor.paste;
+            toolStripItemUndo.Text = Strings.FishingSpotEditor.undo;
+
+            grpSpots.Text = Strings.FishingSpotEditor.tables;
+            grpFishes.Text = Strings.FishingSpotEditor.fishes;
+
+            lblAddFish.Text = Strings.FishingSpotEditor.addfishlabel;
+            btnAddFish.Text = Strings.FishingSpotEditor.add;
+            btnRemoveFish.Text = Strings.FishingSpotEditor.remove;
+
+            grpGeneral.Text = Strings.FishingSpotEditor.general;
+            lblName.Text = Strings.FishingSpotEditor.name;
+
+            //Searching/Sorting
+            btnAlphabetical.ToolTipText = Strings.FishingSpotEditor.sortalphabetically;
+            txtSearch.Text = Strings.FishingSpotEditor.searchplaceholder;
+            lblFolder.Text = Strings.FishingSpotEditor.folderlabel;
+
+            btnSave.Text = Strings.FishingSpotEditor.save;
+            btnCancel.Text = Strings.FishingSpotEditor.cancel;
+
+            lblTimeMin.Text = Strings.FishingSpotEditor.fishingtimemin;
+            lblTimeMax.Text = Strings.FishingSpotEditor.fishingtimemax;
+        }
+
+        public void UpdateList()
+        {
+            lstFishes.Items.Clear();
+            foreach (var id in currentSpotEdit.Fishes)
+            {
+                lstFishes.Items.Add(FishBase.GetName(id));
+            }
+        }
+
+        private void btnAddFish_Click(object sender, EventArgs e)
+        {
+            var id = FishBase.IdFromList(cmbFishes.SelectedIndex);
+            var fish = FishBase.Get(id);
+            if (fish != null && !currentSpotEdit.Fishes.Contains(id))
+            {
+                currentSpotEdit.Fishes.Add(id);
+                UpdateList();
+            }
+        }
+
+        private void btnRemoveFish_Click(object sender, EventArgs e)
+        {
+            if (lstFishes.SelectedIndex > -1)
+            {
+                currentSpotEdit.Fishes.RemoveAt(lstFishes.SelectedIndex);
+                UpdateList();
+            }
+        }
+
+        private void btnFishUp_Click(object sender, EventArgs e)
+        {
+            if (lstFishes.SelectedIndex > 0 && lstFishes.Items.Count > 1)
+            {
+                var index = lstFishes.SelectedIndex;
+                var swapWith = currentSpotEdit.Fishes[index - 1];
+                currentSpotEdit.Fishes[index - 1] = currentSpotEdit.Fishes[index];
+                currentSpotEdit.Fishes[index] = swapWith;
+                UpdateList();
+                lstFishes.SelectedIndex = index - 1;
+            }
+        }
+
+        private void btnFishDown_Click(object sender, EventArgs e)
+        {
+            if (lstFishes.SelectedIndex > -1 && lstFishes.SelectedIndex + 1 != lstFishes.Items.Count)
+            {
+                var index = lstFishes.SelectedIndex;
+                var swapWith = currentSpotEdit.Fishes[index + 1];
+                currentSpotEdit.Fishes[index + 1] = currentSpotEdit.Fishes[index];
+                currentSpotEdit.Fishes[index] = swapWith;
+                UpdateList();
+                lstFishes.SelectedIndex = index + 1;
+            }
+        }
+
+        #region "Item List - Folders, Searching, Sorting, Etc"
+
+        public void InitEditor()
+        {
+            //Collect folders
+            var mFolders = new List<string>();
+            foreach (var itm in FishingSpotBase.Lookup)
+            {
+                if (!string.IsNullOrEmpty(((FishingSpotBase)itm.Value).Folder) &&
+                    !mFolders.Contains(((FishingSpotBase)itm.Value).Folder))
+                {
+                    mFolders.Add(((FishingSpotBase)itm.Value).Folder);
+                    if (!mKnownFolders.Contains(((FishingSpotBase)itm.Value).Folder))
+                    {
+                        mKnownFolders.Add(((FishingSpotBase)itm.Value).Folder);
+                    }
+                }
+            }
+
+            mFolders.Sort();
+            mKnownFolders.Sort();
+            cmbFolder.Items.Clear();
+            cmbFolder.Items.Add("");
+            cmbFolder.Items.AddRange(mKnownFolders.ToArray());
+
+            var items = FishingSpotBase.Lookup.OrderBy(p => p.Value?.Name).Select(pair => new KeyValuePair<Guid, KeyValuePair<string, string>>(pair.Key,
+                new KeyValuePair<string, string>(((FishingSpotBase)pair.Value)?.Name ?? Models.DatabaseObject<FishingSpotBase>.Deleted, ((FishingSpotBase)pair.Value)?.Folder ?? ""))).ToArray();
+            lstGameObjects.Repopulate(items, mFolders, btnAlphabetical.Checked, CustomSearch(), txtSearch.Text);
+        }
+
+        private void btnAddFolder_Click(object sender, EventArgs e)
+        {
+            var folderName = "";
+            var result = DarkInputBox.ShowInformation(
+                Strings.FishingSpotEditor.folderprompt, Strings.FishingSpotEditor.foldertitle, ref folderName,
+                DarkDialogButton.OkCancel
+            );
+
+            if (result == DialogResult.OK && !string.IsNullOrEmpty(folderName))
+            {
+                if (!cmbFolder.Items.Contains(folderName))
+                {
+                    currentSpotEdit.Folder = folderName;
+                    lstGameObjects.ExpandFolder(folderName);
+                    InitEditor();
+                    cmbFolder.Text = folderName;
+                }
+            }
+        }
+
+        private void cmbFolder_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            currentSpotEdit.Folder = cmbFolder.Text;
+            InitEditor();
+        }
+
+        private void btnAlphabetical_Click(object sender, EventArgs e)
+        {
+            btnAlphabetical.Checked = !btnAlphabetical.Checked;
+            InitEditor();
+        }
+
+        private void txtSearch_TextChanged(object sender, EventArgs e)
+        {
+            InitEditor();
+        }
+
+        private void txtSearch_Leave(object sender, EventArgs e)
+        {
+            if (string.IsNullOrWhiteSpace(txtSearch.Text))
+            {
+                txtSearch.Text = Strings.FishingSpotEditor.searchplaceholder;
+            }
+        }
+
+        private void txtSearch_Enter(object sender, EventArgs e)
+        {
+            txtSearch.SelectAll();
+            txtSearch.Focus();
+        }
+
+        private void btnClearSearch_Click(object sender, EventArgs e)
+        {
+            txtSearch.Text = Strings.FishingSpotEditor.searchplaceholder;
+        }
+
+        private bool CustomSearch()
+        {
+            return !string.IsNullOrWhiteSpace(txtSearch.Text) &&
+                   txtSearch.Text != Strings.FishingSpotEditor.searchplaceholder;
+        }
+
+        private void txtSearch_Click(object sender, EventArgs e)
+        {
+            if (txtSearch.Text == Strings.FishingSpotEditor.searchplaceholder)
+            {
+                txtSearch.SelectAll();
+            }
+        }
+
+        #endregion
+
+        private void btnFishRequirements_Click(object sender, EventArgs e)
+        {
+            var frm = new FrmDynamicRequirements(currentSpotEdit.FishingRequirements, RequirementType.FishingSpot);
+            frm.ShowDialog();
+        }
+    }
+
+}

--- a/Intersect.Editor/Forms/Editors/frmFishingSpots.resx
+++ b/Intersect.Editor/Forms/Editors/frmFishingSpots.resx
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!--
+    Microsoft ResX Schema
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="toolStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+</root>

--- a/Intersect.Editor/Forms/frmMain.Designer.cs
+++ b/Intersect.Editor/Forms/frmMain.Designer.cs
@@ -112,6 +112,8 @@ namespace Intersect.Editor.Forms
             this.projectileEditorToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.questEditorToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.resourceEditorToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.fishEditorToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.fishingSpotEditorToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.shopEditorToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.spellEditorToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.variableEditorToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -815,6 +817,8 @@ namespace Intersect.Editor.Forms
             this.projectileEditorToolStripMenuItem,
             this.questEditorToolStripMenuItem,
             this.resourceEditorToolStripMenuItem,
+            this.fishEditorToolStripMenuItem,
+            this.fishingSpotEditorToolStripMenuItem,
             this.shopEditorToolStripMenuItem,
             this.spellEditorToolStripMenuItem,
             this.variableEditorToolStripMenuItem,
@@ -904,9 +908,25 @@ namespace Intersect.Editor.Forms
             this.resourceEditorToolStripMenuItem.Size = new System.Drawing.Size(191, 22);
             this.resourceEditorToolStripMenuItem.Text = "Resource Editor";
             this.resourceEditorToolStripMenuItem.Click += new System.EventHandler(this.resourceEditorToolStripMenuItem_Click);
-            // 
+            //
+            // fishEditorToolStripMenuItem
+            //
+            this.fishEditorToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
+            this.fishEditorToolStripMenuItem.Name = "fishEditorToolStripMenuItem";
+            this.fishEditorToolStripMenuItem.Size = new System.Drawing.Size(191, 22);
+            this.fishEditorToolStripMenuItem.Text = "Fish Editor";
+            this.fishEditorToolStripMenuItem.Click += new System.EventHandler(this.fishEditorToolStripMenuItem_Click);
+            //
+            // fishingSpotEditorToolStripMenuItem
+            //
+            this.fishingSpotEditorToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
+            this.fishingSpotEditorToolStripMenuItem.Name = "fishingSpotEditorToolStripMenuItem";
+            this.fishingSpotEditorToolStripMenuItem.Size = new System.Drawing.Size(191, 22);
+            this.fishingSpotEditorToolStripMenuItem.Text = "Fishing Spot Editor";
+            this.fishingSpotEditorToolStripMenuItem.Click += new System.EventHandler(this.fishingSpotEditorToolStripMenuItem_Click);
+            //
             // shopEditorToolStripMenuItem
-            // 
+            //
             this.shopEditorToolStripMenuItem.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
             this.shopEditorToolStripMenuItem.Name = "shopEditorToolStripMenuItem";
             this.shopEditorToolStripMenuItem.Size = new System.Drawing.Size(191, 22);
@@ -1113,10 +1133,12 @@ namespace Intersect.Editor.Forms
 		private ToolStripMenuItem craftingTableEditorToolStripMenuItem;
 		private ToolStripMenuItem itemEditorToolStripMenuItem;
 		private ToolStripMenuItem npcEditorToolStripMenuItem;
-		private ToolStripMenuItem projectileEditorToolStripMenuItem;
-		private ToolStripMenuItem questEditorToolStripMenuItem;
-		private ToolStripMenuItem resourceEditorToolStripMenuItem;
-		private ToolStripMenuItem shopEditorToolStripMenuItem;
+           private ToolStripMenuItem projectileEditorToolStripMenuItem;
+           private ToolStripMenuItem questEditorToolStripMenuItem;
+           private ToolStripMenuItem resourceEditorToolStripMenuItem;
+            private ToolStripMenuItem fishEditorToolStripMenuItem;
+            private ToolStripMenuItem fishingSpotEditorToolStripMenuItem;
+            private ToolStripMenuItem shopEditorToolStripMenuItem;
                 private ToolStripMenuItem spellEditorToolStripMenuItem;
                 private ToolStripMenuItem variableEditorToolStripMenuItem;
                 private ToolStripMenuItem timeEditorToolStripMenuItem;

--- a/Intersect.Editor/Forms/frmMain.cs
+++ b/Intersect.Editor/Forms/frmMain.cs
@@ -63,6 +63,10 @@ public partial class FrmMain : Form
 
     private FrmResource mResourceEditor;
 
+    private FrmFishes _fishEditor;
+
+    private FrmFishingSpots _fishingSpotEditor;
+
     private FrmShop mShopEditor;
 
     private FrmSpell mSpellEditor;
@@ -190,6 +194,8 @@ public partial class FrmMain : Form
         projectileEditorToolStripMenuItem.Text = Strings.MainForm.projectileeditor;
         questEditorToolStripMenuItem.Text = Strings.MainForm.questeditor;
         resourceEditorToolStripMenuItem.Text = Strings.MainForm.resourceeditor;
+        fishEditorToolStripMenuItem.Text = Strings.MainForm.fisheditor;
+        fishingSpotEditorToolStripMenuItem.Text = Strings.MainForm.fishingspoteditor;
         shopEditorToolStripMenuItem.Text = Strings.MainForm.shopeditor;
         spellEditorToolStripMenuItem.Text = Strings.MainForm.spelleditor;
         variableEditorToolStripMenuItem.Text = Strings.MainForm.variableeditor;
@@ -1268,6 +1274,16 @@ public partial class FrmMain : Form
         PacketSender.SendOpenEditor(GameObjectType.Resource);
     }
 
+    private void fishEditorToolStripMenuItem_Click(object sender, EventArgs e)
+    {
+        PacketSender.SendOpenEditor(GameObjectType.Fish);
+    }
+
+    private void fishingSpotEditorToolStripMenuItem_Click(object sender, EventArgs e)
+    {
+        PacketSender.SendOpenEditor(GameObjectType.FishingSpot);
+    }
+
     private void classEditorToolStripMenuItem_Click(object sender, EventArgs e)
     {
         PacketSender.SendOpenEditor(GameObjectType.Class);
@@ -1643,6 +1659,24 @@ public partial class FrmMain : Form
                         mResourceEditor = new FrmResource();
                         mResourceEditor.InitEditor();
                         mResourceEditor.Show();
+                    }
+
+                    break;
+                case GameObjectType.Fish:
+                    if (_fishEditor == null || _fishEditor.Visible == false)
+                    {
+                        _fishEditor = new FrmFishes();
+                        _fishEditor.InitEditor();
+                        _fishEditor.Show();
+                    }
+
+                    break;
+                case GameObjectType.FishingSpot:
+                    if (_fishingSpotEditor == null || _fishingSpotEditor.Visible == false)
+                    {
+                        _fishingSpotEditor = new FrmFishingSpots();
+                        _fishingSpotEditor.InitEditor();
+                        _fishingSpotEditor.Show();
                     }
 
                     break;

--- a/Intersect.Editor/Localization/Strings.cs
+++ b/Intersect.Editor/Localization/Strings.cs
@@ -932,6 +932,7 @@ public static partial class Strings
             {(int) MapAttributeType.Item, @"Item Spawn" },
             {(int) MapAttributeType.NpcAvoid, @"Npc Avoid" },
             {(int) MapAttributeType.Resource, @"Resource Spawn" },
+            {(int) MapAttributeType.FishingSpot, @"Fishing Spot" },
             {(int) MapAttributeType.Slide, @"Slide" },
             {(int) MapAttributeType.Sound, @"Map Sound" },
             {(int) MapAttributeType.Walkable, @"Walkable" },
@@ -1027,6 +1028,8 @@ public static partial class Strings
         public static LocalizedString Resource = @"Resource";
 
         public static LocalizedString ResourceSpawn = @"Resource";
+
+        public static LocalizedString FishingSpot = @"Fishing Spot";
 
         public static LocalizedString RespawnTime = @"Respawn Time (ms)";
 
@@ -1587,6 +1590,12 @@ Tick timer saved in server config.json.";
 
         public static LocalizedString instructionsresource =
             @"Below are condition lists. If conditions are met on any of the lists then the player can harvest the resource.";
+
+        public static LocalizedString instructionsfish =
+            @"Below are condition lists. If conditions are met on any of the lists then the player can catch this fish.";
+
+        public static LocalizedString instructionsfishingspot =
+            @"Below are condition lists. If conditions are met on any of the lists then the player can fish at this spot.";
 
         public static LocalizedString instructionsspell =
             @"Below are condition lists. If conditions are met on any of the lists then the player can use cast the spell.";
@@ -3799,6 +3808,30 @@ Tick timer saved in server config.json.";
         public static LocalizedString Okay = @"Okay";
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Save = @"Save";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Name = @"Name";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Folder = @"Folder";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString New = @"New";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Copy = @"Copy";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Undo = @"Undo";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Paste = @"Paste";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString Delete = @"Delete";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public static LocalizedString True = @"True";
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
@@ -4353,6 +4386,10 @@ Tick timer saved in server config.json.";
         public static LocalizedString reportbug = @"Report Bug";
 
         public static LocalizedString resourceeditor = @"Resource Editor";
+
+        public static LocalizedString fisheditor = @"Fish Editor";
+
+        public static LocalizedString fishingspoteditor = @"Fishing Spot Editor";
 
         public static LocalizedString resources = @"Resources";
 
@@ -6006,6 +6043,183 @@ Negative values for time to flow backwards.";
             {(int) VariableType.UserVariable, @"User Variable" },
         };
 
+    }
+
+    public partial struct FishEditor
+    {
+        public static LocalizedString Title = @"Fish Editor";
+
+        public static LocalizedString New = @"New Fish";
+
+        public static LocalizedString delete = @"Delete Fish";
+
+        public static LocalizedString copy = @"Copy Fish";
+
+        public static LocalizedString paste = @"Paste Fish";
+
+        public static LocalizedString undo = @"Undo Changes";
+
+        public static LocalizedString fishes = @"Fishes";
+
+        public static LocalizedString general = @"General";
+
+        public static LocalizedString name = @"Name:";
+
+        public static LocalizedString item = @"Item:";
+
+        public static LocalizedString parameters = @"Parameters";
+
+        public static LocalizedString commonevent = @"Common Event:";
+
+        public static LocalizedString sortalphabetically = @"Order Alphabetically";
+
+        public static LocalizedString searchplaceholder = @"Search...";
+
+        public static LocalizedString folderlabel = @"Folder:";
+
+        public static LocalizedString save = @"Save";
+
+        public static LocalizedString cancel = @"Cancel";
+
+        public static LocalizedString chance = @"Chance (%)";
+
+        public static LocalizedString coeffUnpredictability = @"Coeff Unpredictability (%)";
+
+        public static LocalizedString position = @"Position";
+
+        public static LocalizedString pushStrength = @"Push Strength";
+
+        public static LocalizedString rangeSize = @"Range Size";
+
+        public static LocalizedString speedMove = @"Speed Move";
+
+        public static LocalizedString speedResize = @"Speed Resize";
+
+        public static LocalizedString strength = @"Strength";
+
+        public static LocalizedString timeChangeRangeSize = @"Timer Change Resize (MS)";
+
+        public static LocalizedString nudTimeChangeSpeed = @"Timer Change Speed (MS)";
+
+        public static LocalizedString weight = @"Weight";
+
+        public static LocalizedString Chance = @"Chance";
+
+        public static LocalizedString Strength = @"Strength";
+
+        public static LocalizedString Speed = @"Speed";
+
+        public static LocalizedString Hooks = @"Hooks";
+
+        public static LocalizedString AddHook = @"Add Hook";
+
+        public static LocalizedString RemoveHook = @"Remove Hook";
+
+        public static LocalizedString Requirements = @"Requirements";
+
+        public static LocalizedString DeletePrompt = @"Are you sure you want to delete this fish?";
+
+        public static LocalizedString DeleteTitle = @"Delete Fish";
+
+        public static LocalizedString UndoPrompt = @"Revert changes to this fish?";
+
+        public static LocalizedString UndoTitle = @"Undo Fish";
+    }
+
+    public partial struct FishesEditor
+    {
+        public static LocalizedString deleteprompt =
+            @"Are you sure you want to delete this fish? This action cannot be reverted!";
+
+        public static LocalizedString deletetitle = @"Delete Fish";
+
+        public static LocalizedString undoprompt =
+            @"Are you sure you want to undo changes made to this fish? This action cannot be reverted!";
+
+        public static LocalizedString undotitle = @"Undo Changes";
+
+        public static LocalizedString folderprompt = @"Enter a name for the folder you'd like to add:";
+
+        public static LocalizedString foldertitle = @"Add Folder";
+
+        public static LocalizedString searchplaceholder = @"Search...";
+    }
+
+    public partial struct FishingSpotEditor
+    {
+        public static LocalizedString Title = @"Fishing Spot Editor";
+
+        public static LocalizedString title = @"Fishing Spot Editor";
+
+        public static LocalizedString New = @"New Fishing Spot";
+
+        public static LocalizedString delete = @"Delete Fishing Spot";
+
+        public static LocalizedString copy = @"Copy Fishing Spot";
+
+        public static LocalizedString paste = @"Paste Fishing Spot";
+
+        public static LocalizedString undo = @"Undo Changes";
+
+        public static LocalizedString tables = @"Spots";
+
+        public static LocalizedString fishes = @"Available Fishes";
+
+        public static LocalizedString addfishlabel = @"Add Fish To Be Fishing:";
+
+        public static LocalizedString add = @"Add Selected";
+
+        public static LocalizedString remove = @"Remove Selected";
+
+        public static LocalizedString general = @"General";
+
+        public static LocalizedString name = @"Name:";
+
+        public static LocalizedString sortalphabetically = @"Order Alphabetically";
+
+        public static LocalizedString searchplaceholder = @"Search...";
+
+        public static LocalizedString folderlabel = @"Folder:";
+
+        public static LocalizedString save = @"Save";
+
+        public static LocalizedString cancel = @"Cancel";
+
+        public static LocalizedString fishingtimemin = @"Fishing Time Min";
+
+        public static LocalizedString fishingtimemax = @"Fishing Time Max";
+
+        public static LocalizedString Chance = @"Chance";
+
+        public static LocalizedString Strength = @"Strength";
+
+        public static LocalizedString Speed = @"Speed";
+
+        public static LocalizedString Hooks = @"Hooks";
+
+        public static LocalizedString AddHook = @"Add Hook";
+
+        public static LocalizedString RemoveHook = @"Remove Hook";
+
+        public static LocalizedString Requirements = @"Requirements";
+
+        public static LocalizedString DeletePrompt = @"Are you sure you want to delete this fishing spot?";
+
+        public static LocalizedString DeleteTitle = @"Delete Fishing Spot";
+
+        public static LocalizedString UndoPrompt = @"Revert changes to this fishing spot?";
+
+        public static LocalizedString UndoTitle = @"Undo Fishing Spot";
+
+        public static LocalizedString deleteprompt = @"Are you sure you want to delete this fishing spot?";
+
+        public static LocalizedString undoprompt = @"Revert changes to this fishing spot?";
+
+        public static LocalizedString undotitle = @"Undo Fishing Spot";
+
+        public static LocalizedString folderprompt = @"Enter a name for the folder you'd like to add:";
+
+        public static LocalizedString foldertitle = @"Add Folder";
     }
 
 }

--- a/Intersect.Editor/Networking/PacketHandler.cs
+++ b/Intersect.Editor/Networking/PacketHandler.cs
@@ -8,6 +8,7 @@ using Intersect.Enums;
 using Intersect.Framework.Core.GameObjects.Animations;
 using Intersect.Framework.Core.GameObjects.Crafting;
 using Intersect.Framework.Core.GameObjects.Events;
+using Intersect.Framework.Core.GameObjects.Fishing;
 using Intersect.Framework.Core.GameObjects.Items;
 using Intersect.Framework.Core.GameObjects.Mapping.Tilesets;
 using Intersect.Framework.Core.GameObjects.Maps;
@@ -747,6 +748,35 @@ internal sealed partial class PacketHandler
                     var set = new SetDescriptor(id);
                     set.Load(json);
                     SetDescriptor.Lookup.Set(id, set);
+                }
+
+                break;
+            case GameObjectType.Fish:
+                if (deleted)
+                {
+                    var cft = FishBase.Get(id);
+                    cft.Delete();
+                }
+                else
+                {
+                    var cft = new FishBase(id);
+                    cft.Load(json);
+                    FishBase.Lookup.Set(id, cft);
+                }
+
+                break;
+
+            case GameObjectType.FishingSpot:
+                if (deleted)
+                {
+                    var cft = FishingSpotBase.Get(id);
+                    cft.Delete();
+                }
+                else
+                {
+                    var cft = new FishingSpotBase(id);
+                    cft.Load(json);
+                    FishingSpotBase.Lookup.Set(id, cft);
                 }
 
                 break;

--- a/Intersect.Server.Core/Database/DbInterface.cs
+++ b/Intersect.Server.Core/Database/DbInterface.cs
@@ -14,6 +14,7 @@ using Intersect.Enums;
 using Intersect.Framework.Core.GameObjects.Animations;
 using Intersect.Framework.Core.GameObjects.Crafting;
 using Intersect.Framework.Core.GameObjects.Events;
+using Intersect.Framework.Core.GameObjects.Fishing;
 using Intersect.Framework.Core.GameObjects.Items;
 using Intersect.Framework.Core.GameObjects.Mapping.Tilesets;
 using Intersect.Framework.Core.GameObjects.Maps;
@@ -746,6 +747,14 @@ public static partial class DbInterface
                 ResourceDescriptor.Lookup.Clear();
 
                 break;
+            case GameObjectType.Fish:
+                FishBase.Lookup.Clear();
+
+                break;
+            case GameObjectType.FishingSpot:
+                FishingSpotBase.Lookup.Clear();
+
+                break;
             case GameObjectType.Shop:
                 ShopDescriptor.Lookup.Clear();
 
@@ -853,18 +862,32 @@ public static partial class DbInterface
                         }
 
                         break;
-                    case GameObjectType.Resource:
-                        foreach (var res in context.Resources)
-                        {
-                            ResourceDescriptor.Lookup.Set(res.Id, res);
-                        }
+            case GameObjectType.Resource:
+                foreach (var res in context.Resources)
+                {
+                    ResourceDescriptor.Lookup.Set(res.Id, res);
+                }
 
-                        break;
-                    case GameObjectType.Shop:
-                        foreach (var shp in context.Shops)
-                        {
-                            ShopDescriptor.Lookup.Set(shp.Id, shp);
-                        }
+                break;
+            case GameObjectType.Fish:
+                foreach (var fish in context.Fish)
+                {
+                    FishBase.Lookup.Set(fish.Id, fish);
+                }
+
+                break;
+            case GameObjectType.FishingSpot:
+                foreach (var fishingSpot in context.FishingSpots)
+                {
+                    FishingSpotBase.Lookup.Set(fishingSpot.Id, fishingSpot);
+                }
+
+                break;
+            case GameObjectType.Shop:
+                foreach (var shp in context.Shops)
+                {
+                    ShopDescriptor.Lookup.Set(shp.Id, shp);
+                }
 
                         break;
                     case GameObjectType.Spell:
@@ -1143,6 +1166,14 @@ public static partial class DbInterface
                 dbObj = new ResourceDescriptor(predefinedid);
 
                 break;
+            case GameObjectType.Fish:
+                dbObj = new FishBase(predefinedid);
+
+                break;
+            case GameObjectType.FishingSpot:
+                dbObj = new FishingSpotBase(predefinedid);
+
+                break;
             case GameObjectType.Shop:
                 dbObj = new ShopDescriptor(predefinedid);
 
@@ -1258,6 +1289,18 @@ public static partial class DbInterface
                     case GameObjectType.Resource:
                         context.Resources.Add((ResourceDescriptor)dbObj);
                         ResourceDescriptor.Lookup.Set(dbObj.Id, dbObj);
+
+                        break;
+
+                    case GameObjectType.Fish:
+                        context.Fish.Add((FishBase)dbObj);
+                        FishBase.Lookup.Set(dbObj.Id, dbObj);
+
+                        break;
+
+                    case GameObjectType.FishingSpot:
+                        context.FishingSpots.Add((FishingSpotBase)dbObj);
+                        FishingSpotBase.Lookup.Set(dbObj.Id, dbObj);
 
                         break;
 
@@ -1416,6 +1459,14 @@ public static partial class DbInterface
                         break;
                     case GameObjectType.Resource:
                         context.Resources.Remove((ResourceDescriptor)gameObject);
+
+                        break;
+                    case GameObjectType.Fish:
+                        context.Fish.Remove((FishBase)gameObject);
+
+                        break;
+                    case GameObjectType.FishingSpot:
+                        context.FishingSpots.Remove((FishingSpotBase)gameObject);
 
                         break;
                     case GameObjectType.Shop:
@@ -1589,6 +1640,14 @@ public static partial class DbInterface
                         break;
                     case GameObjectType.Resource:
                         context.Resources.Update((ResourceDescriptor)gameObject);
+
+                        break;
+                    case GameObjectType.Fish:
+                        context.Fish.Update((FishBase)gameObject);
+
+                        break;
+                    case GameObjectType.FishingSpot:
+                        context.FishingSpots.Update((FishingSpotBase)gameObject);
 
                         break;
                     case GameObjectType.Shop:

--- a/Intersect.Server.Core/Database/GameData/GameContext.cs
+++ b/Intersect.Server.Core/Database/GameData/GameContext.cs
@@ -2,6 +2,7 @@ using Intersect.Extensions;
 using Intersect.Framework.Core.GameObjects.Animations;
 using Intersect.Framework.Core.GameObjects.Crafting;
 using Intersect.Framework.Core.GameObjects.Events;
+using Intersect.Framework.Core.GameObjects.Fishing;
 using Intersect.Framework.Core.GameObjects.Items;
 using Intersect.Framework.Core.GameObjects;
 using Intersect.Framework.Core.GameObjects.Mapping.Tilesets;
@@ -63,6 +64,11 @@ public abstract partial class GameContext : IntersectDbContext<GameContext>, IGa
 
     //Resources
     public DbSet<ResourceDescriptor> Resources { get; set; }
+
+    //Fishing
+    public DbSet<FishBase> Fish { get; set; }
+
+    public DbSet<FishingSpotBase> FishingSpots { get; set; }
 
     //Shops
     public DbSet<ShopDescriptor> Shops { get; set; }

--- a/Intersect.Server.Core/Entities/Entity.cs
+++ b/Intersect.Server.Core/Entities/Entity.cs
@@ -218,6 +218,22 @@ public abstract partial class Entity : IEntity
     [NotMapped, JsonIgnore]
     public Entity CastTarget { get; set; }
 
+    //Fishing
+    [NotMapped]
+    public bool IsFishing { get; set; }
+
+    [NotMapped]
+    public int FishingStageIndex { get; set; }
+
+    [NotMapped]
+    public bool IsFishingRodPressed { get; set; }
+
+    [NotMapped]
+    public long FishingStageTimer { get; set; }
+
+    [NotMapped]
+    public long FishingStageDuration { get; set; }
+
     [NotMapped, JsonIgnore]
     public bool SoftRetargetOnSelfCast { get; set; }
 
@@ -3437,6 +3453,11 @@ public abstract partial class Entity : IEntity
         packet.NameColor = NameColor;
         packet.HeaderLabel = new LabelPacket(HeaderLabel.Text, HeaderLabel.Color);
         packet.FooterLabel = new LabelPacket(FooterLabel.Text, FooterLabel.Color);
+        packet.IsFishing = IsFishing;
+        packet.FishingStageIndex = FishingStageIndex;
+        packet.IsFishingRodPressed = IsFishingRodPressed;
+        packet.FishingStageTimer = FishingStageTimer;
+        packet.FishingStageDuration = FishingStageDuration;
 
         return packet;
     }

--- a/Intersect.Server.Core/Entities/Events/FishEventServer.cs
+++ b/Intersect.Server.Core/Entities/Events/FishEventServer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Intersect.Enums;
 using Intersect.Framework.Core;
 using Intersect.Framework.Core.GameObjects.Fishing;
@@ -43,8 +44,7 @@ public class FishEventServer
             _fishingSpotId = fishingSpotId;
             _stage = 1;
 
-            var random = new Random();
-            var timer = random.Next(spot.FishingTimeMin, spot.FishingTimeMax);
+            var timer = Randomization.Next(spot.FishingTimeMin, spot.FishingTimeMax);
             _timerWaitFish = Timing.Global.MillisecondsUtc + timer;
             PacketSender.SendClientResultCastFishingRod(_player, true);
         }
@@ -83,11 +83,11 @@ public class FishEventServer
     private Guid GetRandomFish() //Даём рыбу
     {
         var fishingSpot = FishingSpotBase.Get(_fishingSpotId);
-        var result = Guid.Empty;
-        var fishes = new List<Guid>();
+        var fishes = new List<FishBase>();
 
         //Сортируем рыбку по возрастанию на редкость
         var fishesSort = fishingSpot?.SortingFishByRarity(FishingSpotBase.SortByType.INCREASING).ToArray();
+
         //Проверяем рыбу на соблюдение требований пожарной безопасности
         if (fishesSort != null)
         {
@@ -96,35 +96,41 @@ public class FishEventServer
                 var fish = FishBase.Get(fishGuid);
                 if (fish != null && Conditions.MeetsConditionLists(fish.FishingRequirements, _player, null))
                 {
-                    fishes.Add(fishGuid);
+                    fishes.Add(fish);
                 }
             }
         }
 
         if (fishes.Count == 0)
         {
-            return result;
+            return Guid.Empty;
         }
 
-        var randomFish = new Random();
-        for (var i = 0; i < fishes.Count; i++)
+        var totalChance = fishes.Sum(fish => Math.Max(0, fish.chance));
+
+        // If all chances are zero or negative, give each fish an even weight to avoid dead ends
+        if (totalChance <= 0)
         {
-            if (i == fishes.Count - 1)
+            totalChance = fishes.Count;
+        }
+
+        var roll = Randomization.Next(1, totalChance + 1);
+        var accumulated = 0;
+
+        foreach (var fish in fishes)
+        {
+            var weight = Math.Max(0, fish.chance);
+            weight = weight == 0 ? 1 : weight;
+
+            accumulated += weight;
+
+            if (roll <= accumulated)
             {
-                result = fishes[fishes.Count - 1];
-            }
-            else
-            {
-                var randomChange = randomFish.Next(1, 101);
-                if (randomChange <= FishBase.Get(fishes[i]).chance)
-                {
-                    result = fishes[i];
-                    break;
-                }
+                return fish.Id;
             }
         }
 
-        return result;
+        return fishes.Last().Id;
     }
 
     #endregion
@@ -175,7 +181,10 @@ public class FishEventServer
                     }
                     else
                     {
-                        _timerWaitFish = Timing.Global.MillisecondsUtc + (1000 * 60 * 60 * 24);
+                        _stage = 0;
+                        _fishingSpotId = Guid.Empty;
+                        _timerWaitFish = 0;
+                        _currentFishId = Guid.Empty;
                     }
                 }
 
@@ -220,8 +229,7 @@ public class FishEventServer
         {
             "Сорвалась..", "Блин..", "Неудача.."
         };
-        var randInstance = new Random();
-        var rand = randInstance.Next(0, strings.Length);
+        var rand = Randomization.Next(0, strings.Length);
         PacketSender.SendChatBubble(_player.Id, _player.MapInstanceId, (int)EntityType.GlobalEntity, strings[rand],
             _player.MapId);
         _stage = 0;

--- a/Intersect.Server.Core/Entities/Events/FishEventServer.cs
+++ b/Intersect.Server.Core/Entities/Events/FishEventServer.cs
@@ -1,0 +1,235 @@
+using System;
+using System.Collections.Generic;
+using Intersect.Enums;
+using Intersect.Framework.Core;
+using Intersect.Framework.Core.GameObjects.Fishing;
+using Intersect.Network.Packets.Server;
+using Intersect.Server.Entities;
+using Intersect.Server.Maps;
+using Intersect.Server.Networking;
+using Intersect.Utilities;
+
+namespace Intersect.Server.Entities.Events;
+
+public class FishEventServer
+{
+    #region Vars
+
+    private readonly Player _player;
+
+    private int[]? _fishingPosition;
+    private Direction _fishingDirection;
+    private Guid _fishingSpotId;
+    private long _timerWaitFish;
+    private Guid _currentFishId;
+    private int _stage;
+
+    #endregion
+
+    public FishEventServer(Player player)
+    {
+        _player = player;
+    }
+
+    #region Stage 0 — грок забрасывает удочку или возвращает её
+
+    public void ServerCastFishingRod(Guid fishingSpotId) //Удочку игрок закинул
+    {
+        var spot = FishingSpotBase.Get(fishingSpotId);
+        if (spot != null && Conditions.MeetsConditionLists(spot.FishingRequirements, _player, null))
+        {
+            _fishingPosition = new[] { _player.X, _player.Y };
+            _fishingDirection = _player.Dir;
+            _fishingSpotId = fishingSpotId;
+            _stage = 1;
+
+            var random = new Random();
+            var timer = random.Next(spot.FishingTimeMin, spot.FishingTimeMax);
+            _timerWaitFish = Timing.Global.MillisecondsUtc + timer;
+            PacketSender.SendClientResultCastFishingRod(_player, true);
+        }
+        else
+        {
+            PacketSender.SendClientResultCastFishingRod(_player, false);
+        }
+    }
+
+    public void ServerReturnFishingRod() //Удочку игрок вернул
+    {
+        _stage = 0;
+        _fishingSpotId = Guid.Empty;
+        _timerWaitFish = 0;
+    }
+
+    #endregion
+
+    #region Stage 1 Спустя время игроку отправляется случайная рыба
+
+    private bool WaitingCatchFish() //Ждём рыбу
+    {
+        if (_fishingPosition != null && (_player.X != _fishingPosition[0] || _player.Y != _fishingPosition[1] ||
+                                         _fishingDirection != _player.Dir))
+        {
+            //Отправить отмену или не стоит.
+            _stage = 0;
+            _fishingSpotId = Guid.Empty;
+            _timerWaitFish = 0;
+            return false;
+        }
+
+        return Timing.Global.MillisecondsUtc >= _timerWaitFish;
+    }
+
+    private Guid GetRandomFish() //Даём рыбу
+    {
+        var fishingSpot = FishingSpotBase.Get(_fishingSpotId);
+        var result = Guid.Empty;
+        var fishes = new List<Guid>();
+
+        //Сортируем рыбку по возрастанию на редкость
+        var fishesSort = fishingSpot?.SortingFishByRarity(FishingSpotBase.SortByType.INCREASING).ToArray();
+        //Проверяем рыбу на соблюдение требований пожарной безопасности
+        if (fishesSort != null)
+        {
+            foreach (var fishGuid in fishesSort)
+            {
+                var fish = FishBase.Get(fishGuid);
+                if (fish != null && Conditions.MeetsConditionLists(fish.FishingRequirements, _player, null))
+                {
+                    fishes.Add(fishGuid);
+                }
+            }
+        }
+
+        if (fishes.Count == 0)
+        {
+            return result;
+        }
+
+        var randomFish = new Random();
+        for (var i = 0; i < fishes.Count; i++)
+        {
+            if (i == fishes.Count - 1)
+            {
+                result = fishes[fishes.Count - 1];
+            }
+            else
+            {
+                var randomChange = randomFish.Next(1, 101);
+                if (randomChange <= FishBase.Get(fishes[i]).chance)
+                {
+                    result = fishes[i];
+                    break;
+                }
+            }
+        }
+
+        return result;
+    }
+
+    #endregion
+
+    private long _packetTime;
+    private bool _isFishingVisual;
+    private int _stageVisual;
+    private bool _isPressed;
+    private bool _oldFishingVisual;
+    private int _oldStageVisual;
+    private bool _oldPressed;
+
+    public void UpdateVisual(bool isFishingVisual, int stageVisual, bool isPressed)
+    {
+        _isFishingVisual = isFishingVisual;
+        _stageVisual = stageVisual;
+        _isPressed = isPressed;
+        //Console.Write($"Обновление игрока {_player.Name}\n");
+    }
+
+    public void FishingUpdate()
+    {
+        if (Timing.Global.Milliseconds > _packetTime)
+        {
+            if (_isFishingVisual != _oldFishingVisual ||
+                _stageVisual != _oldStageVisual ||
+                _isPressed != _oldPressed)
+            {
+                PacketSender.SendEntityFishing(_player, _isFishingVisual, _stageVisual, _isPressed);
+                _oldFishingVisual = _isFishingVisual;
+                _oldStageVisual = _stageVisual;
+                _oldPressed = _isPressed;
+            }
+
+            _packetTime = Timing.Global.Milliseconds + 100;
+        }
+
+        switch (_stage)
+        {
+            case 1:
+                if (WaitingCatchFish())
+                {
+                    _currentFishId = GetRandomFish();
+                    if (_currentFishId != Guid.Empty)
+                    {
+                        PacketSender.SendClientFish(_player, _currentFishId);
+                        _stage = 2;
+                    }
+                    else
+                    {
+                        _timerWaitFish = Timing.Global.MillisecondsUtc + (1000 * 60 * 60 * 24);
+                    }
+                }
+
+                break;
+        }
+    }
+
+    #region Stage 3 Результат рыбалки
+
+    public void FishingSuccess()
+    {
+        var fish = FishBase.Get(_currentFishId);
+        if (fish == null)
+        {
+            return;
+        }
+
+        if (!_player.TryGiveItem(fish.ItemId, 1))
+        {
+            if (MapController.TryGetInstanceFromMap(_player.MapId, _player.MapInstanceId, out var instance))
+            {
+                var item = new Database.Item(fish.ItemId, 1);
+                instance.SpawnItem((Framework.Items.IItemSource)_player, _player.X, _player.Y, item, 1, _player.Id);
+            }
+        }
+
+        if (fish.Event != default)
+        {
+            _player.EnqueueStartCommonEvent(fish.Event);
+        }
+
+        //Console.Write($"{_player.Name} поймал на удочку {FishBase.Get(_currentFishId).Name}.\n");
+        _stage = 0;
+        _fishingSpotId = Guid.Empty;
+        _timerWaitFish = 0;
+        _currentFishId = Guid.Empty;
+    }
+
+    public void FishingFailed()
+    {
+        string[] strings =
+        {
+            "Сорвалась..", "Блин..", "Неудача.."
+        };
+        var randInstance = new Random();
+        var rand = randInstance.Next(0, strings.Length);
+        PacketSender.SendChatBubble(_player.Id, _player.MapInstanceId, (int)EntityType.GlobalEntity, strings[rand],
+            _player.MapId);
+        _stage = 0;
+        _fishingSpotId = Guid.Empty;
+        _timerWaitFish = 0;
+        _currentFishId = Guid.Empty;
+        //Console.Write($"{_player.Name} не поймал рыбу.\n");
+    }
+
+    #endregion
+}

--- a/Intersect.Server.Core/Entities/Events/FishEventServer.cs
+++ b/Intersect.Server.Core/Entities/Events/FishEventServer.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Intersect.Core;
 using Intersect.Enums;
 using Intersect.Framework.Core;
 using Intersect.Framework.Core.GameObjects.Fishing;
@@ -148,6 +149,12 @@ public class FishEventServer
         _isFishingVisual = isFishingVisual;
         _stageVisual = stageVisual;
         _isPressed = isPressed;
+
+        _player.IsFishing = _isFishingVisual;
+        _player.FishingStageIndex = _stageVisual;
+        _player.IsFishingRodPressed = _isPressed;
+        _player.FishingStageTimer = Timing.Global.Milliseconds;
+        _player.FishingStageDuration = Options.Instance.Sprites.IdleFrameDuration;
         //Console.Write($"Обновление игрока {_player.Name}\n");
     }
 

--- a/Intersect.Server.Core/Entities/Player.Fishing.cs
+++ b/Intersect.Server.Core/Entities/Player.Fishing.cs
@@ -1,0 +1,71 @@
+using System;
+using System.ComponentModel.DataAnnotations.Schema;
+using Intersect.Enums;
+using Intersect.Network.Packets.Server;
+using Intersect.Server.Entities.Events;
+using Intersect.Server.Networking;
+using Newtonsoft.Json;
+
+namespace Intersect.Server.Entities;
+
+public partial class Player
+{
+    [NotMapped, JsonIgnore]
+    private FishEventServer? _fishEvent;
+
+    [NotMapped, JsonIgnore]
+    public FishEventServer FishEvent => _fishEvent ??= new FishEventServer(this);
+
+    [NotMapped, JsonIgnore]
+    public Guid? FishingFishId { get; private set; }
+
+    [NotMapped, JsonIgnore]
+    public long FishingStageTimer { get; private set; }
+
+    [NotMapped, JsonIgnore]
+    public long FishingResolveTimer { get; private set; }
+
+    [NotMapped, JsonIgnore]
+    public FishingStage FishingStage { get; private set; } = FishingStage.None;
+
+    [NotMapped, JsonIgnore]
+    public bool FishingCancelRequested { get; private set; }
+
+    [NotMapped, JsonIgnore]
+    public bool FishingCanceled { get; private set; }
+
+    public void StartFishing(Guid fishId, long stageTimer, long resolveTimer, FishingStage stage, bool cancelRequested)
+    {
+        FishingFishId = fishId;
+        FishingStageTimer = stageTimer;
+        FishingResolveTimer = resolveTimer;
+        FishingStage = stage;
+        FishingCancelRequested = cancelRequested;
+        FishingCanceled = false;
+
+        PacketSender.SendStartFishing(this, fishId, stageTimer, resolveTimer, stage, cancelRequested);
+    }
+
+    public void ResolveFishing(Guid fishId, long resolveTimer, bool cancelRequested, bool canceled)
+    {
+        FishingFishId = fishId;
+        FishingResolveTimer = resolveTimer;
+        FishingStage = FishingStage.Resolving;
+        FishingCancelRequested = cancelRequested;
+        FishingCanceled = canceled;
+
+        PacketSender.SendResolveFishing(this, fishId, resolveTimer, cancelRequested, canceled);
+    }
+
+    public void StopFishing(bool canceled)
+    {
+        FishingCanceled = canceled;
+        FishingStage = FishingStage.None;
+        FishingFishId = null;
+        FishingStageTimer = 0;
+        FishingResolveTimer = 0;
+        FishingCancelRequested = false;
+
+        PacketSender.SendStopFishing(this, canceled);
+    }
+}

--- a/Intersect.Server.Core/Entities/Player.cs
+++ b/Intersect.Server.Core/Entities/Player.cs
@@ -871,6 +871,8 @@ public partial class Player : Entity
 
                 base.Update(timeMs);
 
+                FishEvent.FishingUpdate();
+
                 if (mAutorunCommonEventTimer < Timing.Global.Milliseconds)
                 {
                     var autorunEvents = 0;

--- a/Intersect.Server.Core/Migrations/Sqlite/Game/20251218011015_AddFishinggame.Designer.cs
+++ b/Intersect.Server.Core/Migrations/Sqlite/Game/20251218011015_AddFishinggame.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Intersect.Server.Database.GameData;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Intersect.Server.Migrations.Sqlite.Game
 {
     [DbContext(typeof(SqliteGameContext))]
-    partial class SqliteGameContextModelSnapshot : ModelSnapshot
+    [Migration("20251218011015_AddFishinggame")]
+    partial class AddFishinggame
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "8.0.11");

--- a/Intersect.Server.Core/Migrations/Sqlite/Game/20251218011015_AddFishinggame.cs
+++ b/Intersect.Server.Core/Migrations/Sqlite/Game/20251218011015_AddFishinggame.cs
@@ -1,0 +1,111 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Intersect.Server.Migrations.Sqlite.Game
+{
+    /// <inheritdoc />
+    public partial class AddFishinggame : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "StatRange_Cures_HighRange",
+                table: "Items_EquipmentProperties");
+
+            migrationBuilder.DropColumn(
+                name: "StatRange_Cures_LowRange",
+                table: "Items_EquipmentProperties");
+
+            migrationBuilder.DropColumn(
+                name: "StatRange_Damages_HighRange",
+                table: "Items_EquipmentProperties");
+
+            migrationBuilder.DropColumn(
+                name: "StatRange_Damages_LowRange",
+                table: "Items_EquipmentProperties");
+
+            migrationBuilder.CreateTable(
+                name: "Fish",
+                columns: table => new
+                {
+                    Name = table.Column<string>(type: "TEXT", nullable: true),
+                    Id = table.Column<Guid>(type: "TEXT", nullable: false),
+                    chance = table.Column<int>(type: "INTEGER", nullable: false),
+                    weight = table.Column<int>(type: "INTEGER", nullable: false),
+                    pushStrength = table.Column<int>(type: "INTEGER", nullable: false),
+                    strength = table.Column<int>(type: "INTEGER", nullable: false),
+                    position = table.Column<int>(type: "INTEGER", nullable: false),
+                    rangeSize = table.Column<int>(type: "INTEGER", nullable: false),
+                    speedMove = table.Column<int>(type: "INTEGER", nullable: false),
+                    speedChangeRangeSize = table.Column<int>(type: "INTEGER", nullable: false),
+                    coeffUnpredictability = table.Column<int>(type: "INTEGER", nullable: false),
+                    timeChangeSpeed = table.Column<int>(type: "INTEGER", nullable: false),
+                    timeChangeRangeSize = table.Column<int>(type: "INTEGER", nullable: false),
+                    ItemId = table.Column<Guid>(type: "TEXT", nullable: false),
+                    Folder = table.Column<string>(type: "TEXT", nullable: true),
+                    Event = table.Column<Guid>(type: "TEXT", nullable: false),
+                    FishingRequirements = table.Column<string>(type: "TEXT", nullable: true),
+                    TimeCreated = table.Column<long>(type: "INTEGER", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Fish", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "FishingSpots",
+                columns: table => new
+                {
+                    Name = table.Column<string>(type: "TEXT", nullable: true),
+                    Id = table.Column<Guid>(type: "TEXT", nullable: false),
+                    Fishes = table.Column<string>(type: "TEXT", nullable: true),
+                    FishingTimeMin = table.Column<int>(type: "INTEGER", nullable: false),
+                    FishingTimeMax = table.Column<int>(type: "INTEGER", nullable: false),
+                    Folder = table.Column<string>(type: "TEXT", nullable: true),
+                    FishingRequirements = table.Column<string>(type: "TEXT", nullable: true),
+                    TimeCreated = table.Column<long>(type: "INTEGER", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_FishingSpots", x => x.Id);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Fish");
+
+            migrationBuilder.DropTable(
+                name: "FishingSpots");
+
+            migrationBuilder.AddColumn<int>(
+                name: "StatRange_Cures_HighRange",
+                table: "Items_EquipmentProperties",
+                type: "INTEGER",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "StatRange_Cures_LowRange",
+                table: "Items_EquipmentProperties",
+                type: "INTEGER",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "StatRange_Damages_HighRange",
+                table: "Items_EquipmentProperties",
+                type: "INTEGER",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "StatRange_Damages_LowRange",
+                table: "Items_EquipmentProperties",
+                type: "INTEGER",
+                nullable: true);
+        }
+    }
+}

--- a/Intersect.Server.Core/Networking/PacketHandler.cs
+++ b/Intersect.Server.Core/Networking/PacketHandler.cs
@@ -25,6 +25,7 @@ using Intersect.Framework.Core.GameObjects.Crafting;
 using Intersect.Framework.Core.GameObjects.Events;
 using Intersect.Framework.Core.GameObjects.Items;
 using Intersect.Framework.Core.GameObjects.Maps;
+using Intersect.Framework.Core.GameObjects.Maps.Attributes;
 using Intersect.Framework.Core.GameObjects.PlayerClass;
 using Intersect.Framework.Core.Security;
 using Intersect.Network.Packets.Server;
@@ -482,6 +483,44 @@ internal sealed partial class PacketHandler
             }
         }
 
+        return true;
+    }
+
+    private bool TryGetFishingSpotAttribute(Client client, out MapFishingSpotAttribute fishingAttribute)
+    {
+        fishingAttribute = default;
+
+        var player = client?.Entity;
+        if (player == null)
+        {
+            return false;
+        }
+
+        if (!MapController.TryGet(player.MapId, out var mapController))
+        {
+            return false;
+        }
+
+        var attributes = mapController.Attributes;
+        if (attributes == null ||
+            player.X < 0 || player.Y < 0 ||
+            player.X >= attributes.GetLength(0) ||
+            player.Y >= attributes.GetLength(1))
+        {
+            return false;
+        }
+
+        if (attributes[player.X, player.Y] is not MapFishingSpotAttribute fishingSpotAttribute)
+        {
+            return false;
+        }
+
+        if (fishingSpotAttribute.FishingSpotType == Guid.Empty)
+        {
+            return false;
+        }
+
+        fishingAttribute = fishingSpotAttribute;
         return true;
     }
 
@@ -3245,6 +3284,64 @@ internal sealed partial class PacketHandler
             return;
         }
         player.IsFading = false;
+    }
+
+    //FishingPacket
+    public void HandlePacket(Client client, FishingPacket packet)
+    {
+        HandleFishingCast(client);
+    }
+
+    //SendFishingSpot
+    public void HandlePacket(Client client, SendFishingSpot packet)
+    {
+        HandleFishingCast(client);
+    }
+
+    //SendCancelFishing
+    public void HandlePacket(Client client, SendCancelFishing packet)
+    {
+        var player = client?.Entity;
+        if (player == null)
+        {
+            return;
+        }
+
+        player.FishEvent.ServerReturnFishingRod();
+    }
+
+    //SendSuccessFishing
+    public void HandlePacket(Client client, SendSuccessFishing packet)
+    {
+        var player = client?.Entity;
+        if (player == null)
+        {
+            return;
+        }
+
+        player.FishEvent.FishingSuccess();
+    }
+
+    //SendFailedFishing
+    public void HandlePacket(Client client, SendFailedFishing packet)
+    {
+        var player = client?.Entity;
+        if (player == null)
+        {
+            return;
+        }
+
+        player.FishEvent.FishingFailed();
+    }
+
+    private void HandleFishingCast(Client client)
+    {
+        if (!TryGetFishingSpotAttribute(client, out var fishingAttribute))
+        {
+            return;
+        }
+
+        client.Entity.FishEvent.ServerCastFishingRod(fishingAttribute.FishingSpotType);
     }
 
     public void HandlePacket(Client client, TargetPacket packet)

--- a/Intersect.Server.Core/Networking/PacketSender.cs
+++ b/Intersect.Server.Core/Networking/PacketSender.cs
@@ -1737,9 +1737,12 @@ public static partial class PacketSender
 
     public static void SendEntityFishing(Player player, bool isFishing, int stage, bool isPressed)
     {
-        player.SendPacket(
+        SendDataToProximityOnMapInstance(
+            player.MapId,
+            player.MapInstanceId,
             new EntityFishingPacket(player.Id, player.GetEntityType(), player.MapId, isFishing, stage, isPressed),
-            TransmissionMode.All
+            player,
+            TransmissionMode.Any
         );
     }
 

--- a/Intersect.Server.Core/Networking/PacketSender.cs
+++ b/Intersect.Server.Core/Networking/PacketSender.cs
@@ -9,6 +9,7 @@ using Intersect.Framework.Core.GameObjects;
 using Intersect.Framework.Core.GameObjects.Animations;
 using Intersect.Framework.Core.GameObjects.Crafting;
 using Intersect.Framework.Core.GameObjects.Events;
+using Intersect.Framework.Core.GameObjects.Fishing;
 using Intersect.Framework.Core.GameObjects.Items;
 using Intersect.Framework.Core.GameObjects.Mapping.Tilesets;
 using Intersect.Framework.Core.GameObjects.Maps.MapList;
@@ -1689,6 +1690,69 @@ public static partial class PacketSender
         player.SendPacket(new GlobalCooldownPacket(cooldown - Timing.Global.MillisecondsUtc), TransmissionMode.All);
     }
 
+    public static void SendStartFishing(
+        Player player,
+        Guid fishId,
+        long stageTimer,
+        long resolveTimer,
+        FishingStage stage,
+        bool cancelRequested
+    )
+    {
+        player.SendPacket(
+            new StartFishingPacket(
+                fishId,
+                Math.Max(0, stageTimer - Timing.Global.Milliseconds),
+                Math.Max(0, resolveTimer - Timing.Global.Milliseconds),
+                stage,
+                cancelRequested
+            ),
+            TransmissionMode.All
+        );
+    }
+
+    public static void SendResolveFishing(
+        Player player,
+        Guid fishId,
+        long resolveTimer,
+        bool cancelRequested,
+        bool canceled
+    )
+    {
+        player.SendPacket(
+            new ResolveFishingPacket(
+                fishId,
+                Math.Max(0, resolveTimer - Timing.Global.Milliseconds),
+                cancelRequested,
+                canceled
+            ),
+            TransmissionMode.All
+        );
+    }
+
+    public static void SendStopFishing(Player player, bool canceled)
+    {
+        player.SendPacket(new StopFishingPacket(canceled), TransmissionMode.All);
+    }
+
+    public static void SendEntityFishing(Player player, bool isFishing, int stage, bool isPressed)
+    {
+        player.SendPacket(
+            new EntityFishingPacket(player.Id, player.GetEntityType(), player.MapId, isFishing, stage, isPressed),
+            TransmissionMode.All
+        );
+    }
+
+    public static void SendClientFish(Player player, Guid fishId)
+    {
+        player.SendPacket(new SendClientFish(fishId), TransmissionMode.All);
+    }
+
+    public static void SendClientResultCastFishingRod(Player player, bool success)
+    {
+        player.SendPacket(new SendClientResultCastFishingRod(success), TransmissionMode.All);
+    }
+
     //ExperiencePacket
     public static void SendExperience(Player player)
     {
@@ -1887,6 +1951,20 @@ public static partial class PacketSender
                 break;
             case GameObjectType.Resource:
                 foreach (var obj in ResourceDescriptor.Lookup)
+                {
+                    SendGameObject(client, obj.Value, false, false, packetList);
+                }
+
+                break;
+            case GameObjectType.Fish:
+                foreach (var obj in FishBase.Lookup)
+                {
+                    SendGameObject(client, obj.Value, false, false, packetList);
+                }
+
+                break;
+            case GameObjectType.FishingSpot:
+                foreach (var obj in FishingSpotBase.Lookup)
                 {
                     SendGameObject(client, obj.Value, false, false, packetList);
                 }

--- a/Intersect.Server/Networking/NetworkedPacketHandler.cs
+++ b/Intersect.Server/Networking/NetworkedPacketHandler.cs
@@ -6,6 +6,7 @@ using Intersect.Framework.Core.GameObjects.Animations;
 using Intersect.Framework.Core.GameObjects.Crafting;
 using Intersect.Framework.Core.GameObjects.Events;
 using Intersect.Framework.Core.GameObjects.Items;
+using Intersect.Framework.Core.GameObjects.Maps.Attributes;
 using Intersect.Framework.Core.GameObjects.Mapping.Tilesets;
 using Intersect.Framework.Core.GameObjects.Maps;
 using Intersect.Framework.Core.GameObjects.Maps.MapList;
@@ -30,12 +31,51 @@ using Intersect.Server.Core.Services;
 using Intersect.Server.Maps;
 using Intersect.Server.Notifications;
 using Intersect.Utilities;
+using System;
 using System.Linq;
 
 namespace Intersect.Server.Networking;
 
 internal sealed partial class NetworkedPacketHandler
 {
+    private bool TryGetFishingSpotAttribute(Client client, out MapFishingSpotAttribute fishingAttribute)
+    {
+        fishingAttribute = default;
+
+        var player = client?.Entity;
+        if (player == null)
+        {
+            return false;
+        }
+
+        if (!MapController.TryGet(player.MapId, out var mapController))
+        {
+            return false;
+        }
+
+        var attributes = mapController.Attributes;
+        if (attributes == null ||
+            player.X < 0 || player.Y < 0 ||
+            player.X >= attributes.GetLength(0) ||
+            player.Y >= attributes.GetLength(1))
+        {
+            return false;
+        }
+
+        if (attributes[player.X, player.Y] is not MapFishingSpotAttribute fishingSpotAttribute)
+        {
+            return false;
+        }
+
+        if (fishingSpotAttribute.FishingSpotType == Guid.Empty)
+        {
+            return false;
+        }
+
+        fishingAttribute = fishingSpotAttribute;
+        return true;
+    }
+
     //AdminActionPacket
     public void HandlePacket(Client client, AdminActionPacket packet)
     {
@@ -100,6 +140,64 @@ internal sealed partial class NetworkedPacketHandler
         }
 
         ApplicationContext.CurrentContext.Logger.LogInformation("Send password reset email to {UserId}", user.Id);
+    }
+
+    //FishingPacket
+    public void HandlePacket(Client client, FishingPacket packet)
+    {
+        HandleFishingCast(client);
+    }
+
+    //SendFishingSpot
+    public void HandlePacket(Client client, SendFishingSpot packet)
+    {
+        HandleFishingCast(client);
+    }
+
+    //SendCancelFishing
+    public void HandlePacket(Client client, SendCancelFishing packet)
+    {
+        var player = client?.Entity;
+        if (player == null)
+        {
+            return;
+        }
+
+        player.FishEvent.ServerReturnFishingRod();
+    }
+
+    //SendSuccessFishing
+    public void HandlePacket(Client client, SendSuccessFishing packet)
+    {
+        var player = client?.Entity;
+        if (player == null)
+        {
+            return;
+        }
+
+        player.FishEvent.FishingSuccess();
+    }
+
+    //SendFailedFishing
+    public void HandlePacket(Client client, SendFailedFishing packet)
+    {
+        var player = client?.Entity;
+        if (player == null)
+        {
+            return;
+        }
+
+        player.FishEvent.FishingFailed();
+    }
+
+    private void HandleFishingCast(Client client)
+    {
+        if (!TryGetFishingSpotAttribute(client, out var fishingAttribute))
+        {
+            return;
+        }
+
+        client.Entity.FishEvent.ServerCastFishingRod(fishingAttribute.FishingSpotType);
     }
 
         #region "Editor Packets"


### PR DESCRIPTION
## Summary
- broadcast fishing state packets to nearby map viewers instead of only the initiating player
- use proximity routing to keep remote fishing animations in sync

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69432cf32aec832b85eb8ad5f5aa4760)