### PR TITLE
Document translation scope for chat, UI, and game content

### DIFF
--- a/Intersect.Client.Core/Localization/TranslationService.cs
+++ b/Intersect.Client.Core/Localization/TranslationService.cs
@@ -371,11 +371,16 @@ public class TranslationService
 
     private static async Task TranslateInterface()
     {
+        // UI strings are translated here (menus, HUD, dialogs, etc.).
         await Strings.TranslateAll(Instance);
     }
 
     public static async Task TranslateGameContent()
     {
+        // Game content translation scope:
+        // - Included: item, quest, and spell names/descriptions.
+        // - Not yet included: event text, job/class text, and player chat.
+        // Chat translation is handled separately and excludes player chat channels for now.
         // Give the game a moment to load loaded descriptors from server/cache
         // Wait a short delay to ensure deserialization is fully complete if needed, but primarily triggered by GameData
         await Task.Delay(TimeSpan.FromSeconds(2));

--- a/Intersect.Client.Core/Networking/PacketHandler.cs
+++ b/Intersect.Client.Core/Networking/PacketHandler.cs
@@ -643,9 +643,10 @@ internal sealed partial class PacketHandler
                 packet.Target, packet.Items
             )
         );
-        // Define which channels contain player communication which should NOT be translated to avoid freezing/lag
-        // Local, Global, Party, Guild, PM, Admin are typically user-generated text.
-        // Server messages (Experience, Loot, Combat, Notice, Error, etc) should be translated.
+        // Chat translation policy:
+        // - Player chat channels are excluded from translation for now (Local, Global, Party, Guild, PM, Admin).
+        // - Non-player/system channels (Experience, Loot, Combat, Notice, Error, etc.) can be translated.
+        // This keeps player-to-player chat unmodified while allowing system messages to be localized.
         bool shouldTranslate = packet.Type != ChatMessageType.Local &&
                                packet.Type != ChatMessageType.Global &&
                                packet.Type != ChatMessageType.Party &&


### PR DESCRIPTION
### Motivation
- Clarify which chat channels are excluded from automated translation to avoid translating player-to-player messages and to document the intended translation scope for UI and game content.

### Description
- Added a chat translation policy comment in `Intersect.Client.Core/Networking/PacketHandler.cs` stating player channels (Local, Global, Party, Guild, PM, Admin) are excluded from translation and system channels (Experience, Loot, Combat, Notice, Error, etc.) may be translated while retaining the existing runtime behavior.
- Added documentation comments in `Intersect.Client.Core/Localization/TranslationService.cs` explaining that UI strings are translated in `TranslateInterface` and that `TranslateGameContent` currently queues item, quest, and spell names/descriptions for batch translation while explicitly noting that event text, job/class text, and player chat are not yet included.

### Testing
- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966f9039030832baac51df5cedae08e)