### PR TITLE
Add translations.db and LocalizationRepository with startup initialization

### DIFF
--- a/Intersect.Client.Core/Interface/Shared/SettingsWindow.cs
+++ b/Intersect.Client.Core/Interface/Shared/SettingsWindow.cs
@@ -44,6 +44,7 @@ public partial class SettingsWindow : Window
     private readonly LabeledCheckBox _showHealthAsPercentageCheckbox;
     private readonly LabeledCheckBox _showManaAsPercentageCheckbox;
     private readonly LabeledCheckBox _simplifiedEscapeMenu;
+    private readonly LabeledComboBox _languageList;
 
     // Game Settings - Information
     private readonly TabButton _gameSettingsTabInformation;
@@ -107,6 +108,15 @@ public partial class SettingsWindow : Window
     private int _keyEdit = -1;
 
     private Base? _returnTo;
+
+    private static readonly (string Code, string Label)[] LanguageOptions =
+    [
+        ("en", "English"),
+        ("es", "Español"),
+        ("pt", "Português"),
+        ("fr", "Français"),
+        ("ru", "Русский"),
+    ];
 
     // Initialize.
     public SettingsWindow(Base parent) : base(parent: parent, title: Strings.Settings.Title, modal: false, name: nameof(SettingsWindow))
@@ -176,6 +186,21 @@ public partial class SettingsWindow : Window
         );
 
         // Game Settings - Interface.
+
+        _languageList = new LabeledComboBox(parent: _interfaceSettings, name: nameof(_languageList))
+        {
+            Dock = Pos.Top,
+            Font = _defaultFont,
+            FontSize = 12,
+            Label = Strings.Settings.Language,
+            TextPadding = new Padding(8, 4, 0, 4),
+        };
+
+        foreach (var (code, label) in LanguageOptions)
+        {
+            var item = _languageList.AddItem(label: label, userData: code);
+            item.TextAlign = Pos.Left;
+        }
 
         // Game Settings - Interface: Auto-close Windows.
         _autoCloseWindowsCheckbox = new LabeledCheckBox(parent: _interfaceSettings, name: nameof(_autoCloseWindowsCheckbox))
@@ -990,6 +1015,11 @@ public partial class SettingsWindow : Window
         _autoTurnToTarget.IsChecked = Globals.Database.AutoTurnToTarget;
         _autoSoftRetargetOnSelfCast.IsChecked = Globals.Database.AutoSoftRetargetOnSelfCast;
         _typewriterCheckbox.IsChecked = Globals.Database.TypewriterBehavior == Enums.TypewriterBehavior.Word;
+        var savedLanguage = string.IsNullOrWhiteSpace(Globals.Database.Language) ? "en" : Globals.Database.Language;
+        if (!_languageList.SelectByUserData(savedLanguage))
+        {
+            _languageList.SelectByUserData("en");
+        }
 
         // Video Settings.
         _fullscreenCheckbox.IsChecked = Globals.Database.FullScreen;
@@ -1171,6 +1201,9 @@ public partial class SettingsWindow : Window
         Globals.Database.AutoTurnToTarget = _autoTurnToTarget.IsChecked;
         Globals.Database.AutoSoftRetargetOnSelfCast = _autoSoftRetargetOnSelfCast.IsChecked;
         Globals.Database.TypewriterBehavior = _typewriterCheckbox.IsChecked ? Enums.TypewriterBehavior.Word : Enums.TypewriterBehavior.Off;
+        var selectedLanguage = _languageList.SelectedItem?.UserData as string ?? "en";
+        var languageChanged = !string.Equals(Globals.Database.Language, selectedLanguage, StringComparison.OrdinalIgnoreCase);
+        Globals.Database.Language = selectedLanguage;
 
         // Video Settings.
         Globals.Database.EnableScrollingWorldZoom = _enableScrollingWorldZoomCheckbox.IsChecked;
@@ -1239,6 +1272,12 @@ public partial class SettingsWindow : Window
 
         // Save Preferences.
         Globals.Database.SavePreferences();
+
+        if (languageChanged)
+        {
+            Strings.Load(selectedLanguage);
+            Interface.ShowAlert(Strings.Settings.LanguageReloadNotice, alertType: AlertType.Warning);
+        }
 
         if (shouldReset && Graphics.Renderer != default)
         {

--- a/Intersect.Client.Core/Localization/Strings.cs
+++ b/Intersect.Client.Core/Localization/Strings.cs
@@ -20,6 +20,7 @@ namespace Intersect.Client.Localization;
 public static partial class Strings
 {
     private const string StringsFileName = "client_strings.json";
+    private const string DefaultLanguage = "en";
     private static char[] mQuantityTrimChars = new char[] { '.', '0' };
 
     private static string[] _unitsBits = [string.Empty, "Ki", "Mi", "Gi", "Ti"];
@@ -142,7 +143,7 @@ public static partial class Strings
         public int Compare(T? x, T? y) => string.CompareOrdinal(x?.ToString(), y?.ToString());
     }
 
-    public static void Load() => Load(null);
+    public static void Load() => Load(DefaultLanguage);
 
     public static void Load(string? language)
     {
@@ -150,11 +151,12 @@ public static partial class Strings
 
         try
         {
-            var serialized = string.IsNullOrWhiteSpace(language)
-                ? LoadSerializedStrings(Path.Combine(ClientConfiguration.ResourcesDirectory, StringsFileName))
-                : LoadLocalizedSerializedStrings(language);
+            var normalizedLanguage = string.IsNullOrWhiteSpace(language)
+                ? DefaultLanguage
+                : language.Trim().ToLowerInvariant();
+            var serialized = LoadLocalizedSerializedStrings(normalizedLanguage);
 
-            LoadSerialized(serialized, string.IsNullOrWhiteSpace(language));
+            LoadSerialized(serialized, string.Equals(normalizedLanguage, DefaultLanguage, StringComparison.OrdinalIgnoreCase));
         }
         catch (Exception exception)
         {
@@ -167,6 +169,11 @@ public static partial class Strings
 
     private static Dictionary<string, Dictionary<string, object>> LoadSerializedStrings(string path)
     {
+        if (!File.Exists(path))
+        {
+            return new Dictionary<string, Dictionary<string, object>>();
+        }
+
         return JsonConvert.DeserializeObject<Dictionary<string, Dictionary<string, object>>>(
             File.ReadAllText(path)
         ) ?? new Dictionary<string, Dictionary<string, object>>();
@@ -174,12 +181,14 @@ public static partial class Strings
 
     private static Dictionary<string, Dictionary<string, object>> LoadLocalizedSerializedStrings(string language)
     {
-        var normalizedLanguage = language.Trim();
+        var normalizedLanguage = string.IsNullOrWhiteSpace(language)
+            ? DefaultLanguage
+            : language.Trim().ToLowerInvariant();
         var basePath = Path.Combine(
             ClientConfiguration.ResourcesDirectory,
             "localization",
             "client",
-            "en",
+            DefaultLanguage,
             StringsFileName
         );
         var overridePath = Path.Combine(
@@ -189,8 +198,15 @@ public static partial class Strings
             normalizedLanguage,
             StringsFileName
         );
+        var legacyPath = Path.Combine(ClientConfiguration.ResourcesDirectory, StringsFileName);
 
         var baseLoaded = TryLoadSerializedStrings(basePath, out var baseSerialized);
+        if (!baseLoaded && TryLoadSerializedStrings(legacyPath, out var legacySerialized))
+        {
+            baseSerialized = legacySerialized;
+            baseLoaded = true;
+        }
+
         if (!baseLoaded)
         {
             ApplicationContext.Context.Value?.Logger.LogWarning(
@@ -917,14 +933,17 @@ public static partial class Strings
 
     private static void SaveSerialized(Dictionary<string, Dictionary<string, object>> serialized)
     {
-        var languageDirectory = Path.Combine(ClientConfiguration.ResourcesDirectory);
-        if (Directory.Exists(languageDirectory))
-        {
-            File.WriteAllText(
-                Path.Combine(languageDirectory, StringsFileName),
-                JsonConvert.SerializeObject(serialized, Formatting.Indented)
-            );
-        }
+        var languageDirectory = Path.Combine(
+            ClientConfiguration.ResourcesDirectory,
+            "localization",
+            "client",
+            DefaultLanguage
+        );
+        Directory.CreateDirectory(languageDirectory);
+        File.WriteAllText(
+            Path.Combine(languageDirectory, StringsFileName),
+            JsonConvert.SerializeObject(serialized, Formatting.Indented)
+        );
     }
 
     public static void Save()
@@ -2792,6 +2811,9 @@ If you are sure you want to hand over your guild enter '\c{{#ff8080}}{02}\c{{}}'
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public static LocalizedString Language = @"Language";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString LanguageReloadNotice = @"Algunas ventanas requieren reabrirse.";
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public static LocalizedString MusicVolume = @"Music Volume: {00}%";

--- a/Intersect.Client.Core/MonoGame/IntersectGame.cs
+++ b/Intersect.Client.Core/MonoGame/IntersectGame.cs
@@ -105,6 +105,7 @@ internal partial class IntersectGame : Game
 
         // Load configuration.
         Globals.Database.LoadPreferences();
+        Strings.Load(Globals.Database.Language);
 
         Window.IsBorderless = Context.StartupOptions.BorderlessWindow;
 

--- a/Intersect.Client.Core/Networking/PacketHandler.cs
+++ b/Intersect.Client.Core/Networking/PacketHandler.cs
@@ -181,7 +181,7 @@ internal sealed partial class PacketHandler
         MainMenu.HandleReceivedConfiguration();
         try
         {
-            Strings.Load();
+            Strings.Load(Globals.Database?.Language);
         }
         catch (Exception exception)
         {

--- a/Intersect.Client.Framework/Database/GameDatabase.cs
+++ b/Intersect.Client.Framework/Database/GameDatabase.cs
@@ -77,6 +77,8 @@ public abstract partial class GameDatabase
 
     public float WorldZoom { get; set; } = 1.0f;
 
+    public string Language { get; set; } = "en";
+
     public abstract void DeletePreference(string key);
 
     public abstract bool HasPreference(string key);
@@ -150,6 +152,7 @@ public abstract partial class GameDatabase
         UIScale = LoadPreference(nameof(UIScale), 1.0f);
         EnableScrollingWorldZoom = LoadPreference(nameof(EnableScrollingWorldZoom), false);
         WorldZoom = LoadPreference(nameof(WorldZoom), 1.0f);
+        Language = LoadPreference(nameof(Language), "en");
     }
 
     /// <summary>
@@ -191,6 +194,7 @@ public abstract partial class GameDatabase
         SavePreference(nameof(UIScale), UIScale);
         SavePreference(nameof(EnableScrollingWorldZoom), EnableScrollingWorldZoom);
         SavePreference(nameof(WorldZoom), WorldZoom);
+        SavePreference(nameof(Language), Language);
     }
 
     public abstract bool LoadConfig();

--- a/Intersect.Server.Core/Core/Bootstrapper.cs
+++ b/Intersect.Server.Core/Core/Bootstrapper.cs
@@ -231,6 +231,7 @@ internal static class Bootstrapper
         }
 
         DbInterface.CheckDirectories();
+        LocalizationRepository.InitializeDefault();
 
         PrintIntroduction();
 

--- a/Intersect.Server.Core/Localization/LocalizationRepository.cs
+++ b/Intersect.Server.Core/Localization/LocalizationRepository.cs
@@ -1,0 +1,151 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Intersect.Server.Core;
+using Microsoft.Data.Sqlite;
+
+namespace Intersect.Server.Localization;
+
+public sealed class LocalizationRepository
+{
+    private const string DefaultLanguage = "en";
+    private readonly string _databasePath;
+
+    private static LocalizationRepository? _default;
+
+    public static LocalizationRepository Default => _default ??= new LocalizationRepository(DefaultDatabasePath);
+
+    public static string DefaultDatabasePath => Path.Combine(ServerContext.ResourceDirectory, "translations.db");
+
+    public LocalizationRepository(string databasePath)
+    {
+        _databasePath = databasePath;
+    }
+
+    public static void InitializeDefault()
+    {
+        Default.EnsureSchema();
+    }
+
+    public void EnsureSchema()
+    {
+        var directory = Path.GetDirectoryName(_databasePath);
+        if (!string.IsNullOrWhiteSpace(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        using var connection = OpenConnection();
+        using var command = connection.CreateCommand();
+        command.CommandText =
+            """
+            CREATE TABLE IF NOT EXISTS translations (
+                entity_type TEXT NOT NULL,
+                entity_id TEXT NOT NULL,
+                field TEXT NOT NULL,
+                lang TEXT NOT NULL,
+                text TEXT NOT NULL,
+                source_hash TEXT NOT NULL,
+                updated_utc TEXT NOT NULL,
+                PRIMARY KEY (entity_type, entity_id, field, lang)
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_translations_identity
+                ON translations (entity_type, entity_id, field, lang);
+
+            CREATE INDEX IF NOT EXISTS idx_translations_lang
+                ON translations (lang);
+            """;
+        command.ExecuteNonQuery();
+    }
+
+    public void Upsert(
+        string entityType,
+        string entityId,
+        string field,
+        string language,
+        string text,
+        string sourceHash
+    )
+    {
+        using var connection = OpenConnection();
+        using var command = connection.CreateCommand();
+        command.CommandText =
+            """
+            INSERT INTO translations (entity_type, entity_id, field, lang, text, source_hash, updated_utc)
+            VALUES ($entityType, $entityId, $field, $lang, $text, $sourceHash, $updatedUtc)
+            ON CONFLICT(entity_type, entity_id, field, lang)
+            DO UPDATE SET
+                text = excluded.text,
+                source_hash = excluded.source_hash,
+                updated_utc = excluded.updated_utc;
+            """;
+        command.Parameters.AddWithValue("$entityType", entityType);
+        command.Parameters.AddWithValue("$entityId", entityId);
+        command.Parameters.AddWithValue("$field", field);
+        command.Parameters.AddWithValue("$lang", NormalizeLanguage(language));
+        command.Parameters.AddWithValue("$text", text);
+        command.Parameters.AddWithValue("$sourceHash", sourceHash);
+        command.Parameters.AddWithValue("$updatedUtc", DateTime.UtcNow.ToString("O"));
+        command.ExecuteNonQuery();
+    }
+
+    public string? Get(string entityType, string entityId, string field, string language)
+    {
+        using var connection = OpenConnection();
+        using var command = connection.CreateCommand();
+        command.CommandText =
+            """
+            SELECT text
+            FROM translations
+            WHERE entity_type = $entityType
+              AND entity_id = $entityId
+              AND field = $field
+              AND lang IN ($language, $fallback)
+            ORDER BY CASE WHEN lang = $language THEN 0 ELSE 1 END
+            LIMIT 1;
+            """;
+        var normalizedLanguage = NormalizeLanguage(language);
+        command.Parameters.AddWithValue("$entityType", entityType);
+        command.Parameters.AddWithValue("$entityId", entityId);
+        command.Parameters.AddWithValue("$field", field);
+        command.Parameters.AddWithValue("$language", normalizedLanguage);
+        command.Parameters.AddWithValue("$fallback", DefaultLanguage);
+        var result = command.ExecuteScalar();
+        return result == DBNull.Value ? null : result as string;
+    }
+
+    public Dictionary<LocalizationKey, string> GetBatch(IEnumerable<LocalizationKey> keys, string language)
+    {
+        var results = new Dictionary<LocalizationKey, string>();
+        foreach (var key in keys)
+        {
+            var text = Get(key.EntityType, key.EntityId, key.Field, language);
+            if (!string.IsNullOrWhiteSpace(text))
+            {
+                results[key] = text;
+            }
+        }
+
+        return results;
+    }
+
+    private SqliteConnection OpenConnection()
+    {
+        var connection = new SqliteConnection($"Data Source={_databasePath}");
+        connection.Open();
+        using var pragma = connection.CreateCommand();
+        pragma.CommandText = "PRAGMA journal_mode=WAL;";
+        pragma.ExecuteNonQuery();
+        return connection;
+    }
+
+    private static string NormalizeLanguage(string language)
+    {
+        return string.IsNullOrWhiteSpace(language)
+            ? DefaultLanguage
+            : language.Trim().ToLowerInvariant();
+    }
+}
+
+public readonly record struct LocalizationKey(string EntityType, string EntityId, string Field);

--- a/Intersect.Tests.Server/Database/LocalizationRepositoryTests.cs
+++ b/Intersect.Tests.Server/Database/LocalizationRepositoryTests.cs
@@ -1,0 +1,42 @@
+using System;
+using System.IO;
+using Intersect.Server.Localization;
+using NUnit.Framework;
+
+namespace Intersect.Tests.Server.Database;
+
+[TestFixture]
+public class LocalizationRepositoryTests
+{
+    private string _tempDirectory = string.Empty;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _tempDirectory = Path.Combine(Path.GetTempPath(), $"intersect-localization-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDirectory);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        if (Directory.Exists(_tempDirectory))
+        {
+            Directory.Delete(_tempDirectory, recursive: true);
+        }
+    }
+
+    [Test]
+    public void GetReturnsFallbackLanguageWhenMissing()
+    {
+        var databasePath = Path.Combine(_tempDirectory, "translations.db");
+        var repository = new LocalizationRepository(databasePath);
+        repository.EnsureSchema();
+
+        repository.Upsert("Item", "item-1", "Name", "en", "Sword", "hash1");
+        repository.Upsert("Item", "item-1", "Name", "es", "Espada", "hash1");
+
+        Assert.That(repository.Get("Item", "item-1", "Name", "es"), Is.EqualTo("Espada"));
+        Assert.That(repository.Get("Item", "item-1", "Name", "fr"), Is.EqualTo("Sword"));
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a normalized, separate translations store (`translations.db`) so server-side translated fields can be managed without modifying the original gamedata DB.
- Expose a small server-side localization API for upserting and retrieving translations with an English fallback and optional batch reads.
- Ensure the translations DB is created at server startup and add a minimal automated test to validate fallback behavior.
- Keep client-side language preferences and runtime localized string reloads intact so client can select language and reload UI strings at runtime.

### Description
- Added `LocalizationRepository` (`Intersect.Server.Core/Localization/LocalizationRepository.cs`) which creates `translations.db` and the `translations` table and indexes, and provides `Upsert`, `Get` (with `en` fallback), `GetBatch`, and connection handling with `PRAGMA journal_mode=WAL;`.
- Initialized the translations DB at server startup by calling `LocalizationRepository.InitializeDefault()` from `Bootstrapper.PreContextSetup()` so schema exists on launch.
- Added an NUnit test `LocalizationRepositoryTests` (`Intersect.Tests.Server/Database/LocalizationRepositoryTests.cs`) that uses a temporary `translations.db` to verify language fallback behavior.
- Client-side changes included persisting a `Language` property in `GameDatabase`, adding a language `LabeledComboBox` to the settings UI and apply flow that calls `Strings.Load(...)` and shows a reload notice, and updates to `Strings` to load localized files with an English base fallback and save defaults into the localization directory; `Strings.Load` is invoked at startup and when configuration is received from the server.

### Testing
- Added an automated NUnit test (`LocalizationRepositoryTests`) that verifies `Get` returns a language override when present and falls back to English when missing, and the test file was committed to the repository.
- No test suite or CI runs were executed as part of this change (automated tests were not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69684f674144832ba1b5c890839bcb1e)