### PR TITLE
Add server translation API and route client translation through it

### DIFF
--- a/Intersect.Client.Core/Localization/TranslationService.cs
+++ b/Intersect.Client.Core/Localization/TranslationService.cs
@@ -19,9 +19,7 @@ public class TranslationService
     private static TranslationService _instance;
     public static TranslationService Instance => _instance ??= new TranslationService();
 
-    // Configuration - In a real app, move these to ClientConfiguration
-    private const string ApiUrl = "https://jlrootsloud-3174sfw-resource.cognitiveservices.azure.com/openai/deployments/gpt-4.1-mini/chat/completions?api-version=2024-05-01-preview";
-    private const string Model = "gpt-4.1-mini"; // Fastest and most cost-effective model currently
+    private const string TranslationEndpointPath = "api/translation";
 
     private readonly HttpClient _httpClient;
     private readonly ConcurrentDictionary<string, string> _translationCache;
@@ -106,16 +104,6 @@ public class TranslationService
             return text;
         }
 
-        // Use key from Options, which comes from Server or Local Config
-        var apiKey = Options.Instance?.TranslationApiKey;
-
-        // If no API Key is available, we cannot translate (and we missed the cache above).
-        // Just return the original text.
-        if (string.IsNullOrEmpty(apiKey))
-        {
-            return text;
-        }
-
         try
         {
             // Fallback to single if called directly
@@ -178,15 +166,6 @@ public class TranslationService
                 results[kvp.Key] = kvp.Value;
             }
 
-            return results;
-        }
-
-        // Use key from Options
-        var apiKey = Options.Instance?.TranslationApiKey;
-
-        // If no API Key is available, do not process uncached strings
-        if (string.IsNullOrEmpty(apiKey))
-        {
             return results;
         }
 
@@ -336,68 +315,67 @@ public class TranslationService
 
     private async Task<string> RequestTranslationSingle(string text)
     {
-        // ... (Keep existing logic if needed for single calls) ...
-        // Re-using batch logic logic for simplicity could be better, but keeping single prompt simple
-        var prompt = $"Translate to {_targetLanguage}. Return ONLY translated text. Text: {text}";
-        return await SendLlmRequest(prompt);
+        var response = await SendLlmRequest(
+            new TranslationRequestBody
+            {
+                Text = text,
+                TargetLanguage = _targetLanguage,
+            }
+        );
+        return response.Translation ?? text;
     }
 
     private async Task<Dictionary<string, string>> RequestTranslationBatch(Dictionary<string, string> texts)
     {
-        // Construct JSON for the LLM to translate values
-        var jsonPayload = JsonConvert.SerializeObject(texts);
-        var prompt = $"You are a localization system. Translate the VALUES of the following JSON object to {_targetLanguage}. \n" +
-                     $"Do NOT translate keys. Do NOT add explanations. Return ONLY the valid JSON object.\n" +
-                     $"Preserve formatting tokens ({{0}}, \\c{{...}}).\n\n" +
-                     $"JSON:\n{jsonPayload}";
-
-        var responseText = await SendLlmRequest(prompt);
-
-        // Clean up response if LLM adds markdown blocks
-        responseText = responseText.Replace("```json", "").Replace("```", "").Trim();
-
-        try
-        {
-            return JsonConvert.DeserializeObject<Dictionary<string, string>>(responseText) ?? new Dictionary<string, string>();
-        }
-        catch (JsonException)
-        {
-            // If JSON parsing fails, log and return empty (or try repair)
-            ApplicationContext.Context.Value?.Logger.LogWarning("LLM returned invalid JSON for batch.");
-            return new Dictionary<string, string>();
-        }
+        var response = await SendLlmRequest(
+            new TranslationRequestBody
+            {
+                Batch = texts,
+                TargetLanguage = _targetLanguage,
+            }
+        );
+        return response.Translations ?? new Dictionary<string, string>();
     }
 
-    private async Task<string> SendLlmRequest(string prompt)
+    private async Task<TranslationResponseBody> SendLlmRequest(TranslationRequestBody request)
     {
-        var requestBody = new
-        {
-            model = Model,
-            messages = new[]
-            {
-                new { role = "system", content = "You are a professional game localization assistant. Be concise." },
-                new { role = "user", content = prompt }
-            },
-            temperature = 0.1, // Lower temperature for more deterministic/consistent JSON
-            max_tokens = 2048
-        };
-
-        var json = JsonConvert.SerializeObject(requestBody);
+        var json = JsonConvert.SerializeObject(request);
         var content = new StringContent(json, Encoding.UTF8, "application/json");
 
-        var apiKey = Options.Instance?.TranslationApiKey;
-
-        if (!_httpClient.DefaultRequestHeaders.Contains("Authorization") && !string.IsNullOrEmpty(apiKey))
-        {
-            _httpClient.DefaultRequestHeaders.Add("Authorization", $"Bearer {apiKey}");
-        }
-
-        var response = await _httpClient.PostAsync(ApiUrl, content);
+        var response = await _httpClient.PostAsync(BuildTranslationEndpoint(), content);
         response.EnsureSuccessStatusCode();
-
         var responseString = await response.Content.ReadAsStringAsync();
-        dynamic result = JsonConvert.DeserializeObject(responseString);
-        return result.choices[0].message.content;
+        return JsonConvert.DeserializeObject<TranslationResponseBody>(responseString)
+            ?? new TranslationResponseBody();
+    }
+
+    private static Uri BuildTranslationEndpoint() => new UriBuilder
+    {
+        Scheme = Uri.UriSchemeHttp,
+        Host = ClientConfiguration.Instance.Host,
+        Port = ClientConfiguration.Instance.Port,
+        Path = TranslationEndpointPath,
+    }.Uri;
+
+    private sealed class TranslationRequestBody
+    {
+        [JsonProperty("text")]
+        public string? Text { get; set; }
+
+        [JsonProperty("batch")]
+        public Dictionary<string, string>? Batch { get; set; }
+
+        [JsonProperty("targetLanguage")]
+        public string? TargetLanguage { get; set; }
+    }
+
+    private sealed class TranslationResponseBody
+    {
+        [JsonProperty("translation")]
+        public string? Translation { get; set; }
+
+        [JsonProperty("translations")]
+        public Dictionary<string, string>? Translations { get; set; }
     }
 
     public static async Task TranslateGameContent()

--- a/Intersect.Server/Web/Controllers/Api/TranslationController.cs
+++ b/Intersect.Server/Web/Controllers/Api/TranslationController.cs
@@ -1,0 +1,151 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using Intersect.Core;
+using Intersect.Framework.Core.Config;
+using Intersect.Server.Web.Http;
+using Intersect.Server.Web.Types;
+using Intersect.Server.Web.Types.Translation;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Intersect.Server.Web.Controllers.Api;
+
+[Route("api/translation")]
+public sealed class TranslationController : IntersectController
+{
+    private const string ApiUrl =
+        "https://jlrootsloud-3174sfw-resource.cognitiveservices.azure.com/openai/deployments/gpt-4.1-mini/chat/completions?api-version=2024-05-01-preview";
+    private const string Model = "gpt-4.1-mini";
+    private static readonly HttpClient HttpClient = new() { Timeout = TimeSpan.FromSeconds(30) };
+
+    [HttpPost]
+    [AllowAnonymous]
+    [Consumes(typeof(TranslationRequestBody), ContentTypes.Json)]
+    [ProducesResponseType(typeof(TranslationResponseBody), (int)HttpStatusCode.OK, ContentTypes.Json)]
+    [ProducesResponseType(typeof(StatusMessageResponseBody), (int)HttpStatusCode.BadRequest, ContentTypes.Json)]
+    [ProducesResponseType(typeof(StatusMessageResponseBody), (int)HttpStatusCode.ServiceUnavailable, ContentTypes.Json)]
+    public async Task<IActionResult> Translate([FromBody] TranslationRequestBody request, CancellationToken cancellationToken)
+    {
+        if (request == null)
+        {
+            return BadRequest(new StatusMessageResponseBody("Missing translation request body."));
+        }
+
+        if (string.IsNullOrWhiteSpace(request.TargetLanguage))
+        {
+            return BadRequest(new StatusMessageResponseBody("Target language is required."));
+        }
+
+        bool hasText = !string.IsNullOrWhiteSpace(request.Text);
+        bool hasBatch = request.Batch is { Count: > 0 };
+
+        if (!hasText && !hasBatch)
+        {
+            return BadRequest(new StatusMessageResponseBody("Provide text or batch values to translate."));
+        }
+
+        if (hasText && hasBatch)
+        {
+            return BadRequest(new StatusMessageResponseBody("Provide either text or batch values, not both."));
+        }
+
+        if (string.IsNullOrWhiteSpace(Options.Instance?.TranslationApiKey))
+        {
+            return StatusCode(
+                (int)HttpStatusCode.ServiceUnavailable,
+                new StatusMessageResponseBody("Translation API key is not configured.")
+            );
+        }
+
+        try
+        {
+            if (hasText)
+            {
+                var translation = await RequestTranslationSingle(request.Text!, request.TargetLanguage!, cancellationToken);
+                return Ok(new TranslationResponseBody { Translation = translation });
+            }
+
+            var translations = await RequestTranslationBatch(request.Batch!, request.TargetLanguage!, cancellationToken);
+            return Ok(new TranslationResponseBody { Translations = translations });
+        }
+        catch (Exception exception)
+        {
+            ApplicationContext.Context.Value?.Logger.LogError(exception, "Translation request failed");
+            return StatusCode((int)HttpStatusCode.BadGateway, new StatusMessageResponseBody("Translation request failed."));
+        }
+    }
+
+    private async Task<string> RequestTranslationSingle(
+        string text,
+        string targetLanguage,
+        CancellationToken cancellationToken
+    )
+    {
+        var prompt = $"Translate to {targetLanguage}. Return ONLY translated text. Text: {text}";
+        return await SendLlmRequest(prompt, cancellationToken);
+    }
+
+    private async Task<Dictionary<string, string>> RequestTranslationBatch(
+        Dictionary<string, string> texts,
+        string targetLanguage,
+        CancellationToken cancellationToken
+    )
+    {
+        var jsonPayload = JsonConvert.SerializeObject(texts);
+        var prompt = $"You are a localization system. Translate the VALUES of the following JSON object to {targetLanguage}. \n" +
+                     "Do NOT translate keys. Do NOT add explanations. Return ONLY the valid JSON object.\n" +
+                     "Preserve formatting tokens ({0}, \\c{...}).\n\n" +
+                     $"JSON:\n{jsonPayload}";
+
+        var responseText = await SendLlmRequest(prompt, cancellationToken);
+        responseText = responseText.Replace("```json", "").Replace("```", "").Trim();
+
+        try
+        {
+            return JsonConvert.DeserializeObject<Dictionary<string, string>>(responseText)
+                ?? new Dictionary<string, string>();
+        }
+        catch (JsonException)
+        {
+            ApplicationContext.Context.Value?.Logger.LogWarning("LLM returned invalid JSON for batch.");
+            return new Dictionary<string, string>();
+        }
+    }
+
+    private static async Task<string> SendLlmRequest(string prompt, CancellationToken cancellationToken)
+    {
+        var requestBody = new
+        {
+            model = Model,
+            messages = new[]
+            {
+                new { role = "system", content = "You are a professional game localization assistant. Be concise." },
+                new { role = "user", content = prompt },
+            },
+            temperature = 0.1,
+            max_tokens = 2048,
+        };
+
+        var json = JsonConvert.SerializeObject(requestBody);
+        using var content = new StringContent(json, Encoding.UTF8, "application/json");
+        using var requestMessage = new HttpRequestMessage(HttpMethod.Post, ApiUrl)
+        {
+            Content = content,
+        };
+
+        requestMessage.Headers.Authorization = new AuthenticationHeaderValue(
+            "Bearer",
+            Options.Instance?.TranslationApiKey
+        );
+
+        using var response = await HttpClient.SendAsync(requestMessage, cancellationToken);
+        response.EnsureSuccessStatusCode();
+
+        var responseString = await response.Content.ReadAsStringAsync(cancellationToken);
+        var result = JObject.Parse(responseString);
+        return result["choices"]?[0]?["message"]?["content"]?.ToString() ?? string.Empty;
+    }
+}

--- a/Intersect.Server/Web/Types/Translation/TranslationRequestBody.cs
+++ b/Intersect.Server/Web/Types/Translation/TranslationRequestBody.cs
@@ -1,0 +1,15 @@
+using Newtonsoft.Json;
+
+namespace Intersect.Server.Web.Types.Translation;
+
+public sealed class TranslationRequestBody
+{
+    [JsonProperty("text")]
+    public string? Text { get; set; }
+
+    [JsonProperty("batch")]
+    public Dictionary<string, string>? Batch { get; set; }
+
+    [JsonProperty("targetLanguage")]
+    public string? TargetLanguage { get; set; }
+}

--- a/Intersect.Server/Web/Types/Translation/TranslationResponseBody.cs
+++ b/Intersect.Server/Web/Types/Translation/TranslationResponseBody.cs
@@ -1,0 +1,12 @@
+using Newtonsoft.Json;
+
+namespace Intersect.Server.Web.Types.Translation;
+
+public sealed class TranslationResponseBody
+{
+    [JsonProperty("translation")]
+    public string? Translation { get; set; }
+
+    [JsonProperty("translations")]
+    public Dictionary<string, string>? Translations { get; set; }
+}


### PR DESCRIPTION
### Motivation
- Provide a server-side translation endpoint so the server-side API key is used for LLM requests instead of exposing/reading the key in the client.
- Allow clients to request single or batched translations through the server to centralize translation usage and configuration.

### Description
- Added `TranslationController` with route `api/translation` that validates requests, checks `Options.Instance.TranslationApiKey`, and forwards prompts to the configured LLM endpoint supporting single `text` and `batch` requests in `Intersect.Server/Web/Controllers/Api/TranslationController.cs`.
- Introduced request/response DTOs `TranslationRequestBody` and `TranslationResponseBody` in `Intersect.Server/Web/Types/Translation/` for the new endpoint.
- Updated client `TranslationService` in `Intersect.Client.Core/Localization/TranslationService.cs` to send requests to the server endpoint (`/api/translation`) and consume the new response shapes instead of calling the LLM directly or reading the API key locally.
- Replaced client-side LLM prompt serialization with a simple client→server JSON payload and added `BuildTranslationEndpoint()` to use the configured client host/port when targeting the server API.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696709817954832bb165f9e542a74382)