### PR TITLE
Initialize localization repository on server startup

### DIFF
--- a/Intersect.Server.Core/Core/Bootstrapper.cs
+++ b/Intersect.Server.Core/Core/Bootstrapper.cs
@@ -303,6 +303,8 @@ internal static class Bootstrapper
             return false;
         }
 
+        LocalizationRepository.InitializeDefault();
+
 
         Time.Update();
 


### PR DESCRIPTION
### Motivation
- Ensure the localization DB schema, indexes and migrations are applied before the server begins handling translation/pending requests so the Translation Workbench and server handlers can safely call `LocalizationRepository.QueryPending` and related APIs.

### Description
- Call `LocalizationRepository.InitializeDefault()` from `PostContextSetup()` in `Intersect.Server.Core/Core/Bootstrapper.cs` immediately after database initialization to run `EnsureSchema()` and necessary migrations.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c037b73a8832ba7f5e7810fd573a3)