### PR TITLE
Optimize achievement progress lookups

### DIFF
--- a/Intersect.Server.Core/Services/Achievements/AchievementService.cs
+++ b/Intersect.Server.Core/Services/Achievements/AchievementService.cs
@@ -254,6 +254,7 @@ public static class AchievementService
         }
 
         var hasChanges = false;
+        var progressById = BuildAchievementProgressIndex(player);
         var achievementDescriptors = GetIndexedAchievements(trigger, context);
 
         foreach (var achievement in achievementDescriptors)
@@ -263,7 +264,7 @@ public static class AchievementService
                 continue;
             }
 
-            var progress = GetOrCreateProgress(player, achievement, ref hasChanges);
+            var progress = GetOrCreateProgress(player, achievement, progressById, ref hasChanges);
             if (progress.Completed)
             {
                 continue;
@@ -404,6 +405,36 @@ public static class AchievementService
         player.Achievements.Add(progress);
         hasChanges = true;
         return progress;
+    }
+
+    private static ServerAchievementProgress GetOrCreateProgress(
+        Player player,
+        AchievementDescriptor achievement,
+        Dictionary<Guid, ServerAchievementProgress> progressById,
+        ref bool hasChanges
+    )
+    {
+        if (progressById.TryGetValue(achievement.Id, out var progress))
+        {
+            return progress;
+        }
+
+        progress = new ServerAchievementProgress(achievement.Id);
+        player.Achievements.Add(progress);
+        progressById[achievement.Id] = progress;
+        hasChanges = true;
+        return progress;
+    }
+
+    private static Dictionary<Guid, ServerAchievementProgress> BuildAchievementProgressIndex(Player player)
+    {
+        var progressById = new Dictionary<Guid, ServerAchievementProgress>(player.Achievements.Count);
+        foreach (var progress in player.Achievements)
+        {
+            progressById.TryAdd(progress.AchievementId, progress);
+        }
+
+        return progressById;
     }
 
     private static bool UpdateProgressFromConditions(


### PR DESCRIPTION
### Motivation
- Reduce repeated O(n) scans of `player.Achievements` during `UpdateAchievements` to improve performance when processing many achievements.
- Ensure creation of new `ServerAchievementProgress` instances remains synchronized with the `player.Achievements` list while allowing O(1) lookups during a single update pass.
- Leave room for a future persistent index on `Player` if there are other hot paths accessing achievement progress.

### Description
- Build a per-update dictionary index with `BuildAchievementProgressIndex(player)` at the start of `UpdateAchievements` to map `AchievementId` to `ServerAchievementProgress`.
- Add a dictionary-backed overload `GetOrCreateProgress(player, achievement, progressById, ref hasChanges)` that performs O(1) lookups, creates new progress when missing, adds it to `player.Achievements`, and updates the dictionary.
- Keep the original `GetOrCreateProgress` overload for backward compatibility and use `Dictionary.TryAdd` when populating the index.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69802be0fd0c832b8158983da171142e)