### PR TITLE
MapItem: explicitly construct EffectData when copying EffectModifiers

### DIFF
--- a/Framework/Intersect.Framework.Core/GameObjects/Items/EffectData.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Items/EffectData.cs
@@ -45,6 +45,19 @@ public partial class EffectData
         IsFlat = false;
     }
 
+    public EffectData Clone()
+    {
+        return new EffectData
+        {
+            Type = Type,
+            Percentage = Percentage,
+            FlatAmount = FlatAmount,
+            IsFlat = IsFlat,
+            IsPassive = IsPassive,
+            Stacking = Stacking,
+        };
+    }
+
     public ItemEffect Type { get; set; }
 
     public int Percentage { get; set; }

--- a/Framework/Intersect.Framework.Core/GameObjects/Items/EffectData.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Items/EffectData.cs
@@ -2,19 +2,6 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Intersect.Framework.Core.GameObjects.Items;
 
-public readonly record struct EffectValue(int Percentage, int Flat)
-{
-    public int GetPrimaryValue(bool preferFlat = false)
-    {
-        return Percentage;
-    }
-
-    public EffectValue Add(EffectValue other)
-    {
-        return new EffectValue(Percentage + other.Percentage, 0);
-    }
-}
-
 [Owned]
 public partial class EffectData
 {
@@ -24,64 +11,26 @@ public partial class EffectData
         Percentage = default;
         IsPassive = true;
         Stacking = EffectStacking.Stack;
-        FlatAmount = 0;
-        IsFlat = false;
     }
 
     public EffectData(
         ItemEffect type,
         int percentage,
         bool isPassive = true,
-        EffectStacking stacking = EffectStacking.Stack,
-        int flatAmount = 0,
-        bool isFlat = false
+        EffectStacking stacking = EffectStacking.Stack
     )
     {
         Type = type;
         Percentage = percentage;
         IsPassive = isPassive;
         Stacking = stacking;
-        FlatAmount = 0;
-        IsFlat = false;
-    }
-
-    public EffectData Clone()
-    {
-        return new EffectData
-        {
-            Type = Type,
-            Percentage = Percentage,
-            FlatAmount = FlatAmount,
-            IsFlat = IsFlat,
-            IsPassive = IsPassive,
-            Stacking = Stacking,
-        };
     }
 
     public ItemEffect Type { get; set; }
 
     public int Percentage { get; set; }
 
-    public int FlatAmount { get; set; }
-
-    public bool IsFlat { get; set; }
-
     public bool IsPassive { get; set; }
 
     public EffectStacking Stacking { get; set; }
-
-    public static bool SupportsFlatAndPercentage(ItemEffect effect)
-    {
-        return false;
-    }
-
-    public int GetValue()
-    {
-        return Percentage;
-    }
-
-    public EffectValue GetValues()
-    {
-        return new EffectValue(Percentage, 0);
-    }
 }

--- a/Framework/Intersect.Framework.Core/GameObjects/Items/EffectExtensions.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Items/EffectExtensions.cs
@@ -4,14 +4,14 @@ namespace Intersect.Framework.Core.GameObjects.Items;
 
 public static class EffectExtensions
 {
-    public static void ApplyEffect(this IDictionary<ItemEffect, EffectValue> dest, EffectData effect)
+    public static void ApplyEffect(this IDictionary<ItemEffect, int> dest, EffectData effect)
     {
         if (!effect.IsPassive)
         {
             return;
         }
 
-        var value = effect.GetValues();
+        var value = effect.Percentage;
         switch (effect.Stacking)
         {
             case EffectStacking.Ignore:
@@ -28,7 +28,7 @@ public static class EffectExtensions
             default:
                 if (dest.ContainsKey(effect.Type))
                 {
-                    dest[effect.Type] = dest[effect.Type].Add(value);
+                    dest[effect.Type] += value;
                 }
                 else
                 {

--- a/Framework/Intersect.Framework.Core/GameObjects/Items/ItemDescriptor.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Items/ItemDescriptor.cs
@@ -516,6 +516,9 @@ public partial class ItemDescriptor : DatabaseObject<ItemDescriptor>, IFolderabl
         Consumable = new ConsumableData();
         Effects = [];
         Color = new Color(255, 255, 255, 255);
+        TargetStat = (Stat)(-1);
+        TargetVital = (Vital)(-1);
+        TargetEffect = ItemEffect.None;
         if (ItemType != ItemType.Equipment)
         {
             SetId = Guid.Empty;
@@ -548,7 +551,8 @@ public partial class ItemDescriptor : DatabaseObject<ItemDescriptor>, IFolderabl
         return Math.Max(0.1, 1.0 - (0.1 * level)); // Probabilidad decreciente
     }
     public Stat TargetStat { get; set; }
-    public Vital TargetVital { get; set; }  
+    public Vital TargetVital { get; set; }
+    public ItemEffect TargetEffect { get; set; }
     public int AmountModifier { get; set; }
 
 }

--- a/Framework/Intersect.Framework.Core/GameObjects/Items/ItemDescriptor.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Items/ItemDescriptor.cs
@@ -349,7 +349,10 @@ public partial class ItemDescriptor : DatabaseObject<ItemDescriptor>, IFolderabl
     public string EffectsJson
     {
         get => JsonConvert.SerializeObject(Effects);
-        set => Effects = JsonConvert.DeserializeObject<List<EffectData>>(value ?? "") ?? [];
+        set
+        {
+            Effects = JsonConvert.DeserializeObject<List<EffectData>>(value ?? "") ?? [];
+        }
     }
 
     public EquipmentProperties? EquipmentProperties { get; set; }
@@ -427,12 +430,7 @@ public partial class ItemDescriptor : DatabaseObject<ItemDescriptor>, IFolderabl
 
     public int GetEffectPercentage(ItemEffect type)
     {
-        return Effects.Find(effect => effect.Type == type)?.GetValue() ?? 0;
-    }
-
-    public EffectValue GetEffectValues(ItemEffect type)
-    {
-        return Effects.Find(effect => effect.Type == type)?.GetValues() ?? default;
+        return Effects.Find(effect => effect.Type == type)?.Percentage ?? 0;
     }
 
     public EffectData? GetEffect(ItemEffect type)
@@ -446,7 +444,7 @@ public partial class ItemDescriptor : DatabaseObject<ItemDescriptor>, IFolderabl
         get => Effects.Select(effect => effect.Type).ToArray();
     }
 
-    public void SetEffectOfType(ItemEffect type, int percentage, int flatAmount, bool isFlat = false)
+    public void SetEffectOfType(ItemEffect type, int percentage)
     {
         var effectToEdit = Effects.Find(effect => effect.Type == type);
         if (effectToEdit == default)
@@ -454,9 +452,7 @@ public partial class ItemDescriptor : DatabaseObject<ItemDescriptor>, IFolderabl
             return;
         }
 
-        effectToEdit.IsFlat = false;
         effectToEdit.Percentage = percentage;
-        effectToEdit.FlatAmount = 0;
     }
 
     /// <inheritdoc />

--- a/Framework/Intersect.Framework.Core/GameObjects/Items/ItemProperties.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Items/ItemProperties.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using Intersect.Enums;
 using MessagePack;
 
@@ -21,6 +24,13 @@ public partial class ItemProperties
         BaseDamageModifier = other.BaseDamageModifier;
         Array.Copy(other.StatModifiers, StatModifiers, Enum.GetValues<Stat>().Length);
         Array.Copy(other.VitalModifiers, VitalModifiers, Enum.GetValues<Vital>().Length);
+        EffectModifiers = other.EffectModifiers?.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.Clone()) ??
+                          new Dictionary<ItemEffect, EffectData>();
+        EnchantmentEffectRolls =
+            other.EnchantmentEffectRolls?.ToDictionary(
+                kvp => kvp.Key,
+                kvp => kvp.Value.ToDictionary(effect => effect.Key, effect => effect.Value)
+            ) ?? new Dictionary<int, Dictionary<ItemEffect, int>>();
 
     }
 
@@ -37,4 +47,8 @@ public partial class ItemProperties
     public int MageSink { get;  set; }
     [Key(5)]
     public int BaseDamageModifier { get; set; }
+    [Key(6)]
+    public Dictionary<ItemEffect, EffectData> EffectModifiers { get; set; } = new();
+    [Key(7)]
+    public Dictionary<int, Dictionary<ItemEffect, int>> EnchantmentEffectRolls { get; set; } = new();
 }

--- a/Framework/Intersect.Framework.Core/GameObjects/Items/ItemProperties.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Items/ItemProperties.cs
@@ -24,7 +24,10 @@ public partial class ItemProperties
         BaseDamageModifier = other.BaseDamageModifier;
         Array.Copy(other.StatModifiers, StatModifiers, Enum.GetValues<Stat>().Length);
         Array.Copy(other.VitalModifiers, VitalModifiers, Enum.GetValues<Vital>().Length);
-        EffectModifiers = other.EffectModifiers?.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.Clone()) ??
+        EffectModifiers = other.EffectModifiers?.ToDictionary(
+            kvp => kvp.Key,
+            kvp => new EffectData(kvp.Value.Type, kvp.Value.Percentage, kvp.Value.IsPassive, kvp.Value.Stacking)
+        ) ??
                           new Dictionary<ItemEffect, EffectData>();
         EnchantmentEffectRolls =
             other.EnchantmentEffectRolls?.ToDictionary(

--- a/Framework/Intersect.Framework.Core/GameObjects/SetDescriptor.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/SetDescriptor.cs
@@ -110,7 +110,11 @@ public partial class SetDescriptor : DatabaseObject<SetDescriptor>, IFolderable
     public string EffectsJson
     {
         get => JsonConvert.SerializeObject(Effects);
-        set => Effects = JsonConvert.DeserializeObject<List<EffectData>>(value ?? "") ?? new List<EffectData>();
+        set
+        {
+            Effects = JsonConvert.DeserializeObject<List<EffectData>>(value ?? "") ?? new List<EffectData>();
+            NormalizeLoadedEffects();
+        }
     }
 
     public string Folder { get; set; } = "";
@@ -132,6 +136,11 @@ public partial class SetDescriptor : DatabaseObject<SetDescriptor>, IFolderable
 
         // (Opcional) limpiar ItemIds que ya no coinciden
         ItemIds = ItemIds.Where(id => ItemDescriptor.Get(id)?.SetId == Id).ToList();
+    }
+
+    private void NormalizeLoadedEffects()
+    {
+        Effects ??= new List<EffectData>();
     }
 
     public (int[] stats, int[] percentStats, long[] vitals, long[] vitalsRegen, int[] percentVitals, List<EffectData> effects) GetBonuses(int pieces)
@@ -186,12 +195,7 @@ public partial class SetDescriptor : DatabaseObject<SetDescriptor>, IFolderable
 
     public int GetEffectPercentage(ItemEffect type)
     {
-        return Effects.Find(effect => effect.Type == type)?.GetValue() ?? 0;
-    }
-
-    public EffectValue GetEffectValues(ItemEffect type)
-    {
-        return Effects.Find(effect => effect.Type == type)?.GetValues() ?? default;
+        return Effects.Find(effect => effect.Type == type)?.Percentage ?? 0;
     }
 
     public EffectData? GetEffect(ItemEffect type)
@@ -199,14 +203,12 @@ public partial class SetDescriptor : DatabaseObject<SetDescriptor>, IFolderable
         return Effects.Find(effect => effect.Type == type);
     }
 
-    public void SetEffectOfType(ItemEffect type, int percentage, int flatAmount, bool isFlat = false)
+    public void SetEffectOfType(ItemEffect type, int percentage)
     {
         var effectToEdit = Effects.Find(effect => effect.Type == type);
         if (effectToEdit != null)
         {
-            effectToEdit.IsFlat = false;
             effectToEdit.Percentage = percentage;
-            effectToEdit.FlatAmount = 0;
         }
     }
 

--- a/Framework/Intersect.Framework.Core/Network/Packets/Server/UpdateItemLevelPacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Server/UpdateItemLevelPacket.cs
@@ -1,3 +1,4 @@
+using Intersect.Framework.Core.GameObjects.Items;
 using MessagePack;
 
 namespace Intersect.Network.Packets.Server
@@ -17,6 +18,7 @@ namespace Intersect.Network.Packets.Server
         {
             ItemIndex = itemId;
             NewEnchantmentLevel = newEnchantmentLevel;
+           
         }
     }
 }

--- a/Intersect.Client.Core/CustomChanges/PacketHandlerCustom.cs
+++ b/Intersect.Client.Core/CustomChanges/PacketHandlerCustom.cs
@@ -172,7 +172,8 @@ internal sealed partial class PacketHandler
         {
             // Actualizar nivel de encantamiento
             // Como UpdateItemLevelPacket no tiene ItemProperties, solo usamos NewEnchantmentLevel
-            inventoryItem.ItemProperties = new ItemProperties { EnchantmentLevel = packet.NewEnchantmentLevel };
+            inventoryItem.ItemProperties ??= new ItemProperties();
+            inventoryItem.ItemProperties.EnchantmentLevel = packet.NewEnchantmentLevel;
             Interface.Interface.GameUi?.mEnchantItemWindow.UpdateProjection();
         }
         else

--- a/Intersect.Client.Core/CustomChanges/PacketHandlerCustom.cs
+++ b/Intersect.Client.Core/CustomChanges/PacketHandlerCustom.cs
@@ -29,6 +29,7 @@ using Intersect.Framework.Core.GameObjects.Mapping.Tilesets;
 using Intersect.Framework.Core.GameObjects.Maps;
 using Intersect.Framework.Core.GameObjects.Maps.Attributes;
 using Intersect.Framework.Core.GameObjects.Maps.MapList;
+using Intersect.Framework.Core.GameObjects.Items;
 using Intersect.Framework.Core.Security;
 using Intersect.Localization;
 using Microsoft.Extensions.Logging;
@@ -170,9 +171,9 @@ internal sealed partial class PacketHandler
         if (inventoryItem != null)
         {
             // Actualizar nivel de encantamiento
-            inventoryItem.ItemProperties.EnchantmentLevel = packet.NewEnchantmentLevel;
+            // Como UpdateItemLevelPacket no tiene ItemProperties, solo usamos NewEnchantmentLevel
+            inventoryItem.ItemProperties = new ItemProperties { EnchantmentLevel = packet.NewEnchantmentLevel };
             Interface.Interface.GameUi?.mEnchantItemWindow.UpdateProjection();
-
         }
         else
         {

--- a/Intersect.Client.Core/Entities/Player.cs
+++ b/Intersect.Client.Core/Entities/Player.cs
@@ -2650,9 +2650,9 @@ public partial class Player : Entity, IPlayer
         return weapon;
     }
 
-    public EffectValue GetEquipmentEffectValues(ItemEffect effect)
+    public int GetEquipmentEffectValues(ItemEffect effect)
     {
-        var effects = new Dictionary<ItemEffect, EffectValue>();
+        var effects = new Dictionary<ItemEffect, int>();
 
         void ApplyEffects(ItemDescriptor? descriptor)
         {
@@ -2697,7 +2697,7 @@ public partial class Player : Entity, IPlayer
         return effects.TryGetValue(effect, out var value) ? value : default;
     }
 
-    public int GetEquipmentEffect(ItemEffect effect) => GetEquipmentEffectValues(effect).GetPrimaryValue();
+    public int GetEquipmentEffect(ItemEffect effect) => GetEquipmentEffectValues(effect);
 
     public int GetBaseCriticalChance()
     {

--- a/Intersect.Client.Core/Interface/Game/Breaking/RuneEnchantWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Breaking/RuneEnchantWindow.cs
@@ -13,6 +13,7 @@ using Intersect.Client.Framework.File_Management;
 using Intersect.Enums;
 using Intersect.Extensions;
 using Intersect.Client.Interface.Game.Breaking;
+using Intersect.Framework.Core.GameObjects.Items;
 
 public partial class RuneEnchantWindow : Window
 {
@@ -91,22 +92,34 @@ public partial class RuneEnchantWindow : Window
 
     public void SelectTargetItem(Item? item)
     {
-        if (item == null || item.Descriptor == null) return;
-
         _selectedItem = item;
-        _itemSlot.Texture = Globals.ContentManager.GetTexture(Intersect.Client.Framework.Content.TextureType.Item, item.Descriptor.Icon)
-                              ?? Graphics.Renderer.WhitePixel;
+
+        if (item?.Descriptor != null)
+        {
+            _itemSlot.Texture = Globals.ContentManager.GetTexture(Intersect.Client.Framework.Content.TextureType.Item, item.Descriptor.Icon)
+                                  ?? Graphics.Renderer.WhitePixel;
+        }
+        else
+        {
+            _itemSlot.Texture = Graphics.Renderer.WhitePixel;
+        }
 
         UpdateProjection();
     }
 
     public void SelectRuneItem(Item? rune)
     {
-        if (rune == null || rune.Descriptor == null) return;
-
         _selectedRune = rune;
-        _runeSlot.Texture = Globals.ContentManager.GetTexture(Intersect.Client.Framework.Content.TextureType.Item, rune.Descriptor.Icon)
-                             ?? Graphics.Renderer.WhitePixel;
+
+        if (rune?.Descriptor != null)
+        {
+            _runeSlot.Texture = Globals.ContentManager.GetTexture(Intersect.Client.Framework.Content.TextureType.Item, rune.Descriptor.Icon)
+                                 ?? Graphics.Renderer.WhitePixel;
+        }
+        else
+        {
+            _runeSlot.Texture = Graphics.Renderer.WhitePixel;
+        }
 
         UpdateProjection();
     }
@@ -124,33 +137,36 @@ public partial class RuneEnchantWindow : Window
         var rune = _selectedRune.Descriptor;
         var stat = rune.TargetStat;
         var vital = rune.TargetVital;
+        var targetEffect = rune.TargetEffect;
         var amount = rune.AmountModifier;
-       
+
         var residualItem = _selectedItem.ItemProperties.MageSink/100.0;
 
         string labelStatOrVital;
-        string labelAmount = $"Cantidad: +{amount}";
-      
+        var amountSign = amount > 0 ? "+" : string.Empty;
+        string labelAmount = $"Cantidad: {amountSign}{amount}";
+
         string labelMageSink = $"Carga residual del ítem: {residualItem}";
 
-        if (amount == 0)
+        if (targetEffect != ItemEffect.None)
         {
-            labelStatOrVital = "Efecto: Sin efecto";
+            var effectName = Strings.ItemDescription.BonusEffects.TryGetValue((int)targetEffect, out var localizedEffect)
+                ? localizedEffect.ToString()
+                : targetEffect.ToString();
+            labelStatOrVital = $"Efecto: {effectName.TrimEnd(':')}";
+            labelAmount = $"Bonus: {amountSign}{amount}%";
+        }
+        else if (stat >= 0 && (int)stat < Enum.GetValues<Stat>().Length)
+        {
+            labelStatOrVital = $"Stat: {Strings.ItemDescription.StatCounts[(int)stat]}";
+        }
+        else if (vital >= 0 && (int)vital < Enum.GetValues<Vital>().Length)
+        {
+            labelStatOrVital = $"Vital: {Strings.ItemDescription.Vitals[(int)vital]}";
         }
         else
         {
-            if (stat >= 0 && (int)stat < Enum.GetValues<Stat>().Length)
-            {
-                labelStatOrVital = $"Stat: {Strings.ItemDescription.StatCounts[(int)stat]}";
-            }
-            else if (vital >= 0 && (int)vital < Enum.GetValues<Vital>().Length)
-            {
-                labelStatOrVital = $"Vital: {Strings.ItemDescription.Vitals[(int)vital]}";
-            }
-            else
-            {
-                labelStatOrVital = "Efecto: Desconocido";
-            }
+            labelStatOrVital = amount == 0 ? "Efecto: Sin efecto" : "Efecto: Desconocido";
         }
 
         // Posicionamiento dinámico

--- a/Intersect.Client.Core/Interface/Game/Breaking/RuneInventoryItem.cs
+++ b/Intersect.Client.Core/Interface/Game/Breaking/RuneInventoryItem.cs
@@ -13,6 +13,7 @@ using Intersect.Client.Interface.Game.DescriptionWindows;
 using Intersect.Client.Interface.Game.Inventory;
 using Intersect.Client.Items;
 using Intersect.Client.Localization;
+using Intersect.Enums;
 using Intersect.Framework.Core.GameObjects.Items;
 using Intersect.GameObjects;
 using Intersect.Utilities;
@@ -130,6 +131,11 @@ public class RuneInventoryItem : SlotItem
         if (inventorySlot is not Items.Item item)
             return;
 
+        if (!IsRune(inventorySlot.Descriptor) && arguments.MouseButton is MouseButton.Right)
+        {
+            return;
+        }
+
         if (arguments.MouseButton is MouseButton.Left)
         {
             // Si el item ya está como runa, lo deseleccionamos
@@ -215,5 +221,17 @@ public class RuneInventoryItem : SlotItem
         Icon.Texture = null;
         _quantityLabel.IsVisibleInParent = false;
         _cooldownLabel.IsVisibleInParent = false;
+    }
+
+    private static bool IsRune(ItemDescriptor descriptor)
+    {
+        if (!string.Equals(descriptor.Subtype, "Rune", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        return descriptor.TargetStat != (Stat)(-1)
+               || descriptor.TargetVital != (Vital)(-1)
+               || descriptor.TargetEffect != ItemEffect.None;
     }
 }

--- a/Intersect.Client.Core/Interface/Game/Character/CharacterWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Character/CharacterWindow.cs
@@ -120,15 +120,15 @@ public partial class CharacterWindow : Window
     int CooldownAmount = 0;
     int ManaStealAmount = 0;
 
-    private EffectValue _accuracy = default;
-    private EffectValue _evasion = default;
-    private EffectValue _critBonus = default;
-    private EffectValue _antiCrit = default;
-    private EffectValue _armorPenetration = default;
-    private EffectValue _damageReduction = default;
-    private EffectValue _damageReflect = default;
-    private EffectValue _flatDamage = default;
-    private EffectValue _flatCures = default;
+    private int _accuracy = default;
+    private int _evasion = default;
+    private int _critBonus = default;
+    private int _antiCrit = default;
+    private int _armorPenetration = default;
+    private int _damageReduction = default;
+    private int _damageReflect = default;
+    private int _flatDamage = default;
+    private int _flatCures = default;
 
     // -------------------------
     // Helpers
@@ -196,20 +196,9 @@ public partial class CharacterWindow : Window
         return y + ctrl.Height + spacing;
     }
 
-    private string FormatEffectValue(EffectValue value)
+    private string FormatEffectValue(int value)
     {
-        var segments = new List<string>();
-        if (value.Percentage != 0)
-        {
-            segments.Add($"{value.Percentage}%");
-        }
-
-        if (value.Flat != 0)
-        {
-            segments.Add($"+{value.Flat}");
-        }
-
-        return segments.Count == 0 ? "0" : string.Join(" / ", segments);
+        return value == 0 ? "0" : $"{value}%";
     }
 
     // -------------------------
@@ -777,28 +766,30 @@ public partial class CharacterWindow : Window
 
                 foreach (var effect in descriptor.Effects)
                 {
-                    var effectValue = effect.GetValues();
-                    if (effectValue.GetPrimaryValue() == 0)
+                    var effectValue = effect.Percentage;
+                    if (effectValue == 0)
+                    {
                         continue;
+                    }
 
                     switch (effect.Type)
                     {
-                        case ItemEffect.CooldownReduction: CooldownAmount += effectValue.GetPrimaryValue(); break;
-                        case ItemEffect.Lifesteal: LifeStealAmount += effectValue.GetPrimaryValue(); break;
-                        case ItemEffect.Tenacity: TenacityAmount += effectValue.GetPrimaryValue(); break;
-                        case ItemEffect.Luck: LuckAmount += effectValue.GetPrimaryValue(); break;
-                        case ItemEffect.EXP: ExtraExpAmount += effectValue.GetPrimaryValue(); break;
-                        case ItemEffect.Manasteal: ManaStealAmount += effectValue.GetPrimaryValue(); break;
+                        case ItemEffect.CooldownReduction: CooldownAmount += effectValue; break;
+                        case ItemEffect.Lifesteal: LifeStealAmount += effectValue; break;
+                        case ItemEffect.Tenacity: TenacityAmount += effectValue; break;
+                        case ItemEffect.Luck: LuckAmount += effectValue; break;
+                        case ItemEffect.EXP: ExtraExpAmount += effectValue; break;
+                        case ItemEffect.Manasteal: ManaStealAmount += effectValue; break;
 
-                        case ItemEffect.Accuracy: _accuracy = _accuracy.Add(effectValue); break;
-                        case ItemEffect.Evasion: _evasion = _evasion.Add(effectValue); break;
-                        case ItemEffect.CriticalChance: _critBonus = _critBonus.Add(effectValue); break;
-                        case ItemEffect.AntiCritChance: _antiCrit = _antiCrit.Add(effectValue); break;
-                        case ItemEffect.ArmorPenetration: _armorPenetration = _armorPenetration.Add(effectValue); break;
-                        case ItemEffect.DamageReduction: _damageReduction = _damageReduction.Add(effectValue); break;
-                        case ItemEffect.DamageReflect: _damageReflect = _damageReflect.Add(effectValue); break;
-                        case ItemEffect.Damages: _flatDamage = _flatDamage.Add(effectValue); break;
-                        case ItemEffect.Cures: _flatCures = _flatCures.Add(effectValue); break;
+                        case ItemEffect.Accuracy: _accuracy += effectValue; break;
+                        case ItemEffect.Evasion: _evasion += effectValue; break;
+                        case ItemEffect.CriticalChance: _critBonus += effectValue; break;
+                        case ItemEffect.AntiCritChance: _antiCrit += effectValue; break;
+                        case ItemEffect.ArmorPenetration: _armorPenetration += effectValue; break;
+                        case ItemEffect.DamageReduction: _damageReduction += effectValue; break;
+                        case ItemEffect.DamageReflect: _damageReflect += effectValue; break;
+                        case ItemEffect.Damages: _flatDamage += effectValue; break;
+                        case ItemEffect.Cures: _flatCures += effectValue; break;
                     }
                 }
             }
@@ -823,7 +814,7 @@ public partial class CharacterWindow : Window
 
             var statValue = player.Stat[(int)sourceScalingStat];
             var scaledBase = sourceBaseDamage + statValue * (sourceScalingPercent / 100f);
-            var afterBonuses = (scaledBase + _flatDamage.Flat) * (1f + _flatDamage.Percentage / 100f);
+            var afterBonuses = scaledBase * (1f + _flatDamage / 100f);
 
             var minTrueDamage = afterBonuses * 0.975f;
             var maxTrueDamage = afterBonuses * 1.025f;

--- a/Intersect.Client.Core/Interface/Game/DescriptionWindows/ItemDescriptionWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/DescriptionWindows/ItemDescriptionWindow.cs
@@ -169,21 +169,30 @@ public partial class ItemDescriptionWindow() : DescriptionWindowBase(Interface.G
 
         if (_itemDescriptor.Subtype == "Rune")
         {
-           
             var amount = _itemDescriptor.AmountModifier;
+            var amountPrefix = amount > 0 ? "+" : string.Empty;
+            var hasStatTarget = Enum.IsDefined(typeof(Stat), _itemDescriptor.TargetStat);
+            var hasVitalTarget = Enum.IsDefined(typeof(Vital), _itemDescriptor.TargetVital);
+            var hasEffectTarget = _itemDescriptor.TargetEffect != ItemEffect.None;
 
-            if (amount != 0)
+            if (hasEffectTarget)
             {
-                if (Enum.IsDefined(typeof(Stat), _itemDescriptor.TargetStat))
-                {
-                    rows.AddKeyValueRow("Stat Modified", _itemDescriptor.TargetStat.ToString());
-                    rows.AddKeyValueRow("Bonus", $"{(amount > 0 ? "+" : "")}{amount}");
-                }
-                else if (Enum.IsDefined(typeof(Vital), _itemDescriptor.TargetVital))
-                {
-                    rows.AddKeyValueRow("Vital Modified", _itemDescriptor.TargetVital.ToString());
-                    rows.AddKeyValueRow("Bonus", $"{(amount > 0 ? "+" : "")}{amount}");
-                }
+                var effectName = Strings.ItemDescription.BonusEffects.TryGetValue((int)_itemDescriptor.TargetEffect, out var localizedEffect)
+                    ? localizedEffect.ToString()
+                    : _itemDescriptor.TargetEffect.ToString();
+
+                rows.AddKeyValueRow("Efecto", effectName.TrimEnd(':'));
+                rows.AddKeyValueRow("Bonus", Strings.ItemDescription.Percentage.ToString(amount));
+            }
+            else if (hasStatTarget)
+            {
+                rows.AddKeyValueRow("Stat Modified", _itemDescriptor.TargetStat.ToString());
+                rows.AddKeyValueRow("Bonus", $"{amountPrefix}{amount}");
+            }
+            else if (hasVitalTarget)
+            {
+                rows.AddKeyValueRow("Vital Modified", _itemDescriptor.TargetVital.ToString());
+                rows.AddKeyValueRow("Bonus", $"{amountPrefix}{amount}");
             }
         }
 
@@ -591,6 +600,61 @@ public partial class ItemDescriptionWindow() : DescriptionWindowBase(Interface.G
 
         return newValue;
     }
+
+    private Dictionary<ItemEffect, EffectValue> GetTotalEffects(ItemDescriptor descriptor, ItemProperties? properties)
+    {
+        var totals = new Dictionary<ItemEffect, EffectValue>();
+
+        if (descriptor?.Effects != null)
+        {
+            foreach (var effect in descriptor.Effects)
+            {
+                totals.ApplyEffect(effect);
+            }
+        }
+
+        if (properties?.EffectModifiers != null)
+        {
+            foreach (var effect in properties.EffectModifiers.Values)
+            {
+                totals.ApplyEffect(effect);
+            }
+        }
+
+        return totals;
+    }
+
+    private int GetEffectDifference(ItemEffect effectType)
+    {
+        if (_itemDescriptor == null)
+        {
+            return 0;
+        }
+
+        var newEffects = GetTotalEffects(_itemDescriptor, _itemProperties);
+        var newValue = newEffects.TryGetValue(effectType, out var value) ? value.GetPrimaryValue() : 0;
+
+        var slot = _itemDescriptor.EquipmentSlot;
+
+        if (slot >= 0 &&
+            Globals.Me.MyEquipment.TryGetValue(slot, out var equippedSlots) &&
+            equippedSlots.Count > 0)
+        {
+            var firstSlot = equippedSlots[0];
+            if (firstSlot >= 0 && firstSlot < Globals.Me.Inventory.Length)
+            {
+                var equipped = Globals.Me.Inventory[firstSlot];
+                if (equipped?.Descriptor != null)
+                {
+                    var equippedEffects = GetTotalEffects(equipped.Descriptor, equipped.ItemProperties);
+                    var oldValue = equippedEffects.TryGetValue(effectType, out var eqValue) ? eqValue.GetPrimaryValue() : 0;
+                    return newValue - oldValue;
+                }
+            }
+        }
+
+        return newValue;
+    }
     private int GetAttackSpeedDifference()
     {
         if (_itemDescriptor == null) return 0;
@@ -832,12 +896,38 @@ public partial class ItemDescriptionWindow() : DescriptionWindowBase(Interface.G
         }
 
         // ====== Bonus Effects ======
-        foreach (var effect in _itemDescriptor.Effects)
+        var effectTotals = GetTotalEffects(_itemDescriptor, _itemProperties);
+        foreach (var effectEntry in effectTotals.OrderBy(e => (int)e.Key))
         {
-            if (effect.Type != ItemEffect.None && effect.Percentage != 0)
+            var effectType = effectEntry.Key;
+            if (effectType == ItemEffect.None)
             {
-                rows.AddKeyValueRow(Strings.ItemDescription.BonusEffects[(int)effect.Type], Strings.ItemDescription.Percentage.ToString(effect.Percentage));
+                continue;
             }
+
+            if (!Strings.ItemDescription.BonusEffects.TryGetValue((int)effectType, out var effectName))
+            {
+                continue;
+            }
+
+            var values = effectEntry.Value;
+            var parts = new List<string>();
+            if (values.Percentage != 0)
+            {
+                parts.Add(Strings.ItemDescription.Percentage.ToString(values.Percentage));
+            }
+            if (values.Flat != 0)
+            {
+                parts.Add($"{(values.Flat > 0 ? "+" : string.Empty)}{values.Flat}");
+            }
+
+            if (parts.Count == 0)
+            {
+                continue;
+            }
+
+            var diff = GetEffectDifference(effectType);
+            AddRowWithDifference(rows, effectName, string.Join(" / ", parts), diff);
         }
         rows.SizeToChildren(true, true);
     }

--- a/Intersect.Client.Core/Interface/Game/DescriptionWindows/ItemDescriptionWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/DescriptionWindows/ItemDescriptionWindow.cs
@@ -601,9 +601,9 @@ public partial class ItemDescriptionWindow() : DescriptionWindowBase(Interface.G
         return newValue;
     }
 
-    private Dictionary<ItemEffect, EffectValue> GetTotalEffects(ItemDescriptor descriptor, ItemProperties? properties)
+    private Dictionary<ItemEffect, int> GetTotalEffects(ItemDescriptor descriptor, ItemProperties? properties)
     {
-        var totals = new Dictionary<ItemEffect, EffectValue>();
+        var totals = new Dictionary<ItemEffect, int>();
 
         if (descriptor?.Effects != null)
         {
@@ -632,7 +632,7 @@ public partial class ItemDescriptionWindow() : DescriptionWindowBase(Interface.G
         }
 
         var newEffects = GetTotalEffects(_itemDescriptor, _itemProperties);
-        var newValue = newEffects.TryGetValue(effectType, out var value) ? value.GetPrimaryValue() : 0;
+        var newValue = newEffects.TryGetValue(effectType, out var value) ? value : 0;
 
         var slot = _itemDescriptor.EquipmentSlot;
 
@@ -647,7 +647,7 @@ public partial class ItemDescriptionWindow() : DescriptionWindowBase(Interface.G
                 if (equipped?.Descriptor != null)
                 {
                     var equippedEffects = GetTotalEffects(equipped.Descriptor, equipped.ItemProperties);
-                    var oldValue = equippedEffects.TryGetValue(effectType, out var eqValue) ? eqValue.GetPrimaryValue() : 0;
+                    var oldValue = equippedEffects.TryGetValue(effectType, out var eqValue) ? eqValue : 0;
                     return newValue - oldValue;
                 }
             }
@@ -910,15 +910,11 @@ public partial class ItemDescriptionWindow() : DescriptionWindowBase(Interface.G
                 continue;
             }
 
-            var values = effectEntry.Value;
+            var value = effectEntry.Value;
             var parts = new List<string>();
-            if (values.Percentage != 0)
+            if (value != 0)
             {
-                parts.Add(Strings.ItemDescription.Percentage.ToString(values.Percentage));
-            }
-            if (values.Flat != 0)
-            {
-                parts.Add($"{(values.Flat > 0 ? "+" : string.Empty)}{values.Flat}");
+                parts.Add(Strings.ItemDescription.Percentage.ToString(value));
             }
 
             if (parts.Count == 0)

--- a/Intersect.Client.Core/Interface/Game/Enchantment/EnchantItemWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Enchantment/EnchantItemWindow.cs
@@ -288,7 +288,7 @@ namespace Intersect.Client.Interface.Game.Enchanting
                     continue;
                 }
 
-                var currentEffect = effect.Value.GetPrimaryValue();
+                var currentEffect = effect.Value;
                 var projectedEffect = currentEffect;
 
                 double bonusFactor = 0.05;
@@ -375,9 +375,9 @@ namespace Intersect.Client.Interface.Game.Enchanting
             PacketSender.SendEnchantItem(itemIndex, targetLevel, currencyId, currencyAmount, useAmulet);
         }
 
-        private static Dictionary<ItemEffect, EffectValue> GetTotalEffects(ItemDescriptor descriptor, ItemProperties? properties)
+        private static Dictionary<ItemEffect, int> GetTotalEffects(ItemDescriptor descriptor, ItemProperties? properties)
         {
-            var totals = new Dictionary<ItemEffect, EffectValue>();
+            var totals = new Dictionary<ItemEffect, int>();
 
             if (descriptor?.Effects != null)
             {

--- a/Intersect.Client.Core/Interface/Game/Enchantment/EnchantItemWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Enchantment/EnchantItemWindow.cs
@@ -12,6 +12,8 @@ using Intersect.Enums;
 using Intersect.Extensions;
 using Intersect.Framework.Core.GameObjects.Items;
 using Intersect.GameObjects;
+using System.Collections.Generic;
+using System.Linq;
 
 
 namespace Intersect.Client.Interface.Game.Enchanting
@@ -277,6 +279,49 @@ namespace Intersect.Client.Interface.Game.Enchanting
                 yOffset += spacing;
             }
 
+            var effectTotals = GetTotalEffects(_selectedItem.Descriptor, _selectedItem.ItemProperties);
+            foreach (var effect in effectTotals.OrderBy(e => (int)e.Key))
+            {
+                var effectType = effect.Key;
+                if (effectType == ItemEffect.None)
+                {
+                    continue;
+                }
+
+                var currentEffect = effect.Value.GetPrimaryValue();
+                var projectedEffect = currentEffect;
+
+                double bonusFactor = 0.05;
+                for (int lvl = _selectedItem.ItemProperties.EnchantmentLevel + 1; lvl <= projectedLevel; lvl++)
+                {
+                    int bonus = (int)Math.Ceiling(projectedEffect * bonusFactor);
+                    projectedEffect += bonus;
+                }
+
+                if (currentEffect == 0 && projectedEffect == 0)
+                {
+                    continue;
+                }
+
+                Strings.ItemDescription.BonusEffects.TryGetValue((int)effectType, out var effectLabel);
+                var effectColor = projectedEffect > currentEffect
+                    ? Color.Green
+                    : projectedEffect < currentEffect
+                        ? Color.Red
+                        : Color.White;
+
+                var lblEffect = new Label(_projectionContainer, $"EffectLabel_{(int)effectType}")
+                {
+                    Text = $"{effectLabel ?? effectType.ToString()}: {currentEffect}% → {projectedEffect}%",
+                    FontName = "sourcesansproblack",
+                    FontSize = 10
+                };
+                lblEffect.SetPosition(10, yOffset);
+                lblEffect.SetSize(labelWidth, labelHeight);
+                lblEffect.SetTextColor(effectColor, ComponentState.Normal);
+                yOffset += spacing;
+            }
+
             _projectionContainer.SizeToChildren(true, true);
         }
 
@@ -328,6 +373,29 @@ namespace Intersect.Client.Interface.Game.Enchanting
             }
 
             PacketSender.SendEnchantItem(itemIndex, targetLevel, currencyId, currencyAmount, useAmulet);
+        }
+
+        private static Dictionary<ItemEffect, EffectValue> GetTotalEffects(ItemDescriptor descriptor, ItemProperties? properties)
+        {
+            var totals = new Dictionary<ItemEffect, EffectValue>();
+
+            if (descriptor?.Effects != null)
+            {
+                foreach (var effect in descriptor.Effects)
+                {
+                    totals.ApplyEffect(effect);
+                }
+            }
+
+            if (properties?.EffectModifiers != null)
+            {
+                foreach (var effect in properties.EffectModifiers.Values)
+                {
+                    totals.ApplyEffect(effect);
+                }
+            }
+
+            return totals;
         }
 
         public override void Hide()

--- a/Intersect.Editor/Forms/Editors/frmItem.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/frmItem.Designer.cs
@@ -1976,7 +1976,7 @@ namespace Intersect.Editor.Forms.Editors
             grpEffects.Margin = new Padding(4, 3, 4, 3);
             grpEffects.Name = "grpEffects";
             grpEffects.Padding = new Padding(4, 3, 4, 3);
-            grpEffects.Size = new Size(307, 273);
+            grpEffects.Size = new Size(307, 190);
             grpEffects.TabIndex = 57;
             grpEffects.TabStop = false;
             grpEffects.Text = "Bonus Effects";
@@ -1990,6 +1990,7 @@ namespace Intersect.Editor.Forms.Editors
             chkEffectIsFlat.Size = new Size(96, 19);
             chkEffectIsFlat.TabIndex = 59;
             chkEffectIsFlat.Text = "Use flat value";
+            chkEffectIsFlat.Visible = false;
             chkEffectIsFlat.CheckedChanged += chkEffectIsFlat_CheckedChanged;
             // 
             // lblEffectFlat
@@ -2001,6 +2002,7 @@ namespace Intersect.Editor.Forms.Editors
             lblEffectFlat.Size = new Size(105, 15);
             lblEffectFlat.TabIndex = 61;
             lblEffectFlat.Text = "Effect Amount (#):";
+            lblEffectFlat.Visible = false;
             // 
             // nudEffectFlat
             // 
@@ -2012,6 +2014,7 @@ namespace Intersect.Editor.Forms.Editors
             nudEffectFlat.Size = new Size(282, 23);
             nudEffectFlat.TabIndex = 60;
             nudEffectFlat.Value = new decimal(new int[] { 0, 0, 0, 0 });
+            nudEffectFlat.Visible = false;
             nudEffectFlat.ValueChanged += nudEffectFlat_ValueChanged;
             // 
             // lstBonusEffects

--- a/Intersect.Editor/Forms/Editors/frmItem.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/frmItem.Designer.cs
@@ -42,6 +42,8 @@ namespace Intersect.Editor.Forms.Editors
             btnSave = new DarkButton();
             grpGeneral = new DarkGroupBox();
             grpEnchanting = new DarkGroupBox();
+            cmbRuneEffect = new DarkComboBox();
+            lblRuneEffect = new Label();
             cmbRuneVital = new DarkComboBox();
             lblRuneVital = new Label();
             cmbRuneStat = new DarkComboBox();
@@ -475,6 +477,8 @@ namespace Intersect.Editor.Forms.Editors
             // 
             grpEnchanting.BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
             grpEnchanting.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            grpEnchanting.Controls.Add(cmbRuneEffect);
+            grpEnchanting.Controls.Add(lblRuneEffect);
             grpEnchanting.Controls.Add(cmbRuneVital);
             grpEnchanting.Controls.Add(lblRuneVital);
             grpEnchanting.Controls.Add(cmbRuneStat);
@@ -490,10 +494,38 @@ namespace Intersect.Editor.Forms.Editors
             grpEnchanting.Margin = new Padding(4, 3, 4, 3);
             grpEnchanting.Name = "grpEnchanting";
             grpEnchanting.Padding = new Padding(4, 3, 4, 3);
-            grpEnchanting.Size = new Size(252, 109);
+            grpEnchanting.Size = new Size(252, 145);
             grpEnchanting.TabIndex = 106;
             grpEnchanting.TabStop = false;
             grpEnchanting.Text = "Enchanting";
+            // 
+            // cmbRuneEffect
+            // 
+            cmbRuneEffect.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            cmbRuneEffect.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            cmbRuneEffect.BorderStyle = ButtonBorderStyle.Solid;
+            cmbRuneEffect.ButtonColor = System.Drawing.Color.FromArgb(43, 43, 43);
+            cmbRuneEffect.DrawDropdownHoverOutline = false;
+            cmbRuneEffect.DrawFocusRectangle = false;
+            cmbRuneEffect.DrawMode = DrawMode.OwnerDrawVariable;
+            cmbRuneEffect.DropDownStyle = ComboBoxStyle.DropDownList;
+            cmbRuneEffect.FlatStyle = FlatStyle.Flat;
+            cmbRuneEffect.ForeColor = System.Drawing.Color.Gainsboro;
+            cmbRuneEffect.Location = new System.Drawing.Point(91, 16);
+            cmbRuneEffect.Name = "cmbRuneEffect";
+            cmbRuneEffect.Size = new Size(152, 24);
+            cmbRuneEffect.TabIndex = 84;
+            cmbRuneEffect.Text = null;
+            cmbRuneEffect.TextPadding = new Padding(2);
+            cmbRuneEffect.SelectedIndexChanged += cmbRuneEffect_SelectedIndexChanged;
+            // 
+            // lblRuneEffect
+            // 
+            lblRuneEffect.Location = new System.Drawing.Point(5, 19);
+            lblRuneEffect.Name = "lblRuneEffect";
+            lblRuneEffect.Size = new Size(80, 23);
+            lblRuneEffect.TabIndex = 83;
+            lblRuneEffect.Text = "Effect:";
             // 
             // cmbRuneVital
             // 
@@ -507,7 +539,7 @@ namespace Intersect.Editor.Forms.Editors
             cmbRuneVital.DropDownStyle = ComboBoxStyle.DropDownList;
             cmbRuneVital.FlatStyle = FlatStyle.Flat;
             cmbRuneVital.ForeColor = System.Drawing.Color.Gainsboro;
-            cmbRuneVital.Location = new System.Drawing.Point(91, 16);
+            cmbRuneVital.Location = new System.Drawing.Point(91, 46);
             cmbRuneVital.Name = "cmbRuneVital";
             cmbRuneVital.Size = new Size(152, 24);
             cmbRuneVital.TabIndex = 82;
@@ -517,7 +549,7 @@ namespace Intersect.Editor.Forms.Editors
             // 
             // lblRuneVital
             // 
-            lblRuneVital.Location = new System.Drawing.Point(5, 19);
+            lblRuneVital.Location = new System.Drawing.Point(5, 49);
             lblRuneVital.Name = "lblRuneVital";
             lblRuneVital.Size = new Size(80, 23);
             lblRuneVital.TabIndex = 81;
@@ -535,7 +567,7 @@ namespace Intersect.Editor.Forms.Editors
             cmbRuneStat.DropDownStyle = ComboBoxStyle.DropDownList;
             cmbRuneStat.FlatStyle = FlatStyle.Flat;
             cmbRuneStat.ForeColor = System.Drawing.Color.Gainsboro;
-            cmbRuneStat.Location = new System.Drawing.Point(91, 46);
+            cmbRuneStat.Location = new System.Drawing.Point(91, 76);
             cmbRuneStat.Name = "cmbRuneStat";
             cmbRuneStat.Size = new Size(152, 24);
             cmbRuneStat.TabIndex = 78;
@@ -593,7 +625,7 @@ namespace Intersect.Editor.Forms.Editors
             // 
             // lblRuneStat
             // 
-            lblRuneStat.Location = new System.Drawing.Point(5, 49);
+            lblRuneStat.Location = new System.Drawing.Point(5, 79);
             lblRuneStat.Name = "lblRuneStat";
             lblRuneStat.Size = new Size(50, 23);
             lblRuneStat.TabIndex = 77;
@@ -601,7 +633,7 @@ namespace Intersect.Editor.Forms.Editors
             // 
             // lblRuneValue
             // 
-            lblRuneValue.Location = new System.Drawing.Point(5, 76);
+            lblRuneValue.Location = new System.Drawing.Point(5, 106);
             lblRuneValue.Name = "lblRuneValue";
             lblRuneValue.Size = new Size(64, 23);
             lblRuneValue.TabIndex = 79;
@@ -611,7 +643,7 @@ namespace Intersect.Editor.Forms.Editors
             // 
             nudRuneValue.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
             nudRuneValue.ForeColor = System.Drawing.Color.Gainsboro;
-            nudRuneValue.Location = new System.Drawing.Point(91, 76);
+            nudRuneValue.Location = new System.Drawing.Point(91, 106);
             nudRuneValue.Name = "nudRuneValue";
             nudRuneValue.Size = new Size(152, 23);
             nudRuneValue.TabIndex = 80;
@@ -3588,6 +3620,8 @@ namespace Intersect.Editor.Forms.Editors
         private Label lblEventForTrigger;
         private ListBox lstEventTriggers;
         private DarkGroupBox grpEnchanting;
+        private DarkComboBox cmbRuneEffect;
+        private Label lblRuneEffect;
         private DarkComboBox cmbRuneVital;
         private Label lblRuneVital;
         private DarkComboBox cmbRuneStat;

--- a/Intersect.Editor/Forms/Editors/frmItem.cs
+++ b/Intersect.Editor/Forms/Editors/frmItem.cs
@@ -32,7 +32,8 @@ public partial class FrmItem : EditorForm
 
     private List<string> mKnownCooldownGroups = new List<string>();
 
-    private bool EffectValueUpdating = false;
+    private bool EffectValueUpdating;
+    private bool mUpdatingRuneTargets;
 
     public FrmItem()
     {
@@ -506,15 +507,7 @@ public partial class FrmItem : EditorForm
 
             var subtype = cmbSubType.SelectedItem?.ToString();
 
-            if (cmbRuneStat.Items.Count > (int)mEditorItem.TargetStat)
-                cmbRuneStat.SelectedIndex = (int)mEditorItem.TargetStat;
-            else
-                cmbRuneStat.SelectedIndex = -1;
-
-            if (cmbRuneVital.Items.Count > (int)mEditorItem.TargetVital)
-                cmbRuneVital.SelectedIndex = (int)mEditorItem.TargetVital;
-            else
-                cmbRuneVital.SelectedIndex = -1;
+            UpdateRuneTargetSelections();
 
             nudRuneValue.Value = mEditorItem.AmountModifier;
 
@@ -1787,6 +1780,13 @@ public partial class FrmItem : EditorForm
             cmbRuneStat.Items.Add(stat.ToString());
         }
 
+        cmbRuneEffect.Items.Clear();
+
+        foreach (var effect in Enum.GetValues<ItemEffect>())
+        {
+            cmbRuneEffect.Items.Add(effect);
+        }
+
         cmbRuneVital.Items.Clear();
 
         foreach (var vital in Enum.GetValues<Vital>())
@@ -1795,22 +1795,133 @@ public partial class FrmItem : EditorForm
         }
     }
 
+    private void UpdateRuneTargetSelections()
+    {
+        mUpdatingRuneTargets = true;
+
+        try
+        {
+            var hasRuneEffectItems = cmbRuneEffect.Items.Count > 0;
+            var hasRuneStatItems = cmbRuneStat.Items.Count > 0;
+            var hasRuneVitalItems = cmbRuneVital.Items.Count > 0;
+
+            if (mEditorItem.TargetEffect != ItemEffect.None)
+            {
+                if (hasRuneEffectItems)
+                {
+                    cmbRuneEffect.SelectedIndex = cmbRuneEffect.Items.IndexOf(mEditorItem.TargetEffect);
+                }
+
+                if (hasRuneStatItems)
+                {
+                    cmbRuneStat.SelectedIndex = -1;
+                }
+
+                if (hasRuneVitalItems)
+                {
+                    cmbRuneVital.SelectedIndex = -1;
+                }
+
+                mEditorItem.TargetStat = (Stat)(-1);
+                mEditorItem.TargetVital = (Vital)(-1);
+
+                return;
+            }
+
+            if (hasRuneEffectItems)
+            {
+                cmbRuneEffect.SelectedIndex = cmbRuneEffect.Items.IndexOf(ItemEffect.None);
+            }
+
+            if (hasRuneStatItems && (int)mEditorItem.TargetStat >= 0 && cmbRuneStat.Items.Count > (int)mEditorItem.TargetStat)
+            {
+                cmbRuneStat.SelectedIndex = (int)mEditorItem.TargetStat;
+            }
+            else if (hasRuneStatItems)
+            {
+                cmbRuneStat.SelectedIndex = -1;
+                mEditorItem.TargetStat = (Stat)(-1);
+            }
+
+            if (hasRuneVitalItems && (int)mEditorItem.TargetVital >= 0 && cmbRuneVital.Items.Count > (int)mEditorItem.TargetVital)
+            {
+                cmbRuneVital.SelectedIndex = (int)mEditorItem.TargetVital;
+            }
+            else if (hasRuneVitalItems)
+            {
+                cmbRuneVital.SelectedIndex = -1;
+                mEditorItem.TargetVital = (Vital)(-1);
+            }
+        }
+        finally
+        {
+            mUpdatingRuneTargets = false;
+        }
+    }
+
     private void cmbRuneStat_SelectedIndexChanged(object sender, EventArgs e)
     {
-        mEditorItem.TargetStat = (Stat)cmbRuneStat.SelectedIndex;
+        if (mUpdatingRuneTargets)
+        {
+            return;
+        }
+
+        mEditorItem.TargetStat = cmbRuneStat.SelectedIndex >= 0 ? (Stat)cmbRuneStat.SelectedIndex : (Stat)(-1);
 
         // Resetear el TargetVital si se asigna un stat
         if (cmbRuneStat.SelectedIndex >= 0)
+        {
             cmbRuneVital.SelectedIndex = -1;
+            cmbRuneEffect.SelectedIndex = cmbRuneEffect.Items.IndexOf(ItemEffect.None);
+            mEditorItem.TargetVital = (Vital)(-1);
+            mEditorItem.TargetEffect = ItemEffect.None;
+        }
     }
 
     private void cmbRuneVital_SelectedIndexChanged(object sender, EventArgs e)
     {
-        mEditorItem.TargetVital = (Vital)cmbRuneVital.SelectedIndex;
+        if (mUpdatingRuneTargets)
+        {
+            return;
+        }
+
+        mEditorItem.TargetVital = cmbRuneVital.SelectedIndex >= 0 ? (Vital)cmbRuneVital.SelectedIndex : (Vital)(-1);
 
         // Resetear el TargetStat si se asigna un vital
         if (cmbRuneVital.SelectedIndex >= 0)
+        {
             cmbRuneStat.SelectedIndex = -1;
+            cmbRuneEffect.SelectedIndex = cmbRuneEffect.Items.IndexOf(ItemEffect.None);
+            mEditorItem.TargetStat = (Stat)(-1);
+            mEditorItem.TargetEffect = ItemEffect.None;
+        }
+    }
+
+    private void cmbRuneEffect_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        if (mUpdatingRuneTargets)
+        {
+            return;
+        }
+
+        var selectedEffect = cmbRuneEffect.SelectedItem is ItemEffect itemEffect ? itemEffect : ItemEffect.None;
+        mEditorItem.TargetEffect = selectedEffect;
+
+        if (selectedEffect != ItemEffect.None)
+        {
+            mEditorItem.TargetStat = (Stat)(-1);
+            mEditorItem.TargetVital = (Vital)(-1);
+            mUpdatingRuneTargets = true;
+            try
+            {
+                cmbRuneStat.SelectedIndex = -1;
+                cmbRuneVital.SelectedIndex = -1;
+            }
+            finally
+            {
+                mUpdatingRuneTargets = false;
+            }
+        }
     }
 
     private void nudRuneValue_ValueChanged(object sender, EventArgs e)

--- a/Intersect.Editor/Forms/Editors/frmItem.cs
+++ b/Intersect.Editor/Forms/Editors/frmItem.cs
@@ -1022,9 +1022,7 @@ public partial class FrmItem : EditorForm
 
         mEditorItem.SetEffectOfType(
             SelectedEffect,
-            (int)nudEffectPercent.Value,
-            (int)nudEffectFlat.Value,
-            chkEffectIsFlat.Checked
+            (int)nudEffectPercent.Value
         );
         lstBonusEffects.Items[lstBonusEffects.SelectedIndex] = GetBonusEffectRow(SelectedEffect);
     }
@@ -1038,9 +1036,7 @@ public partial class FrmItem : EditorForm
 
         mEditorItem.SetEffectOfType(
             SelectedEffect,
-            (int)nudEffectPercent.Value,
-            (int)nudEffectFlat.Value,
-            chkEffectIsFlat.Checked
+            (int)nudEffectPercent.Value
         );
         lstBonusEffects.Items[lstBonusEffects.SelectedIndex] = GetBonusEffectRow(SelectedEffect);
     }
@@ -1631,9 +1627,9 @@ public partial class FrmItem : EditorForm
     private string GetBonusEffectRow(ItemEffect itemEffect)
     {
         var effectName = Strings.ItemEditor.bonuseffects[(int)itemEffect];
-        var values = mEditorItem.GetEffectValues(itemEffect);
+        var percentage = mEditorItem.GetEffectPercentage(itemEffect);
 
-        return Strings.ItemEditor.BonusEffectItem.ToString(effectName, $"{values.Percentage}%");
+        return Strings.ItemEditor.BonusEffectItem.ToString(effectName, $"{percentage}%");
     }
 
     private Stat? SelectedStatRange
@@ -1665,12 +1661,12 @@ public partial class FrmItem : EditorForm
         }
 
         EffectValueUpdating = true;
-        var values = mEditorItem.GetEffectValues(selected);
+        var percentage = mEditorItem.GetEffectPercentage(selected);
 
         chkEffectIsFlat.Enabled = false;
         chkEffectIsFlat.Checked = false;
 
-        nudEffectPercent.Value = values.Percentage;
+        nudEffectPercent.Value = percentage;
         nudEffectFlat.Value = 0;
 
         nudEffectPercent.Enabled = true;

--- a/Intersect.Editor/Forms/Editors/frmSets.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/frmSets.Designer.cs
@@ -1102,7 +1102,7 @@ partial class frmSets
         grpEffects.Margin = new Padding(4, 3, 4, 3);
         grpEffects.Name = "grpEffects";
         grpEffects.Padding = new Padding(4, 3, 4, 3);
-        grpEffects.Size = new Size(307, 248);
+        grpEffects.Size = new Size(307, 190);
         grpEffects.TabIndex = 60;
         grpEffects.TabStop = false;
         grpEffects.Text = "Bonus Effects";
@@ -1116,6 +1116,7 @@ partial class frmSets
         chkEffectIsFlat.Size = new System.Drawing.Size(95, 19);
         chkEffectIsFlat.TabIndex = 61;
         chkEffectIsFlat.Text = "Use flat value";
+        chkEffectIsFlat.Visible = false;
         chkEffectIsFlat.CheckedChanged += chkEffectIsFlat_CheckedChanged;
         //
         // lblEffectFlat
@@ -1127,6 +1128,7 @@ partial class frmSets
         lblEffectFlat.Size = new Size(105, 15);
         lblEffectFlat.TabIndex = 63;
         lblEffectFlat.Text = "Effect Amount (#):";
+        lblEffectFlat.Visible = false;
         //
         // nudEffectFlat
         //
@@ -1138,6 +1140,7 @@ partial class frmSets
         nudEffectFlat.Size = new Size(282, 23);
         nudEffectFlat.TabIndex = 62;
         nudEffectFlat.Value = new decimal(new int[] { 0, 0, 0, 0 });
+        nudEffectFlat.Visible = false;
         nudEffectFlat.ValueChanged += nudEffectFlat_ValueChanged;
         //
         // lstBonusEffects

--- a/Intersect.Editor/Forms/Editors/frmSets.cs
+++ b/Intersect.Editor/Forms/Editors/frmSets.cs
@@ -479,9 +479,7 @@ public partial class frmSets : EditorForm
 
         mEditorSet.SetEffectOfType(
             SelectedEffect,
-            (int)nudEffectPercent.Value,
-            (int)nudEffectFlat.Value,
-            chkEffectIsFlat.Checked
+            (int)nudEffectPercent.Value
         );
         lstBonusEffects.Items[lstBonusEffects.SelectedIndex] = GetBonusEffectRow(SelectedEffect);
     }
@@ -495,9 +493,7 @@ public partial class frmSets : EditorForm
 
         mEditorSet.SetEffectOfType(
             SelectedEffect,
-            (int)nudEffectPercent.Value,
-            (int)nudEffectFlat.Value,
-            chkEffectIsFlat.Checked
+            (int)nudEffectPercent.Value
         );
         lstBonusEffects.Items[lstBonusEffects.SelectedIndex] = GetBonusEffectRow(SelectedEffect);
     }
@@ -596,8 +592,8 @@ public partial class frmSets : EditorForm
     private string GetBonusEffectRow(ItemEffect itemEffect)
     {
         var effectName = Strings.ItemEditor.bonuseffects[(int)itemEffect];
-        var values = mEditorSet.GetEffectValues(itemEffect);
-        return Strings.ItemEditor.BonusEffectItem.ToString(effectName, $"{values.Percentage}%");
+        var percentage = mEditorSet.GetEffectPercentage(itemEffect);
+        return Strings.ItemEditor.BonusEffectItem.ToString(effectName, $"{percentage}%");
     }
     private void lstBonusEffects_SelectedIndexChanged(object sender, EventArgs e)
     {
@@ -613,12 +609,12 @@ public partial class frmSets : EditorForm
         }
 
         EffectValueUpdating = true;
-        var values = mEditorSet.GetEffectValues(selected);
+        var percentage = mEditorSet.GetEffectPercentage(selected);
 
         chkEffectIsFlat.Enabled = false;
         chkEffectIsFlat.Checked = false;
 
-        nudEffectPercent.Value = values.Percentage;
+        nudEffectPercent.Value = percentage;
         nudEffectFlat.Value = 0;
         nudEffectPercent.Enabled = true;
         nudEffectFlat.Enabled = false;

--- a/Intersect.Server.Core/CustomChanges/ItemBreakerHelper.cs
+++ b/Intersect.Server.Core/CustomChanges/ItemBreakerHelper.cs
@@ -9,6 +9,11 @@ public static class ItemBreakHelper
     // Lista global de todas las runas
     private static List<ItemDescriptor> AllRunes = new();
 
+    private const int StatThreshold = 10;
+    private const int VitalThreshold = 20;
+    private const int EffectPercentThreshold = 5;
+    private const int EffectFlatThreshold = 15;
+
     /// <summary>
     /// Debe llamarse una vez al arrancar el servidor, tras cargar los ItemDescriptor.
     /// </summary>
@@ -18,7 +23,8 @@ public static class ItemBreakHelper
             .OfType<ItemDescriptor>()
             .Where(d =>
                 d.ItemType == ItemType.Resource &&
-                d.Subtype == "Rune"
+                d.Subtype == "Rune" &&
+                HasRuneTarget(d)
             )
             .ToList();
     }
@@ -43,28 +49,8 @@ public static class ItemBreakHelper
 
             if (totalStat <= 0) continue;
 
-            // Filtrar runas para este stat
-            var pool = AllRunes
-                .Where(r =>
-                    r.TargetStat == stat &&
-                    IsRuneAllowedForRarity(r, rarity)
-                )
-                .OrderBy(r => r.AmountModifier)
-                .ToList();
-
-            if (pool.Count == 0) continue;
-
-            int guaranteed = (totalStat / 10) * multiplier;
-            double extraP = (totalStat % 10) / 10.0;
-
-            for (int i = 0; i < guaranteed; i++)
-            {
-                result.Add(RandomRune(pool));
-            }
-            if (Random.Shared.NextDouble() < extraP)
-            {
-                result.Add(RandomRune(pool));
-            }
+            var pool = GetRunePool(stat, rarity);
+            AddRunesFromValue(result, pool, totalStat, StatThreshold, multiplier);
         }
 
         // --- Procesar TODOS los Vitals ---
@@ -77,37 +63,128 @@ public static class ItemBreakHelper
             int totalVital = baseVal + flatMod;
             if (totalVital <= 0) continue;
 
-            // Filtrar runas para este vital
-            var pool = AllRunes
-                .Where(r =>
-                    r.TargetVital == vital &&
-                    IsRuneAllowedForRarity(r, rarity)
-                )
-                .OrderBy(r => r.AmountModifier)
-                .ToList();
+            var pool = GetRunePool(vital, rarity);
+            AddRunesFromValue(result, pool, (int)totalVital, VitalThreshold, multiplier);
+        }
 
-            if (pool.Count == 0) continue;
+        // --- Procesar TODOS los efectos ---
+        foreach (var kvp in AggregateEffects(item, props))
+        {
+            var effect = kvp.Key;
+            var totals = kvp.Value;
 
-            int guaranteed = (totalVital / 20) * multiplier;
-            double extraP = (totalVital % 20) / 20.0;
-
-            for (int i = 0; i < guaranteed; i++)
+            var hasPercent = totals.percent > 0;
+            var totalEffect = hasPercent ? totals.percent : totals.flat;
+            if (hasPercent && totals.flat > 0)
             {
-                result.Add(RandomRune(pool));
+                // Ajustar el valor plano a una escala porcentual para no perder potencia combinada.
+                totalEffect += (int)Math.Ceiling(totals.flat / (double)EffectFlatThreshold * EffectPercentThreshold);
             }
-            if (Random.Shared.NextDouble() < extraP)
+
+            if (totalEffect <= 0)
             {
-                result.Add(RandomRune(pool));
+                continue;
             }
+
+            var pool = GetRunePool(effect, rarity, hasPercent);
+            var threshold = hasPercent ? EffectPercentThreshold : EffectFlatThreshold;
+
+            AddRunesFromValue(result, pool, totalEffect, threshold, multiplier);
         }
 
         return result;
     }
 
-    private static bool IsRuneAllowedForRarity(ItemDescriptor rune, int rarity)
+    private static List<ItemDescriptor> GetRunePool(Stat stat, int rarity)
     {
-        // Ejemplo de filtro por rareza
-        if (rune.AmountModifier > 3 && rarity < 3) return false;
+        return AllRunes
+            .Where(r =>
+                r.TargetStat == stat &&
+                IsRuneAllowedForRarity(r, rarity, false, false)
+            )
+            .OrderBy(r => r.AmountModifier)
+            .ToList();
+    }
+
+    private static List<ItemDescriptor> GetRunePool(Vital vital, int rarity)
+    {
+        return AllRunes
+            .Where(r =>
+                r.TargetVital == vital &&
+                IsRuneAllowedForRarity(r, rarity, false, true)
+            )
+            .OrderBy(r => r.AmountModifier)
+            .ToList();
+    }
+
+    private static List<ItemDescriptor> GetRunePool(ItemEffect effect, int rarity, bool isPercent)
+    {
+        return AllRunes
+            .Where(r =>
+                r.TargetEffect == effect &&
+                IsRuneAllowedForRarity(r, rarity, isPercent, false, true)
+            )
+            .OrderBy(r => r.AmountModifier)
+            .ToList();
+    }
+
+    private static void AddRunesFromValue(List<ItemDescriptor> acc, List<ItemDescriptor> pool, int totalValue, int threshold, int multiplier)
+    {
+        if (totalValue <= 0 || pool.Count == 0)
+        {
+            return;
+        }
+
+        int guaranteed = (totalValue / threshold) * multiplier;
+        double extraP = (totalValue % threshold) / (double)threshold;
+
+        for (int i = 0; i < guaranteed; i++)
+        {
+            acc.Add(RandomRune(pool));
+        }
+
+        if (Random.Shared.NextDouble() < extraP)
+        {
+            acc.Add(RandomRune(pool));
+        }
+    }
+
+    private static bool IsRuneAllowedForRarity(
+        ItemDescriptor rune,
+        int rarity,
+        bool isPercentEffect,
+        bool isVitalRune,
+        bool isEffectRune = false
+    )
+    {
+        var amount = Math.Abs(rune.AmountModifier);
+        if (amount == 0)
+        {
+            return false;
+        }
+
+        if (isEffectRune)
+        {
+            // Los efectos porcentuales son más sensibles que los valores planos.
+            var weight = isPercentEffect ? amount * 2 : amount;
+            var allowance = rarity switch
+            {
+                <= 0 => 3,
+                1 => 5,
+                2 => 7,
+                3 => 10,
+                4 => 13,
+                _ => 16,
+            };
+
+            return weight <= allowance;
+        }
+
+        if (!isVitalRune && rune.AmountModifier > 3 && rarity < 3)
+        {
+            return false;
+        }
+
         return true;
     }
 
@@ -116,6 +193,51 @@ public static class ItemBreakHelper
         var idx = Random.Shared.Next(runes.Count);
         return runes[idx];
     }
+
+    private static bool HasRuneTarget(ItemDescriptor descriptor)
+    {
+        return descriptor.TargetStat >= 0 ||
+               descriptor.TargetVital >= 0 ||
+               descriptor.TargetEffect != ItemEffect.None;
+    }
+
+    private static Dictionary<ItemEffect, (int percent, int flat)> AggregateEffects(ItemDescriptor item, ItemProperties? props)
+    {
+        var totals = new Dictionary<ItemEffect, (int percent, int flat)>();
+
+        void AddEffect(EffectData effect)
+        {
+            if (!effect.IsPassive || effect.Type == ItemEffect.None)
+            {
+                return;
+            }
+
+            totals.TryGetValue(effect.Type, out var current);
+            if (effect.IsFlat)
+            {
+                current.flat += effect.FlatAmount;
+            }
+            else
+            {
+                current.percent += effect.Percentage;
+            }
+
+            totals[effect.Type] = current;
+        }
+
+        foreach (var effect in item.Effects)
+        {
+            AddEffect(effect);
+        }
+
+        if (props?.EffectModifiers != null)
+        {
+            foreach (var effect in props.EffectModifiers.Values)
+            {
+                AddEffect(effect);
+            }
+        }
+
+        return totals;
+    }
 }
-
-

--- a/Intersect.Server.Core/CustomChanges/ItemBreakerHelper.cs
+++ b/Intersect.Server.Core/CustomChanges/ItemBreakerHelper.cs
@@ -12,7 +12,6 @@ public static class ItemBreakHelper
     private const int StatThreshold = 10;
     private const int VitalThreshold = 20;
     private const int EffectPercentThreshold = 5;
-    private const int EffectFlatThreshold = 15;
 
     /// <summary>
     /// Debe llamarse una vez al arrancar el servidor, tras cargar los ItemDescriptor.
@@ -71,25 +70,15 @@ public static class ItemBreakHelper
         foreach (var kvp in AggregateEffects(item, props))
         {
             var effect = kvp.Key;
-            var totals = kvp.Value;
-
-            var hasPercent = totals.percent > 0;
-            var totalEffect = hasPercent ? totals.percent : totals.flat;
-            if (hasPercent && totals.flat > 0)
-            {
-                // Ajustar el valor plano a una escala porcentual para no perder potencia combinada.
-                totalEffect += (int)Math.Ceiling(totals.flat / (double)EffectFlatThreshold * EffectPercentThreshold);
-            }
+            var totalEffect = kvp.Value;
 
             if (totalEffect <= 0)
             {
                 continue;
             }
 
-            var pool = GetRunePool(effect, rarity, hasPercent);
-            var threshold = hasPercent ? EffectPercentThreshold : EffectFlatThreshold;
-
-            AddRunesFromValue(result, pool, totalEffect, threshold, multiplier);
+            var pool = GetRunePool(effect, rarity);
+            AddRunesFromValue(result, pool, totalEffect, EffectPercentThreshold, multiplier);
         }
 
         return result;
@@ -100,7 +89,7 @@ public static class ItemBreakHelper
         return AllRunes
             .Where(r =>
                 r.TargetStat == stat &&
-                IsRuneAllowedForRarity(r, rarity, false, false)
+                IsRuneAllowedForRarity(r, rarity, false)
             )
             .OrderBy(r => r.AmountModifier)
             .ToList();
@@ -111,18 +100,18 @@ public static class ItemBreakHelper
         return AllRunes
             .Where(r =>
                 r.TargetVital == vital &&
-                IsRuneAllowedForRarity(r, rarity, false, true)
+                IsRuneAllowedForRarity(r, rarity, true)
             )
             .OrderBy(r => r.AmountModifier)
             .ToList();
     }
 
-    private static List<ItemDescriptor> GetRunePool(ItemEffect effect, int rarity, bool isPercent)
+    private static List<ItemDescriptor> GetRunePool(ItemEffect effect, int rarity)
     {
         return AllRunes
             .Where(r =>
                 r.TargetEffect == effect &&
-                IsRuneAllowedForRarity(r, rarity, isPercent, false, true)
+                IsRuneAllowedForRarity(r, rarity, false, true)
             )
             .OrderBy(r => r.AmountModifier)
             .ToList();
@@ -152,7 +141,6 @@ public static class ItemBreakHelper
     private static bool IsRuneAllowedForRarity(
         ItemDescriptor rune,
         int rarity,
-        bool isPercentEffect,
         bool isVitalRune,
         bool isEffectRune = false
     )
@@ -165,8 +153,6 @@ public static class ItemBreakHelper
 
         if (isEffectRune)
         {
-            // Los efectos porcentuales son más sensibles que los valores planos.
-            var weight = isPercentEffect ? amount * 2 : amount;
             var allowance = rarity switch
             {
                 <= 0 => 3,
@@ -177,7 +163,7 @@ public static class ItemBreakHelper
                 _ => 16,
             };
 
-            return weight <= allowance;
+            return amount <= allowance;
         }
 
         if (!isVitalRune && rune.AmountModifier > 3 && rarity < 3)
@@ -201,9 +187,9 @@ public static class ItemBreakHelper
                descriptor.TargetEffect != ItemEffect.None;
     }
 
-    private static Dictionary<ItemEffect, (int percent, int flat)> AggregateEffects(ItemDescriptor item, ItemProperties? props)
+    private static Dictionary<ItemEffect, int> AggregateEffects(ItemDescriptor item, ItemProperties? props)
     {
-        var totals = new Dictionary<ItemEffect, (int percent, int flat)>();
+        var totals = new Dictionary<ItemEffect, int>();
 
         void AddEffect(EffectData effect)
         {
@@ -213,15 +199,7 @@ public static class ItemBreakHelper
             }
 
             totals.TryGetValue(effect.Type, out var current);
-            if (effect.IsFlat)
-            {
-                current.flat += effect.FlatAmount;
-            }
-            else
-            {
-                current.percent += effect.Percentage;
-            }
-
+            current += effect.Percentage;
             totals[effect.Type] = current;
         }
 

--- a/Intersect.Server.Core/CustomChanges/PlayerCustom.cs
+++ b/Intersect.Server.Core/CustomChanges/PlayerCustom.cs
@@ -238,7 +238,7 @@ namespace Intersect.Server.Entities
 
                 // Prepara resumen visual
                 var runeSummary = string.Join(", ", runes
-                    .GroupBy(r => r.Name)
+                    .GroupBy(DescribeRune)
                     .Select(g => $"{g.Count()}x {g.Key}"));
 
                 PacketSender.SendChatMsg(this, $"Rompiste {descriptor.Name} y obtuviste: {runeSummary}.", ChatMessageType.Experience);
@@ -246,6 +246,21 @@ namespace Intersect.Server.Entities
 
             // Actualiza inventario en cliente
             PacketSender.SendInventory(this);
+        }
+
+        private string DescribeRune(ItemDescriptor rune)
+        {
+            var modifier = rune.AmountModifier;
+            var target = rune.TargetEffect != ItemEffect.None
+                ? rune.TargetEffect.ToString()
+                : Convert.ToInt32(rune.TargetStat) >= 0 && Convert.ToInt32(rune.TargetStat) < Enum.GetValues<Stat>().Length
+                    ? ((Stat)rune.TargetStat).ToString()
+                    : Convert.ToInt32(rune.TargetVital) >= 0 && Convert.ToInt32(rune.TargetVital) < Enum.GetValues<Vital>().Length
+                        ? ((Vital)rune.TargetVital).ToString()
+                        : "Desconocido";
+
+            var suffix = modifier != 0 ? $" ({(modifier > 0 ? "+" : "")}{modifier} {target})" : $" ({target})";
+            return $"{rune.Name}{suffix}";
         }
 
         public void OpenEnchantment()
@@ -363,6 +378,25 @@ namespace Intersect.Server.Entities
             return (mSetBonusStats, mSetBonusPercentStats, mSetBonusVitals, mSetBonusVitalsRegen, mSetBonusPercentVitals, mSetBonusEffects);
         }
 
+        private static IEnumerable<EffectData> GetItemEffects(ItemDescriptor descriptor, ItemProperties? properties)
+        {
+            if (descriptor?.Effects != null)
+            {
+                foreach (var effect in descriptor.Effects)
+                {
+                    yield return effect;
+                }
+            }
+
+            if (properties?.EffectModifiers != null)
+            {
+                foreach (var effect in properties.EffectModifiers.Values)
+                {
+                    yield return effect;
+                }
+            }
+        }
+
         public static void ApplySetBonuses(Player p)
         {
             Array.Clear(p.mEquipmentFlatStats, 0, p.mEquipmentFlatStats.Length);
@@ -401,7 +435,7 @@ namespace Intersect.Server.Entities
                     p.mEquipmentVitalRegen[i] += descriptor.VitalsRegen[i];
                 }
 
-                foreach (var effect in descriptor.Effects)
+                foreach (var effect in GetItemEffects(descriptor, item.Properties))
                 {
                     p.mEquipmentBonusEffects.ApplyEffect(effect);
                 }

--- a/Intersect.Server.Core/Database/Item.cs
+++ b/Intersect.Server.Core/Database/Item.cs
@@ -1,6 +1,8 @@
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using Intersect.Enums;
 using Intersect.Framework.Core.Config;
 using Intersect.Framework.Core.GameObjects.Items;
@@ -442,10 +444,56 @@ public class Item : IItem
         if (newLevel > currentLevel)
         {
             double factor = 0.01;
+            int GetEnchantmentEffectBonus(ItemEffect effectType)
+            {
+                var total = 0;
+                if (Properties.EnchantmentEffectRolls != null)
+                {
+                    foreach (var levelBonuses in Properties.EnchantmentEffectRolls.Values)
+                    {
+                        if (levelBonuses.TryGetValue(effectType, out var bonus))
+                        {
+                            total += bonus;
+                        }
+                    }
+                }
+
+                return total;
+            }
+
+            var baseEffects = new Dictionary<ItemEffect, int>();
+
+            if (Descriptor.Effects?.Count > 0)
+            {
+                foreach (var effect in Descriptor.Effects)
+                {
+                    baseEffects[effect.Type] = effect.Percentage;
+                }
+            }
+
+            if (Properties.EffectModifiers?.Count > 0)
+            {
+                foreach (var (effectType, effectData) in Properties.EffectModifiers)
+                {
+                    if (baseEffects.ContainsKey(effectType))
+                    {
+                        continue;
+                    }
+
+                    var recordedBonus = GetEnchantmentEffectBonus(effectType);
+                    var baseValue = Math.Max(0, effectData.Percentage - recordedBonus);
+                    if (baseValue > 0)
+                    {
+                        baseEffects[effectType] = baseValue;
+                    }
+                }
+            }
+
             for (int lvl = currentLevel + 1; lvl <= newLevel; lvl++)
             {
                 int[] statBonuses = new int[Enum.GetValues(typeof(Stat)).Length];
                 int[] vitalBonuses = new int[Enum.GetValues(typeof(Vital)).Length];
+                Dictionary<ItemEffect, int> effectBonuses = new();
                 var baseDamageBonus = 0;
 
                 foreach (Stat stat in Enum.GetValues(typeof(Stat)))
@@ -472,6 +520,28 @@ public class Item : IItem
                     vitalBonuses[vitalIndex] = bonus;
                 }
 
+                if (baseEffects.Count > 0)
+                {
+                    Properties.EffectModifiers ??= new Dictionary<ItemEffect, EffectData>();
+
+                    foreach (var (effectType, baseValue) in baseEffects)
+                    {
+                        var levelInfluence = Math.Log2(lvl + 1) + Math.Sqrt(lvl);
+                        var bonus = (int)Math.Ceiling(baseValue * factor * levelInfluence);
+                        if (bonus == 0)
+                        {
+                            continue;
+                        }
+
+                        Properties.EffectModifiers.TryGetValue(effectType, out var existingEffect);
+                        existingEffect ??= new EffectData(effectType, 0);
+                        existingEffect.Percentage += bonus;
+                        existingEffect.IsPassive = true;
+                        Properties.EffectModifiers[effectType] = existingEffect;
+                        effectBonuses[effectType] = bonus;
+                    }
+                }
+
                 if (Descriptor.EquipmentSlot == Options.Instance.Equipment.WeaponSlot)
                 {
                     var baseDamage = Descriptor.Damage;
@@ -487,6 +557,11 @@ public class Item : IItem
                         .Concat(vitalBonuses)
                         .Concat(new[] { baseDamageBonus })
                         .ToArray();
+
+                if (effectBonuses.Count > 0)
+                {
+                    Properties.EnchantmentEffectRolls[lvl] = new Dictionary<ItemEffect, int>(effectBonuses);
+                }
             }
         }
         else
@@ -522,6 +597,33 @@ public class Item : IItem
 
                     Properties.EnchantmentRolls.Remove(lvl);
                 }
+
+                if (Properties.EnchantmentEffectRolls.TryGetValue(lvl, out var effectBonuses))
+                {
+                    if (Properties.EffectModifiers != null)
+                    {
+                        foreach (var (effectType, bonus) in effectBonuses)
+                        {
+                            if (!Properties.EffectModifiers.TryGetValue(effectType, out var effectData))
+                            {
+                                continue;
+                            }
+
+                            effectData.Percentage = Math.Max(0, effectData.Percentage - bonus);
+
+                            if (effectData.Percentage <= 0)
+                            {
+                                Properties.EffectModifiers.Remove(effectType);
+                            }
+                            else
+                            {
+                                Properties.EffectModifiers[effectType] = effectData;
+                            }
+                        }
+                    }
+
+                    Properties.EnchantmentEffectRolls.Remove(lvl);
+                }
             }
         }
 
@@ -548,8 +650,9 @@ public class Item : IItem
 
         // 2) ¿A qué apunta la runa y cuánto modifica?
         var desc = runeItem.Descriptor;
-       int targetStat = (int)desc.TargetStat;
+        int targetStat = (int)desc.TargetStat;
         int targetVit = (int)desc.TargetVital;
+        var targetEffect = desc.TargetEffect;
         var amount = desc.AmountModifier;
 
         if (amount == 0)
@@ -560,11 +663,22 @@ public class Item : IItem
 
         bool isStat = targetStat >= 0 && targetStat < Properties.StatModifiers.Length;
         bool isVital = targetVit >= 0 && targetVit < Properties.VitalModifiers.Length;
+        bool isEffect = targetEffect != ItemEffect.None;
 
+        var validTargets = 0;
+        validTargets += isStat ? 1 : 0;
+        validTargets += isVital ? 1 : 0;
+        validTargets += isEffect ? 1 : 0;
 
-        if (!isStat && !isVital)
+        if (validTargets == 0)
         {
-            resultMessage = "La Runa no apunta a un atributo válido.";
+            resultMessage = "La Runa no apunta a un destino válido.";
+            return false;
+        }
+
+        if (validTargets > 1)
+        {
+            resultMessage = "La Runa no puede modificar más de un destino a la vez.";
             return false;
         }
 
@@ -574,7 +688,9 @@ public class Item : IItem
             : (int)targetVit;
         int currentValue = isStat
             ? Properties.StatModifiers[idx]
-            : Properties.VitalModifiers[idx];
+            : isVital
+                ? Properties.VitalModifiers[idx]
+                : Properties.EffectModifiers?.GetValueOrDefault(targetEffect)?.Percentage ?? 0;
 
         // 5) Calcular tasa de éxito sólo en función de MageSink
         var sinkMod = RarityMageoSettings.GetSinkMod(Descriptor.Rarity);
@@ -600,22 +716,38 @@ public class Item : IItem
             {
                 Properties.StatModifiers[idx] += amount;
             }
-            else
+            else if (isVital)
             {
                 Properties.VitalModifiers[idx] += amount;
+            }
+            else if (isEffect)
+            {
+                Properties.EffectModifiers ??= new Dictionary<ItemEffect, EffectData>();
+                if (!Properties.EffectModifiers.TryGetValue(targetEffect, out var effectData))
+                {
+                    effectData = new EffectData(targetEffect, 0);
+                }
+                effectData.Percentage += amount;
+                effectData.IsPassive = true;
+                effectData.Stacking = EffectStacking.Stack;
+                Properties.EffectModifiers[targetEffect] = effectData;
             }
 
             // 6c) Penalización suave si pasamos 2× valor base (30% de chance, -½ amount)
             int baseVal = isStat
                 ? equipment.Descriptor.StatsGiven[idx]
-                : (int)equipment.Descriptor.VitalsGiven[idx];
+                : isVital
+                    ? (int)equipment.Descriptor.VitalsGiven[idx]
+                    : equipment.Descriptor.GetEffect(targetEffect)?.Percentage ?? 0;
             int newValue = isStat
                 ? Properties.StatModifiers[idx]
-                : Properties.VitalModifiers[idx];
+                : isVital
+                    ? Properties.VitalModifiers[idx]
+                    : Properties.EffectModifiers!.GetValueOrDefault(targetEffect)?.Percentage ?? 0;
             if (newValue > baseVal * 2 && Random.Shared.NextDouble() < 0.30)
             {
                 int penal = Math.Max(1, amount / 2);
-                PenalizeOtherRandomAttribute(isStat, penal);
+                PenalizeOtherRandomAttribute(isStat, penal, isEffect ? targetEffect : null);
             }
 
             // 6d) Reducir MageSink
@@ -626,7 +758,11 @@ public class Item : IItem
 
             // 6e) Mensaje de éxito
             success = true;
-            var name = (isStat ? targetStat : (object)targetVit).ToString();
+            var name = isStat
+                ? targetStat.ToString()
+                : isVital
+                    ? targetVit.ToString()
+                    : targetEffect.ToString();
             resultMessage = isCritical
                 ? $"🔥 ¡Éxito Crítico! {name} +{amount}."
                 : $"¡Éxito! {name} +{amount}.";
@@ -641,11 +777,29 @@ public class Item : IItem
                 {
                     Properties.StatModifiers[idx] -= penalty;
                 }
-                else
+                else if (isVital)
                 {
                     Properties.VitalModifiers[idx] -= penalty;
                 }
-                var name = (isStat ? targetStat : (object)targetVit).ToString();
+                else if (isEffect)
+                {
+                    Properties.EffectModifiers ??= new Dictionary<ItemEffect, EffectData>();
+                    if (!Properties.EffectModifiers.TryGetValue(targetEffect, out var effectData))
+                    {
+                        effectData = new EffectData(targetEffect, 0);
+                        Properties.EffectModifiers[targetEffect] = effectData;
+                    }
+                    effectData.Percentage -= penalty;
+                    if (effectData.Percentage <= 0)
+                    {
+                        Properties.EffectModifiers.Remove(targetEffect);
+                    }
+                }
+                var name = isStat
+                    ? targetStat.ToString()
+                    : isVital
+                        ? targetVit.ToString()
+                        : targetEffect.ToString();
                 resultMessage = $"Falló. {name} -{penalty}.";
             }
             Properties.MageSink += (int)(amount * 10 * sinkMod);
@@ -658,7 +812,7 @@ public class Item : IItem
         return true;
     }
 
-    private void PenalizeOtherRandomAttribute(bool isStat, int amount)
+    private void PenalizeOtherRandomAttribute(bool isStat, int amount, ItemEffect? effectToProtect = null)
     {
         var rng = Random.Shared;
         if (isStat)
@@ -675,15 +829,39 @@ public class Item : IItem
         }
         else
         {
-            // Igual para vitals
-            var candidates = Properties.VitalModifiers
-                .Select((v, i) => (v, i))
-                .Where(x => x.v > 0)
-                .ToArray();
-            if (candidates.Length == 0) return;
-            var idx = candidates[rng.Next(candidates.Length)].i;
-            int reduce = Math.Min(Properties.VitalModifiers[idx], amount);
-            Properties.VitalModifiers[idx] -= reduce;
+            // Igual para vitals o efectos adicionales
+            if (effectToProtect == null)
+            {
+                var candidates = Properties.VitalModifiers
+                    .Select((v, i) => (v, i))
+                    .Where(x => x.v > 0)
+                    .ToArray();
+                if (candidates.Length == 0) return;
+                var idx = candidates[rng.Next(candidates.Length)].i;
+                int reduce = Math.Min(Properties.VitalModifiers[idx], amount);
+                Properties.VitalModifiers[idx] -= reduce;
+            }
+            else
+            {
+                Properties.EffectModifiers ??= new Dictionary<ItemEffect, EffectData>();
+                var candidates = Properties.EffectModifiers
+                    .Where(kvp => kvp.Key != effectToProtect && kvp.Value.Percentage > 0)
+                    .Select(kvp => kvp.Key)
+                    .ToArray();
+                if (candidates.Length == 0) return;
+                var chosen = candidates[rng.Next(candidates.Length)];
+                var effect = Properties.EffectModifiers[chosen];
+                var reduce = Math.Min(effect.Percentage, amount);
+                effect.Percentage -= reduce;
+                if (effect.Percentage <= 0)
+                {
+                    Properties.EffectModifiers.Remove(chosen);
+                }
+                else
+                {
+                    Properties.EffectModifiers[chosen] = effect;
+                }
+            }
         }
     }
 

--- a/Intersect.Server.Core/Entities/Combat/CombatEffectCollection.cs
+++ b/Intersect.Server.Core/Entities/Combat/CombatEffectCollection.cs
@@ -8,7 +8,7 @@ namespace Intersect.Server.Entities.Combat;
 
 public sealed class CombatEffectCollection
 {
-    private readonly Dictionary<ItemEffect, EffectValue> mEffects = new();
+    private readonly Dictionary<ItemEffect, int> mEffects = new();
 
     public static CombatEffectCollection From(IEnumerable<EffectData> effects)
     {
@@ -18,7 +18,7 @@ public sealed class CombatEffectCollection
         return collection;
     }
 
-    public EffectValue Get(ItemEffect effect)
+    public int Get(ItemEffect effect)
     {
         return mEffects.TryGetValue(effect, out var value) ? value : default;
     }
@@ -38,7 +38,7 @@ public sealed class CombatEffectCollection
 
     private void Add(EffectData effect)
     {
-        var value = effect.GetValues();
+        var value = effect.Percentage;
         switch (effect.Stacking)
         {
             case EffectStacking.Ignore:
@@ -55,7 +55,7 @@ public sealed class CombatEffectCollection
             default:
                 if (mEffects.ContainsKey(effect.Type))
                 {
-                    mEffects[effect.Type] = mEffects[effect.Type].Add(value);
+                    mEffects[effect.Type] += value;
                 }
                 else
                 {
@@ -69,12 +69,12 @@ public sealed class CombatEffectCollection
 
 public sealed record CombatantEffects(Entity Entity, CombatEffectCollection ActiveEffects)
 {
-    public EffectValue GetTotalEffectValue(ItemEffect effect)
+    public int GetTotalEffectValue(ItemEffect effect)
     {
         var passive = Entity.GetPassiveEffectValues(effect);
         var active = ActiveEffects.Get(effect);
 
-        return passive.Add(active);
+        return passive + active;
     }
 }
 

--- a/Intersect.Server.Core/Entities/Combat/CombatResolver.cs
+++ b/Intersect.Server.Core/Entities/Combat/CombatResolver.cs
@@ -35,12 +35,12 @@ public static class CombatResolver
         var accuracy =
             attacker.Stat[(int)Enums.Stat.Agility].Value() * 0.5d +
             attacker.Stat[(int)Enums.Stat.Attack].Value() * 0.3d +
-            attackerEffects.GetTotalEffectValue(ItemEffect.Accuracy).GetPrimaryValue();
+            attackerEffects.GetTotalEffectValue(ItemEffect.Accuracy);
 
         var evasion =
             defender.Stat[(int)Enums.Stat.Agility].Value() * 0.7d +
             defender.Stat[(int)Enums.Stat.Defense].Value() * 0.2d +
-            defenderEffects.GetTotalEffectValue(ItemEffect.Evasion).GetPrimaryValue();
+            defenderEffects.GetTotalEffectValue(ItemEffect.Evasion);
 
         var statBalance = accuracy - evasion;
         var normalization = Math.Max(50d, accuracy + evasion);
@@ -59,10 +59,10 @@ public static class CombatResolver
 
         var agilityPerCrit = Math.Max(1, Options.Instance.Combat.AgilityPerCritChance);
         critChance += attackerEffects.Entity.Stat[(int)Enums.Stat.Agility].Value() / agilityPerCrit;
-        critChance += attackerEffects.GetTotalEffectValue(ItemEffect.CriticalChance).GetPrimaryValue();
+        critChance += attackerEffects.GetTotalEffectValue(ItemEffect.CriticalChance);
 
         var antiCrit = defenderEffects.GetTotalEffectValue(ItemEffect.AntiCritChance);
-        critChance -= antiCrit.Percentage + antiCrit.Flat;
+        critChance -= antiCrit;
 
         return Math.Max(0, critChance);
     }
@@ -74,7 +74,7 @@ public static class CombatResolver
     )
     {
         var penetration = attackerEffects.GetTotalEffectValue(ItemEffect.ArmorPenetration);
-        if (penetration.Percentage == 0 && penetration.Flat == 0)
+        if (penetration == 0)
         {
             return null;
         }
@@ -91,10 +91,7 @@ public static class CombatResolver
             return null;
         }
 
-        var effectiveDefense = Math.Max(
-            0,
-            (baseDefense - penetration.Flat) * (1 - penetration.Percentage / 100f)
-        );
+        var effectiveDefense = Math.Max(0, baseDefense * (1 - penetration / 100f));
 
         var parameter = damageType == DamageType.Magic ? "V_MagicResist" : "V_Defense";
         return new Dictionary<string, object> { [parameter] = effectiveDefense };
@@ -105,14 +102,9 @@ public static class CombatResolver
         var reduction = defenderEffects.GetTotalEffectValue(ItemEffect.DamageReduction);
         var reduced = damage;
 
-        if (reduction.Percentage != 0)
+        if (reduction != 0)
         {
-            reduced = (long)Math.Round(reduced * (1 - reduction.Percentage / 100f));
-        }
-
-        if (reduction.Flat != 0)
-        {
-            reduced = Math.Max(0, reduced - reduction.Flat);
+            reduced = (long)Math.Round(reduced * (1 - reduction / 100f));
         }
 
         return reduced;
@@ -124,12 +116,12 @@ public static class CombatResolver
         var modifier = isHeal ? attackerEffects.GetTotalEffectValue(ItemEffect.Cures) :
             attackerEffects.GetTotalEffectValue(ItemEffect.Damages);
 
-        if (modifier.Percentage == 0)
+        if (modifier == 0)
         {
             return damage;
         }
 
-        var adjusted = Math.Round(damage * (100 + modifier.Percentage) / 100d);
+        var adjusted = Math.Round(damage * (100 + modifier) / 100d);
 
         return (long)adjusted;
     }
@@ -142,17 +134,11 @@ public static class CombatResolver
         }
 
         var reflect = defenderEffects.GetTotalEffectValue(ItemEffect.DamageReflect);
-        if (reflect.Percentage == 0 && reflect.Flat == 0)
+        if (reflect == 0)
         {
             return 0;
         }
 
-        var reflectedDamage = reflect.Flat;
-        if (reflect.Percentage != 0)
-        {
-            reflectedDamage += (int)(long)Math.Round(appliedDamage * (reflect.Percentage / 100f));
-        }
-
-        return reflectedDamage;
+        return (int)(long)Math.Round(appliedDamage * (reflect / 100f));
     }
 }

--- a/Intersect.Server.Core/Entities/Entity.cs
+++ b/Intersect.Server.Core/Entities/Entity.cs
@@ -2004,7 +2004,7 @@ public abstract partial class Entity : IEntity
         return Array.Empty<EffectData>();
     }
 
-    public virtual EffectValue GetPassiveEffectValues(ItemEffect effect)
+    public virtual int GetPassiveEffectValues(ItemEffect effect)
     {
         return default;
     }
@@ -2358,7 +2358,7 @@ public abstract partial class Entity : IEntity
         {
             var lifestealRate = Math.Max(
                 0f,
-                attackerEffects.GetTotalEffectValue(ItemEffect.Lifesteal).GetPrimaryValue() / 100f
+                attackerEffects.GetTotalEffectValue(ItemEffect.Lifesteal) / 100f
             );
             if (hasVampirism)
             {
@@ -2381,7 +2381,7 @@ public abstract partial class Entity : IEntity
 
             var manastealRate = Math.Max(
                 0f,
-                attackerEffects.GetTotalEffectValue(ItemEffect.Manasteal).GetPrimaryValue() / 100f
+                attackerEffects.GetTotalEffectValue(ItemEffect.Manasteal) / 100f
             );
             if (hasVampirism)
             {

--- a/Intersect.Server.Core/Entities/Player.cs
+++ b/Intersect.Server.Core/Entities/Player.cs
@@ -4170,12 +4170,14 @@ public partial class Player : Entity
         foreach (var item in EquippedItems)
         {
             var descriptor = item.Descriptor;
-            if (descriptor?.Effects == null)
+            if (descriptor == null)
             {
                 continue;
             }
 
-            activeEffects.AddRange(descriptor.Effects.Where(effect => !effect.IsPassive));
+            activeEffects.AddRange(
+                GetItemEffects(descriptor, item.Properties).Where(effect => !effect.IsPassive)
+            );
         }
 
         activeEffects.AddRange(mSetBonusEffects.Where(effect => !effect.IsPassive));

--- a/Intersect.Server.Core/Entities/Player.cs
+++ b/Intersect.Server.Core/Entities/Player.cs
@@ -183,7 +183,7 @@ public partial class Player : Entity
     private readonly long[] mEquipmentVitalRegen = new long[Enum.GetValues<Vital>().Length];
 
     [NotMapped, JsonIgnore]
-    private readonly Dictionary<ItemEffect, EffectValue> mEquipmentBonusEffects = new();
+    private readonly Dictionary<ItemEffect, int> mEquipmentBonusEffects = new();
 
     [NotMapped, JsonIgnore]
     private readonly int[] mSetBonusStats = new int[Enum.GetValues<Stat>().Length];
@@ -4151,14 +4151,14 @@ public partial class Player : Entity
     /// </summary>
     /// <param name="effect">The <see cref="ItemEffect"/> to retrieve the amount for.</param>
     /// <returns></returns>
-    public EffectValue GetEquipmentBonusEffectValues(ItemEffect effect)
+    public int GetEquipmentBonusEffectValues(ItemEffect effect)
     {
         return mEquipmentBonusEffects.TryGetValue(effect, out var value) ? value : default;
     }
 
-    public int GetEquipmentBonusEffect(ItemEffect effect) => GetEquipmentBonusEffectValues(effect).GetPrimaryValue();
+    public int GetEquipmentBonusEffect(ItemEffect effect) => GetEquipmentBonusEffectValues(effect);
 
-    public override EffectValue GetPassiveEffectValues(ItemEffect effect)
+    public override int GetPassiveEffectValues(ItemEffect effect)
     {
         return GetEquipmentBonusEffectValues(effect);
     }

--- a/Intersect.Server.Core/Maps/MapItemInstance.cs
+++ b/Intersect.Server.Core/Maps/MapItemInstance.cs
@@ -95,7 +95,15 @@ public partial class MapItem : Item
         if (item.Properties.EffectModifiers != null)
         {
             Properties.EffectModifiers =
-                item.Properties.EffectModifiers.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.Clone());
+                item.Properties.EffectModifiers.ToDictionary(
+                    kvp => kvp.Key,
+                    kvp => new EffectData(
+                        kvp.Value.Type,
+                        kvp.Value.Percentage,
+                        kvp.Value.IsPassive,
+                        kvp.Value.Stacking
+                    )
+                );
         }
 
         Properties.EnchantmentRolls = new Dictionary<int, int[]>(item.Properties.EnchantmentRolls);

--- a/Intersect.Server.Core/Maps/MapItemInstance.cs
+++ b/Intersect.Server.Core/Maps/MapItemInstance.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using Intersect.Enums;
 using Intersect.Server.Database;
 using Intersect.Server.Database.PlayerData.Players;
 using Newtonsoft.Json;
@@ -90,7 +92,18 @@ public partial class MapItem : Item
             Array.Copy(item.Properties.VitalModifiers, Properties.VitalModifiers, Properties.VitalModifiers.Length);
         }
 
+        if (item.Properties.EffectModifiers != null)
+        {
+            Properties.EffectModifiers =
+                item.Properties.EffectModifiers.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.Clone());
+        }
+
         Properties.EnchantmentRolls = new Dictionary<int, int[]>(item.Properties.EnchantmentRolls);
+        Properties.EnchantmentEffectRolls =
+            item.Properties.EnchantmentEffectRolls.ToDictionary(
+                kvp => kvp.Key,
+                kvp => new Dictionary<ItemEffect, int>(kvp.Value)
+            );
     }
 
 }

--- a/Intersect.Tests/GameObjects/EffectDataSerializationTests.cs
+++ b/Intersect.Tests/GameObjects/EffectDataSerializationTests.cs
@@ -1,4 +1,5 @@
 using Intersect.Framework.Core.GameObjects.Items;
+using Intersect.GameObjects;
 using Newtonsoft.Json;
 using NUnit.Framework;
 
@@ -12,7 +13,7 @@ public class EffectDataSerializationTests
     [TestCase(ItemEffect.DamageReflect)]
     public void EffectDataSerializesNewItemEffects(ItemEffect itemEffect)
     {
-        var effect = new EffectData(itemEffect, 25, isPassive: false, EffectStacking.Renew, flatAmount: 10, isFlat: true);
+        var effect = new EffectData(itemEffect, 25, isPassive: false, EffectStacking.Renew);
 
         var json = JsonConvert.SerializeObject(effect);
         var roundTrip = JsonConvert.DeserializeObject<EffectData>(json);
@@ -20,8 +21,6 @@ public class EffectDataSerializationTests
         Assert.That(roundTrip, Is.Not.Null);
         Assert.That(roundTrip!.Type, Is.EqualTo(itemEffect));
         Assert.That(roundTrip.Percentage, Is.EqualTo(effect.Percentage));
-        Assert.That(roundTrip.FlatAmount, Is.EqualTo(effect.FlatAmount));
-        Assert.That(roundTrip.IsFlat, Is.EqualTo(effect.IsFlat));
         Assert.That(roundTrip.IsPassive, Is.EqualTo(effect.IsPassive));
         Assert.That(roundTrip.Stacking, Is.EqualTo(effect.Stacking));
     }

--- a/Intersect.Tests/GameObjects/EffectStackingTests.cs
+++ b/Intersect.Tests/GameObjects/EffectStackingTests.cs
@@ -10,56 +10,42 @@ public class EffectStackingTests
     [Test]
     public void ApplyEffect_StacksDuplicates()
     {
-        var bonuses = new Dictionary<ItemEffect, EffectValue>();
+        var bonuses = new Dictionary<ItemEffect, int>();
         var effect1 = new EffectData(ItemEffect.Luck, 10, true, EffectStacking.Stack);
         var effect2 = new EffectData(ItemEffect.Luck, 5, true, EffectStacking.Stack);
         bonuses.ApplyEffect(effect1);
         bonuses.ApplyEffect(effect2);
-        Assert.That(bonuses[ItemEffect.Luck].Percentage, Is.EqualTo(15));
+        Assert.That(bonuses[ItemEffect.Luck], Is.EqualTo(15));
     }
 
     [Test]
     public void ApplyEffect_IgnoresDuplicates()
     {
-        var bonuses = new Dictionary<ItemEffect, EffectValue>();
+        var bonuses = new Dictionary<ItemEffect, int>();
         var effect1 = new EffectData(ItemEffect.Luck, 10, true, EffectStacking.Ignore);
         var effect2 = new EffectData(ItemEffect.Luck, 5, true, EffectStacking.Ignore);
         bonuses.ApplyEffect(effect1);
         bonuses.ApplyEffect(effect2);
-        Assert.That(bonuses[ItemEffect.Luck].Percentage, Is.EqualTo(10));
+        Assert.That(bonuses[ItemEffect.Luck], Is.EqualTo(10));
     }
 
     [Test]
     public void ApplyEffect_RenewsDuplicates()
     {
-        var bonuses = new Dictionary<ItemEffect, EffectValue>();
+        var bonuses = new Dictionary<ItemEffect, int>();
         var effect1 = new EffectData(ItemEffect.Luck, 10, true, EffectStacking.Renew);
         var effect2 = new EffectData(ItemEffect.Luck, 5, true, EffectStacking.Renew);
         bonuses.ApplyEffect(effect1);
         bonuses.ApplyEffect(effect2);
-        Assert.That(bonuses[ItemEffect.Luck].Percentage, Is.EqualTo(5));
+        Assert.That(bonuses[ItemEffect.Luck], Is.EqualTo(5));
     }
 
     [Test]
     public void ApplyEffect_SkipsNonPassive()
     {
-        var bonuses = new Dictionary<ItemEffect, EffectValue>();
+        var bonuses = new Dictionary<ItemEffect, int>();
         var effect = new EffectData(ItemEffect.Luck, 10, false, EffectStacking.Stack);
         bonuses.ApplyEffect(effect);
         Assert.That(bonuses.ContainsKey(ItemEffect.Luck), Is.False);
-    }
-
-    [Test]
-    public void ApplyEffect_IgnoresFlatComponents()
-    {
-        var bonuses = new Dictionary<ItemEffect, EffectValue>();
-        var percentOnly = new EffectData(ItemEffect.DamageReflect, 10, true, EffectStacking.Stack, flatAmount: 0, isFlat: false);
-        var flatOnly = new EffectData(ItemEffect.DamageReflect, 0, true, EffectStacking.Stack, flatAmount: 5, isFlat: true);
-
-        bonuses.ApplyEffect(percentOnly);
-        bonuses.ApplyEffect(flatOnly);
-
-        Assert.That(bonuses[ItemEffect.DamageReflect].Percentage, Is.EqualTo(10));
-        Assert.That(bonuses[ItemEffect.DamageReflect].Flat, Is.EqualTo(0));
     }
 }


### PR DESCRIPTION
### Motivation
- Replace the `Clone()` call on `EffectData` when copying effect modifiers because `EffectData` did not expose a `Clone()` method and the implicit call was incorrect.
- Ensure dropped map items retain their effect modifier values and match the behavior used when copying `ItemProperties`.

### Description
- Replace `item.Properties.EffectModifiers.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.Clone())` with an explicit constructor `new EffectData(kvp.Value.Type, kvp.Value.Percentage, kvp.Value.IsPassive, kvp.Value.Stacking)`.
- Change applied in `Intersect.Server.Core/Maps/MapItemInstance.cs` inside the `SetupProperties` method.
- This mirrors the `EffectData` copying already used in `Framework/Intersect.Framework.Core/GameObjects/Items/ItemProperties.cs` and avoids adding a `Clone()` method.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963248352cc832b94736852ea66ebfd)