### PR TITLE
Seed localization files for supported languages

### DIFF
--- a/Intersect (Core)/Localization/SupportedLanguages.cs
+++ b/Intersect (Core)/Localization/SupportedLanguages.cs
@@ -1,0 +1,72 @@
+using Newtonsoft.Json.Linq;
+
+namespace Intersect.Localization;
+
+public readonly record struct SupportedLanguage(string Code, string Label);
+
+public static class SupportedLanguages
+{
+    public static SupportedLanguage[] All { get; } =
+    [
+        new SupportedLanguage("en", "English"),
+        new SupportedLanguage("es", "Español"),
+        new SupportedLanguage("pt", "Português"),
+        new SupportedLanguage("fr", "Français"),
+        new SupportedLanguage("ru", "Русский"),
+    ];
+}
+
+public static class LocalizationJsonMerger
+{
+    public static JObject MergeWithOverrides(JObject baseJson, JObject overrideJson)
+    {
+        var merged = new JObject();
+        foreach (var baseProperty in baseJson.Properties())
+        {
+            if (overrideJson.TryGetValue(baseProperty.Name, out var overrideToken))
+            {
+                merged[baseProperty.Name] = MergeToken(baseProperty.Value, overrideToken);
+            }
+            else
+            {
+                merged[baseProperty.Name] = baseProperty.Value.DeepClone();
+            }
+        }
+
+        foreach (var overrideProperty in overrideJson.Properties())
+        {
+            if (!merged.ContainsKey(overrideProperty.Name))
+            {
+                merged[overrideProperty.Name] = overrideProperty.Value.DeepClone();
+            }
+        }
+
+        return merged;
+    }
+
+    private static JToken MergeToken(JToken baseToken, JToken overrideToken)
+    {
+        if (overrideToken.Type is JTokenType.Null or JTokenType.Undefined)
+        {
+            return baseToken.DeepClone();
+        }
+
+        if (baseToken.Type == JTokenType.Object && overrideToken.Type == JTokenType.Object)
+        {
+            return MergeWithOverrides((JObject)baseToken, (JObject)overrideToken);
+        }
+
+        if (overrideToken.Type == JTokenType.String)
+        {
+            var overrideValue = overrideToken.Value<string>();
+            if (!string.IsNullOrWhiteSpace(overrideValue))
+            {
+                return overrideToken.DeepClone();
+            }
+
+            return baseToken.DeepClone();
+        }
+
+        return overrideToken.DeepClone();
+    }
+}

--- a/Intersect.Client.Core/Interface/Shared/SettingsWindow.cs
+++ b/Intersect.Client.Core/Interface/Shared/SettingsWindow.cs
@@ -14,6 +14,7 @@ using Intersect.Client.Networking;
 using Intersect.Config;
 using Intersect.Core;
 using Intersect.Framework.Core;
+using Intersect.Localization;
 using Intersect.Utilities;
 using Microsoft.Extensions.Logging;
 using static Intersect.Client.Framework.File_Management.GameContentManager;
@@ -110,15 +111,6 @@ public partial class SettingsWindow : Window
 
     private Base? _returnTo;
 
-    private static readonly (string Code, string Label)[] LanguageOptions =
-    [
-        ("en", "English"),
-        ("es", "Español"),
-        ("pt", "Português"),
-        ("fr", "Français"),
-        ("ru", "Русский"),
-    ];
-
     // Initialize.
     public SettingsWindow(Base parent) : base(parent: parent, title: Strings.Settings.Title, modal: false, name: nameof(SettingsWindow))
     {
@@ -197,9 +189,9 @@ public partial class SettingsWindow : Window
             TextPadding = new Padding(8, 4, 0, 4),
         };
 
-        foreach (var (code, label) in LanguageOptions)
+        foreach (var language in SupportedLanguages.All)
         {
-            var item = _languageList.AddItem(label: label, userData: code);
+            var item = _languageList.AddItem(label: language.Label, userData: language.Code);
             item.TextAlign = Pos.Left;
         }
 

--- a/Intersect.Client.Core/Localization/Strings.cs
+++ b/Intersect.Client.Core/Localization/Strings.cs
@@ -22,6 +22,7 @@ public static partial class Strings
     private const string StringsFileName = "client_strings.json";
     private const string DefaultLanguage = "en";
     private static char[] mQuantityTrimChars = new char[] { '.', '0' };
+    private static bool _seeded;
 
     private static string[] _unitsBits = [string.Empty, "Ki", "Mi", "Gi", "Ti"];
     private static string[] _unitsBytes = [string.Empty, "K", "M", "G", "T"];
@@ -148,12 +149,11 @@ public static partial class Strings
     public static void Load(string? language)
     {
         SynchronizeConfigurableStrings();
+        SeedLocalizedStrings();
 
         try
         {
-            var normalizedLanguage = string.IsNullOrWhiteSpace(language)
-                ? DefaultLanguage
-                : language.Trim().ToLowerInvariant();
+            var normalizedLanguage = NormalizeLanguage(language);
             var serialized = LoadLocalizedSerializedStrings(normalizedLanguage);
 
             LoadSerialized(serialized, string.Equals(normalizedLanguage, DefaultLanguage, StringComparison.OrdinalIgnoreCase));
@@ -165,6 +165,34 @@ public static partial class Strings
         }
 
         PostLoad();
+    }
+
+    public static void SeedLocalizedStrings()
+    {
+        if (_seeded)
+        {
+            return;
+        }
+
+        _seeded = true;
+
+        var baseSerialized = BuildSerializedStrings();
+        var baseJson = JObject.FromObject(baseSerialized);
+
+        foreach (var language in SupportedLanguages.All)
+        {
+            var normalizedLanguage = NormalizeLanguage(language.Code);
+            var overridePath = Path.Combine(
+                ClientConfiguration.ResourcesDirectory,
+                "localization",
+                "client",
+                normalizedLanguage,
+                StringsFileName
+            );
+            var overrideJson = ReadSerializedStringsAsJson(overridePath);
+            var mergedJson = LocalizationJsonMerger.MergeWithOverrides(baseJson, overrideJson);
+            WriteSerializedStrings(overridePath, mergedJson);
+        }
     }
 
     private static Dictionary<string, Dictionary<string, object>> LoadSerializedStrings(string path)
@@ -181,9 +209,7 @@ public static partial class Strings
 
     private static Dictionary<string, Dictionary<string, object>> LoadLocalizedSerializedStrings(string language)
     {
-        var normalizedLanguage = string.IsNullOrWhiteSpace(language)
-            ? DefaultLanguage
-            : language.Trim().ToLowerInvariant();
+        var normalizedLanguage = NormalizeLanguage(language);
         var basePath = Path.Combine(
             ClientConfiguration.ResourcesDirectory,
             "localization",
@@ -972,7 +998,24 @@ public static partial class Strings
         File.WriteAllText(path, JsonConvert.SerializeObject(serialized, Formatting.Indented));
     }
 
+    private static void WriteSerializedStrings(string path, JObject serialized)
+    {
+        var directory = Path.GetDirectoryName(path);
+        if (string.IsNullOrWhiteSpace(directory))
+        {
+            return;
+        }
+
+        Directory.CreateDirectory(directory);
+        File.WriteAllText(path, serialized.ToString(Formatting.Indented));
+    }
+
     public static void Save()
+    {
+        SaveSerialized(BuildSerializedStrings());
+    }
+
+    private static Dictionary<string, Dictionary<string, object>> BuildSerializedStrings()
     {
         var serialized = new Dictionary<string, Dictionary<string, object>>();
         var rootType = typeof(Strings);
@@ -984,8 +1027,24 @@ public static partial class Strings
             serialized.Add(groupType.Name, serializedGroup);
         }
 
-        SaveSerialized(serialized);
+        return serialized;
     }
+
+    private static JObject ReadSerializedStringsAsJson(string path)
+    {
+        if (!File.Exists(path))
+        {
+            return new JObject();
+        }
+
+        var json = File.ReadAllText(path);
+        return JsonConvert.DeserializeObject<JObject>(json) ?? new JObject();
+    }
+
+    private static string NormalizeLanguage(string? language) =>
+        string.IsNullOrWhiteSpace(language)
+            ? DefaultLanguage
+            : language.Trim().ToLowerInvariant();
 
     public partial struct AdminWindow
     {

--- a/Intersect.Editor/Forms/frmOptions.cs
+++ b/Intersect.Editor/Forms/frmOptions.cs
@@ -2,21 +2,13 @@
 using System.Globalization;
 using Intersect.Editor.Core;
 using Intersect.Editor.Localization;
+using Intersect.Localization;
 
 namespace Intersect.Editor.Forms;
 
 
 public partial class FrmOptions : Form
 {
-    private static readonly (string Code, string Label)[] LanguageOptions =
-    [
-        ("en", "English"),
-        ("es", "Español"),
-        ("pt", "Português"),
-        ("fr", "Français"),
-        ("ru", "Русский"),
-    ];
-
     public FrmOptions()
     {
         InitializeComponent();
@@ -83,16 +75,21 @@ public partial class FrmOptions : Form
         }
 
         cmbLanguage.Items.Clear();
-        foreach (var (_, label) in LanguageOptions)
+        foreach (var language in SupportedLanguages.All)
         {
-            cmbLanguage.Items.Add(label);
+            cmbLanguage.Items.Add(language.Label);
         }
 
         var preferredLanguage = Preferences.Language;
-        var selectedIndex = Array.FindIndex(
-            LanguageOptions,
-            option => string.Equals(option.Code, preferredLanguage, StringComparison.OrdinalIgnoreCase)
-        );
+        var selectedIndex = 0;
+        for (var index = 0; index < SupportedLanguages.All.Length; index++)
+        {
+            if (string.Equals(SupportedLanguages.All[index].Code, preferredLanguage, StringComparison.OrdinalIgnoreCase))
+            {
+                selectedIndex = index;
+                break;
+            }
+        }
         cmbLanguage.SelectedIndex = selectedIndex >= 0 ? selectedIndex : 0;
     }
 
@@ -124,8 +121,8 @@ public partial class FrmOptions : Form
         Preferences.SavePreference("TexturePackSize", cmbTextureSize.GetItemText(cmbTextureSize.SelectedItem));
 
         var selectedIndex = cmbLanguage.SelectedIndex;
-        var selectedLanguage = selectedIndex >= 0 && selectedIndex < LanguageOptions.Length
-            ? LanguageOptions[selectedIndex].Code
+        var selectedLanguage = selectedIndex >= 0 && selectedIndex < SupportedLanguages.All.Length
+            ? SupportedLanguages.All[selectedIndex].Code
             : "en";
         var languageChanged = !string.Equals(Preferences.Language, selectedLanguage, StringComparison.OrdinalIgnoreCase);
         Preferences.Language = selectedLanguage;

--- a/Intersect.Server.Core/Localization/Strings.cs
+++ b/Intersect.Server.Core/Localization/Strings.cs
@@ -15,6 +15,7 @@ public static partial class Strings
 {
     private const string DefaultLanguage = "en";
     private const string StringsFileName = "server_strings.json";
+    private static bool _seeded;
 
     public sealed partial class AccountNamespace : LocaleNamespace
     {
@@ -1581,6 +1582,7 @@ public static partial class Strings
 
     public static bool Load(string? language)
     {
+        SeedLocalizedStrings();
         var normalizedLanguage = NormalizeLanguage(language);
         var loaded = LoadLocalized(normalizedLanguage);
         if (loaded)
@@ -1629,6 +1631,32 @@ public static partial class Strings
     private static bool LoadDefault()
     {
         return LoadLocalized(DefaultLanguage);
+    }
+
+    public static void SeedLocalizedStrings()
+    {
+        if (_seeded)
+        {
+            return;
+        }
+
+        _seeded = true;
+
+        var baseJson = BuildBaseJson();
+        foreach (var language in SupportedLanguages.All)
+        {
+            var normalizedLanguage = NormalizeLanguage(language.Code);
+            var overridePath = Path.Combine(
+                ServerContext.ResourceDirectory,
+                "localization",
+                "server",
+                normalizedLanguage,
+                StringsFileName
+            );
+            _ = TryLoadSerializedStrings(overridePath, out var overrideJson);
+            var mergedJson = LocalizationJsonMerger.MergeWithOverrides(baseJson, overrideJson);
+            TryWriteSerializedStrings(overridePath, mergedJson);
+        }
     }
 
     private static bool LoadLocalized(string language)
@@ -1775,6 +1803,12 @@ public static partial class Strings
         string.IsNullOrWhiteSpace(language)
             ? DefaultLanguage
             : language.Trim().ToLowerInvariant();
+
+    private static JObject BuildBaseJson()
+    {
+        var json = JsonConvert.SerializeObject(Root, Formatting.Indented, new LocalizedStringConverter());
+        return JsonConvert.DeserializeObject<JObject>(json) ?? new JObject();
+    }
 
     #region Root Namespace
 


### PR DESCRIPTION
### Motivation
- Centralize the supported language list to avoid duplication across client/editor modules and ensure a single authoritative source (`SupportedLanguages`).
- Create per-language localization JSON files for client and server on first run so translations exist for every supported language and new keys added in code are propagated to each locale without overwriting existing non-empty translations.
- Ensure seeding runs at startup (client and server) before the selected language is loaded so the initial run generates all localization copies.

### Description
- Added `Intersect (Core)/Localization/SupportedLanguages.cs` which declares `SupportedLanguage`, `SupportedLanguages.All` and `LocalizationJsonMerger.MergeWithOverrides` to merge base JSON with overrides while preserving non-empty translations.
- Updated UI code to reuse the centralized list by replacing local `LanguageOptions` with `SupportedLanguages.All` in `Intersect.Client.Core/Interface/Shared/SettingsWindow.cs` and `Intersect.Editor/Forms/frmOptions.cs`.
- Implemented client seeding in `Intersect.Client.Core/Localization/Strings.cs` by adding `SeedLocalizedStrings`, `BuildSerializedStrings`, `ReadSerializedStringsAsJson`, `WriteSerializedStrings(JObject)`, `NormalizeLanguage` and invoking seeding from `Load`; existing loading/merge behavior is preserved but now per-language files are created/merged using the new merger.
- Implemented equivalent server seeding in `Intersect.Server.Core/Localization/Strings.cs` by adding `SeedLocalizedStrings`, `BuildBaseJson` and invoking seeding from `Load`, and writing per-language `localization/server/<lang>/server_strings.json` using the same merge logic.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d12318f80832b868f2e3b48cde2f7)