### PR TITLE
Disambiguate AchievementProgress and fix MapEntered handling

### DIFF
--- a/Intersect.Server.Core/Localization/Strings.cs
+++ b/Intersect.Server.Core/Localization/Strings.cs
@@ -15,6 +15,30 @@ public static partial class Strings
     private const string DefaultLanguage = "en";
     private const string StringsFileName = "server_strings.json";
 
+    public sealed partial class AchievementsNamespace : LocaleNamespace
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString CategoryLabel = @"Category: {00}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString CompletedNotification = @"Achievement completed: {00}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString DifficultyLabel = @"Difficulty: {00}";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString FilterCompleted = @"Completed";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString FilterInProgress = @"In Progress";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString FilterPending = @"Pending";
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public readonly LocalizedString Title = @"Achievements";
+    }
+
     public sealed partial class AccountNamespace : LocaleNamespace
     {
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
@@ -1753,6 +1777,8 @@ public static partial class Strings
 
         public readonly AccountNamespace Account = new AccountNamespace();
 
+        public readonly AchievementsNamespace Achievements = new AchievementsNamespace();
+
         public readonly AlignmentNamespace Alignment = new AlignmentNamespace();
 
         public readonly BagNamespace Bags = new BagNamespace();
@@ -1834,6 +1860,8 @@ public static partial class Strings
     #region Namespace Exposure
 
     public static AccountNamespace Account => Root.Account;
+
+    public static AchievementsNamespace Achievements => Root.Achievements;
 
     public static AlignmentNamespace Alignment => Root.Alignment;
 

--- a/Intersect.Server.Core/Services/Achievements/AchievementService.cs
+++ b/Intersect.Server.Core/Services/Achievements/AchievementService.cs
@@ -11,7 +11,7 @@ using Intersect.Framework.Core.GameObjects.Events;
 using Intersect.Framework.Core.GameObjects.Items;
 using Intersect.Framework.Core.GameObjects.Maps;
 using Intersect.Framework.Core.GameObjects.Quests;
-using Intersect.Server.Database.PlayerData.Players;
+using ServerAchievementProgress = Intersect.Server.Database.PlayerData.Players.AchievementProgress;
 using Intersect.Server.Database.PlayerData.Shops;
 using Intersect.Server.Entities;
 using Intersect.Server.Entities.Events;
@@ -73,7 +73,7 @@ public static class AchievementService
 
     public static void HandleMapEntered(Player player, MapController mapController)
     {
-        if (mapController?.MapDescriptor == null)
+        if (mapController == null)
         {
             return;
         }
@@ -81,7 +81,7 @@ public static class AchievementService
         UpdateAchievements(
             player,
             AchievementTrigger.MapEntered,
-            new AchievementContext(1, mapController.MapDescriptor.Id, mapController.MapDescriptor.ZoneType)
+            new AchievementContext(1, mapController.Id, mapController.ZoneType)
         );
     }
 
@@ -203,7 +203,7 @@ public static class AchievementService
         };
     }
 
-    private static AchievementProgress GetOrCreateProgress(
+    private static ServerAchievementProgress GetOrCreateProgress(
         Player player,
         AchievementDescriptor achievement,
         ref bool hasChanges
@@ -215,7 +215,7 @@ public static class AchievementService
             return progress;
         }
 
-        progress = new AchievementProgress(achievement.Id);
+        progress = new ServerAchievementProgress(achievement.Id);
         player.Achievements.Add(progress);
         hasChanges = true;
         return progress;
@@ -224,7 +224,7 @@ public static class AchievementService
     private static bool UpdateProgressFromConditions(
         Player player,
         AchievementDescriptor achievement,
-        AchievementProgress progress
+        ServerAchievementProgress progress
     )
     {
         var progressValues = new List<int>();
@@ -288,7 +288,7 @@ public static class AchievementService
     private static bool IsAchievementCompleted(
         Player player,
         AchievementDescriptor achievement,
-        AchievementProgress progress
+        ServerAchievementProgress progress
     )
     {
         if (achievement.MetaAchievementIds.Count > 0)
@@ -314,7 +314,7 @@ public static class AchievementService
     private static void CompleteAchievement(
         Player player,
         AchievementDescriptor achievement,
-        AchievementProgress progress
+        ServerAchievementProgress progress
     )
     {
         progress.Completed = true;

--- a/Intersect.Server.Core/Services/Achievements/AchievementService.cs
+++ b/Intersect.Server.Core/Services/Achievements/AchievementService.cs
@@ -15,6 +15,7 @@ using Intersect.Server.Database.PlayerData.Players;
 using Intersect.Server.Database.PlayerData.Shops;
 using Intersect.Server.Entities;
 using Intersect.Server.Entities.Events;
+using Intersect.Server.Localization;
 using Intersect.Server.Maps;
 using Intersect.Server.Networking;
 
@@ -324,7 +325,7 @@ public static class AchievementService
 
         PacketSender.SendChatMsg(
             player,
-            $"Logro completado: {achievement.Name}",
+            Strings.Achievements.CompletedNotification.ToString(achievement.Name),
             ChatMessageType.Notice,
             CustomColors.Alerts.Success
         );


### PR DESCRIPTION
### Motivation
- Compilation errors were caused by an ambiguous `AchievementProgress` type between framework and server models and by code assuming `MapController.MapDescriptor` existed. 
- The goal is to use the correct server-side progress model and avoid dereferencing a non-existent `MapDescriptor` property on `MapController`.

### Description
- Introduced an alias `ServerAchievementProgress = Intersect.Server.Database.PlayerData.Players.AchievementProgress` and replaced usages of the ambiguous `AchievementProgress` type with `ServerAchievementProgress` in `AchievementService.cs`.
- Updated `GetOrCreateProgress`, related method signatures, and local variables to use `ServerAchievementProgress` and to instantiate `new ServerAchievementProgress(...)` when creating progress.
- Fixed `HandleMapEntered` to null-check `mapController` and to build the `AchievementContext` using `mapController.Id` and `mapController.ZoneType` instead of `mapController.MapDescriptor.Id` and `mapController.MapDescriptor.ZoneType`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ac901f6a0832b88b7deebcf1a3abc)