### PR TITLE
Localize map item name display

### DIFF
--- a/Intersect.Client.Core/Maps/MapInstance.cs
+++ b/Intersect.Client.Core/Maps/MapInstance.cs
@@ -1046,13 +1046,18 @@ public partial class MapInstance : MapDescriptor, IGameObject<Guid, MapInstance>
             }
 
             // Set up all information we need to draw this name.
-            var name = mapItemInstance.Descriptor.Name;
+            var localizedName = GameLocalization.GetTextOrDefault(
+                "Item",
+                mapItemInstance.ItemId,
+                "Name",
+                itemDescriptor.Name
+            );
             var quantity = mapItemInstance.Quantity;
             var rarity = itemDescriptor.Rarity;
             if (mapItemInstance.Quantity > 1)
             {
-                name = Strings.General.MapItemStackable.ToString(
-                    name,
+                localizedName = Strings.General.MapItemStackable.ToString(
+                    localizedName,
                     Strings.FormatQuantityAbbreviated(quantity)
                 );
             }
@@ -1062,7 +1067,7 @@ public partial class MapInstance : MapDescriptor, IGameObject<Guid, MapInstance>
                 new LabelColor(Color.White, Color.Black, new Color(100, 0, 0, 0))
             );
             var textSize = Graphics.Renderer.MeasureText(
-                name,
+                localizedName,
                 Graphics.EntityNameFont,
                 Graphics.EntityNameFontSize,
                 1
@@ -1084,7 +1089,7 @@ public partial class MapInstance : MapDescriptor, IGameObject<Guid, MapInstance>
 
             // Finaly, draw the actual name!
             Graphics.Renderer.DrawString(
-                name,
+                localizedName,
                 Graphics.EntityNameFont,
                 Graphics.EntityNameFontSize,
                 destX,


### PR DESCRIPTION
### Motivation
- Improve UX by showing localized item names for items on the map when hovering, while keeping existing stackable quantity formatting.

### Description
- In `DrawItemNames()` replace `mapItemInstance.Descriptor.Name` with a localized lookup via `GameLocalization.GetTextOrDefault("Item", mapItemInstance.ItemId, "Name", itemDescriptor.Name)` and store it in `localizedName`.
- Use `localizedName` for measurement and rendering instead of the original name variable.
- Preserve the stackable formatting by applying `Strings.General.MapItemStackable.ToString(localizedName, Strings.FormatQuantityAbbreviated(quantity))` when `Quantity > 1`.
- Rely on `GameLocalization.GetTextOrDefault` to trigger localization requests for missing entries automatically.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696cfd7962f4832bbfa14c5b8071a71f)