### PR TITLE
Show death window on local player health transition and avoid duplicates

### DIFF
--- a/Intersect.Client.Core/Interface/Game/GameInterface.cs
+++ b/Intersect.Client.Core/Interface/Game/GameInterface.cs
@@ -216,6 +216,11 @@ public partial class GameInterface : MutableInterface
 
     public void ShowDeathWindow()
     {
+        if (!DeathWindow.IsHidden)
+        {
+            return;
+        }
+
         DeathWindow.Show();
         DeathWindow.BringToFront();
     }

--- a/Intersect.Client.Core/Networking/PacketHandler.cs
+++ b/Intersect.Client.Core/Networking/PacketHandler.cs
@@ -902,8 +902,15 @@ internal sealed partial class PacketHandler
                 return;
             }
 
+            var wasAlive = entity.Vital[(int)Vital.Health] > 0;
             entity.Vital = en.Vitals;
             entity.MaxVital = en.MaxVitals;
+            var isDead = entity.Vital[(int)Vital.Health] <= 0;
+
+            if (wasAlive && isDead && entity == Globals.Me)
+            {
+                Interface.Interface.EnqueueInGame(gameInterface => gameInterface.ShowDeathWindow());
+            }
 
             if (entity == Globals.Me)
             {
@@ -1033,8 +1040,15 @@ internal sealed partial class PacketHandler
             return;
         }
 
+        var wasAlive = en.Vital[(int)Vital.Health] > 0;
         en.Vital = packet.Vitals;
         en.MaxVital = packet.MaxVitals;
+        var isDead = en.Vital[(int)Vital.Health] <= 0;
+
+        if (wasAlive && isDead && en == Globals.Me)
+        {
+            Interface.Interface.EnqueueInGame(gameInterface => gameInterface.ShowDeathWindow());
+        }
 
         if (en == Globals.Me)
         {


### PR DESCRIPTION
### Motivation
- Ensure the death UI is shown when the local player actually dies (health transitions alive→dead) rather than on every vitals update.
- Prevent reopening the death window multiple times if it is already visible.
- Keep existing respawn cleanup behavior (`HideDeathWindow()`) intact so the UI is cleared on respawn.

### Description
- Detect health transitions in `PacketHandler` during `MapEntityVitalsPacket` and `EntityVitalsPacket` handling by recording `wasAlive` before applying `Vitals` and enqueuing `ShowDeathWindow()` only when `wasAlive` is true and `isDead` is true for `Globals.Me`.
- Add a guard in `GameInterface.ShowDeathWindow()` that returns early when `DeathWindow.IsHidden` is false to avoid duplicate opens.
- Changes applied to `Intersect.Client.Core/Networking/PacketHandler.cs` and `Intersect.Client.Core/Interface/Game/GameInterface.cs` and use `Interface.Interface.EnqueueInGame(...)` to invoke `ShowDeathWindow()` on the UI thread.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971fd369edc832ba798a20ee7b0d681)