### PR TITLE
Usar CultureInfo.Name para idioma objetivo de traducción

### DIFF
--- a/Intersect.Client.Core/Localization/TranslationService.cs
+++ b/Intersect.Client.Core/Localization/TranslationService.cs
@@ -42,7 +42,7 @@ public class TranslationService
 
         // Detect System Language
         var currentCulture = CultureInfo.CurrentUICulture;
-        _targetLanguage = currentCulture.DisplayName;
+        _targetLanguage = currentCulture.Name;
 
         // Define cache path
         // Ensure the directory exists


### PR DESCRIPTION
### Motivation
- Cambiar el identificador de idioma usado en prompts y en nombres de caché a un identificador estable de cultura (por ejemplo `es-AR`, `en-US`) en lugar de la `DisplayName`.

### Description
- Reemplazado `currentCulture.DisplayName` por `currentCulture.Name` en `Intersect.Client.Core/Localization/TranslationService.cs` para asignar `_targetLanguage`, lo que se refleja en el nombre del archivo de caché y en los prompts enviados al servicio de traducción.

### Testing
- No se ejecutaron pruebas automáticas.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966f29c2e1c832bb9331a107b2325c5)