### PR TITLE
Add quest task descriptions to translations

### DIFF
--- a/Intersect.Editor/Forms/Editors/Quest/frmQuest.cs
+++ b/Intersect.Editor/Forms/Editors/Quest/frmQuest.cs
@@ -202,6 +202,15 @@ public partial class FrmQuest : EditorForm
                     "EndDescription",
                     item.EndDescription
                 );
+                foreach (var task in item.Tasks)
+                {
+                    TranslationSourceUpdater.UpdateEnglishSource(
+                        "QuestTask",
+                        task.Id,
+                        "Description",
+                        task.Description
+                    );
+                }
 
                 foreach (var id in item.OriginalTaskEventIds.Keys)
                 {
@@ -278,6 +287,16 @@ public partial class FrmQuest : EditorForm
                 "EndDescription",
                 quest.EndDescription
             );
+            foreach (var task in quest.Tasks)
+            {
+                TranslationSourceUpdater.AddEnglishSource(
+                    entries,
+                    "QuestTask",
+                    task.Id,
+                    "Description",
+                    task.Description
+                );
+            }
         }
 
         TranslationSourceUpdater.QueueBatchEnglishSources(entries);


### PR DESCRIPTION
### Motivation
- Ensure quest task descriptions are saved into the translations database so task texts can be localized, since previously only quest-level fields were submitted for translation.

### Description
- Add per-save upserts by calling `TranslationSourceUpdater.UpdateEnglishSource` for each task's `Description` and include task descriptions in the batch upload via `TranslationSourceUpdater.AddEnglishSource` in `Intersect.Editor/Forms/Editors/Quest/frmQuest.cs` (entity type "QuestTask", field "Description").

### Testing
- No automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969b909ed50832bb4424198d68cc5cd)