### PR TITLE
Separate Settings/Credits into a secondary panel on Main Menu

### DIFF
--- a/Intersect.Client.Core/Interface/Menu/MainMenuWindow.Designer.cs
+++ b/Intersect.Client.Core/Interface/Menu/MainMenuWindow.Designer.cs
@@ -14,33 +14,64 @@ public partial class MainMenuWindow
     {
         var canvas = Canvas ?? throw new InvalidOperationException($"Not attached to a {nameof(Canvas)}");
 
-        Button[] visibleButtons = new []
+        Button[] visiblePrimaryButtons = new []
         {
             _buttonStart,
+            _buttonExit,
+        }.Where(button => button.IsVisibleInTree).ToArray();
+
+        Button[] visibleSecondaryButtons = new []
+        {
             _buttonSettings,
             _buttonCredits,
-            _buttonExit,
         }.Where(button => button.IsVisibleInTree).ToArray();
 
         const int defaultWidth = 87;
         const int defaultHeight = 154;
+        const int secondaryWidth = 64;
+        const int secondaryHeight = 64;
+        const int secondarySpacing = 8;
+
+        var secondaryPanelWidth = visibleSecondaryButtons.Length > 0 ? secondaryWidth : 0;
+        var secondaryPanelHeight = visibleSecondaryButtons.Length > 0
+            ? secondaryHeight * visibleSecondaryButtons.Length + secondarySpacing * (visibleSecondaryButtons.Length - 1)
+            : 0;
+        var secondaryPanelMargin = visibleSecondaryButtons.Length > 0 ? secondarySpacing : 0;
+        var contentHeight = defaultHeight > secondaryPanelHeight ? defaultHeight : secondaryPanelHeight;
 
         Size = new Point(
-            defaultWidth * visibleButtons.Length + InnerPanelPadding.Left + InnerPanelPadding.Right,
-            defaultHeight + TitleBarBounds.Bottom + InnerPanelPadding.Top + InnerPanelPadding.Bottom
+            defaultWidth * visiblePrimaryButtons.Length + secondaryPanelWidth + secondaryPanelMargin + InnerPanelPadding.Left + InnerPanelPadding.Right,
+            contentHeight + TitleBarBounds.Bottom + InnerPanelPadding.Top + InnerPanelPadding.Bottom
         );
 
         Titlebar.MouseInputEnabled = false;
         TitleLabel.FontSize = 14;
         TitleLabel.TextColorOverride = Color.White;
 
-        foreach (var button in visibleButtons)
+        _secondaryButtonsPanel.Size = new Point(secondaryPanelWidth, secondaryPanelHeight);
+        _secondaryButtonsPanel.Margin = new Margin(secondaryPanelMargin, 0, 0, 0);
+
+        foreach (var button in visiblePrimaryButtons)
         {
             button.Size = new Point(defaultWidth, defaultHeight);
             button.FontName = "sourcesansproblack";
             button.FontSize = 12;
             button.Padding = new Padding(0, 24, 0, 0);
             button.Dock = Pos.Left;
+
+            var buttonName = button.Name;
+            button.SetStateTexture(ComponentState.Normal, $"mainmenu{buttonName}.png");
+            button.SetStateTexture(ComponentState.Active, $"mainmenu{buttonName}_clicked.png");
+            button.SetStateTexture(ComponentState.Disabled, $"mainmenu{buttonName}_disabled.png");
+            button.SetStateTexture(ComponentState.Hovered, $"mainmenu{buttonName}_hovered.png");
+        }
+
+        foreach (var button in visibleSecondaryButtons)
+        {
+            button.Size = new Point(secondaryWidth, secondaryHeight);
+            button.FontName = "sourcesansproblack";
+            button.FontSize = 10;
+            button.Padding = new Padding(0, 12, 0, 0);
 
             var buttonName = button.Name;
             button.SetStateTexture(ComponentState.Normal, $"mainmenu{buttonName}.png");

--- a/Intersect.Client.Core/Interface/Menu/MainMenuWindow.cs
+++ b/Intersect.Client.Core/Interface/Menu/MainMenuWindow.cs
@@ -19,6 +19,7 @@ public partial class MainMenuWindow : Window
     private readonly Button _buttonSettings;
     private readonly Button _buttonStart;
     private readonly MainMenu _mainMenu;
+    private readonly Panel _secondaryButtonsPanel;
 
     // ReSharper disable once SuggestBaseTypeForParameterInConstructor
     public MainMenuWindow(Canvas canvas, MainMenu mainMenu) : base(canvas, Strings.MainMenu.Title, false, $"{nameof(MainMenuWindow)}_{(ClientContext.IsSinglePlayer ? "singleplayer" : "online")}")
@@ -33,6 +34,14 @@ public partial class MainMenuWindow : Window
         InnerPanelPadding = new Padding(8);
         Titlebar.MouseInputEnabled = false;
 
+        _secondaryButtonsPanel = new Panel(this, nameof(_secondaryButtonsPanel))
+        {
+            DisplayMode = DisplayMode.FlowTopToBottom,
+            Dock = Pos.Top | Pos.Right,
+            DockChildSpacing = new Padding(0, 8, 0, 0),
+            ShouldDrawBackground = false,
+        };
+
         _buttonStart = new Button(this, nameof(_buttonStart))
         {
             IsTabable = true,
@@ -41,7 +50,7 @@ public partial class MainMenuWindow : Window
         };
         _buttonStart.Clicked += _buttonStart_Clicked;
 
-        _buttonSettings = new Button(this, nameof(_buttonSettings))
+        _buttonSettings = new Button(_secondaryButtonsPanel, nameof(_buttonSettings))
         {
             IsTabable = true,
             Text = Strings.MainMenu.Settings,
@@ -53,7 +62,7 @@ public partial class MainMenuWindow : Window
             _buttonSettings.SetToolTipText(Strings.MainMenu.SettingsTooltip);
         }
 
-        _buttonCredits = new Button(this, nameof(_buttonCredits))
+        _buttonCredits = new Button(_secondaryButtonsPanel, nameof(_buttonCredits))
         {
             IsTabable = true,
             Text = Strings.MainMenu.Credits,


### PR DESCRIPTION
### Motivation
- Prevent `_buttonSettings` and `_buttonCredits` from sharing the primary button layout so they can be placed as smaller, independent controls anchored to the top-right. 
- Keep using existing button textures where possible while adjusting sizes and spacing for the new compact layout.

### Description
- Add a new `Panel` field `_secondaryButtonsPanel` and instantiate it in the `MainMenuWindow` constructor with `DisplayMode.FlowTopToBottom`, `Dock = Pos.Top | Pos.Right`, `DockChildSpacing`, and `ShouldDrawBackground = false` (`Intersect.Client.Core/Interface/Menu/MainMenuWindow.cs`).
- Make `_buttonSettings` and `_buttonCredits` children of the new `_secondaryButtonsPanel` instead of the main window container (`Intersect.Client.Core/Interface/Menu/MainMenuWindow.cs`).
- Split layout logic into `visiblePrimaryButtons` and `visibleSecondaryButtons`, introduce `secondaryWidth`, `secondaryHeight`, and `secondarySpacing`, compute the secondary panel size/margin and `contentHeight`, and adjust overall window `Size` accordingly (`Intersect.Client.Core/Interface/Menu/MainMenuWindow.Designer.cs`).
- Keep texture assignments but apply smaller `Size`, `FontSize`, and `Padding` for secondary buttons while leaving primary button sizing unchanged (`Intersect.Client.Core/Interface/Menu/MainMenuWindow.Designer.cs`).

### Testing
- No automated tests were run for this UI-only layout change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e49cf858c832bb6596eb27804ca5a)