### PR TITLE
Guard numeric control in Item editor to prevent NullReferenceException

### DIFF
--- a/Intersect.Editor/Forms/Editors/frmItem.cs
+++ b/Intersect.Editor/Forms/Editors/frmItem.cs
@@ -197,6 +197,11 @@ public partial class FrmItem : EditorForm
 
     private static void SetNumericValue(NumericUpDown control, int[] values, int index)
     {
+        if (control == null)
+        {
+            return;
+        }
+
         if (values != null && index < values.Length)
         {
             control.Enabled = true;


### PR DESCRIPTION
### Motivation
- Fix a `NullReferenceException` thrown from `FrmItem.SetNumericValue` when a `NumericUpDown` control is null.
- Prevent the item editor from crashing while loading or updating items when not all numeric controls are present.

### Description
- Add a null guard at the start of `SetNumericValue` that returns early if `control == null`.
- Apply the change in `Intersect.Editor/Forms/Editors/frmItem.cs` to avoid dereferencing a null `NumericUpDown`.
- Preserve existing behavior for enabling/disabling the control and clamping values when the control is present.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963a6083958832b98d5a1a10f61223e)