### PR TITLE
Fix stat icon texture lookup

### DIFF
--- a/Intersect.Client.Core/Interface/Game/Character/CharacterWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Character/CharacterWindow.cs
@@ -186,7 +186,7 @@ public partial class CharacterWindow : Window
 
         if (!string.IsNullOrWhiteSpace(iconName))
         {
-            panel.Texture = GameContentManager.Current.GetTexture(TextureType.Misc, iconName);
+            panel.Texture = StatEffectIconProvider.GetIconTexture(iconName);
         }
 
         return panel;

--- a/Intersect.Client.Core/Interface/Game/DescriptionWindows/Components/RowContainerComponent.cs
+++ b/Intersect.Client.Core/Interface/Game/DescriptionWindows/Components/RowContainerComponent.cs
@@ -3,8 +3,8 @@ using Intersect.Client.Framework.Gwen.Control;
 using Intersect.Core;
 using Microsoft.Extensions.Logging;
 using Intersect.Client.Core;
-using Intersect.Client.Framework.Content;
 using Intersect.Client.Framework.File_Management;
+using Intersect.Client.Interface.Game.DescriptionWindows;
 
 namespace Intersect.Client.Interface.Game.DescriptionWindows.Components;
 
@@ -74,7 +74,7 @@ public partial class RowContainerComponent : ComponentBase
         var row = AddKeyValueRow(key, value, keyColor, valueColor);
         if (!string.IsNullOrWhiteSpace(iconName))
         {
-            row.SetIcon(GameContentManager.Current.GetTexture(TextureType.Misc, iconName));
+            row.SetIcon(StatEffectIconProvider.GetIconTexture(iconName));
         }
         else
         {

--- a/Intersect.Client.Core/Interface/Game/DescriptionWindows/StatEffectIconProvider.cs
+++ b/Intersect.Client.Core/Interface/Game/DescriptionWindows/StatEffectIconProvider.cs
@@ -1,3 +1,6 @@
+using Intersect.Client.Framework.Content;
+using Intersect.Client.Framework.File_Management;
+using Intersect.Client.Framework.Graphics;
 using Intersect.Enums;
 using Intersect.Framework.Core.GameObjects.Items;
 
@@ -5,6 +8,18 @@ namespace Intersect.Client.Interface.Game.DescriptionWindows;
 
 public static class StatEffectIconProvider
 {
+    public static IGameTexture? GetIconTexture(string? iconName)
+    {
+        if (string.IsNullOrWhiteSpace(iconName))
+        {
+            return null;
+        }
+
+        var contentManager = GameContentManager.Current;
+        return contentManager.GetTexture(TextureType.Misc, iconName)
+               ?? contentManager.GetTexture(TextureType.Gui, iconName);
+    }
+
     public static string? GetIconForStat(Stat stat)
     {
         return stat switch


### PR DESCRIPTION
### Motivation
- Ensure stat/effect icons are resolved correctly regardless of whether they live under `misc` or `gui` resources so description and character UI always show the correct icons.

### Description
- Add `StatEffectIconProvider.GetIconTexture(string?)` which returns an `IGameTexture?` and falls back from `TextureType.Misc` to `TextureType.Gui`.
- Update description row icon loading to use `StatEffectIconProvider.GetIconTexture` instead of directly calling `GameContentManager.Current.GetTexture(TextureType.Misc, ...)`.
- Update `CharacterWindow.CreateIconPanel` to use `StatEffectIconProvider.GetIconTexture` for stat icons and add the necessary import adjustments.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ef0c315bc832bb3a043e2a91751b8)