### PR TITLE
Add feature flag for Fishing V2

### DIFF
--- a/Framework/Intersect.Framework.Core/Config/FeatureOptions.cs
+++ b/Framework/Intersect.Framework.Core/Config/FeatureOptions.cs
@@ -1,0 +1,12 @@
+using System.ComponentModel;
+
+namespace Intersect.Config;
+
+/// <summary>
+/// Feature flag configuration.
+/// </summary>
+public partial class FeatureOptions
+{
+    [DefaultValue(false)]
+    public bool NewFishingV2 { get; set; } = false;
+}

--- a/Framework/Intersect.Framework.Core/Config/Options.cs
+++ b/Framework/Intersect.Framework.Core/Config/Options.cs
@@ -44,6 +44,8 @@ public partial record Options
 
     public const string CategoryNetworkVisibility = nameof(CategoryNetworkVisibility);
 
+    public const string CategoryFeatures = nameof(CategoryFeatures);
+
     public const string CategorySecurity = nameof(CategorySecurity);
 
     #endregion
@@ -142,6 +144,15 @@ public partial record Options
     public MetricsOptions Metrics { get; set; } = new();
 
     #endregion Logging and Metrics
+
+    #region Features
+
+    [Category(CategoryFeatures)]
+    [JsonProperty(Order = -85)]
+    [RequiresRestart]
+    public FeatureOptions Features { get; set; } = new();
+
+    #endregion Features
 
     #region Database
 

--- a/Intersect.Client.Core/CustomChanges/FishEventClient.cs
+++ b/Intersect.Client.Core/CustomChanges/FishEventClient.cs
@@ -1,6 +1,7 @@
 using Intersect.Client.Core;
 using Intersect.Client.Core.Controls;
 using Intersect.Client.Core.Sounds;
+using Intersect;
 using Intersect.Client.Framework.Entities;
 using Intersect.Client.Framework.Graphics;
 using Intersect.Client.Framework.Input;
@@ -116,6 +117,11 @@ public partial class FishEventClient
 
     public bool TryFishing()
     {
+        if (!Options.Instance.Features.NewFishingV2)
+        {
+            return false;
+        }
+
         if (isFishingEvent)
         {
             if (isDebaging)

--- a/Intersect.Client.Core/Networking/PacketHandler.cs
+++ b/Intersect.Client.Core/Networking/PacketHandler.cs
@@ -1,3 +1,4 @@
+using Intersect;
 using Intersect.Client.Core;
 using Intersect.Client.Entities;
 using Intersect.Client.Entities.Events;
@@ -1202,6 +1203,11 @@ internal sealed partial class PacketHandler
 
     public void HandlePacket(IPacketSender packetSender, EntityFishingPacket packet)
     {
+        if (!Options.Instance.Features.NewFishingV2)
+        {
+            return;
+        }
+
         var id = packet.Id;
         var type = packet.Type;
         var mapId = packet.MapId;
@@ -1617,6 +1623,11 @@ internal sealed partial class PacketHandler
 
     public void HandlePacket(IPacketSender packetSender, StartFishingPacket packet)
     {
+        if (!Options.Instance.Features.NewFishingV2)
+        {
+            return;
+        }
+
         Globals.Me?.StartFishing(
             packet.FishId,
             Timing.Global.Milliseconds + packet.StageTimer,
@@ -1628,6 +1639,11 @@ internal sealed partial class PacketHandler
 
     public void HandlePacket(IPacketSender packetSender, ResolveFishingPacket packet)
     {
+        if (!Options.Instance.Features.NewFishingV2)
+        {
+            return;
+        }
+
         Globals.Me?.ResolveFishing(
             packet.FishId,
             Timing.Global.Milliseconds + packet.ResolveTimer,
@@ -1638,6 +1654,11 @@ internal sealed partial class PacketHandler
 
     public void HandlePacket(IPacketSender packetSender, StopFishingPacket packet)
     {
+        if (!Options.Instance.Features.NewFishingV2)
+        {
+            return;
+        }
+
         Globals.Me?.StopFishing(packet.Canceled);
     }
 

--- a/Intersect.Client.Core/Networking/PacketSender.cs
+++ b/Intersect.Client.Core/Networking/PacketSender.cs
@@ -1,3 +1,4 @@
+using Intersect;
 using Intersect.Client.Entities.Events;
 using Intersect.Client.Framework.Gwen.Control;
 using Intersect.Client.Framework.Gwen.Control.EventArguments;
@@ -578,26 +579,51 @@ public static partial class PacketSender
 
     public static void SendFishingCast()
     {
+        if (!Options.Instance.Features.NewFishingV2)
+        {
+            return;
+        }
+
         Network.SendPacket(new FishingPacket());
     }
 
     public static void SendFishingSpot()
     {
+        if (!Options.Instance.Features.NewFishingV2)
+        {
+            return;
+        }
+
         Network.SendPacket(new SendFishingSpot());
     }
 
     public static void SendSuccessFishing()
     {
+        if (!Options.Instance.Features.NewFishingV2)
+        {
+            return;
+        }
+
         Network.SendPacket(new SendSuccessFishing());
     }
 
     public static void SendCancelFishing()
     {
+        if (!Options.Instance.Features.NewFishingV2)
+        {
+            return;
+        }
+
         Network.SendPacket(new SendCancelFishing());
     }
 
     public static void SendFailedFishing()
     {
+        if (!Options.Instance.Features.NewFishingV2)
+        {
+            return;
+        }
+
         Network.SendPacket(new SendFailedFishing());
     }
 

--- a/Intersect.Server.Core/Entities/Player.cs
+++ b/Intersect.Server.Core/Entities/Player.cs
@@ -871,7 +871,10 @@ public partial class Player : Entity
 
                 base.Update(timeMs);
 
-                FishEvent.FishingUpdate();
+                if (Options.Instance.Features.NewFishingV2)
+                {
+                    FishEvent.FishingUpdate();
+                }
 
                 if (mAutorunCommonEventTimer < Timing.Global.Milliseconds)
                 {

--- a/Intersect.Server.Core/Networking/PacketHandler.cs
+++ b/Intersect.Server.Core/Networking/PacketHandler.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Intersect.Enums;
+using Intersect;
 using Intersect.GameObjects;
 using Intersect.Network;
 using Intersect.Network.Packets;
@@ -3331,6 +3332,11 @@ internal sealed partial class PacketHandler
     //FishingPacket
     public void HandlePacket(Client client, FishingPacket packet)
     {
+        if (!Options.Instance.Features.NewFishingV2)
+        {
+            return;
+        }
+
         if (!TryGetFishingSpotAttribute(client, out var fishingAttribute))
         {
             return;
@@ -3342,6 +3348,11 @@ internal sealed partial class PacketHandler
     //SendFishingSpot
     public void HandlePacket(Client client, SendFishingSpot packet)
     {
+        if (!Options.Instance.Features.NewFishingV2)
+        {
+            return;
+        }
+
         if (!TryGetFishingSpotAttribute(client, out var fishingAttribute))
         {
             return;
@@ -3353,6 +3364,11 @@ internal sealed partial class PacketHandler
     //SendCancelFishing
     public void HandlePacket(Client client, SendCancelFishing packet)
     {
+        if (!Options.Instance.Features.NewFishingV2)
+        {
+            return;
+        }
+
         var player = client?.Entity;
         if (player == null)
         {
@@ -3365,6 +3381,11 @@ internal sealed partial class PacketHandler
     //SendSuccessFishing
     public void HandlePacket(Client client, SendSuccessFishing packet)
     {
+        if (!Options.Instance.Features.NewFishingV2)
+        {
+            return;
+        }
+
         var player = client?.Entity;
         if (player == null)
         {
@@ -3377,6 +3398,11 @@ internal sealed partial class PacketHandler
     //SendFailedFishing
     public void HandlePacket(Client client, SendFailedFishing packet)
     {
+        if (!Options.Instance.Features.NewFishingV2)
+        {
+            return;
+        }
+
         var player = client?.Entity;
         if (player == null)
         {


### PR DESCRIPTION
## Summary
- add a features options section with a NewFishingV2 toggle defaulting to false
- guard client and server fishing handlers and requests behind the new feature flag

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69463561dc40832b95d9dcf4e8c3f2c5)