### PR TITLE
Request localization for job recipe items and ingredients

### DIFF
--- a/Intersect.Client.Core/Interface/Game/Job/JobsWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Job/JobsWindow.cs
@@ -227,6 +227,53 @@ namespace Intersect.Client.Interface.Game.Job
             GameLocalization.RequestEntries(requests);
         }
 
+        private void RequestRecipeItemLocalization(IEnumerable<CraftingRecipeDescriptor> recipes)
+        {
+            if (recipes == null)
+            {
+                return;
+            }
+
+            var itemIds = new HashSet<Guid>();
+            foreach (var recipe in recipes)
+            {
+                if (recipe == null)
+                {
+                    continue;
+                }
+
+                itemIds.Add(recipe.ItemId);
+                foreach (var ingredient in recipe.Ingredients)
+                {
+                    itemIds.Add(ingredient.ItemId);
+                }
+            }
+
+            if (itemIds.Count == 0)
+            {
+                return;
+            }
+
+            var requests = new List<LocalizationRequestEntry>();
+            foreach (var itemId in itemIds)
+            {
+                if (!ItemDescriptor.TryGet(itemId, out var descriptor))
+                {
+                    continue;
+                }
+
+                requests.Add(new LocalizationRequestEntry(descriptor.Type.ToString(), descriptor.Id.ToString(), "Name"));
+                requests.Add(
+                    new LocalizationRequestEntry(descriptor.Type.ToString(), descriptor.Id.ToString(), "Description")
+                );
+            }
+
+            if (requests.Count > 0)
+            {
+                GameLocalization.RequestEntries(requests);
+            }
+        }
+
         private string GetLocalizedRecipeName(CraftingRecipeDescriptor recipe) =>
             recipe == null
                 ? string.Empty
@@ -278,6 +325,7 @@ namespace Intersect.Client.Interface.Game.Job
             }
 
             RequestRecipeLocalization(recipes);
+            RequestRecipeItemLocalization(recipes);
 
             foreach (var recipe in recipes)
             {


### PR DESCRIPTION
### Motivation

- The jobs window requested localization only for recipe entries, so item tooltips for crafted items and ingredients could show untranslated text on hover; the change ensures those item texts are prefetched.

### Description

- Added a new helper `RequestRecipeItemLocalization(IEnumerable<CraftingRecipeDescriptor> recipes)` that collects output and ingredient item IDs and requests `Name` and `Description` localization for each item.
- The new helper is called from `LoadRecipes` immediately after `RequestRecipeLocalization(recipes)` so recipe and related item texts are requested together.
- No UI layout or hover logic was changed; this only prefetches localization entries using `GameLocalization.RequestEntries`.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d4b31dff4832baa34da908027f082)