### PR TITLE
Use OfType<MapInstance>() when iterating MapInstance.Lookup to prevent invalid cast

### DIFF
--- a/Intersect.Client.Core/Entities/Player.cs
+++ b/Intersect.Client.Core/Entities/Player.cs
@@ -2313,7 +2313,7 @@ public partial class Player : Entity, IPlayer
             }
         }
 
-        foreach (MapInstance eventMap in Maps.MapInstance.Lookup.Values.Cast<MapInstance>())
+        foreach (MapInstance eventMap in Maps.MapInstance.Lookup.Values.OfType<MapInstance>())
         {
             foreach (var en in eventMap.LocalEntities)
             {
@@ -2416,7 +2416,7 @@ public partial class Player : Entity, IPlayer
         IEntity? bestMatch = null;
         var bestAreaMatch = 0f;
 
-        foreach (MapInstance map in Maps.MapInstance.Lookup.Values.Cast<MapInstance>())
+        foreach (MapInstance map in Maps.MapInstance.Lookup.Values.OfType<MapInstance>())
         {
             if (x >= map.X && x <= map.X + MapWidth * TileWidth)
             {
@@ -2452,7 +2452,7 @@ public partial class Player : Entity, IPlayer
                             }
                         }
 
-                        foreach (MapInstance eventMap in Maps.MapInstance.Lookup.Values.Cast<MapInstance>())
+                        foreach (MapInstance eventMap in Maps.MapInstance.Lookup.Values.OfType<MapInstance>())
                         {
                             foreach (var en in eventMap.LocalEntities)
                             {
@@ -3366,7 +3366,7 @@ public partial class Player : Entity, IPlayer
             ToggleTargetContextMenu(en.Value);
         }
 
-        foreach (MapInstance eventMap in Maps.MapInstance.Lookup.Values.Cast<MapInstance>())
+        foreach (MapInstance eventMap in Maps.MapInstance.Lookup.Values.OfType<MapInstance>())
         {
             foreach (var en in eventMap.LocalEntities)
             {
@@ -3409,7 +3409,7 @@ public partial class Player : Entity, IPlayer
         if (!Interface.Interface.DoesMouseHitInterface())
         {
             var mouseInWorld = Graphics.ConvertToWorldPoint(Globals.InputManager.GetMousePosition());
-            foreach (MapInstance map in Maps.MapInstance.Lookup.Values.Cast<MapInstance>())
+            foreach (MapInstance map in Maps.MapInstance.Lookup.Values.OfType<MapInstance>())
             {
                 if (mouseInWorld.X >= map.X && mouseInWorld.X <= map.X + MapWidth * TileWidth)
                 {
@@ -3442,7 +3442,7 @@ public partial class Player : Entity, IPlayer
                             }
                         }
 
-                        foreach (MapInstance eventMap in Maps.MapInstance.Lookup.Values.Cast<MapInstance>())
+                        foreach (MapInstance eventMap in Maps.MapInstance.Lookup.Values.OfType<MapInstance>())
                         {
                             foreach (var en in eventMap.LocalEntities)
                             {


### PR DESCRIPTION
### Motivation

- The client was crashing with a `System.InvalidCastException` while iterating `Maps.MapInstance.Lookup.Values` in player rendering/targeting code because the lookup can contain non-`MapInstance` entries, so iteration must filter to only `MapInstance` objects.

### Description

- Replaced occurrences of `.Values.Cast<MapInstance>()` with `.Values.OfType<MapInstance>()` in `Intersect.Client.Core/Entities/Player.cs` to safely filter the lookup values.
- The changes touch player interaction and targeting flows including attack/event interaction, `TryTarget` hit-testing, `DrawTargets` selection/hover handling, and related map-iteration blocks.
- This makes the code tolerant of non-map entries in the lookup and prevents runtime cast failures during target/draw operations.

### Testing

- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697656f8ab58832ba4d3a6883aac227a)