### PR TITLE
Localize mailbox labels and defaults

### DIFF
--- a/Intersect.Client.Core/Interface/Game/Mail/MailBoxWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Mail/MailBoxWindow.cs
@@ -95,7 +95,7 @@ public partial class MailBoxWindow : Window
         // 🎁 Adjuntos (Debajo del Mensaje)
         mAttachmentLabel = new Label(this, "Attachments")
         {
-            Text = "Attachments",
+            Text = Strings.MailBox.attachments.ToString(),
             FontName = defaultFont,
             FontSize = fontSize
         };
@@ -160,7 +160,7 @@ public partial class MailBoxWindow : Window
         {
             // 📤 Enviar Correo
             mSendMailButton = new Button(this, "SendMailButton");
-            mSendMailButton.SetText("📤 Send Mail");
+            mSendMailButton.SetText(Strings.MailBox.sendMailButton.ToString());
             mSendMailButton.SetBounds(20, 460, 120, 30);
             mSendMailButton.Clicked += SendMail_Clicked;
 
@@ -173,7 +173,7 @@ public partial class MailBoxWindow : Window
 
             // ❌ Cerrar Ventana
             mCloseButton = new Button(this, "CloseButton");
-            mCloseButton.SetText("❌ Close");
+            mCloseButton.SetText(Strings.MailBox.closeButton.ToString());
             mCloseButton.SetBounds(500, 460, 150, 30);
             mCloseButton.Clicked += CloseButton_Clicked;
         }
@@ -199,9 +199,14 @@ public partial class MailBoxWindow : Window
     {
         if (mMailListBox.SelectedRow?.UserData is Client.Mail mail)
         {
-            string senderName = !string.IsNullOrWhiteSpace(mail.SenderName) ? mail.SenderName : "Unknown Sender";
-            mSender.Text = $"{Strings.MailBox.sender}: {senderName}";
-            mTitle.Text = $"{Strings.MailBox.mailtitle}: {mail.Name}";
+            string senderName = !string.IsNullOrWhiteSpace(mail.SenderName)
+                ? mail.SenderName
+                : Strings.MailBox.unknownSender.ToString();
+            string mailTitle = !string.IsNullOrWhiteSpace(mail.Name)
+                ? mail.Name.Trim()
+                : Strings.MailBox.noSubject.ToString();
+            mSender.Text = $"{Strings.MailBox.sender.ToString()}: {senderName}";
+            mTitle.Text = $"{Strings.MailBox.mailtitle.ToString()}: {mailTitle}";
             mMessage.ClearText();
             mMessage.AddText(mail.Message, Color.White);
 
@@ -289,8 +294,12 @@ public partial class MailBoxWindow : Window
                     mail.SenderName,
                     mail.Name);
 
-                string senderName = !string.IsNullOrWhiteSpace(mail.SenderName) ? mail.SenderName : "Unknown Sender";
-                string mailTitle = !string.IsNullOrWhiteSpace(mail.Name) ? mail.Name.Trim() : "No Subject";
+                string senderName = !string.IsNullOrWhiteSpace(mail.SenderName)
+                    ? mail.SenderName
+                    : Strings.MailBox.unknownSender.ToString();
+                string mailTitle = !string.IsNullOrWhiteSpace(mail.Name)
+                    ? mail.Name.Trim()
+                    : Strings.MailBox.noSubject.ToString();
                 string displayText = $"📩 {senderName}: {mailTitle}";
 
                 var row = mMailListBox.AddRow(displayText, "", mail);
@@ -323,4 +332,3 @@ public partial class MailBoxWindow : Window
             base.Show();
         }
     }
-

--- a/Intersect.Client.Core/Interface/Game/Market/SellMarketWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Market/SellMarketWindow.cs
@@ -114,7 +114,10 @@ namespace Intersect.Client.Interface.Game.Market
             foreach (var type in Enum.GetValues<ItemType>())
             {
                 if (type == ItemType.None) continue;
-                _typeBox.AddItem(type.ToString(), userData: type);
+                var typeLabel = Strings.ItemDescription.ItemTypes.TryGetValue((int)type, out var localizedType)
+                    ? localizedType
+                    : type.ToString();
+                _typeBox.AddItem(typeLabel, userData: type);
             }
 
             BuildSubtypeLookup();

--- a/Intersect.Client.Core/Localization/Strings.cs
+++ b/Intersect.Client.Core/Localization/Strings.cs
@@ -657,6 +657,14 @@ public static partial class Strings
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public static LocalizedString attachments = @"Attachments";
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString sendMailButton = @"📤 Send Mail";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString closeButton = @"❌ Close";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString unknownSender = @"Unknown Sender";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public static LocalizedString noSubject = @"No Subject";
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public static LocalizedString selectQuantity=@"Select Quantity";
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public static LocalizedString enterQuantity= @"Enter Quantity";


### PR DESCRIPTION
### Motivation
- Remove hard-coded mailbox UI literals and use the localization system so UI text can be translated and defaults are consistent.
- Ensure default fallback texts for unknown sender and empty subject use localized strings.

### Description
- Added localization keys to `Strings.MailBox`: `sendMailButton`, `closeButton`, `unknownSender`, and `noSubject` and kept `attachments` entry usage consistent.
- Replaced literal label text in `MailBoxWindow` with localized values for the attachments label, the send and close buttons, and the take button already using `Strings.MailBox.take`.
- Updated both `Selected_MailListBox` and `UpdateMail` to use `Strings.MailBox.unknownSender` and `Strings.MailBox.noSubject` as fallbacks and to format `mSender.Text` and `mTitle.Text` using localized keys.
- Used `.ToString()` on `LocalizedString` entries where the code expects a `string` value.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696be21fa0fc832b945cedd3dcdcb581)