### PR TITLE
Fix localization tooling build errors

### DIFF
--- a/Intersect.Editor/Forms/Editors/Events/frmEvent.cs
+++ b/Intersect.Editor/Forms/Editors/Events/frmEvent.cs
@@ -15,6 +15,7 @@ using Intersect.Framework.Core.GameObjects.Variables;
 using Intersect.Framework.Core.Localization;
 using Intersect.GameObjects;
 using Intersect.Network.Packets.Editor;
+using Intersect.Network.Packets.Localization;
 using Intersect.Utilities;
 using Newtonsoft.Json;
 using Graphics = System.Drawing.Graphics;

--- a/Intersect.Editor/Forms/Editors/Quest/frmQuest.cs
+++ b/Intersect.Editor/Forms/Editors/Quest/frmQuest.cs
@@ -7,6 +7,9 @@ using Intersect.Editor.Localization;
 using Intersect.Editor.Networking;
 using Intersect.Enums;
 using Intersect.Framework.Core.GameObjects.Events;
+using Intersect.Framework.Core.GameObjects.Items;
+using Intersect.Framework.Core.GameObjects.NPCs;
+using Intersect.Framework.Core.GameObjects.Quests;
 using Intersect.GameObjects;
 using Intersect.Network.Packets.Editor;
 using Microsoft.Extensions.Logging;
@@ -854,14 +857,23 @@ public partial class FrmQuest : EditorForm
         btnTranslateTask.Enabled = lstTasks.SelectedIndex > -1;
     }
 
-    private static (string Text, Color Color) GetTaskBadge(QuestObjective objective)
+    private static (string Text, System.Drawing.Color Color) GetTaskBadge(QuestObjective objective)
     {
         return objective switch
         {
-            QuestObjective.EventDriven => (Strings.TaskEditor.types[(int)QuestObjective.EventDriven].ToString(), Color.MediumSlateBlue),
-            QuestObjective.GatherItems => (Strings.TaskEditor.types[(int)QuestObjective.GatherItems].ToString(), Color.SeaGreen),
-            QuestObjective.KillNpcs => (Strings.TaskEditor.types[(int)QuestObjective.KillNpcs].ToString(), Color.IndianRed),
-            _ => (objective.ToString(), Color.DimGray)
+            QuestObjective.EventDriven => (
+                Strings.TaskEditor.types[(int)QuestObjective.EventDriven].ToString(),
+                System.Drawing.Color.MediumSlateBlue
+            ),
+            QuestObjective.GatherItems => (
+                Strings.TaskEditor.types[(int)QuestObjective.GatherItems].ToString(),
+                System.Drawing.Color.SeaGreen
+            ),
+            QuestObjective.KillNpcs => (
+                Strings.TaskEditor.types[(int)QuestObjective.KillNpcs].ToString(),
+                System.Drawing.Color.IndianRed
+            ),
+            _ => (objective.ToString(), System.Drawing.Color.DimGray)
         };
     }
 

--- a/Intersect.Editor/Forms/WpfWindows/TranslationQueueViewModel.cs
+++ b/Intersect.Editor/Forms/WpfWindows/TranslationQueueViewModel.cs
@@ -7,7 +7,6 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
-using System.Windows;
 using System.Windows.Input;
 using Intersect.Editor.Localization;
 using Intersect.Editor.Networking;
@@ -227,7 +226,7 @@ public sealed class TranslationQueueViewModel : INotifyPropertyChanged, IDisposa
             SelectedEntry = FilteredEntries.FirstOrDefault();
         }
 
-        var dispatcher = Application.Current?.Dispatcher;
+        var dispatcher = System.Windows.Application.Current?.Dispatcher;
         if (dispatcher != null && !dispatcher.CheckAccess())
         {
             dispatcher.Invoke(UpdateEntries);
@@ -285,11 +284,15 @@ public sealed class TranslationQueueViewModel : INotifyPropertyChanged, IDisposa
         var entries = TranslationRepository.Default.LastPendingEntries;
         if (entries.Count == 0)
         {
-            MessageBox.Show("No pending entries to export.", "Translation Workbench", MessageBoxButton.OK);
+            System.Windows.MessageBox.Show(
+                "No pending entries to export.",
+                "Translation Workbench",
+                System.Windows.MessageBoxButton.OK
+            );
             return;
         }
 
-        var dialog = new SaveFileDialog
+        var dialog = new Microsoft.Win32.SaveFileDialog
         {
             Filter = "CSV files (*.csv)|*.csv|All files (*.*)|*.*",
             DefaultExt = "csv",
@@ -303,7 +306,7 @@ public sealed class TranslationQueueViewModel : INotifyPropertyChanged, IDisposa
             return;
         }
 
-        using var writer = new StreamWriter(dialog.FileName, false, System.Text.Encoding.UTF8);
+        using var writer = new StreamWriter(dialog.FileName, System.Text.Encoding.UTF8);
         writer.WriteLine(
             string.Join(
                 ",",
@@ -335,16 +338,16 @@ public sealed class TranslationQueueViewModel : INotifyPropertyChanged, IDisposa
             ));
         }
 
-        MessageBox.Show(
+        System.Windows.MessageBox.Show(
             $"Exported {entries.Count} pending entries.",
             "Translation Workbench",
-            MessageBoxButton.OK
+            System.Windows.MessageBoxButton.OK
         );
     }
 
     private void ImportCsv()
     {
-        var dialog = new OpenFileDialog
+        var dialog = new Microsoft.Win32.OpenFileDialog
         {
             Filter = "CSV files (*.csv)|*.csv|All files (*.*)|*.*",
             DefaultExt = "csv",
@@ -361,31 +364,40 @@ public sealed class TranslationQueueViewModel : INotifyPropertyChanged, IDisposa
             var (entries, message) = ParseCsvTranslations(dialog.FileName);
             if (!string.IsNullOrWhiteSpace(message))
             {
-                MessageBox.Show(message, "Translation Workbench", MessageBoxButton.OK, MessageBoxImage.Warning);
+                System.Windows.MessageBox.Show(
+                    message,
+                    "Translation Workbench",
+                    System.Windows.MessageBoxButton.OK,
+                    System.Windows.MessageBoxImage.Warning
+                );
                 return;
             }
 
             if (entries.Count == 0)
             {
-                MessageBox.Show("No translations to import.", "Translation Workbench", MessageBoxButton.OK);
+                System.Windows.MessageBox.Show(
+                    "No translations to import.",
+                    "Translation Workbench",
+                    System.Windows.MessageBoxButton.OK
+                );
                 return;
             }
 
             SendTranslationBatches(entries);
 
-            MessageBox.Show(
+            System.Windows.MessageBox.Show(
                 $"Imported {entries.Count} translations.",
                 "Translation Workbench",
-                MessageBoxButton.OK
+                System.Windows.MessageBoxButton.OK
             );
         }
         catch (Exception ex)
         {
-            MessageBox.Show(
+            System.Windows.MessageBox.Show(
                 $"Failed to import CSV: {ex.Message}",
                 "Translation Workbench",
-                MessageBoxButton.OK,
-                MessageBoxImage.Error
+                System.Windows.MessageBoxButton.OK,
+                System.Windows.MessageBoxImage.Error
             );
         }
     }
@@ -801,13 +813,13 @@ public sealed class TranslationQueueEntryViewModel
     {
         if (!string.IsNullOrWhiteSpace(_entry.SourceText))
         {
-            Clipboard.SetText(_entry.SourceText);
+            System.Windows.Clipboard.SetText(_entry.SourceText);
         }
     }
 
     private void QuickPaste()
     {
-        if (!Clipboard.ContainsText())
+        if (!System.Windows.Clipboard.ContainsText())
         {
             return;
         }
@@ -815,7 +827,7 @@ public sealed class TranslationQueueEntryViewModel
         var translation = GetActiveTranslation();
         if (translation != null)
         {
-            var clipboardText = Clipboard.GetText();
+            var clipboardText = System.Windows.Clipboard.GetText();
             if (TryParseQuickPaste(clipboardText, out var translations))
             {
                 if (translations.TryGetValue(translation.LanguageName, out var matchedText))

--- a/Intersect.Server.Core/Services/Achievements/AchievementService.cs
+++ b/Intersect.Server.Core/Services/Achievements/AchievementService.cs
@@ -362,7 +362,7 @@ public static class AchievementService
 
         foreach (var titleId in rewards.TitleIds)
         {
-            if (!TitleDescriptor.Lookup.ContainsKey(titleId))
+            if (!TitleDescriptor.Lookup.TryGetValue(titleId, out _))
             {
                 continue;
             }


### PR DESCRIPTION
### Motivation

- Resolve compiler errors in the editor and server caused by ambiguous WPF types, missing usings, and API mismatches that prevented building localization tooling and some editor UI code.
- Ensure color and descriptor types referenced in the quest editor match the available framework types to fix type resolution errors.

### Description

- Disambiguated WPF usages in `TranslationQueueViewModel.cs` by fully qualifying `Application`, `MessageBox`, and `Clipboard` as `System.Windows.*`, and switched dialogs to `Microsoft.Win32.SaveFileDialog`/`OpenFileDialog`, and adjusted the `StreamWriter` constructor to use the `Encoding` overload. 
- Added `Intersect.Network.Packets.Localization` import to `frmEvent.cs` so event editor translation updates are available. 
- Fixed quest editor type issues in `frmQuest.cs` by adding `Items`, `NPCs`, and `Quests` imports and changing the badge color type to `System.Drawing.Color` in `GetTaskBadge`. 
- Replaced `TitleDescriptor.Lookup.ContainsKey(titleId)` with `TitleDescriptor.Lookup.TryGetValue(titleId, out _)` in `AchievementService.cs` to match the `DatabaseObjectLookup` API. 

### Testing

- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c1c9bafcc832b9d917009ccabdce1)