### PR TITLE
Add MessagePack attributes to EffectData

### DIFF
--- a/Framework/Intersect.Framework.Core/GameObjects/Items/EffectData.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Items/EffectData.cs
@@ -1,7 +1,9 @@
+using MessagePack;
 using Microsoft.EntityFrameworkCore;
 
 namespace Intersect.Framework.Core.GameObjects.Items;
 
+[MessagePackObject]
 [Owned]
 public partial class EffectData
 {
@@ -26,11 +28,15 @@ public partial class EffectData
         Stacking = stacking;
     }
 
+    [Key(0)]
     public ItemEffect Type { get; set; }
 
+    [Key(1)]
     public int Percentage { get; set; }
 
+    [Key(2)]
     public bool IsPassive { get; set; }
 
+    [Key(3)]
     public EffectStacking Stacking { get; set; }
 }


### PR DESCRIPTION
### Motivation
- Fix the MessagePack analyzer error `MsgPack003` by marking `EffectData` as a MessagePack serializable type with explicit keys.
- Ensure `EffectData` instances can be serialized/deserialized consistently by the project's MessagePack usage (e.g., within `ItemProperties`).
- Preserve existing Entity Framework semantics by keeping the `[Owned]` attribute on the class.

### Description
- Added `using MessagePack;` to the file to enable MessagePack attributes.
- Annotated the class with the `[MessagePackObject]` attribute and retained the `[Owned]` attribute.
- Added `[Key(0)]`, `[Key(1)]`, `[Key(2)]`, and `[Key(3)]` to the `Type`, `Percentage`, `IsPassive`, and `Stacking` properties respectively.
- No runtime behavior changes were made beyond adding MessagePack serialization metadata.

### Testing
- No automated tests were executed for this change.
- The change is targeted to resolve the previously reported analyzer warning `MsgPack003` related to `EffectData`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963385294c4832baf94a961fa1e12ba)