### PR TITLE
Use client-side IsDead flag and block player actions when dead

### DIFF
--- a/Intersect.Client.Core/Core/Input.cs
+++ b/Intersect.Client.Core/Core/Input.cs
@@ -264,6 +264,11 @@ public static partial class Input
                     switch (control)
                     {
                         case Control.Block:
+                            if (Globals.Me?.IsDead == true)
+                            {
+                                break;
+                            }
+
                             _ = (Globals.Me?.TryBlock());
                             break;
 
@@ -280,6 +285,11 @@ public static partial class Input
                             break;
 
                         case Control.PickUp:
+                            if (Globals.Me?.IsDead == true)
+                            {
+                                break;
+                            }
+
                             if (Globals.Me != default && Globals.Me.MapInstance != default)
                             {
                                 _ = Player.TryPickupItem(

--- a/Intersect.Client.Core/Entities/Entity.cs
+++ b/Intersect.Client.Core/Entities/Entity.cs
@@ -230,6 +230,8 @@ public partial class Entity : IEntity
     IReadOnlyDictionary<Vital, long> IEntity.Vitals =>
         Enum.GetValues<Vital>().ToDictionary(vital => vital, vital => Vital[(int)vital]);
 
+    public virtual bool IsDead { get; protected set; }
+
     public int WalkFrame { get; set; }
 
     public FloatRect WorldPos { get; set; } = new FloatRect();
@@ -472,6 +474,7 @@ public partial class Entity : IEntity
 
         Vital = packet.Vital;
         MaxVital = packet.MaxVital;
+        IsDead = Vital[(int)Enums.Vital.Health] <= 0;
 
         //Update status effects
         Status.Clear();
@@ -1926,7 +1929,7 @@ public partial class Entity : IEntity
     {
         get
         {
-            return LatestMap == default || !ShouldDraw || Vital[(int)Enums.Vital.Health] < 1;
+            return LatestMap == default || !ShouldDraw || IsDead;
         }
     }
 

--- a/Intersect.Client.Core/Entities/Player.cs
+++ b/Intersect.Client.Core/Entities/Player.cs
@@ -322,36 +322,39 @@ public partial class Player : Entity, IPlayer
 
         if (!IsBusy)
         {
-            if (this == Globals.Me && IsMoving == false)
+            if (!IsDead)
             {
-                ProcessDirectionalInput();
-            }
-
-            if (Controls.IsControlPressed(Control.AttackInteract))
-            {
-                if (IsCasting)
+                if (this == Globals.Me && IsMoving == false)
                 {
-                    if (IsCastingCheckTimer < Timing.Global.Milliseconds &&
-                        Options.Instance.Combat.EnableCombatChatMessages)
+                    ProcessDirectionalInput();
+                }
+
+                if (Controls.IsControlPressed(Control.AttackInteract))
+                {
+                    if (IsCasting)
                     {
-                        ChatboxMsg.AddMessage(new ChatboxMsg(Strings.Combat.AttackWhileCastingDeny,
-                            CustomColors.Alerts.Declined, ChatMessageType.Combat));
-                        IsCastingCheckTimer = Timing.Global.Milliseconds + 350;
+                        if (IsCastingCheckTimer < Timing.Global.Milliseconds &&
+                            Options.Instance.Combat.EnableCombatChatMessages)
+                        {
+                            ChatboxMsg.AddMessage(new ChatboxMsg(Strings.Combat.AttackWhileCastingDeny,
+                                CustomColors.Alerts.Declined, ChatMessageType.Combat));
+                            IsCastingCheckTimer = Timing.Global.Milliseconds + 350;
+                        }
+                    }
+                    else if (Globals.Me?.TryAttack() == false)
+                    {
+                        if (!Globals.Me.IsAttacking && (!IsMoving || Options.Instance.Player.AllowCombatMovement))
+                        {
+                            Globals.Me.AttackTimer = Timing.Global.Milliseconds + Globals.Me.CalculateAttackTime();
+                        }
                     }
                 }
-                else if (Globals.Me?.TryAttack() == false)
-                {
-                    if (!Globals.Me.IsAttacking && (!IsMoving || Options.Instance.Player.AllowCombatMovement))
-                    {
-                        Globals.Me.AttackTimer = Timing.Global.Milliseconds + Globals.Me.CalculateAttackTime();
-                    }
-                }
-            }
 
-            //Holding block button for "auto blocking"
-            if (Controls.IsControlPressed(Control.Block))
-            {
-                _ = TryBlock();
+                //Holding block button for "auto blocking"
+                if (Controls.IsControlPressed(Control.Block))
+                {
+                    _ = TryBlock();
+                }
             }
         }
 
@@ -861,6 +864,11 @@ public partial class Player : Entity, IPlayer
 
     public void TrySellItem(int inventorySlotIndex)
     {
+        if (IsDead)
+        {
+            return;
+        }
+
         var inventorySlot = Inventory[inventorySlotIndex];
         if (inventorySlot == null || inventorySlot.ItemId == Guid.Empty)
         {
@@ -946,6 +954,11 @@ public partial class Player : Entity, IPlayer
 
     public void TryBuyItem(int shopSlotIndex)
     {
+        if (IsDead)
+        {
+            return;
+        }
+
         //Confirm the purchase
         var shopSlot = Globals.GameShop?.SellingItems[shopSlotIndex];
         if (shopSlot == default || !ItemDescriptor.TryGet(shopSlot.ItemId, out var itemDescriptor))
@@ -1024,6 +1037,11 @@ public partial class Player : Entity, IPlayer
         bool skipPrompt = false
     )
     {
+        if (IsDead)
+        {
+            return false;
+        }
+
         // Permission Check for Guild Bank
         if (Globals.IsGuildBank && !IsGuildBankDepositAllowed())
         {
@@ -1157,6 +1175,11 @@ public partial class Player : Entity, IPlayer
         bool skipPrompt = false
     )
     {
+        if (IsDead)
+        {
+            return false;
+        }
+
         // Permission Check for Guild Bank
         if (Globals.IsGuildBank && !IsGuildBankWithdrawAllowed())
         {
@@ -1382,6 +1405,11 @@ public partial class Player : Entity, IPlayer
     //Trade
     public void TryOfferItemToTrade(int index)
     {
+        if (IsDead)
+        {
+            return;
+        }
+
         var slot = Inventory[index];
         if (slot == null || slot.ItemId == Guid.Empty)
         {
@@ -1435,6 +1463,11 @@ public partial class Player : Entity, IPlayer
 
     public void TryCancelOfferToTradeItem(int index)
     {
+        if (IsDead)
+        {
+            return;
+        }
+
         var slot = Globals.Trade[0, index];
         var quantity = slot.Quantity;
         var revokedItem = ItemDescriptor.Get(slot.ItemId);
@@ -1513,6 +1546,11 @@ public partial class Player : Entity, IPlayer
 
     public void TryUseSpell(int index)
     {
+        if (IsDead)
+        {
+            return;
+        }
+
         if (index < 0 || Spells.Length <= index)
         {
             return;
@@ -1562,6 +1600,11 @@ public partial class Player : Entity, IPlayer
 
     public void TryUseSpell(Guid spellId)
     {
+        if (IsDead)
+        {
+            return;
+        }
+
         if (spellId == Guid.Empty)
         {
             return;
@@ -1772,6 +1815,12 @@ public partial class Player : Entity, IPlayer
 
         if (Interface.Interface.HasInputFocus())
         {
+            return;
+        }
+
+        if (IsDead)
+        {
+            DirectionMoving = Direction.None;
             return;
         }
 
@@ -2136,6 +2185,11 @@ public partial class Player : Entity, IPlayer
 
     public bool TryBlock()
     {
+        if (IsDead)
+        {
+            return false;
+        }
+
         var shieldIndex = Options.Instance.Equipment.ShieldSlot;
         var myShieldIndex = MyEquipment?.GetValueOrDefault(shieldIndex)?.FirstOrDefault(-1) ?? -1;
 
@@ -2166,6 +2220,11 @@ public partial class Player : Entity, IPlayer
 
     public bool TryAttack()
     {
+        if (IsDead)
+        {
+            return false;
+        }
+
         if (IsAttacking || IsBlocking || (IsMoving && !Options.Instance.Player.AllowCombatMovement) || Globals.Me == default)
         {
             return false;
@@ -2536,6 +2595,11 @@ public partial class Player : Entity, IPlayer
     /// <returns> Whether the action was successful or not </returns>
     public static bool TryPickupItem(Guid mapId, int tileIndex, Guid uniqueId = new(), bool firstOnly = false)
     {
+        if (Globals.Me?.IsDead == true)
+        {
+            return false;
+        }
+
         var map = Maps.MapInstance.Get(mapId);
         if (map == null || tileIndex < 0 || tileIndex >= Options.Instance.Map.MapWidth * Options.Instance.Map.MapHeight)
         {
@@ -2739,6 +2803,11 @@ public partial class Player : Entity, IPlayer
     private void ProcessDirectionalInput()
     {
         if (Globals.Me == default || Globals.MapGrid == default)
+        {
+            return;
+        }
+
+        if (IsDead)
         {
             return;
         }

--- a/Intersect.Client.Core/Entities/Resource.cs
+++ b/Intersect.Client.Core/Entities/Resource.cs
@@ -59,10 +59,10 @@ public partial class Resource : Entity, IResource
         }
     }
 
-    public bool IsDead
+    public override bool IsDead
     {
         get => _isDead;
-        set
+        protected set
         {
             if (value == _isDead)
             {

--- a/Intersect.Client.Core/Interface/Game/Bank/BankItem.cs
+++ b/Intersect.Client.Core/Interface/Game/Bank/BankItem.cs
@@ -223,6 +223,11 @@ public partial class BankItem : SlotItem
             switch (targetNode)
             {
                 case BankItem bankItem:
+                    if (player.IsDead)
+                    {
+                        return false;
+                    }
+
                     PacketSender.SendMoveBankItems(SlotIndex, bankItem.SlotIndex);
                     return true;
 

--- a/Intersect.Client.Core/Interface/Game/Crafting/CraftingWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Crafting/CraftingWindow.cs
@@ -491,6 +491,11 @@ public partial class CraftingWindow : Window
             return;
         }
 
+        if (Globals.Me?.IsDead == true)
+        {
+            return;
+        }
+
         if (CanCraft())
         {
             mRemainingCrafts = count;

--- a/Intersect.Client.Core/Interface/Game/EntityPanel/EntityBox.cs
+++ b/Intersect.Client.Core/Interface/Game/EntityPanel/EntityBox.cs
@@ -415,7 +415,7 @@ public partial class EntityBox
 
         if (MyEntity.Type == EntityType.Player && MyEntity != Globals.Me)
         {
-            if (MyEntity.Vitals[Vital.Health] <= 0)
+            if (MyEntity.IsDead)
             {
                 _contextMenuButton.Hide();
             }

--- a/Intersect.Client.Core/Interface/Game/Shops/PlayerShopBrowseWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Shops/PlayerShopBrowseWindow.cs
@@ -309,6 +309,11 @@ namespace Intersect.Client.Interface.Game.Shops
 
         internal void RequestPurchase(PlayerShopBrowseItemRow row)
         {
+            if (Globals.Me?.IsDead == true)
+            {
+                return;
+            }
+
             var quantity = row.RequestedQuantity;
             if (quantity <= 0)
             {

--- a/Intersect.Client.Core/Interface/Game/TargetContextMenu.cs
+++ b/Intersect.Client.Core/Interface/Game/TargetContextMenu.cs
@@ -205,7 +205,7 @@ public sealed partial class TargetContextMenu : ContextMenu
 
     void tradeRequest_Clicked(Base sender, MouseButtonState arguments)
     {
-        if (_me == null || _entity is not Player || _entity == _me)
+        if (_me == null || _entity is not Player || _entity == _me || _me.IsDead)
         {
             return;
         }

--- a/Intersect.Client.Core/Interface/Game/Trades/TradingWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Trades/TradingWindow.cs
@@ -196,6 +196,11 @@ public partial class TradingWindow
     //Trade the item
     void trade_Clicked(Base sender, MouseButtonState arguments)
     {
+        if (Globals.Me?.IsDead == true)
+        {
+            return;
+        }
+
         mTrade.Text = Strings.Trading.Pending;
         mTrade.IsDisabled = true;
         PacketSender.SendAcceptTrade();

--- a/Intersect.Client.Core/Networking/PacketSender.cs
+++ b/Intersect.Client.Core/Networking/PacketSender.cs
@@ -432,6 +432,11 @@ public static partial class PacketSender
     {
         if (sender is InputBox inputBox && inputBox.UserData is Guid tradeId)
         {
+            if (Globals.Me?.IsDead == true)
+            {
+                return;
+            }
+
             Network.SendPacket(new TradeRequestResponsePacket(tradeId, true));
         }
     }

--- a/Intersect.Client.Framework/Entities/IEntity.cs
+++ b/Intersect.Client.Framework/Entities/IEntity.cs
@@ -47,6 +47,7 @@ public interface IEntity : IDisposable
     IReadOnlyList<IItem> Items { get; }
     IReadOnlyDictionary<int, List<int>> EquipmentSlots { get; }
 
+    bool IsDead { get; }
 
     IReadOnlyList<Guid> Spells { get; }
     IReadOnlyList<IStatus> Status { get; }


### PR DESCRIPTION
### Motivation
- Centralize client-side "dead" state by exposing `IsDead` on the entity model and derive it from health to avoid scattered health comparisons.
- Prevent players from executing actions (movement, combat, spells, UI interactions like trade/shop/bank/crafting/loot) while dead to ensure consistent client behavior and avoid sending invalid packets.

### Description
- Added `bool IsDead { get; }` to `IEntity` and implemented `public virtual bool IsDead { get; protected set; }` on `Entity`, setting it during `Load(...)` based on `Vital[Health] <= 0`.
- Made `Resource.IsDead` override `protected set` and retained server-driven updates for resources.
- Replaced direct health checks with `IsDead` for UI/logic that hides HP bars and disables context menu actions (e.g. `ShouldNotDrawHpBar`, `EntityBox`).
- Blocked player-side actions when dead across input and controllers, including movement, directional processing, attack/block, spell usage, pickup/loot, trade offers/accepts/requests, bank operations, shop purchases, crafting, and drag/drop bank moves.
- Added guards in input handling (`Input.OnKeyPressed`), UI windows (`BankItem`, `CraftingWindow`, `PlayerShopBrowseWindow`, `TradingWindow`, `TargetContextMenu`) and packet helper (`PacketSender.SendTradeRequestAccept`) to prevent action execution or packet sends when `IsDead`.
- Small defensive checks added to static pickup helper `Player.TryPickupItem` to avoid loot attempts while dead.

### Testing
- No automated tests were executed as part of this change (no test run requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69712f334504832ba965da6669bff6cf)