### PR TITLE
Guard legacy fishing packets when V2 enabled

### DIFF
--- a/Intersect.Client.Core/CustomChanges/FishEventClient.cs
+++ b/Intersect.Client.Core/CustomChanges/FishEventClient.cs
@@ -611,7 +611,10 @@ public partial class FishEventClient
     {
         stage = 3;
         isFishingEvent = false;
-        PacketSender.SendFailedFishing();
+        if (!Options.Instance.Features.NewFishingV2)
+        {
+            PacketSender.SendFailedFishing();
+        }
         timeFishingRod = Timing.Global.Milliseconds + timerFishingRod;
         if (eventUI != null)
             eventUI.HideBars();
@@ -622,7 +625,10 @@ public partial class FishEventClient
     {
         stage = 3;
         isFishingEvent = false;
-        PacketSender.SendSuccessFishing();
+        if (!Options.Instance.Features.NewFishingV2)
+        {
+            PacketSender.SendSuccessFishing();
+        }
         timeFishingRod = Timing.Global.Milliseconds + timerFishingRod;
         if (eventUI != null && fish != null)
         {

--- a/Intersect.Client.Core/Networking/PacketSender.cs
+++ b/Intersect.Client.Core/Networking/PacketSender.cs
@@ -610,7 +610,7 @@ public static partial class PacketSender
 
     public static void SendSuccessFishing()
     {
-        if (!Options.Instance.Features.NewFishingV2)
+        if (Options.Instance.Features.NewFishingV2)
         {
             return;
         }
@@ -640,7 +640,7 @@ public static partial class PacketSender
 
     public static void SendFailedFishing()
     {
-        if (!Options.Instance.Features.NewFishingV2)
+        if (Options.Instance.Features.NewFishingV2)
         {
             return;
         }


### PR DESCRIPTION
## Summary
- prevent legacy fishing success/failure packets from sending when NewFishingV2 is enabled
- guard fishing event client triggers to avoid legacy packet calls in V2 mode

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69471fe6ae0c832b8de44e43e3b73590)