### PR TITLE
Handle TargetEffect runes in UI

### DIFF
--- a/Intersect.Client.Core/Interface/Game/Breaking/RuneEnchantWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Breaking/RuneEnchantWindow.cs
@@ -92,22 +92,34 @@ public partial class RuneEnchantWindow : Window
 
     public void SelectTargetItem(Item? item)
     {
-        if (item == null || item.Descriptor == null) return;
-
         _selectedItem = item;
-        _itemSlot.Texture = Globals.ContentManager.GetTexture(Intersect.Client.Framework.Content.TextureType.Item, item.Descriptor.Icon)
-                              ?? Graphics.Renderer.WhitePixel;
+
+        if (item?.Descriptor != null)
+        {
+            _itemSlot.Texture = Globals.ContentManager.GetTexture(Intersect.Client.Framework.Content.TextureType.Item, item.Descriptor.Icon)
+                                  ?? Graphics.Renderer.WhitePixel;
+        }
+        else
+        {
+            _itemSlot.Texture = Graphics.Renderer.WhitePixel;
+        }
 
         UpdateProjection();
     }
 
     public void SelectRuneItem(Item? rune)
     {
-        if (rune == null || rune.Descriptor == null) return;
-
         _selectedRune = rune;
-        _runeSlot.Texture = Globals.ContentManager.GetTexture(Intersect.Client.Framework.Content.TextureType.Item, rune.Descriptor.Icon)
-                             ?? Graphics.Renderer.WhitePixel;
+
+        if (rune?.Descriptor != null)
+        {
+            _runeSlot.Texture = Globals.ContentManager.GetTexture(Intersect.Client.Framework.Content.TextureType.Item, rune.Descriptor.Icon)
+                                 ?? Graphics.Renderer.WhitePixel;
+        }
+        else
+        {
+            _runeSlot.Texture = Graphics.Renderer.WhitePixel;
+        }
 
         UpdateProjection();
     }
@@ -127,36 +139,34 @@ public partial class RuneEnchantWindow : Window
         var vital = rune.TargetVital;
         var targetEffect = rune.TargetEffect;
         var amount = rune.AmountModifier;
-       
+
         var residualItem = _selectedItem.ItemProperties.MageSink/100.0;
 
         string labelStatOrVital;
-        string labelAmount = $"Cantidad: +{amount}";
-      
+        var amountSign = amount > 0 ? "+" : string.Empty;
+        string labelAmount = $"Cantidad: {amountSign}{amount}";
+
         string labelMageSink = $"Carga residual del ítem: {residualItem}";
 
-        if (amount == 0)
+        if (targetEffect != ItemEffect.None)
         {
-            labelStatOrVital = "Efecto: Sin efecto";
+            var effectName = Strings.ItemDescription.BonusEffects.TryGetValue((int)targetEffect, out var localizedEffect)
+                ? localizedEffect.ToString()
+                : targetEffect.ToString();
+            labelStatOrVital = $"Efecto: {effectName.TrimEnd(':')}";
+            labelAmount = $"Bonus: {amountSign}{amount}%";
+        }
+        else if (stat >= 0 && (int)stat < Enum.GetValues<Stat>().Length)
+        {
+            labelStatOrVital = $"Stat: {Strings.ItemDescription.StatCounts[(int)stat]}";
+        }
+        else if (vital >= 0 && (int)vital < Enum.GetValues<Vital>().Length)
+        {
+            labelStatOrVital = $"Vital: {Strings.ItemDescription.Vitals[(int)vital]}";
         }
         else
         {
-            if (stat >= 0 && (int)stat < Enum.GetValues<Stat>().Length)
-            {
-                labelStatOrVital = $"Stat: {Strings.ItemDescription.StatCounts[(int)stat]}";
-            }
-            else if (vital >= 0 && (int)vital < Enum.GetValues<Vital>().Length)
-            {
-                labelStatOrVital = $"Vital: {Strings.ItemDescription.Vitals[(int)vital]}";
-            }
-            else if (targetEffect != ItemEffect.None)
-            {
-                labelStatOrVital = $"Efecto: {targetEffect}";
-            }
-            else
-            {
-                labelStatOrVital = "Efecto: Desconocido";
-            }
+            labelStatOrVital = amount == 0 ? "Efecto: Sin efecto" : "Efecto: Desconocido";
         }
 
         // Posicionamiento dinámico

--- a/Intersect.Client.Core/Interface/Game/Breaking/RuneInventoryItem.cs
+++ b/Intersect.Client.Core/Interface/Game/Breaking/RuneInventoryItem.cs
@@ -130,6 +130,11 @@ public class RuneInventoryItem : SlotItem
         if (inventorySlot is not Items.Item item)
             return;
 
+        if (!IsRune(inventorySlot.Descriptor) && arguments.MouseButton is MouseButton.Right)
+        {
+            return;
+        }
+
         if (arguments.MouseButton is MouseButton.Left)
         {
             // Si el item ya está como runa, lo deseleccionamos
@@ -215,5 +220,17 @@ public class RuneInventoryItem : SlotItem
         Icon.Texture = null;
         _quantityLabel.IsVisibleInParent = false;
         _cooldownLabel.IsVisibleInParent = false;
+    }
+
+    private static bool IsRune(ItemDescriptor descriptor)
+    {
+        if (!string.Equals(descriptor.Subtype, "Rune", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        return descriptor.TargetStat != (Stat)(-1)
+               || descriptor.TargetVital != (Vital)(-1)
+               || descriptor.TargetEffect != ItemEffect.None;
     }
 }

--- a/Intersect.Client.Core/Interface/Game/DescriptionWindows/ItemDescriptionWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/DescriptionWindows/ItemDescriptionWindow.cs
@@ -169,26 +169,30 @@ public partial class ItemDescriptionWindow() : DescriptionWindowBase(Interface.G
 
         if (_itemDescriptor.Subtype == "Rune")
         {
-           
             var amount = _itemDescriptor.AmountModifier;
+            var amountPrefix = amount > 0 ? "+" : string.Empty;
+            var hasStatTarget = Enum.IsDefined(typeof(Stat), _itemDescriptor.TargetStat);
+            var hasVitalTarget = Enum.IsDefined(typeof(Vital), _itemDescriptor.TargetVital);
+            var hasEffectTarget = _itemDescriptor.TargetEffect != ItemEffect.None;
 
-            if (amount != 0)
+            if (hasEffectTarget)
             {
-                if (Enum.IsDefined(typeof(Stat), _itemDescriptor.TargetStat))
-                {
-                    rows.AddKeyValueRow("Stat Modified", _itemDescriptor.TargetStat.ToString());
-                    rows.AddKeyValueRow("Bonus", $"{(amount > 0 ? "+" : "")}{amount}");
-                }
-                else if (Enum.IsDefined(typeof(Vital), _itemDescriptor.TargetVital))
-                {
-                    rows.AddKeyValueRow("Vital Modified", _itemDescriptor.TargetVital.ToString());
-                    rows.AddKeyValueRow("Bonus", $"{(amount > 0 ? "+" : "")}{amount}");
-                }
-                else if (_itemDescriptor.TargetEffect != ItemEffect.None)
-                {
-                    rows.AddKeyValueRow("Effect Modified", _itemDescriptor.TargetEffect.ToString());
-                    rows.AddKeyValueRow("Bonus", $"{(amount > 0 ? "+" : "")}{amount}");
-                }
+                var effectName = Strings.ItemDescription.BonusEffects.TryGetValue((int)_itemDescriptor.TargetEffect, out var localizedEffect)
+                    ? localizedEffect.ToString()
+                    : _itemDescriptor.TargetEffect.ToString();
+
+                rows.AddKeyValueRow("Efecto", effectName.TrimEnd(':'));
+                rows.AddKeyValueRow("Bonus", Strings.ItemDescription.Percentage.ToString(amount));
+            }
+            else if (hasStatTarget)
+            {
+                rows.AddKeyValueRow("Stat Modified", _itemDescriptor.TargetStat.ToString());
+                rows.AddKeyValueRow("Bonus", $"{amountPrefix}{amount}");
+            }
+            else if (hasVitalTarget)
+            {
+                rows.AddKeyValueRow("Vital Modified", _itemDescriptor.TargetVital.ToString());
+                rows.AddKeyValueRow("Bonus", $"{amountPrefix}{amount}");
             }
         }
 


### PR DESCRIPTION
## Summary
- show effect-specific labels and bonus values in the rune projection preview
- allow selecting rune items that only declare a TargetEffect
- render effect rune details in item descriptions with existing formatting

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69530c448244832bade8b19924528a81)