### PR TITLE
Add fishing input definitions

### DIFF
--- a/Framework/Intersect.Framework.Core/Fishing/FishingInput.cs
+++ b/Framework/Intersect.Framework.Core/Fishing/FishingInput.cs
@@ -1,0 +1,22 @@
+namespace Intersect.Fishing;
+
+[System.Flags]
+public enum FishingInputFlags
+{
+    None = 0,
+    Tap = 1 << 0,
+}
+
+public struct FishingInputFrame
+{
+    public int TickMs { get; init; }
+
+    public FishingInputFlags Flags { get; init; }
+}
+
+public enum FishingSimResult
+{
+    InProgress,
+    Success,
+    Failed,
+}


### PR DESCRIPTION
## Summary
- add fishing input flags, input frame, and simulation result types for the fishing simulator

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946c52ea19c832b8a4400dca4fe3617)