### PR TITLE
Add localization status console report (locstatus)

### DIFF
--- a/Intersect.Server.Core/Localization/CommandsNamespace.cs
+++ b/Intersect.Server.Core/Localization/CommandsNamespace.cs
@@ -181,6 +181,15 @@ public static partial class Strings
         };
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocaleCommand LocalizationStatus = new LocaleCommand
+        {
+            Name = @"locstatus",
+            Description =
+                @"Shows missing or needs-review localization counts grouped by language, entity type, and field.",
+            Help = @"shows missing or needs-review localization counts grouped by language, entity type, and field"
+        };
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public readonly LocaleCommand Migrate = new LocaleCommand
         {
             Name = @"migrate",

--- a/Intersect.Server.Core/Localization/LocalizationRepository.cs
+++ b/Intersect.Server.Core/Localization/LocalizationRepository.cs
@@ -378,6 +378,34 @@ public sealed class LocalizationRepository
         return results;
     }
 
+    public IReadOnlyList<LocalizationTranslationStatusCount> GetMissingAndNeedsReviewCounts()
+    {
+        using var connection = OpenConnection();
+        using var command = connection.CreateCommand();
+        command.CommandText =
+            """
+            SELECT lang, entity_type, field, COUNT(*)
+            FROM localization_translation
+            WHERE status IN ($missing, $needsReview)
+            GROUP BY lang, entity_type, field;
+            """;
+        command.Parameters.AddWithValue("$missing", (int)TranslationStatus.Missing);
+        command.Parameters.AddWithValue("$needsReview", (int)TranslationStatus.NeedsReview);
+
+        var results = new List<LocalizationTranslationStatusCount>();
+        using var reader = command.ExecuteReader();
+        while (reader.Read())
+        {
+            var lang = reader.GetString(0);
+            var entityType = reader.GetString(1);
+            var field = reader.GetString(2);
+            var count = reader.GetInt64(3);
+            results.Add(new LocalizationTranslationStatusCount(lang, entityType, field, count));
+        }
+
+        return results;
+    }
+
     // --- Helpers / Migration ---
 
     private void MigrateLegacySchemaIfNeeded()
@@ -624,3 +652,10 @@ public sealed class LocalizationRepository
 }
 
 public readonly record struct LocalizationKey(string EntityType, string EntityId, string Field);
+
+public readonly record struct LocalizationTranslationStatusCount(
+    string Language,
+    string EntityType,
+    string Field,
+    long Count
+);

--- a/Intersect.Server.Core/Localization/Strings.cs
+++ b/Intersect.Server.Core/Localization/Strings.cs
@@ -445,6 +445,10 @@ public static partial class Strings
         public readonly LocalizedString EventCount = @" - {00} Events.";
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString LocalizationStatusEmpty =
+            @"No missing or needs-review localization entries were found.";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public readonly LocalizedString ExperimentalFeatureEnablement = @"{00} is {01}.";
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]

--- a/Intersect.Server/Core/Commands/LocalizationStatusCommand.cs
+++ b/Intersect.Server/Core/Commands/LocalizationStatusCommand.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Linq;
+using Intersect.Server.Core.CommandParsing;
+using Intersect.Server.Localization;
+
+namespace Intersect.Server.Core.Commands;
+
+internal sealed partial class LocalizationStatusCommand : ServerCommand
+{
+    public LocalizationStatusCommand() : base(Strings.Commands.LocalizationStatus)
+    {
+    }
+
+    protected override void HandleValue(ServerContext context, ParserResult result)
+    {
+        var entries = LocalizationRepository.Default.GetMissingAndNeedsReviewCounts();
+        if (entries.Count == 0)
+        {
+            Console.WriteLine(Strings.Commandoutput.LocalizationStatusEmpty);
+            return;
+        }
+
+        var langWidth = Math.Max("Lang".Length, entries.Max(entry => entry.Language.Length));
+        var entityTypeWidth = Math.Max("EntityType".Length, entries.Max(entry => entry.EntityType.Length));
+        var fieldWidth = Math.Max("Field".Length, entries.Max(entry => entry.Field.Length));
+
+        Console.WriteLine($"{"Lang",-langWidth} {"EntityType",-entityTypeWidth} {"Field",-fieldWidth} {"Count",5}");
+        foreach (var entry in entries.OrderBy(entry => entry.Language).ThenBy(entry => entry.EntityType).ThenBy(entry => entry.Field))
+        {
+            Console.WriteLine($"{entry.Language,-langWidth} {entry.EntityType,-entityTypeWidth} {entry.Field,-fieldWidth} {entry.Count,5}");
+        }
+    }
+}

--- a/Intersect.Server/Core/ConsoleService.ConsoleThread.cs
+++ b/Intersect.Server/Core/ConsoleService.ConsoleThread.cs
@@ -38,6 +38,7 @@ namespace Intersect.Server.Core
                 Parser.Register<KickCommand>();
                 Parser.Register<KillCommand>();
                 Parser.Register<ListVariablesCommand>();
+                Parser.Register<LocalizationStatusCommand>();
                 Parser.Register<MetricsCommand>();
                 Parser.Register<MakePrivateCommand>();
                 Parser.Register<MakePublicCommand>();


### PR DESCRIPTION
### Motivation
- Provide an easy way for admins/operators to see how many localization entries are in `Missing` or `NeedsReview` state grouped by language, entity type and field so translators and maintainers can prioritize work.

### Description
- Added `GetMissingAndNeedsReviewCounts()` to `LocalizationRepository` which runs the grouped query on `localization_translation` and returns `LocalizationTranslationStatusCount` records.
- Added `LocalizationTranslationStatusCount` record type to carry `Language`, `EntityType`, `Field` and `Count` values.
- Implemented a console command `locstatus` (`LocalizationStatusCommand`) that queries the repository and prints a simple aligned table of `Lang`, `EntityType`, `Field`, and `Count` ordered by language/entity/field.
- Registered the new command in the console parser and added localization entries: `Strings.Commands.LocalizationStatus` and `Strings.Commandoutput.LocalizationStatusEmpty` for the empty result message.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d7a976694832bb98dfffc046d7321)