### PR TITLE
Soporte para esquema de cache `keyCache`/`textCache` y compatibilidad con legacy

### DIFF
--- a/Intersect.Client.Core/Localization/TranslationService.cs
+++ b/Intersect.Client.Core/Localization/TranslationService.cs
@@ -2,6 +2,7 @@ using System.Text;
 using System.Globalization;
 using System.Collections.Concurrent;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Intersect.Client.General;
 using Intersect.Configuration;
 using Intersect.Core;
@@ -213,10 +214,11 @@ public class TranslationService
             if (File.Exists(_cacheFilePath))
             {
                 var json = File.ReadAllText(_cacheFilePath, Encoding.UTF8);
-                var loadedPayload = JsonConvert.DeserializeObject<TranslationCachePayload>(json);
-                if (loadedPayload?.KeyCache != null || loadedPayload?.TextCache != null)
+                var token = JsonConvert.DeserializeObject<JToken>(json);
+                if (token is JObject obj && (obj.Property("keyCache") != null || obj.Property("textCache") != null))
                 {
-                    if (loadedPayload.KeyCache != null)
+                    var loadedPayload = obj.ToObject<TranslationCachePayload>();
+                    if (loadedPayload?.KeyCache != null)
                     {
                         foreach (var kvp in loadedPayload.KeyCache)
                         {
@@ -224,7 +226,7 @@ public class TranslationService
                         }
                     }
 
-                    if (loadedPayload.TextCache != null)
+                    if (loadedPayload?.TextCache != null)
                     {
                         foreach (var kvp in loadedPayload.TextCache)
                         {
@@ -238,7 +240,7 @@ public class TranslationService
                     return;
                 }
 
-                var loadedLegacyCache = JsonConvert.DeserializeObject<Dictionary<string, string>>(json);
+                var loadedLegacyCache = token?.ToObject<Dictionary<string, string>>();
                 if (loadedLegacyCache != null)
                 {
                     foreach (var kvp in loadedLegacyCache)


### PR DESCRIPTION
### Motivation

- Adaptar la carga del caché para soportar el nuevo esquema que separa cache por clave (IDs como `ITEM_NAME_{id}`) y cache por texto (UI/traducciones directas). 
- Mantener compatibilidad con el formato legacy de caché que era un `Dictionary<string,string>` plano.

### Description

- Detecta y parsea el payload con esquema mediante `Newtonsoft.Json.Linq.JToken` y carga `keyCache` y `textCache` cuando existen en el JSON. 
- Convierte el `JObject` a `TranslationCachePayload` y pobló `_translationKeyCache` y `_translationCache` desde `KeyCache` y `TextCache` respectivamente. 
- Si no se detectan las propiedades del nuevo esquema, reutiliza el token parseado y lo convierte a `Dictionary<string,string>` para la ruta de compatibilidad legacy. 
- Añadió la referencia a `Newtonsoft.Json.Linq` y ajustes menores de null-safety durante la carga.

### Testing

- No se ejecutaron pruebas automatizadas durante el cambio (ninguna corrida solicitada).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696707b0ca2c832b8b1cb870ae659e03)