### PR TITLE
Localize sell market item type filter

### DIFF
--- a/Intersect.Client.Core/Interface/Game/Market/SellMarketWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Market/SellMarketWindow.cs
@@ -114,7 +114,10 @@ namespace Intersect.Client.Interface.Game.Market
             foreach (var type in Enum.GetValues<ItemType>())
             {
                 if (type == ItemType.None) continue;
-                _typeBox.AddItem(type.ToString(), userData: type);
+                var typeLabel = Strings.ItemDescription.ItemTypes.TryGetValue((int)type, out var localizedType)
+                    ? localizedType
+                    : type.ToString();
+                _typeBox.AddItem(typeLabel, userData: type);
             }
 
             BuildSubtypeLookup();


### PR DESCRIPTION
### Motivation
- Ensure the item type filter in the Sell Market UI shows localized labels instead of raw enum names while preserving the existing "All" entry.

### Description
- Replace `type.ToString()` when populating the `_typeBox` with a lookup into `Strings.ItemDescription.ItemTypes` using `TryGetValue((int)type, out var localizedType)` and fall back to `type.ToString()` if no localized entry exists, while keeping the `All` entry as `Strings.Inventory.All` (file: `Intersect.Client.Core/Interface/Game/Market/SellMarketWindow.cs`).

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b779caf60832bb3c225d41cde51d7)