### PR TITLE
Add per-command translation badges, workbench filtering, and event-source fallback

### DIFF
--- a/Intersect.Editor/Forms/Editors/Events/frmEvent.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/Events/frmEvent.Designer.cs
@@ -165,6 +165,7 @@ namespace Intersect.Editor.Forms.Editors.Events
             lstCommands = new TreeView();
             grpEventCommands = new DarkGroupBox();
             lstEventCommands = new ListBox();
+            btnTranslateCommand = new DarkButton();
             grpCreateCommands = new DarkGroupBox();
             btnSave = new DarkButton();
             btnCancel = new DarkButton();
@@ -1039,6 +1040,7 @@ namespace Intersect.Editor.Forms.Editors.Events
             // 
             grpEventCommands.BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
             grpEventCommands.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            grpEventCommands.Controls.Add(btnTranslateCommand);
             grpEventCommands.Controls.Add(lstEventCommands);
             grpEventCommands.ForeColor = System.Drawing.Color.Gainsboro;
             grpEventCommands.Location = new System.Drawing.Point(389, 0);
@@ -1062,13 +1064,24 @@ namespace Intersect.Editor.Forms.Editors.Events
             lstEventCommands.Location = new System.Drawing.Point(7, 22);
             lstEventCommands.Margin = new Padding(4, 3, 4, 3);
             lstEventCommands.Name = "lstEventCommands";
-            lstEventCommands.Size = new Size(500, 530);
+            lstEventCommands.Size = new Size(500, 500);
             lstEventCommands.TabIndex = 0;
             lstEventCommands.DrawItem += lstEventCommands_DrawItem;
             lstEventCommands.SelectedIndexChanged += lstEventCommands_SelectedIndexChanged;
             lstEventCommands.DoubleClick += lstEventCommands_DoubleClick;
             lstEventCommands.KeyDown += lstEventCommands_KeyDown;
             lstEventCommands.MouseDown += lstEventCommands_Click;
+            // 
+            // btnTranslateCommand
+            // 
+            btnTranslateCommand.Location = new System.Drawing.Point(7, 528);
+            btnTranslateCommand.Margin = new Padding(4, 3, 4, 3);
+            btnTranslateCommand.Name = "btnTranslateCommand";
+            btnTranslateCommand.Padding = new Padding(6);
+            btnTranslateCommand.Size = new Size(500, 24);
+            btnTranslateCommand.TabIndex = 1;
+            btnTranslateCommand.Text = "Translate this command";
+            btnTranslateCommand.Click += btnTranslateCommand_Click;
             // 
             // grpCreateCommands
             // 
@@ -1398,6 +1411,7 @@ namespace Intersect.Editor.Forms.Editors.Events
         private DarkTextBox txtEventname;
         private DarkGroupBox grpEventCommands;
         private ListBox lstEventCommands;
+        private DarkButton btnTranslateCommand;
         private DarkGroupBox grpEventConditions;
         private DarkGroupBox grpExtra;
         private DarkGroupBox grpMovement;

--- a/Intersect.Editor/Forms/Editors/Events/frmEvent.cs
+++ b/Intersect.Editor/Forms/Editors/Events/frmEvent.cs
@@ -12,6 +12,7 @@ using Intersect.Framework.Core.GameObjects.Events;
 using Intersect.Framework.Core.GameObjects.Events.Commands;
 using Intersect.Framework.Core.GameObjects.Maps;
 using Intersect.Framework.Core.GameObjects.Variables;
+using Intersect.Framework.Core.Localization;
 using Intersect.GameObjects;
 using Intersect.Network.Packets.Editor;
 using Intersect.Utilities;
@@ -58,6 +59,15 @@ public partial class FrmEvent : Form
 
     public int mOldSelectedCommand;
 
+    private static readonly Dictionary<TranslationStatus, int> TranslationStatusPriority = new()
+    {
+        { TranslationStatus.Ok, 0 },
+        { TranslationStatus.Machine, 1 },
+        { TranslationStatus.NeedsReview, 2 },
+        { TranslationStatus.Missing, 3 },
+        { TranslationStatus.Broken, 4 },
+    };
+
     private void txtEventname_TextChanged(object sender, EventArgs e)
     {
         MyEvent.Name = txtEventname.Text;
@@ -68,6 +78,7 @@ public partial class FrmEvent : Form
     {
         mCurrentCommand = lstEventCommands.SelectedIndex;
         mOldSelectedCommand = lstEventCommands.SelectedIndex;
+        UpdateTranslateCommandState();
     }
 
     private void lstEventCommands_KeyDown(object sender, KeyEventArgs e)
@@ -878,6 +889,9 @@ public partial class FrmEvent : Form
         MinimumSize = default;
 
         FrmEvent_Move(sender, e);
+
+        TranslationRepository.Default.PendingTranslationsUpdated += OnPendingTranslationsUpdated;
+        RequestEventTranslationStatuses();
     }
 
     private void FrmEvent_Move(object? sender, EventArgs e)
@@ -940,6 +954,7 @@ public partial class FrmEvent : Form
 
     private void FrmEvent_FormClosed(object sender, FormClosedEventArgs e)
     {
+        TranslationRepository.Default.PendingTranslationsUpdated -= OnPendingTranslationsUpdated;
     }
 
     private void FrmEvent_VisibleChanged(object sender, EventArgs e)
@@ -1018,6 +1033,7 @@ public partial class FrmEvent : Form
         btnCopy.Text = Strings.EventEditor.copycommand;
         btnCut.Text = Strings.EventEditor.cutcommand;
         btnPaste.Text = Strings.EventEditor.pastecommand;
+        btnTranslateCommand.Text = "Translate this command";
         btnSave.Text = Strings.EventEditor.save;
         btnCancel.Text = Strings.EventEditor.cancel;
 
@@ -1246,6 +1262,176 @@ public partial class FrmEvent : Form
         {
             lstEventCommands.SelectedIndex = mOldSelectedCommand;
         }
+
+        UpdateTranslateCommandState();
+    }
+
+    private void RequestEventTranslationStatuses()
+    {
+        if (MyEvent == null || MyEvent.Id == Guid.Empty)
+        {
+            return;
+        }
+
+        TranslationRepository.Default.RequestPending(
+            LocalizationEntityTypes.Event,
+            MyEvent.Id.ToString(),
+            null,
+            null,
+            null,
+            200,
+            0
+        );
+    }
+
+    private void OnPendingTranslationsUpdated(IReadOnlyList<TranslationPendingEntry> entries, long totalCount)
+    {
+        if (IsDisposed)
+        {
+            return;
+        }
+
+        lstEventCommands.Invalidate();
+    }
+
+    private void UpdateTranslateCommandState()
+    {
+        if (btnTranslateCommand == null)
+        {
+            return;
+        }
+
+        if (mCurrentCommand < 0 || mCurrentCommand >= mCommandProperties.Count)
+        {
+            btnTranslateCommand.Enabled = false;
+            return;
+        }
+
+        var properties = mCommandProperties[mCurrentCommand];
+        btnTranslateCommand.Enabled = properties.Editable && IsTranslatableCommand(properties.Cmd);
+    }
+
+    private static bool IsTranslatableCommand(EventCommand command)
+    {
+        return command is ShowTextCommand
+            or AddChatboxTextCommand
+            or ShowOptionsCommand
+            or InputVariableCommand
+            or ChangePlayerLabelCommand;
+    }
+
+    private bool TryGetCommandBaseField(CommandListProperties properties, out string baseField)
+    {
+        baseField = string.Empty;
+        if (MyEvent == null || CurrentPage == null)
+        {
+            return false;
+        }
+
+        if (properties?.MyList == null || properties.MyIndex < 0)
+        {
+            return false;
+        }
+
+        var listEntry = CurrentPage.CommandLists.FirstOrDefault(pair => ReferenceEquals(pair.Value, properties.MyList));
+        if (listEntry.Key == Guid.Empty)
+        {
+            return false;
+        }
+
+        baseField = $"Page:{CurrentPageIndex}:List:{listEntry.Key}:Command:{properties.MyIndex}";
+        return true;
+    }
+
+    private bool TryGetCommandTranslationStatus(CommandListProperties properties, out TranslationStatus status)
+    {
+        status = TranslationStatus.Ok;
+        if (MyEvent == null || !IsTranslatableCommand(properties.Cmd))
+        {
+            return false;
+        }
+
+        if (!TryGetCommandBaseField(properties, out var baseField))
+        {
+            return false;
+        }
+
+        var entries = TranslationRepository.Default.LastPendingEntries;
+        if (entries == null || entries.Count == 0)
+        {
+            status = TranslationStatus.Ok;
+            return true;
+        }
+
+        var matching = entries.Where(entry =>
+            string.Equals(entry.EntityType, LocalizationEntityTypes.Event, StringComparison.OrdinalIgnoreCase) &&
+            string.Equals(entry.EntityId, MyEvent.Id.ToString(), StringComparison.OrdinalIgnoreCase) &&
+            entry.Field.StartsWith(baseField, StringComparison.OrdinalIgnoreCase)
+        );
+
+        var bestStatus = TranslationStatus.Ok;
+        var bestScore = TranslationStatusPriority[bestStatus];
+        foreach (var entry in matching)
+        {
+            if (!TranslationStatusPriority.TryGetValue(entry.Status, out var score))
+            {
+                continue;
+            }
+
+            if (score > bestScore)
+            {
+                bestScore = score;
+                bestStatus = entry.Status;
+            }
+        }
+
+        status = bestStatus;
+        return true;
+    }
+
+    private static (string Label, System.Drawing.Color Background, System.Drawing.Color Foreground)
+        GetStatusBadge(TranslationStatus status)
+    {
+        return status switch
+        {
+            TranslationStatus.NeedsReview => ("NR", System.Drawing.Color.DarkOrange, System.Drawing.Color.Black),
+            TranslationStatus.Missing => ("MISS", System.Drawing.Color.Firebrick, System.Drawing.Color.White),
+            TranslationStatus.Machine => ("MACH", System.Drawing.Color.SteelBlue, System.Drawing.Color.White),
+            TranslationStatus.Broken => ("BRK", System.Drawing.Color.Maroon, System.Drawing.Color.White),
+            _ => ("OK", System.Drawing.Color.ForestGreen, System.Drawing.Color.White),
+        };
+    }
+
+    private void btnTranslateCommand_Click(object sender, EventArgs e)
+    {
+        if (mCurrentCommand < 0 || mCurrentCommand >= mCommandProperties.Count)
+        {
+            return;
+        }
+
+        var properties = mCommandProperties[mCurrentCommand];
+        if (!TryGetCommandBaseField(properties, out var baseField))
+        {
+            return;
+        }
+
+        if (MyEvent == null || MyEvent.Id == Guid.Empty)
+        {
+            return;
+        }
+
+        var entityType = LocalizationEntityTypes.Event;
+        if (Globals.MainForm != null)
+        {
+            Globals.MainForm.OpenTranslationWorkbench(entityType, MyEvent.Id, baseField);
+            return;
+        }
+
+        var workbench = new FrmTranslationWorkbench(entityType, MyEvent.Id.ToString(), baseField)
+        {
+            Owner = this,
+        };
+        workbench.Show(this);
     }
 
     /// <summary>
@@ -1865,20 +2051,57 @@ public partial class FrmEvent : Form
     private void lstEventCommands_DrawItem(object sender, DrawItemEventArgs e)
     {
         e.DrawBackground();
-        Graphics g = e.Graphics;
+        var g = e.Graphics;
 
         if (e.Index > -1 && e.Index < lstEventCommands.Items.Count && e.Index < mCommandProperties.Count)
         {
-            if (mCommandProperties[e.Index].Type == EventCommandType.Label)
-            {
-                g.DrawString(lstEventCommands.Items[e.Index].ToString(), e.Font, Brushes.SpringGreen, new PointF(e.Bounds.X, e.Bounds.Y));
-            }
-            else
-            {
-                g.DrawString(lstEventCommands.Items[e.Index].ToString(), e.Font, new SolidBrush(e.ForeColor), new PointF(e.Bounds.X, e.Bounds.Y));
-            }
-        }
+            var text = lstEventCommands.Items[e.Index].ToString();
+            var properties = mCommandProperties[e.Index];
+            var textColor = properties.Type == EventCommandType.Label
+                ? System.Drawing.Color.SpringGreen
+                : e.ForeColor;
+            var badgeWidth = 0;
 
+            if (TryGetCommandTranslationStatus(properties, out var status))
+            {
+                var (label, background, foreground) = GetStatusBadge(status);
+                var badgeSize = TextRenderer.MeasureText(label, e.Font);
+                badgeWidth = badgeSize.Width + 12;
+                var badgeBounds = new System.Drawing.Rectangle(
+                    e.Bounds.Right - badgeWidth - 4,
+                    e.Bounds.Top + 2,
+                    badgeWidth,
+                    e.Bounds.Height - 4
+                );
+
+                using var badgeBrush = new SolidBrush(background);
+                using var badgeTextBrush = new SolidBrush(foreground);
+                g.FillRectangle(badgeBrush, badgeBounds);
+                TextRenderer.DrawText(
+                    g,
+                    label,
+                    e.Font,
+                    badgeBounds,
+                    foreground,
+                    TextFormatFlags.HorizontalCenter | TextFormatFlags.VerticalCenter | TextFormatFlags.NoPadding
+                );
+            }
+
+            var textBounds = new System.Drawing.Rectangle(
+                e.Bounds.X + 2,
+                e.Bounds.Y,
+                e.Bounds.Width - badgeWidth - 8,
+                e.Bounds.Height
+            );
+            TextRenderer.DrawText(
+                g,
+                text,
+                e.Font,
+                textBounds,
+                textColor,
+                TextFormatFlags.Left | TextFormatFlags.VerticalCenter | TextFormatFlags.EndEllipsis
+            );
+        }
 
         e.DrawFocusRectangle();
     }

--- a/Intersect.Editor/Forms/FrmTranslationWorkbench.cs
+++ b/Intersect.Editor/Forms/FrmTranslationWorkbench.cs
@@ -13,8 +13,9 @@ public sealed class FrmTranslationWorkbench : Form
     private TranslationQueueWindow? _translationWindow;
     private string? _pendingEntityType;
     private string? _pendingEntityId;
+    private string? _pendingSearchText;
 
-    public FrmTranslationWorkbench(string? entityType = null, string? entityId = null)
+    public FrmTranslationWorkbench(string? entityType = null, string? entityId = null, string? searchText = null)
     {
         Text = "Translation Workbench";
         Icon = Program.Icon;
@@ -22,6 +23,7 @@ public sealed class FrmTranslationWorkbench : Form
         StartPosition = FormStartPosition.CenterParent;
         _pendingEntityType = entityType;
         _pendingEntityId = entityId;
+        _pendingSearchText = searchText;
 
         _elementHost = new ElementHost
         {
@@ -82,10 +84,11 @@ public sealed class FrmTranslationWorkbench : Form
         }
     }
 
-    public void SetFilter(string? entityType, string? entityId)
+    public void SetFilter(string? entityType, string? entityId, string? searchText = null)
     {
         _pendingEntityType = entityType;
         _pendingEntityId = entityId;
+        _pendingSearchText = searchText;
         ApplyFilter();
     }
 
@@ -96,8 +99,9 @@ public sealed class FrmTranslationWorkbench : Form
             return;
         }
 
-        _translationWindow.ApplyFilter(_pendingEntityType, _pendingEntityId);
+        _translationWindow.ApplyFilter(_pendingEntityType, _pendingEntityId, _pendingSearchText);
         _pendingEntityType = null;
         _pendingEntityId = null;
+        _pendingSearchText = null;
     }
 }

--- a/Intersect.Editor/Forms/WpfWindows/TranslationQueueViewModel.cs
+++ b/Intersect.Editor/Forms/WpfWindows/TranslationQueueViewModel.cs
@@ -90,7 +90,7 @@ public sealed class TranslationQueueViewModel : INotifyPropertyChanged, IDisposa
 
     public ICommand NextCommand => _nextCommand;
 
-    public void ApplyFilter(string? entityType, string? entityId)
+    public void ApplyFilter(string? entityType, string? entityId, string? searchText = null)
     {
         _suppressRefresh = true;
         try
@@ -108,6 +108,12 @@ public sealed class TranslationQueueViewModel : INotifyPropertyChanged, IDisposa
                     _selectedEntityType = match;
                     OnPropertyChanged(nameof(SelectedEntityType));
                 }
+            }
+
+            if (searchText != null)
+            {
+                _searchText = searchText;
+                OnPropertyChanged(nameof(SearchText));
             }
         }
         finally
@@ -298,8 +304,9 @@ public sealed class TranslationQueueEntryViewModel
         EntityType = entry.EntityType;
         EntityId = entry.EntityId;
         EntityNameDisplay = string.IsNullOrWhiteSpace(entry.EntityName) ? string.Empty : $" - {entry.EntityName}";
-        Field = entry.Field;
-        SubPath = string.Empty;
+        var (field, subPath) = SplitField(entry.Field);
+        Field = field;
+        SubPath = subPath;
         Status = entry.Status.ToString();
 
         var updatedUtc = DateTime.TryParse(
@@ -357,6 +364,35 @@ public sealed class TranslationQueueEntryViewModel
     public ICommand QuickPasteCommand => _quickPasteCommand;
 
     private TranslationEntryViewModel? GetActiveTranslation() => TranslationEntries.FirstOrDefault();
+
+    private static (string Field, string SubPath) SplitField(string field)
+    {
+        if (string.IsNullOrWhiteSpace(field))
+        {
+            return (string.Empty, string.Empty);
+        }
+
+        var tokens = field.Split(':');
+        if (tokens.Length >= 3 &&
+            string.Equals(tokens[0], "Page", StringComparison.OrdinalIgnoreCase) &&
+            int.TryParse(tokens[1], out _))
+        {
+            if (tokens.Length >= 6 &&
+                string.Equals(tokens[2], "List", StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(tokens[4], "Command", StringComparison.OrdinalIgnoreCase))
+            {
+                var subPath = string.Join(":", tokens.Take(6));
+                var remainder = string.Join(":", tokens.Skip(6));
+                return (string.IsNullOrWhiteSpace(remainder) ? field : remainder, subPath);
+            }
+
+            var pageSubPath = string.Join(":", tokens.Take(2));
+            var pageRemainder = string.Join(":", tokens.Skip(2));
+            return (string.IsNullOrWhiteSpace(pageRemainder) ? field : pageRemainder, pageSubPath);
+        }
+
+        return (field, string.Empty);
+    }
 
     private void Save()
     {

--- a/Intersect.Editor/Forms/WpfWindows/TranslationQueueWindow.xaml.cs
+++ b/Intersect.Editor/Forms/WpfWindows/TranslationQueueWindow.xaml.cs
@@ -12,11 +12,11 @@ public sealed partial class TranslationQueueWindow : Window
         Closed += OnClosed;
     }
 
-    public void ApplyFilter(string? entityType, string? entityId)
+    public void ApplyFilter(string? entityType, string? entityId, string? searchText = null)
     {
         if (DataContext is TranslationQueueViewModel viewModel)
         {
-            viewModel.ApplyFilter(entityType, entityId);
+            viewModel.ApplyFilter(entityType, entityId, searchText);
         }
     }
 

--- a/Intersect.Editor/Forms/frmMain.cs
+++ b/Intersect.Editor/Forms/frmMain.cs
@@ -1816,13 +1816,13 @@ public partial class FrmMain : Form
         OpenTranslationWorkbench();
     }
 
-    public void OpenTranslationWorkbench(string? entityType = null, Guid? entityId = null)
+    public void OpenTranslationWorkbench(string? entityType = null, Guid? entityId = null, string? searchText = null)
     {
         var entityIdValue = entityId?.ToString();
 
         if (_translationWorkbench == null || _translationWorkbench.IsDisposed)
         {
-            _translationWorkbench = new FrmTranslationWorkbench(entityType, entityIdValue)
+            _translationWorkbench = new FrmTranslationWorkbench(entityType, entityIdValue, searchText)
             {
                 Owner = this,
             };
@@ -1831,7 +1831,7 @@ public partial class FrmMain : Form
         }
         else
         {
-            _translationWorkbench.SetFilter(entityType, entityIdValue);
+            _translationWorkbench.SetFilter(entityType, entityIdValue, searchText);
 
             if (_translationWorkbench.WindowState == FormWindowState.Minimized)
             {

--- a/Intersect.Server.Core/Localization/LocalizationRepository.cs
+++ b/Intersect.Server.Core/Localization/LocalizationRepository.cs
@@ -7,6 +7,8 @@ using System.Text;
 using System.Threading;
 using Intersect.Enums;
 using Intersect.Framework.Core.GameObjects.Crafting;
+using Intersect.Framework.Core.GameObjects.Events;
+using Intersect.Framework.Core.GameObjects.Events.Commands;
 using Intersect.Framework.Core.Localization;
 using Intersect.Localization;
 using Intersect.Network.Packets.Localization;
@@ -492,7 +494,7 @@ public sealed class LocalizationRepository
             }
         }
 
-        return null;
+        return GetFallbackSourceText(entityType, entityId, field);
     }
 
     public Dictionary<LocalizationKey, string> GetBatch(IEnumerable<LocalizationKey> keys, string language)
@@ -509,6 +511,179 @@ public sealed class LocalizationRepository
         }
 
         return results;
+    }
+
+    private static string? GetFallbackSourceText(string entityType, string entityId, string field)
+    {
+        if (!string.Equals(entityType, LocalizationEntityTypes.Event, StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        return TryGetEventTextFallback(entityId, field, out var fallback)
+            ? fallback
+            : null;
+    }
+
+    private static bool TryGetEventTextFallback(string entityId, string field, out string? fallback)
+    {
+        fallback = null;
+        if (!Guid.TryParse(entityId, out var eventId))
+        {
+            return false;
+        }
+
+        var eventDescriptor = EventDescriptor.Get(eventId);
+        if (eventDescriptor?.Pages == null)
+        {
+            return false;
+        }
+
+        if (!TryParseEventField(field, out var pageIndex, out var listId, out var commandIndex, out var fieldKey))
+        {
+            return false;
+        }
+
+        if (pageIndex < 0 || pageIndex >= eventDescriptor.Pages.Count)
+        {
+            return false;
+        }
+
+        var page = eventDescriptor.Pages[pageIndex];
+        if (string.Equals(fieldKey, "Description", StringComparison.OrdinalIgnoreCase))
+        {
+            fallback = page.Description;
+            return true;
+        }
+
+        if (listId == Guid.Empty || commandIndex < 0)
+        {
+            return false;
+        }
+
+        if (!page.CommandLists.TryGetValue(listId, out var commands) ||
+            commandIndex >= commands.Count)
+        {
+            return false;
+        }
+
+        var command = commands[commandIndex];
+        switch (command)
+        {
+            case ShowTextCommand showText when fieldKey.Equals("ShowText", StringComparison.OrdinalIgnoreCase):
+                fallback = showText.Text;
+                return true;
+            case AddChatboxTextCommand chatboxText when fieldKey.Equals("ChatboxText", StringComparison.OrdinalIgnoreCase):
+                fallback = chatboxText.Text;
+                return true;
+            case ShowOptionsCommand showOptions:
+                if (fieldKey.Equals("OptionsText", StringComparison.OrdinalIgnoreCase))
+                {
+                    fallback = showOptions.Text;
+                    return true;
+                }
+
+                if (TryParseOptionIndex(fieldKey, out var optionIndex) &&
+                    showOptions.Options != null &&
+                    optionIndex >= 0 &&
+                    optionIndex < showOptions.Options.Length)
+                {
+                    fallback = showOptions.Options[optionIndex];
+                    return true;
+                }
+                return false;
+            case InputVariableCommand inputVariable:
+                if (fieldKey.Equals("InputTitle", StringComparison.OrdinalIgnoreCase))
+                {
+                    fallback = inputVariable.Title;
+                    return true;
+                }
+
+                if (fieldKey.Equals("InputText", StringComparison.OrdinalIgnoreCase))
+                {
+                    fallback = inputVariable.Text;
+                    return true;
+                }
+                return false;
+            case ChangePlayerLabelCommand changeLabel when fieldKey.Equals("PlayerLabel", StringComparison.OrdinalIgnoreCase):
+                fallback = changeLabel.Value;
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool TryParseEventField(
+        string field,
+        out int pageIndex,
+        out Guid listId,
+        out int commandIndex,
+        out string fieldKey)
+    {
+        pageIndex = -1;
+        listId = Guid.Empty;
+        commandIndex = -1;
+        fieldKey = string.Empty;
+
+        if (string.IsNullOrWhiteSpace(field))
+        {
+            return false;
+        }
+
+        var tokens = field.Split(':');
+        if (tokens.Length < 3 || !tokens[0].Equals("Page", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (!int.TryParse(tokens[1], out pageIndex))
+        {
+            return false;
+        }
+
+        if (tokens.Length == 3)
+        {
+            fieldKey = tokens[2];
+            return true;
+        }
+
+        if (tokens.Length < 6 ||
+            !tokens[2].Equals("List", StringComparison.OrdinalIgnoreCase) ||
+            !tokens[4].Equals("Command", StringComparison.OrdinalIgnoreCase))
+        {
+            fieldKey = string.Join(":", tokens.Skip(2));
+            return true;
+        }
+
+        if (!Guid.TryParse(tokens[3], out listId))
+        {
+            return false;
+        }
+
+        if (!int.TryParse(tokens[5], out commandIndex))
+        {
+            return false;
+        }
+
+        fieldKey = string.Join(":", tokens.Skip(6));
+        return true;
+    }
+
+    private static bool TryParseOptionIndex(string fieldKey, out int optionIndex)
+    {
+        optionIndex = -1;
+        if (string.IsNullOrWhiteSpace(fieldKey))
+        {
+            return false;
+        }
+
+        var tokens = fieldKey.Split(':');
+        if (tokens.Length != 2 || !tokens[0].Equals("Option", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        return int.TryParse(tokens[1], out optionIndex);
     }
 
     public IReadOnlyList<LocalizationTranslationStatusCount> GetMissingAndNeedsReviewCounts()


### PR DESCRIPTION
### Motivation
- Support event command keys that include SubPath (e.g. `Page:{i}:List:{guid}:Command:{j}:...`) so the Translation Workbench can target specific command text and display a clearer field/subpath in the UI.
- Surface translation status per-event-command in the event editor and provide a quick "Translate this command" action to open the workbench filtered to that command.
- Ensure server localization `Get` returns a sensible fallback (the original command/source text) when no translation is available for the requested key.

### Description
- Editor: parsed pending-translation `Field` into `Field` + `SubPath` using `SplitField` in `TranslationQueueEntryViewModel`, and added optional `searchText` filtering to the workbench flow by updating `TranslationQueueViewModel`, `TranslationQueueWindow.xaml.cs`, `FrmTranslationWorkbench`, and `frmMain` to carry an optional search/subpath parameter.
- Editor: added a `Translate this command` button to the Event Editor UI (`frmEvent.Designer.cs`) and implemented logic in `frmEvent.cs` to compute a command base field (`TryGetCommandBaseField`), request pending statuses for the event, show per-command status badges in the command list renderer, and open the Translation Workbench filtered to the command base field.
- Editor: implemented status ranking and badge rendering (labels like `OK`, `NR`, `MISS`, `MACH`, `BRK`) based on `TranslationRepository.Default.LastPendingEntries` and `TranslationStatus` priority.
- Server: `LocalizationRepository.Get` now falls back to a new `GetFallbackSourceText` for `Event` entity types when no translations are found, and added helpers `TryParseEventField` and `TryParseOptionIndex` plus `TryGetEventTextFallback` to extract the original command/source text from an `EventDescriptor` (handles `Description`, `ShowText`, `ChatboxText`, `OptionsText`, `Option:n`, `InputTitle`, `InputText`, `PlayerLabel`, etc.).

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697bc854847c832bad671cf3ca364d23)