### PR TITLE
Add achievement icon ARGB controls

### DIFF
--- a/Framework/Intersect.Framework.Core/GameObjects/Achievements/AchievementDescriptor.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/Achievements/AchievementDescriptor.cs
@@ -28,6 +28,23 @@ public sealed partial class AchievementDescriptor : DatabaseObject<AchievementDe
 
     public string Icon { get; set; } = string.Empty;
 
+    /// <summary>
+    /// The database compatible version of <see cref="Color"/>
+    /// </summary>
+    [Column("Color")]
+    [JsonIgnore]
+    public string JsonColor
+    {
+        get => JsonConvert.SerializeObject(Color);
+        set => Color = !string.IsNullOrWhiteSpace(value) ? JsonConvert.DeserializeObject<Color>(value) : Color.White;
+    }
+
+    /// <summary>
+    /// Defines the ARGB color settings for this Achievement.
+    /// </summary>
+    [NotMapped]
+    public Color Color { get; set; } = Color.White;
+
     [Column("CompletionMode")]
     public AchievementCompletionMode CompletionMode { get; set; } = AchievementCompletionMode.OrListsAndConditions;
 

--- a/Intersect.Client.Core/Interface/Game/AchievementsWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/AchievementsWindow.cs
@@ -428,6 +428,7 @@ public sealed partial class AchievementsWindow : Window
                 Width = ListIconSize,
                 Height = ListIconSize,
                 MouseInputEnabled = false,
+                RenderColor = achievement.Color,
             };
 
             icon.SetPosition(2, (ListRowHeight - ListIconSize) / 2);
@@ -611,6 +612,7 @@ public sealed partial class AchievementsWindow : Window
         }
 
         _iconPanel.Texture = iconTexture;
+        _iconPanel.RenderColor = achievement.Color;
         _iconPanel.Show();
     }
 

--- a/Intersect.Editor/Forms/Editors/Achievements/FrmAchievement.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/Achievements/FrmAchievement.Designer.cs
@@ -833,6 +833,7 @@ namespace Intersect.Editor.Forms.Editors.Achievements
             nudRgbaA.Size = new Size(70, 23);
             nudRgbaA.TabIndex = 93;
             nudRgbaA.Value = new decimal(new int[] { 255, 0, 0, 0 });
+            nudRgbaA.ValueChanged += nudRgbaA_ValueChanged;
             // 
             // nudRgbaB
             // 
@@ -845,6 +846,7 @@ namespace Intersect.Editor.Forms.Editors.Achievements
             nudRgbaB.Size = new Size(70, 23);
             nudRgbaB.TabIndex = 92;
             nudRgbaB.Value = new decimal(new int[] { 255, 0, 0, 0 });
+            nudRgbaB.ValueChanged += nudRgbaB_ValueChanged;
             // 
             // nudRgbaG
             // 
@@ -857,6 +859,7 @@ namespace Intersect.Editor.Forms.Editors.Achievements
             nudRgbaG.Size = new Size(70, 23);
             nudRgbaG.TabIndex = 91;
             nudRgbaG.Value = new decimal(new int[] { 255, 0, 0, 0 });
+            nudRgbaG.ValueChanged += nudRgbaG_ValueChanged;
             // 
             // nudRgbaR
             // 
@@ -869,6 +872,7 @@ namespace Intersect.Editor.Forms.Editors.Achievements
             nudRgbaR.Size = new Size(70, 23);
             nudRgbaR.TabIndex = 90;
             nudRgbaR.Value = new decimal(new int[] { 255, 0, 0, 0 });
+            nudRgbaR.ValueChanged += nudRgbaR_ValueChanged;
             // 
             // cmbPic
             // 
@@ -891,6 +895,7 @@ namespace Intersect.Editor.Forms.Editors.Achievements
             cmbPic.TabIndex = 89;
             cmbPic.Text = "None";
             cmbPic.TextPadding = new Padding(2);
+            cmbPic.SelectedIndexChanged += cmbPic_SelectedIndexChanged;
             // 
             // lblPic
             // 

--- a/Intersect.Editor/Forms/Editors/Achievements/FrmAchievement.cs
+++ b/Intersect.Editor/Forms/Editors/Achievements/FrmAchievement.cs
@@ -1,3 +1,5 @@
+using System.Drawing;
+using System.Drawing.Imaging;
 using System.Linq;
 using DarkUI.Forms;
 using Intersect.Editor.Content;
@@ -60,12 +62,12 @@ public partial class FrmAchievement : EditorForm
         cmbCompletionMode.Items.Clear();
         cmbCompletionMode.Items.AddRange(Enum.GetNames(typeof(AchievementCompletionMode)));
 
-        cmbIcon.Items.Clear();
-        cmbIcon.Items.Add(Strings.General.None);
+        cmbPic.Items.Clear();
+        cmbPic.Items.Add(Strings.General.None);
         var iconNames = GameContentManager.GetSmartSortedTextureNames(GameContentManager.TextureType.Achievement);
         if (iconNames?.Length > 0)
         {
-            cmbIcon.Items.AddRange(iconNames);
+            cmbPic.Items.AddRange(iconNames);
         }
 
         cmbResource.Items.Clear();
@@ -107,7 +109,7 @@ public partial class FrmAchievement : EditorForm
         lblDifficulty.Text = Strings.AchievementEditor.difficulty;
         lblCompletionMode.Text = Strings.AchievementEditor.completionmode;
         lblFolder.Text = Strings.AchievementEditor.folderlabel;
-        lblIcon.Text = Strings.AchievementEditor.icon;
+        lblPic.Text = Strings.AchievementEditor.icon;
 
         grpRequirements.Text = Strings.AchievementEditor.requirements;
         btnEditRequirements.Text = Strings.AchievementEditor.editrequirements;
@@ -201,11 +203,16 @@ public partial class FrmAchievement : EditorForm
             var iconName = string.IsNullOrWhiteSpace(_editorItem.Icon)
                 ? Strings.General.None.ToString()
                 : _editorItem.Icon;
-            cmbIcon.SelectedIndex = cmbIcon.FindString(iconName);
-            if (cmbIcon.SelectedIndex < 0)
+            cmbPic.SelectedIndex = cmbPic.FindString(iconName);
+            if (cmbPic.SelectedIndex < 0)
             {
-                cmbIcon.SelectedIndex = 0;
+                cmbPic.SelectedIndex = 0;
             }
+            nudRgbaR.Value = _editorItem.Color.R;
+            nudRgbaG.Value = _editorItem.Color.G;
+            nudRgbaB.Value = _editorItem.Color.B;
+            nudRgbaA.Value = _editorItem.Color.A;
+            DrawAchievementIcon();
             nudExperience.Value = _editorItem.Rewards.Experience;
             nudCurrency.Value = _editorItem.Rewards.Currency;
 
@@ -343,14 +350,99 @@ public partial class FrmAchievement : EditorForm
         _editorItem.CompletionMode = (AchievementCompletionMode)cmbCompletionMode.SelectedIndex;
     }
 
-    private void cmbIcon_SelectedIndexChanged(object sender, EventArgs e)
+    private void cmbPic_SelectedIndexChanged(object sender, EventArgs e)
     {
         if (_editorItem == null || _updating)
         {
             return;
         }
 
-        _editorItem.Icon = cmbIcon.SelectedIndex <= 0 ? string.Empty : cmbIcon.Text;
+        _editorItem.Icon = cmbPic.SelectedIndex <= 0 ? string.Empty : cmbPic.Text;
+        DrawAchievementIcon();
+    }
+
+    private void nudRgbaR_ValueChanged(object sender, EventArgs e)
+    {
+        if (_editorItem == null || _updating)
+        {
+            return;
+        }
+
+        _editorItem.Color.R = (byte)nudRgbaR.Value;
+        DrawAchievementIcon();
+    }
+
+    private void nudRgbaG_ValueChanged(object sender, EventArgs e)
+    {
+        if (_editorItem == null || _updating)
+        {
+            return;
+        }
+
+        _editorItem.Color.G = (byte)nudRgbaG.Value;
+        DrawAchievementIcon();
+    }
+
+    private void nudRgbaB_ValueChanged(object sender, EventArgs e)
+    {
+        if (_editorItem == null || _updating)
+        {
+            return;
+        }
+
+        _editorItem.Color.B = (byte)nudRgbaB.Value;
+        DrawAchievementIcon();
+    }
+
+    private void nudRgbaA_ValueChanged(object sender, EventArgs e)
+    {
+        if (_editorItem == null || _updating)
+        {
+            return;
+        }
+
+        _editorItem.Color.A = (byte)nudRgbaA.Value;
+        DrawAchievementIcon();
+    }
+
+    private void DrawAchievementIcon()
+    {
+        picItem.BackgroundImage?.Dispose();
+        picItem.BackgroundImage = null;
+
+        var picItemBmp = new Bitmap(picItem.Width, picItem.Height);
+        var gfx = Graphics.FromImage(picItemBmp);
+        gfx.FillRectangle(Brushes.Black, new Rectangle(0, 0, picItem.Width, picItem.Height));
+
+        if (cmbPic.SelectedIndex > 0)
+        {
+            var img = Image.FromFile("resources/achievements/" + cmbPic.Text);
+            var imgAttributes = new ImageAttributes();
+
+            imgAttributes.SetColorMatrix(
+                new ColorMatrix(
+                    new float[][]
+                    {
+                        new float[] { (float)nudRgbaR.Value / 255,  0,  0,  0, 0},
+                        new float[] {0, (float)nudRgbaG.Value / 255,  0,  0, 0},
+                        new float[] {0,  0, (float)nudRgbaB.Value / 255,  0, 0},
+                        new float[] {0,  0,  0, (float)nudRgbaA.Value / 255, 0},
+                        new float[] {0, 0, 0, 0, 1}
+                    }
+                )
+            );
+
+            gfx.DrawImage(
+                img, new Rectangle(0, 0, img.Width, img.Height),
+                0, 0, img.Width, img.Height, GraphicsUnit.Pixel, imgAttributes
+            );
+
+            img.Dispose();
+            imgAttributes.Dispose();
+        }
+
+        gfx.Dispose();
+        picItem.BackgroundImage = picItemBmp;
     }
 
     private static string GetCategoryDisplayName(AchievementCategory category) =>


### PR DESCRIPTION
### Motivation
- Allow authors to select and persist an ARGB tint for achievement icons so icons can be previewed and colored consistently in the editor and client UI.
- Wire editor controls to update the achievement model and preview when icon or color components change.

### Description
- Persist ARGB color in the achievement model by adding `JsonColor` and `Color` properties to `AchievementDescriptor` and serializing the color for the database (`Framework/Intersect.Framework.Core/GameObjects/Achievements/AchievementDescriptor.cs`).
- Add an icon selector and ARGB controls to the achievement editor and preview logic, replace `cmbIcon` usages with `cmbPic`, and implement `DrawAchievementIcon()` which tints the chosen image using a `ColorMatrix` (`Intersect.Editor/Forms/Editors/Achievements/FrmAchievement.cs` and `FrmAchievement.Designer.cs`).
- Apply achievement color when rendering icons in the client achievements list and detail view by setting `RenderColor = achievement.Color` on `ImagePanel` instances and `_iconPanel.RenderColor` in `AchievementsWindow` (`Intersect.Client.Core/Interface/Game/AchievementsWindow.cs`).
- Hook up numeric control events (`nudRgba*`) and combo change handlers to update the achievement object and refresh previews in the editor (`Intersect.Editor/Forms/Editors/Achievements/*`).

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697fd02da798832b8d670ca5f64c3f45)