### PR TITLE
Add cache-only mode to TranslationService

### DIFF
--- a/Intersect.Client.Core/Localization/TranslationService.cs
+++ b/Intersect.Client.Core/Localization/TranslationService.cs
@@ -30,6 +30,8 @@ public class TranslationService
     private readonly string _cacheFilePath; // Cache file path
     private bool _enabled;
 
+    public bool UseCacheOnly { get; set; }
+
     // Batching Configuration
     private const int BATCH_SIZE = 20; // Number of strings per request
 
@@ -99,6 +101,11 @@ public class TranslationService
             return cached;
         }
 
+        if (UseCacheOnly)
+        {
+            return text;
+        }
+
         // Use key from Options, which comes from Server or Local Config
         var apiKey = Options.Instance?.TranslationApiKey;
 
@@ -163,6 +170,16 @@ public class TranslationService
         }
 
         if (uncached.Count == 0) return results;
+
+        if (UseCacheOnly)
+        {
+            foreach (var kvp in uncached)
+            {
+                results[kvp.Key] = kvp.Value;
+            }
+
+            return results;
+        }
 
         // Use key from Options
         var apiKey = Options.Instance?.TranslationApiKey;


### PR DESCRIPTION
### Motivation
- Allow the client to run in a mode where translations are served only from the local cache and no external API calls are made, so untranslated strings fall back to the original source text (useful after pre-translation or when server indicates cache completeness).

### Description
- Added a public `bool UseCacheOnly` property to `TranslationService` to toggle cache-only behavior.
- In `Translate(string)` the method now returns the original `text` when not present in `_translationCache` and `UseCacheOnly` is enabled, avoiding API calls.
- In `TranslateBatch(...)` the service now fills results with original values for any uncached entries and returns early when `UseCacheOnly` is enabled, preventing batch API requests.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967080f6818832bb5c46f731ea12d04)