### PR TITLE
Add startup check for missing Player_Stats table

### DIFF
--- a/Intersect.Server.Core/Database/DbInterface.cs
+++ b/Intersect.Server.Core/Database/DbInterface.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Linq;
+using System.Data;
 using System.Data.Common;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -406,6 +407,14 @@ public static partial class DbInterface
             _methodInfoProcessMigrations.MakeGenericMethod(contextType).Invoke(null, new object[] { context });
         }
 
+        if (!PlayerStatsTableExists(playerContext, playerDatabaseOptions))
+        {
+            ApplicationContext.Context.Value?.Logger.LogError(
+                "Player_Stats table is missing from the player database. Please apply the latest database migrations before starting the server."
+            );
+            return false;
+        }
+
         return true;
     }
 
@@ -441,6 +450,48 @@ public static partial class DbInterface
         PlayerShopManager.RespawnActiveShopEntities();
 
         return true;
+    }
+
+    private static bool PlayerStatsTableExists(PlayerContext playerContext, DatabaseOptions playerDatabaseOptions)
+    {
+        var connection = playerContext.Database.GetDbConnection();
+        var wasClosed = connection.State == ConnectionState.Closed;
+        if (wasClosed)
+        {
+            connection.Open();
+        }
+
+        try
+        {
+            using var command = connection.CreateCommand();
+            switch (playerDatabaseOptions.Type)
+            {
+                case DatabaseType.SQLite:
+                    command.CommandText =
+                        "SELECT name FROM sqlite_master WHERE type='table' AND name='Player_Stats' LIMIT 1;";
+                    break;
+                case DatabaseType.MySQL:
+                    command.CommandText =
+                        "SELECT TABLE_NAME FROM information_schema.tables WHERE table_schema = @database AND table_name = 'Player_Stats' LIMIT 1;";
+                    var databaseParameter = command.CreateParameter();
+                    databaseParameter.ParameterName = "@database";
+                    databaseParameter.Value = playerDatabaseOptions.Database;
+                    command.Parameters.Add(databaseParameter);
+                    break;
+                default:
+                    return true;
+            }
+
+            var result = command.ExecuteScalar();
+            return result != null && result != DBNull.Value;
+        }
+        finally
+        {
+            if (wasClosed)
+            {
+                connection.Close();
+            }
+        }
     }
 
     private static void CheckPlayerDatabaseCaseInsensitiveCollisions()


### PR DESCRIPTION
### Motivation
- Prevent runtime save failures by verifying the player database contains the critical `Player_Stats` table after migrations and before full startup. 
- Provide a clear operator-facing error and short-circuit startup when migrations have not been applied to avoid later data corruption or crashes.

### Description
- Added `using System.Data;` and a new helper `PlayerStatsTableExists` in `Intersect.Server.Core/Database/DbInterface.cs` that checks for a `Player_Stats` table using `sqlite_master` for SQLite and `information_schema.tables` for MySQL. 
- Invoked `PlayerStatsTableExists` after migrations are processed in `EnsureUpdated`, and log a clear error with `ApplicationContext.Context.Value?.Logger.LogError` and return `false` to abort startup when the table is missing. 
- The check safely opens/closes the player DB connection and uses a parameterized query for MySQL (`@database`).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697fd9e9a3d8832b81d3f5afd627013e)