### PR TITLE
Add TranslationEntryKey serializer and TranslationEntryViewModel

### DIFF
--- a/Intersect.Editor/Localization/TranslationEntryKey.cs
+++ b/Intersect.Editor/Localization/TranslationEntryKey.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Text;
+
+namespace Intersect.Editor.Localization;
+
+public sealed class TranslationEntryKey
+{
+    public TranslationEntryKey(string entityType, string entityId, string field, string subPath)
+    {
+        EntityType = entityType;
+        EntityId = entityId;
+        Field = field;
+        SubPath = subPath;
+    }
+
+    public string EntityType { get; set; }
+
+    public string EntityId { get; set; }
+
+    public string Field { get; set; }
+
+    public string SubPath { get; set; }
+
+    public string ToSerializedString()
+    {
+        return TranslationEntryKeySerializer.Serialize(this);
+    }
+
+    public static TranslationEntryKey FromSerializedString(string serialized)
+    {
+        return TranslationEntryKeySerializer.Deserialize(serialized);
+    }
+
+    public static bool TryParseSerialized(string serialized, out TranslationEntryKey? key)
+    {
+        return TranslationEntryKeySerializer.TryDeserialize(serialized, out key);
+    }
+}
+
+public static class TranslationEntryKeySerializer
+{
+    private const string VersionPrefix = "v1";
+    private const char Separator = '.';
+
+    public static string Serialize(TranslationEntryKey key)
+    {
+        if (key == null)
+        {
+            throw new ArgumentNullException(nameof(key));
+        }
+
+        return string.Join(
+            Separator,
+            VersionPrefix,
+            Encode(key.EntityType),
+            Encode(key.EntityId),
+            Encode(key.Field),
+            Encode(key.SubPath)
+        );
+    }
+
+    public static TranslationEntryKey Deserialize(string serialized)
+    {
+        if (TryDeserialize(serialized, out var key) && key != null)
+        {
+            return key;
+        }
+
+        throw new FormatException("Invalid TranslationEntryKey serialization format.");
+    }
+
+    public static bool TryDeserialize(string serialized, out TranslationEntryKey? key)
+    {
+        key = null;
+        if (string.IsNullOrWhiteSpace(serialized))
+        {
+            return false;
+        }
+
+        var parts = serialized.Split(Separator);
+        if (parts.Length != 5 || !string.Equals(parts[0], VersionPrefix, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        try
+        {
+            var entityType = Decode(parts[1]);
+            var entityId = Decode(parts[2]);
+            var field = Decode(parts[3]);
+            var subPath = Decode(parts[4]);
+            key = new TranslationEntryKey(entityType, entityId, field, subPath);
+            return true;
+        }
+        catch (FormatException)
+        {
+            return false;
+        }
+    }
+
+    private static string Encode(string value)
+    {
+        return Convert.ToBase64String(Encoding.UTF8.GetBytes(value ?? string.Empty));
+    }
+
+    private static string Decode(string value)
+    {
+        return Encoding.UTF8.GetString(Convert.FromBase64String(value ?? string.Empty));
+    }
+}

--- a/Intersect.Editor/Localization/TranslationEntryViewModel.cs
+++ b/Intersect.Editor/Localization/TranslationEntryViewModel.cs
@@ -1,0 +1,32 @@
+using System;
+using Intersect.Framework.Core.Localization;
+
+namespace Intersect.Editor.Localization;
+
+public sealed class TranslationEntryViewModel
+{
+    public TranslationEntryViewModel(
+        string sourceText,
+        string sourceHash,
+        TranslationStatus status,
+        DateTime lastUpdated,
+        string fallbackText
+    )
+    {
+        SourceText = sourceText;
+        SourceHash = sourceHash;
+        Status = status;
+        LastUpdated = lastUpdated;
+        FallbackText = fallbackText;
+    }
+
+    public string SourceText { get; set; }
+
+    public string SourceHash { get; set; }
+
+    public TranslationStatus Status { get; set; }
+
+    public DateTime LastUpdated { get; set; }
+
+    public string FallbackText { get; set; }
+}


### PR DESCRIPTION
### Motivation
- Provide a stable representation for translation keys used by the editor and network packets by introducing a dedicated key type and serializer.  
- Ensure `SubPath` can contain existing event key formats such as `Page:{i}:List:{guid}:Command:{j}:Option:{k}` without breaking serialization.  
- Add a small view model to carry source/metadata needed by the translation workbench and editor UI.

### Description
- Add `Intersect.Editor/Localization/TranslationEntryKey.cs` which introduces the `TranslationEntryKey` type and a `TranslationEntryKeySerializer` helper with `Serialize`, `Deserialize`, and `TryDeserialize` APIs.  
- The serializer is versioned (`v1`) and encodes each segment using Base64 then joins them with a `.` separator so characters like `:` and other subpath punctuation are preserved.  
- `TranslationEntryKey` exposes `ToSerializedString`, `FromSerializedString`, and `TryParseSerialized` convenience methods for callers.  
- Add `Intersect.Editor/Localization/TranslationEntryViewModel.cs` which defines `TranslationEntryViewModel` with `SourceText`, `SourceHash`, `Status`, `LastUpdated`, and `FallbackText` properties for editor consumption.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ad4555a84832bba377b7fd9e547d9)