### PR TITLE
Handle invalid localization JSON in string loading

### DIFF
--- a/Intersect.Server.Core/Localization/Strings.cs
+++ b/Intersect.Server.Core/Localization/Strings.cs
@@ -1752,9 +1752,22 @@ public static partial class Strings
             return false;
         }
 
-        var json = File.ReadAllText(path, Encoding.UTF8);
-        serialized = JsonConvert.DeserializeObject<JObject>(json) ?? new JObject();
-        return true;
+        try
+        {
+            var json = File.ReadAllText(path, Encoding.UTF8);
+            serialized = JsonConvert.DeserializeObject<JObject>(json) ?? new JObject();
+            return true;
+        }
+        catch (Exception exception)
+        {
+            serialized = new JObject();
+            ApplicationContext.Context.Value?.Logger.LogWarning(
+                exception,
+                "Failed to parse localization file at {Path}.",
+                path
+            );
+            return false;
+        }
     }
 
     public static bool Save()


### PR DESCRIPTION
### Motivation
- Prevent a malformed localization JSON file from aborting server startup when seeding or loading strings.
- Improve robustness by treating parse failures as non-fatal and falling back to an empty payload instead of throwing.

### Description
- Wrap the file read and `JsonConvert.DeserializeObject<JObject>` call in a try/catch inside `TryLoadSerializedStrings`.
- On parse failure return `false` and an empty `JObject`, and log a warning via `ApplicationContext.Context.Value?.Logger.LogWarning` that includes the file path.
- This change ensures malformed locale files are skipped during seeding and loading, avoiding crashes while preserving normal behavior for valid files.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d1736b618832b808103e58cb5615c)