### PR TITLE
Add debug logging for translation cache and API usage

### DIFF
--- a/Intersect.Client.Core/Localization/TranslationService.cs
+++ b/Intersect.Client.Core/Localization/TranslationService.cs
@@ -98,11 +98,13 @@ public class TranslationService
 
         if (_translationCache.TryGetValue(text, out var cached))
         {
+            ApplicationContext.Context.Value?.Logger.LogDebug("Translation cache hit (text).");
             return cached;
         }
 
         if (UseCacheOnly)
         {
+            ApplicationContext.Context.Value?.Logger.LogDebug("Translation skipped: cache-only mode enabled.");
             return text;
         }
 
@@ -113,12 +115,14 @@ public class TranslationService
         // Just return the original text.
         if (string.IsNullOrEmpty(apiKey))
         {
+            ApplicationContext.Context.Value?.Logger.LogDebug("Translation skipped: missing API key.");
             return text;
         }
 
         try
         {
             // Fallback to single if called directly
+            ApplicationContext.Context.Value?.Logger.LogDebug("Translation miss (text). Requesting single translation via API.");
             var translated = await RequestTranslationSingle(text);
             _translationCache[text] = translated;
             SaveCache(); // Save after new translation
@@ -145,12 +149,14 @@ public class TranslationService
             // First check Key Cache (ID/Key based) - Priority for Game Content
             if (_translationKeyCache.TryGetValue(kvp.Key, out var keyCached))
             {
+                ApplicationContext.Context.Value?.Logger.LogDebug("Translation cache hit (key): {Key}", kvp.Key);
                 results[kvp.Key] = keyCached;
                 cachedResults[kvp.Key] = keyCached;
             }
             // Fallback to Text Cache (Value based) - Optimization for UI
             else if (_translationCache.TryGetValue(kvp.Value, out var textCached))
             {
+                ApplicationContext.Context.Value?.Logger.LogDebug("Translation cache hit (text) for key: {Key}", kvp.Key);
                 results[kvp.Key] = textCached;
                 cachedResults[kvp.Key] = textCached;
 
@@ -187,6 +193,10 @@ public class TranslationService
         // If no API Key is available, do not process uncached strings
         if (string.IsNullOrEmpty(apiKey))
         {
+            ApplicationContext.Context.Value?.Logger.LogDebug(
+                "Translation skipped for {Count} uncached strings: missing API key.",
+                uncached.Count
+            );
             return results;
         }
 
@@ -202,6 +212,10 @@ public class TranslationService
 
             try
             {
+                ApplicationContext.Context.Value?.Logger.LogDebug(
+                    "Requesting translation for batch of {Count} strings via API.",
+                    chunkDict.Count
+                );
                 var translatedChunk = await RequestTranslationBatch(chunkDict);
 
                 foreach (var kvp in translatedChunk)
@@ -392,6 +406,7 @@ public class TranslationService
             _httpClient.DefaultRequestHeaders.Add("Authorization", $"Bearer {apiKey}");
         }
 
+        ApplicationContext.Context.Value?.Logger.LogDebug("Sending translation request to API endpoint.");
         var response = await _httpClient.PostAsync(ApiUrl, content);
         response.EnsureSuccessStatusCode();
 

--- a/Intersect.Client.Core/Localization/TranslationService.cs
+++ b/Intersect.Client.Core/Localization/TranslationService.cs
@@ -67,12 +67,26 @@ public class TranslationService
     {
         if (Instance._enabled)
         {
-            // Start background translation of UI strings
-            Task.Run(TranslateInterface);
-
-            // Start background translation of Game Content (Items, Quests, etc.)
-            // Removed fixed delay task. Replaced by trigger in PacketHandler.
+            // Start background pre-translation at a controlled phase (startup).
+            Task.Run(PreTranslateContent);
         }
+    }
+
+    public static async Task PreTranslateContent()
+    {
+        if (!Instance._enabled)
+        {
+            return;
+        }
+
+        // UI static strings.
+        await Strings.TranslateAll(Instance);
+
+        // Game content (items, quests, spells, etc.).
+        await TranslateGameContent();
+
+        // Ensure any translated results are persisted immediately.
+        Instance.SaveCache();
     }
 
     public async Task<string> Translate(string text)
@@ -367,11 +381,6 @@ public class TranslationService
         var responseString = await response.Content.ReadAsStringAsync();
         dynamic result = JsonConvert.DeserializeObject(responseString);
         return result.choices[0].message.content;
-    }
-
-    private static async Task TranslateInterface()
-    {
-        await Strings.TranslateAll(Instance);
     }
 
     public static async Task TranslateGameContent()

--- a/Intersect.Client.Core/Localization/TranslationService.cs
+++ b/Intersect.Client.Core/Localization/TranslationService.cs
@@ -30,6 +30,8 @@ public class TranslationService
     private readonly string _cacheFilePath; // Cache file path
     private bool _enabled;
 
+    public bool UseCacheOnly { get; set; }
+
     // Batching Configuration
     private const int BATCH_SIZE = 20; // Number of strings per request
 
@@ -99,6 +101,11 @@ public class TranslationService
             return cached;
         }
 
+        if (UseCacheOnly)
+        {
+            return text;
+        }
+
         // Use key from Options, which comes from Server or Local Config
         var apiKey = Options.Instance?.TranslationApiKey;
 
@@ -163,6 +170,16 @@ public class TranslationService
         }
 
         if (uncached.Count == 0) return results;
+
+        if (UseCacheOnly)
+        {
+            foreach (var kvp in uncached)
+            {
+                results[kvp.Key] = kvp.Value;
+            }
+
+            return results;
+        }
 
         // Use key from Options
         var apiKey = Options.Instance?.TranslationApiKey;


### PR DESCRIPTION
### Motivation

- Add debug logs to trace when translations are served from cache, skipped due to configuration, or requested from the remote API so it's possible to verify whether translation and API usage is occurring.

### Description

- Log a debug message on text cache hits in `Translate(string)` and on key/text cache hits in `TranslateBatch`.
- Log a debug message when translation is skipped due to `UseCacheOnly` or missing `TranslationApiKey` for single and batch flows.
- Log a debug message when a single miss triggers an API call and when a batch request is about to be sent to the translation API.
- Log a debug message just before sending the HTTP POST to the translation API endpoint in `SendLlmRequest`.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966ef924008832b91345824ec2d0f51)