### PR TITLE
Add fishing simulation DTOs

### DIFF
--- a/Framework/Intersect.Framework.Core/Fishing/FishingSimConfigDto.cs
+++ b/Framework/Intersect.Framework.Core/Fishing/FishingSimConfigDto.cs
@@ -1,0 +1,86 @@
+using MessagePack;
+
+namespace Intersect.Fishing;
+
+[MessagePackObject]
+public sealed class FishingSimConfigDto
+{
+    [Key(0)]
+    public float BeginValue { get; set; }
+
+    [Key(1)]
+    public float PlayerStrength { get; set; }
+
+    [Key(2)]
+    public float HookSize { get; set; }
+
+    [Key(3)]
+    public float FishInitialPosition { get; set; }
+
+    [Key(4)]
+    public float FishBaseSpeed { get; set; }
+
+    [Key(5)]
+    public float FishRangeBaseSize { get; set; }
+
+    [Key(6)]
+    public float FishRangeChangeSpeed { get; set; }
+
+    [Key(7)]
+    public float FishWeight { get; set; }
+
+    [Key(8)]
+    public float FishStrengthDrain { get; set; }
+
+    [Key(9)]
+    public float FishPushStrength { get; set; }
+
+    [Key(10)]
+    public int TimeChangeSpeedMs { get; set; }
+
+    [Key(11)]
+    public int TimeChangeRangeMs { get; set; }
+
+    [Key(12)]
+    public float Unpredictability { get; set; }
+
+    public static FishingSimConfigDto FromConfig(FishingSimConfig config)
+    {
+        return new FishingSimConfigDto
+        {
+            BeginValue = config.BeginValue,
+            PlayerStrength = config.PlayerStrength,
+            HookSize = config.HookSize,
+            FishInitialPosition = config.FishInitialPosition,
+            FishBaseSpeed = config.FishBaseSpeed,
+            FishRangeBaseSize = config.FishRangeBaseSize,
+            FishRangeChangeSpeed = config.FishRangeChangeSpeed,
+            FishWeight = config.FishWeight,
+            FishStrengthDrain = config.FishStrengthDrain,
+            FishPushStrength = config.FishPushStrength,
+            TimeChangeSpeedMs = config.TimeChangeSpeedMs,
+            TimeChangeRangeMs = config.TimeChangeRangeMs,
+            Unpredictability = config.Unpredictability,
+        };
+    }
+
+    public FishingSimConfig ToConfig()
+    {
+        return new FishingSimConfig
+        {
+            BeginValue = BeginValue,
+            PlayerStrength = PlayerStrength,
+            HookSize = HookSize,
+            FishInitialPosition = FishInitialPosition,
+            FishBaseSpeed = FishBaseSpeed,
+            FishRangeBaseSize = FishRangeBaseSize,
+            FishRangeChangeSpeed = FishRangeChangeSpeed,
+            FishWeight = FishWeight,
+            FishStrengthDrain = FishStrengthDrain,
+            FishPushStrength = FishPushStrength,
+            TimeChangeSpeedMs = TimeChangeSpeedMs,
+            TimeChangeRangeMs = TimeChangeRangeMs,
+            Unpredictability = Unpredictability,
+        };
+    }
+}

--- a/Framework/Intersect.Framework.Core/Fishing/FishingSimStateDto.cs
+++ b/Framework/Intersect.Framework.Core/Fishing/FishingSimStateDto.cs
@@ -1,0 +1,71 @@
+using MessagePack;
+
+namespace Intersect.Fishing;
+
+[MessagePackObject]
+public sealed class FishingSimStateDto
+{
+    [Key(0)]
+    public float CurrentValue { get; set; }
+
+    [Key(1)]
+    public float FishPosition { get; set; }
+
+    [Key(2)]
+    public float FishMoveSpeed { get; set; }
+
+    [Key(3)]
+    public float RangeSize { get; set; }
+
+    [Key(4)]
+    public float TargetRangeSize { get; set; }
+
+    [Key(5)]
+    public float PlayerPosition { get; set; }
+
+    [Key(6)]
+    public float PullMeter { get; set; }
+
+    [Key(7)]
+    public long NextSpeedChangeAtMs { get; set; }
+
+    [Key(8)]
+    public long NextRangeChangeAtMs { get; set; }
+
+    [Key(9)]
+    public long TickMs { get; set; }
+
+    public static FishingSimStateDto FromState(FishingSimState state)
+    {
+        return new FishingSimStateDto
+        {
+            CurrentValue = state.CurrentValue,
+            FishPosition = state.FishPosition,
+            FishMoveSpeed = state.FishMoveSpeed,
+            RangeSize = state.RangeSize,
+            TargetRangeSize = state.TargetRangeSize,
+            PlayerPosition = state.PlayerPosition,
+            PullMeter = state.PullMeter,
+            NextSpeedChangeAtMs = state.NextSpeedChangeAtMs,
+            NextRangeChangeAtMs = state.NextRangeChangeAtMs,
+            TickMs = state.TickMs,
+        };
+    }
+
+    public FishingSimState ToState()
+    {
+        return new FishingSimState
+        {
+            CurrentValue = CurrentValue,
+            FishPosition = FishPosition,
+            FishMoveSpeed = FishMoveSpeed,
+            RangeSize = RangeSize,
+            TargetRangeSize = TargetRangeSize,
+            PlayerPosition = PlayerPosition,
+            PullMeter = PullMeter,
+            NextSpeedChangeAtMs = NextSpeedChangeAtMs,
+            NextRangeChangeAtMs = NextRangeChangeAtMs,
+            TickMs = TickMs,
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- add DTOs for fishing simulation config and state with serialization attributes
- provide helper methods to convert to and from existing config/state objects

## Testing
- not run (dotnet CLI unavailable in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946c708a44c832bb2969bc0e58b7900)