### PR TITLE
Add fishing request packets and sender helpers

### DIFF
--- a/Framework/Intersect.Framework.Core/Network/Packets/Client/Fishing/FishingCancelRequest.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Client/Fishing/FishingCancelRequest.cs
@@ -1,0 +1,24 @@
+using System;
+using MessagePack;
+
+namespace Intersect.Network.Packets.Client;
+
+[MessagePackObject]
+public partial class FishingCancelRequest : IntersectPacket
+{
+    public FishingCancelRequest()
+    {
+    }
+
+    public FishingCancelRequest(Guid sessionId, string reason)
+    {
+        SessionId = sessionId;
+        Reason = reason;
+    }
+
+    [Key(0)]
+    public Guid SessionId { get; set; }
+
+    [Key(1)]
+    public string Reason { get; set; } = string.Empty;
+}

--- a/Framework/Intersect.Framework.Core/Network/Packets/Client/Fishing/FishingCastRequest.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Client/Fishing/FishingCastRequest.cs
@@ -1,0 +1,20 @@
+using System;
+using MessagePack;
+
+namespace Intersect.Network.Packets.Client;
+
+[MessagePackObject]
+public partial class FishingCastRequest : IntersectPacket
+{
+    public FishingCastRequest()
+    {
+    }
+
+    public FishingCastRequest(Guid sessionId)
+    {
+        SessionId = sessionId;
+    }
+
+    [Key(0)]
+    public Guid SessionId { get; set; }
+}

--- a/Framework/Intersect.Framework.Core/Network/Packets/Client/Fishing/FishingInputPacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Client/Fishing/FishingInputPacket.cs
@@ -1,0 +1,29 @@
+using System;
+using Intersect.Fishing;
+using MessagePack;
+
+namespace Intersect.Network.Packets.Client;
+
+[MessagePackObject]
+public partial class FishingInputPacket : IntersectPacket
+{
+    public FishingInputPacket()
+    {
+    }
+
+    public FishingInputPacket(Guid sessionId, int tickMs, FishingInputFlags flags)
+    {
+        SessionId = sessionId;
+        TickMs = tickMs;
+        Flags = flags;
+    }
+
+    [Key(0)]
+    public Guid SessionId { get; set; }
+
+    [Key(1)]
+    public int TickMs { get; set; }
+
+    [Key(2)]
+    public FishingInputFlags Flags { get; set; }
+}

--- a/Intersect.Client.Core/Networking/PacketSender.cs
+++ b/Intersect.Client.Core/Networking/PacketSender.cs
@@ -17,6 +17,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Intersect.Network.Packets;
 using Intersect.Network.Packets.Shops;
+using Intersect.Fishing;
 using AdminAction = Intersect.Admin.Actions.AdminAction;
 
 namespace Intersect.Client.Networking;
@@ -587,6 +588,16 @@ public static partial class PacketSender
         Network.SendPacket(new FishingPacket());
     }
 
+    public static void SendFishingCastRequest(Guid sessionId)
+    {
+        if (!Options.Instance.Features.NewFishingV2)
+        {
+            return;
+        }
+
+        Network.SendPacket(new FishingCastRequest(sessionId));
+    }
+
     public static void SendFishingSpot()
     {
         if (!Options.Instance.Features.NewFishingV2)
@@ -617,6 +628,16 @@ public static partial class PacketSender
         Network.SendPacket(new SendCancelFishing());
     }
 
+    public static void SendFishingCancel(Guid sessionId, string reason)
+    {
+        if (!Options.Instance.Features.NewFishingV2)
+        {
+            return;
+        }
+
+        Network.SendPacket(new FishingCancelRequest(sessionId, reason));
+    }
+
     public static void SendFailedFishing()
     {
         if (!Options.Instance.Features.NewFishingV2)
@@ -625,6 +646,16 @@ public static partial class PacketSender
         }
 
         Network.SendPacket(new SendFailedFishing());
+    }
+
+    public static void SendFishingInput(Guid sessionId, int tickMs, FishingInputFlags flags)
+    {
+        if (!Options.Instance.Features.NewFishingV2)
+        {
+            return;
+        }
+
+        Network.SendPacket(new FishingInputPacket(sessionId, tickMs, flags));
     }
 
 }


### PR DESCRIPTION
## Summary
- add dedicated fishing cast, cancel, and input client packets with session metadata
- expose PacketSender helpers to emit the new fishing packets

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946c7a8d3f4832b916354533d722c43)