### PR TITLE
Remove Speed/Damage/Cure read-only stats from Character panel

### DIFF
--- a/Intersect.Client.Core/Interface/Game/Character/CharacterWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Character/CharacterWindow.cs
@@ -66,10 +66,7 @@ public partial class CharacterWindow : Window
     private Label mAbilityPwrLabel;
     private Label mDefenseLabel;
     private Label mMagicRstLabel;
-    private Label mSpeedLabel;
     private Label mAgilityLabel;
-    private Label mDamageLabel;
-    private Label mCureLabel;
     private Label mCritChanceLabel;
     private Label mBasicAttackDamageLabel;
     private Label mPointsLabel;
@@ -409,12 +406,6 @@ public partial class CharacterWindow : Window
         y += StatRowHeight;
 
         // Read-only stats
-        CreateIconPanel(mStatsContainer, "SpeedIcon", iconX, y, StatRowHeight, StatEffectIconProvider.GetIconForStat(Stat.Speed));
-        mSpeedLabel = CreateBodyLabel(mStatsContainer, "SpeedLabel", labelX, y, labelWidth); y += StatRowHeight;
-        CreateIconPanel(mStatsContainer, "DamageIcon", iconX, y, StatRowHeight, StatEffectIconProvider.GetIconForItemEffect(ItemEffect.Damages));
-        mDamageLabel = CreateBodyLabel(mStatsContainer, "DamageLabel", labelX, y, labelWidth); y += StatRowHeight;
-        CreateIconPanel(mStatsContainer, "CureIcon", iconX, y, StatRowHeight, StatEffectIconProvider.GetIconForItemEffect(ItemEffect.Cures));
-        mCureLabel = CreateBodyLabel(mStatsContainer, "CureLabel", labelX, y, labelWidth); y += StatRowHeight;
         CreateIconPanel(mStatsContainer, "CritIcon", iconX, y, StatRowHeight, StatEffectIconProvider.GetIconForItemEffect(ItemEffect.CriticalChance));
         mCritChanceLabel = CreateBodyLabel(mStatsContainer, "CritLabel", labelX, y, labelWidth); y += StatRowHeight;
         CreateIconPanel(mStatsContainer, "PointsIcon", iconX, y, StatRowHeight, null);
@@ -708,7 +699,6 @@ public partial class CharacterWindow : Window
         mAbilityPwrLabel.SetText(Strings.Character.StatLabelValue.ToString(Strings.Combat.Stats[Stat.Intelligence], player.Stat[(int)Stat.Intelligence]));
         mDefenseLabel.SetText(Strings.Character.StatLabelValue.ToString(Strings.Combat.Stats[Stat.Defense], player.Stat[(int)Stat.Defense]));
         mMagicRstLabel.SetText(Strings.Character.StatLabelValue.ToString(Strings.Combat.Stats[Stat.Vitality], player.Stat[(int)Stat.Vitality]));
-        mSpeedLabel.SetText(Strings.Character.StatLabelValue.ToString(Strings.Combat.Stats[Stat.Speed], player.Stat[(int)Stat.Speed]));
         mAgilityLabel.SetText(Strings.Character.StatLabelValue.ToString(Strings.Combat.Stats[Stat.Agility], player.Stat[(int)Stat.Agility]));
 
         var critChance = player.CalculateCriticalChance(player.GetBaseCriticalChance());
@@ -725,8 +715,6 @@ public partial class CharacterWindow : Window
 
         // Effects
         UpdateExtraBuffs();
-        mDamageLabel.SetText(Strings.Character.FlatDamage.ToString(FormatEffectValue(_flatDamage)));
-        mCureLabel.SetText(Strings.Character.FlatCures.ToString(FormatEffectValue(_flatCures)));
 
         UpdateEquippedItems(true);
     }


### PR DESCRIPTION
### Motivation
- The Speed, Damage and Cure read-only rows in the main stats list are redundant with the Extra Buffs list and should only appear in the Extra Buffs section.

### Description
- Removed the private label fields `mSpeedLabel`, `mDamageLabel` and `mCureLabel` from `CharacterWindow`.
- Deleted the `CreateIconPanel`/`CreateBodyLabel` calls that built the Speed/Damage/Cure rows inside `BuildStatsSection()` so they no longer render in the main stats block.
- Removed the `SetText` assignments for `mSpeedLabel`, `mDamageLabel` and `mCureLabel` from the stats update path so those values are no longer updated there.
- Left `UpdateExtraBuffs()` and the Extra Buffs UI (including `mFlatDamage`, `mFlatCures`, `mSpeedBuff`, `mDamageBuff`, `mCureBuff`) intact so Speed/Damage/Cure continue to appear only in the Extra Buffs list.

### Testing
- No automated tests were run against this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975b0b6d968832b9121e72b61c97cd0)