### PR TITLE
Add localization metadata for event dialogs and input prompts

### DIFF
--- a/Framework/Intersect.Framework.Core/Localization/EventFieldKey.cs
+++ b/Framework/Intersect.Framework.Core/Localization/EventFieldKey.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Intersect.Framework.Core.Localization;
 
 public static class EventFieldKey
@@ -5,24 +7,24 @@ public static class EventFieldKey
     public static string PageDescription(int pageIndex) =>
         $"Page:{pageIndex}:Description";
 
-    public static string ShowText(int pageIndex, int listId, int commandIndex) =>
+    public static string ShowText(int pageIndex, Guid listId, int commandIndex) =>
         $"Page:{pageIndex}:List:{listId}:Command:{commandIndex}:ShowText";
 
-    public static string ChatboxText(int pageIndex, int listId, int commandIndex) =>
+    public static string ChatboxText(int pageIndex, Guid listId, int commandIndex) =>
         $"Page:{pageIndex}:List:{listId}:Command:{commandIndex}:ChatboxText";
 
-    public static string OptionsText(int pageIndex, int listId, int commandIndex) =>
+    public static string OptionsText(int pageIndex, Guid listId, int commandIndex) =>
         $"Page:{pageIndex}:List:{listId}:Command:{commandIndex}:OptionsText";
 
-    public static string Option(int pageIndex, int listId, int commandIndex, int optionIndex) =>
+    public static string Option(int pageIndex, Guid listId, int commandIndex, int optionIndex) =>
         $"Page:{pageIndex}:List:{listId}:Command:{commandIndex}:Option:{optionIndex}";
 
-    public static string InputTitle(int pageIndex, int listId, int commandIndex) =>
+    public static string InputTitle(int pageIndex, Guid listId, int commandIndex) =>
         $"Page:{pageIndex}:List:{listId}:Command:{commandIndex}:InputTitle";
 
-    public static string InputText(int pageIndex, int listId, int commandIndex) =>
+    public static string InputText(int pageIndex, Guid listId, int commandIndex) =>
         $"Page:{pageIndex}:List:{listId}:Command:{commandIndex}:InputText";
 
-    public static string PlayerLabel(int pageIndex, int listId, int commandIndex) =>
+    public static string PlayerLabel(int pageIndex, Guid listId, int commandIndex) =>
         $"Page:{pageIndex}:List:{listId}:Command:{commandIndex}:PlayerLabel";
 }

--- a/Framework/Intersect.Framework.Core/Network/Packets/Server/EventDialogPacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Server/EventDialogPacket.cs
@@ -1,4 +1,5 @@
-﻿using MessagePack;
+﻿using Intersect.Network.Packets.Localization;
+using MessagePack;
 
 namespace Intersect.Network.Packets.Server;
 
@@ -10,13 +11,23 @@ public partial class EventDialogPacket : IntersectPacket
     {
     }
 
-    public EventDialogPacket(Guid eventId, string prompt, string face, byte type, string[] responses)
+    public EventDialogPacket(
+        Guid eventId,
+        string prompt,
+        string face,
+        byte type,
+        string[] responses,
+        LocalizationRequestEntry? promptLocalizationRequest = null,
+        List<LocalizationRequestEntry>? responseLocalizationRequests = null
+    )
     {
         EventId = eventId;
         Prompt = prompt;
         Face = face;
         Type = type;
         Responses = responses;
+        PromptLocalizationRequest = promptLocalizationRequest;
+        ResponseLocalizationRequests = responseLocalizationRequests;
     }
 
     [Key(0)]
@@ -33,5 +44,11 @@ public partial class EventDialogPacket : IntersectPacket
 
     [Key(4)]
     public string[] Responses { get; set; }
+
+    [Key(5)]
+    public LocalizationRequestEntry? PromptLocalizationRequest { get; set; }
+
+    [Key(6)]
+    public List<LocalizationRequestEntry>? ResponseLocalizationRequests { get; set; }
 
 }

--- a/Framework/Intersect.Framework.Core/Network/Packets/Server/InputVariablePacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Server/InputVariablePacket.cs
@@ -1,4 +1,5 @@
-﻿using MessagePack;
+﻿using Intersect.Network.Packets.Localization;
+using MessagePack;
 
 namespace Intersect.Network.Packets.Server;
 
@@ -10,12 +11,21 @@ public partial class InputVariablePacket : IntersectPacket
     {
     }
 
-    public InputVariablePacket(Guid eventId, string title, string prompt, Enums.VariableDataType type)
+    public InputVariablePacket(
+        Guid eventId,
+        string title,
+        string prompt,
+        Enums.VariableDataType type,
+        LocalizationRequestEntry? titleLocalizationRequest = null,
+        LocalizationRequestEntry? promptLocalizationRequest = null
+    )
     {
         EventId = eventId;
         Title = title;
         Prompt = prompt;
         Type = type;
+        TitleLocalizationRequest = titleLocalizationRequest;
+        PromptLocalizationRequest = promptLocalizationRequest;
     }
 
     [Key(0)]
@@ -29,5 +39,11 @@ public partial class InputVariablePacket : IntersectPacket
 
     [Key(3)]
     public Enums.VariableDataType Type { get; set; }
+
+    [Key(4)]
+    public LocalizationRequestEntry? TitleLocalizationRequest { get; set; }
+
+    [Key(5)]
+    public LocalizationRequestEntry? PromptLocalizationRequest { get; set; }
 
 }

--- a/Intersect.Client.Core/Entities/Events/Dialog.cs
+++ b/Intersect.Client.Core/Entities/Events/Dialog.cs
@@ -1,3 +1,5 @@
+using Intersect.Network.Packets.Localization;
+
 namespace Intersect.Client.Entities.Events;
 
 public partial class Dialog
@@ -8,7 +10,15 @@ public partial class Dialog
 
     public string[] Options = [];
 
+    public LocalizationRequestEntry? PromptLocalizationRequest;
+
+    public LocalizationRequestEntry[] OptionLocalizationRequests = [];
+
     public string? Prompt;
+
+    public string? PromptDefault;
+
+    public string[] OptionDefaults = [];
 
     public bool ResponseSent;
 }

--- a/Intersect.Client.Core/Interface/Game/EventWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/EventWindow.cs
@@ -17,7 +17,10 @@ using Intersect.Enums;
 using Intersect.Framework.Core;
 using Intersect.Framework.Threading;
 using Intersect.Utilities;
+using Intersect.Network.Packets.Localization;
 using Microsoft.Extensions.Logging;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Intersect.Client.Interface.Game;
 
@@ -40,6 +43,8 @@ public partial class EventWindow : Panel
     private readonly Typewriter? _writer;
 
     private readonly Dialog _dialog;
+
+    private bool _localizationSubscribed;
 
     private EventWindow(Canvas gameCanvas, Dialog dialog) : base(gameCanvas, nameof(EventWindow))
     {
@@ -209,9 +214,105 @@ public partial class EventWindow : Panel
         MakeModal(dim: true);
         BringToFront();
         Interface.InputBlockingComponents.Add(this);
+        SubscribeToLocalizationUpdates();
         ApplicationContext.CurrentContext.Logger.LogTrace("Event window opened");
 
         #endregion Configure and Display
+    }
+
+    private void SubscribeToLocalizationUpdates()
+    {
+        if (_localizationSubscribed)
+        {
+            return;
+        }
+
+        GameLocalization.LocalizedTextsUpdated += OnLocalizedTextsUpdated;
+        _localizationSubscribed = true;
+    }
+
+    private void UnsubscribeFromLocalizationUpdates()
+    {
+        if (!_localizationSubscribed)
+        {
+            return;
+        }
+
+        GameLocalization.LocalizedTextsUpdated -= OnLocalizedTextsUpdated;
+        _localizationSubscribed = false;
+    }
+
+    private void OnLocalizedTextsUpdated(string language, IReadOnlyCollection<LocalizationRequestEntry> requests)
+    {
+        if (!IsVisibleInTree || _dialog.ResponseSent)
+        {
+            return;
+        }
+
+        var shouldRefreshPrompt = _dialog.PromptLocalizationRequest != null && requests.Any(
+            request => request.EntityType == _dialog.PromptLocalizationRequest.EntityType &&
+                       request.EntityId == _dialog.PromptLocalizationRequest.EntityId &&
+                       request.Field == _dialog.PromptLocalizationRequest.Field
+        );
+
+        var shouldRefreshOptions = _dialog.OptionLocalizationRequests.Any(
+            optionRequest => optionRequest != null && requests.Any(
+                request => request.EntityType == optionRequest.EntityType &&
+                           request.EntityId == optionRequest.EntityId &&
+                           request.Field == optionRequest.Field
+            )
+        );
+
+        if (!shouldRefreshPrompt && !shouldRefreshOptions)
+        {
+            return;
+        }
+
+        if (shouldRefreshPrompt && _dialog.PromptLocalizationRequest != null)
+        {
+            var promptRequest = _dialog.PromptLocalizationRequest;
+            _dialog.Prompt = GameLocalization.GetTextOrDefault(
+                promptRequest.EntityType,
+                Guid.TryParse(promptRequest.EntityId, out var entityId) ? entityId : Guid.Empty,
+                promptRequest.Field,
+                _dialog.PromptDefault ?? _dialog.Prompt ?? string.Empty
+            );
+        }
+
+        if (shouldRefreshOptions && _dialog.Options.Length > 0)
+        {
+            for (var optionIndex = 0; optionIndex < _dialog.Options.Length; optionIndex++)
+            {
+                if (optionIndex >= _dialog.OptionLocalizationRequests.Length)
+                {
+                    continue;
+                }
+
+                var optionRequest = _dialog.OptionLocalizationRequests[optionIndex];
+                if (optionRequest == null)
+                {
+                    continue;
+                }
+
+                var fallback = optionIndex < _dialog.OptionDefaults.Length
+                    ? _dialog.OptionDefaults[optionIndex]
+                    : _dialog.Options[optionIndex];
+                _dialog.Options[optionIndex] = GameLocalization.GetTextOrDefault(
+                    optionRequest.EntityType,
+                    Guid.TryParse(optionRequest.EntityId, out var optionEntityId) ? optionEntityId : Guid.Empty,
+                    optionRequest.Field,
+                    fallback
+                );
+            }
+        }
+
+        if (Parent is not Canvas canvas)
+        {
+            return;
+        }
+
+        EnsureDestroyed();
+        _instance = new EventWindow(canvas, _dialog);
     }
 
     private static void ResizeOptionsPanelToChildren(Panel optionsPanel)
@@ -228,6 +329,7 @@ public partial class EventWindow : Panel
 
     protected override void Dispose(bool disposing)
     {
+        UnsubscribeFromLocalizationUpdates();
         EnsureControlRestored();
         base.Dispose(disposing);
     }

--- a/Intersect.Client.Core/Networking/PacketHandler.cs
+++ b/Intersect.Client.Core/Networking/PacketHandler.cs
@@ -18,6 +18,7 @@ using Intersect.GameObjects;
 using Intersect.Network;
 using Intersect.Network.Packets;
 using Intersect.Network.Packets.Server;
+using Intersect.Network.Packets.Localization;
 using Intersect.Utilities;
 using Intersect.Framework;
 using Intersect.Models;
@@ -37,6 +38,7 @@ using Intersect.Framework.Threading;
 using Intersect.Localization;
 using Microsoft.Extensions.Logging;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Intersect.Framework.Core.GameObjects.Spells;
@@ -1274,21 +1276,103 @@ internal sealed partial class PacketHandler
     //EventDialogPacket
     public void HandlePacket(IPacketSender packetSender, EventDialogPacket packet)
     {
-        var ed = new Dialog();
-        ed.Prompt = packet.Prompt;
-        ed.Face = packet.Face;
-        if (packet.Type != 0)
+        var requests = new List<LocalizationRequestEntry>();
+        var prompt = packet.Prompt;
+        if (packet.PromptLocalizationRequest is { } promptLocalizationRequest)
         {
-            ed.Options = packet.Responses;
+            prompt = GameLocalization.GetTextOrDefault(
+                promptLocalizationRequest.EntityType,
+                Guid.TryParse(promptLocalizationRequest.EntityId, out var promptEntityId) ? promptEntityId : Guid.Empty,
+                promptLocalizationRequest.Field,
+                packet.Prompt
+            );
+            requests.Add(promptLocalizationRequest);
         }
 
-        ed.EventId = packet.EventId;
+        var ed = new Dialog
+        {
+            Prompt = prompt,
+            Face = packet.Face,
+            EventId = packet.EventId,
+            PromptLocalizationRequest = packet.PromptLocalizationRequest,
+            PromptDefault = packet.Prompt,
+        };
+
+        if (packet.Type != 0)
+        {
+            var responseDefaults = packet.Responses?.ToArray() ?? [];
+            var responses = responseDefaults.ToArray();
+            var optionLocalizationRequests = packet.ResponseLocalizationRequests;
+            var optionRequestsForDialog = new LocalizationRequestEntry[responses.Length];
+            for (var optionIndex = 0; optionIndex < responses.Length; optionIndex++)
+            {
+                if (optionLocalizationRequests == null || optionIndex >= optionLocalizationRequests.Count)
+                {
+                    continue;
+                }
+
+                var optionLocalizationRequest = optionLocalizationRequests[optionIndex];
+                if (optionLocalizationRequest == null)
+                {
+                    continue;
+                }
+
+                responses[optionIndex] = GameLocalization.GetTextOrDefault(
+                    optionLocalizationRequest.EntityType,
+                    Guid.TryParse(optionLocalizationRequest.EntityId, out var optionEntityId) ? optionEntityId : Guid.Empty,
+                    optionLocalizationRequest.Field,
+                    responses[optionIndex]
+                );
+                optionRequestsForDialog[optionIndex] = optionLocalizationRequest;
+                requests.Add(optionLocalizationRequest);
+            }
+
+            ed.Options = responses;
+            ed.OptionDefaults = responseDefaults;
+            ed.OptionLocalizationRequests = optionRequestsForDialog;
+        }
+
+        if (requests.Count > 0)
+        {
+            GameLocalization.RequestEntries(requests);
+        }
+
         Globals.EventDialogs.Add(ed);
     }
 
     //InputVariablePacket
     public void HandlePacket(IPacketSender packetSender, InputVariablePacket packet)
     {
+        var requests = new List<LocalizationRequestEntry>();
+        var title = packet.Title;
+        if (packet.TitleLocalizationRequest is { } titleLocalizationRequest)
+        {
+            title = GameLocalization.GetTextOrDefault(
+                titleLocalizationRequest.EntityType,
+                Guid.TryParse(titleLocalizationRequest.EntityId, out var titleEntityId) ? titleEntityId : Guid.Empty,
+                titleLocalizationRequest.Field,
+                packet.Title
+            );
+            requests.Add(titleLocalizationRequest);
+        }
+
+        var prompt = packet.Prompt;
+        if (packet.PromptLocalizationRequest is { } promptLocalizationRequest)
+        {
+            prompt = GameLocalization.GetTextOrDefault(
+                promptLocalizationRequest.EntityType,
+                Guid.TryParse(promptLocalizationRequest.EntityId, out var promptEntityId) ? promptEntityId : Guid.Empty,
+                promptLocalizationRequest.Field,
+                packet.Prompt
+            );
+            requests.Add(promptLocalizationRequest);
+        }
+
+        if (requests.Count > 0)
+        {
+            GameLocalization.RequestEntries(requests);
+        }
+
         var type = packet.Type switch
         {
             VariableDataType.String => InputType.TextInput,
@@ -1297,8 +1381,8 @@ internal sealed partial class PacketHandler
         };
 
         _ = new InputBox(
-            title: packet.Title,
-            prompt: packet.Prompt,
+            title: title,
+            prompt: prompt,
             inputType: type,
             userData: packet.EventId,
             onSubmit: PacketSender.SendEventInputVariable,

--- a/Intersect.Server.Core/Entities/Events/CommandProcessing.cs
+++ b/Intersect.Server.Core/Entities/Events/CommandProcessing.cs
@@ -11,6 +11,7 @@ using Intersect.Framework.Core.GameObjects.Maps;
 using Intersect.Framework.Core.GameObjects.PlayerClass;
 using Intersect.Framework.Core.GameObjects.Variables;
 using Intersect.Framework.Core.GameObjects.NPCs;
+using Intersect.Framework.Core.Localization;
 using Intersect.GameObjects;
 using Intersect.Server.Core.MapInstancing;
 using Intersect.Server.Database;
@@ -24,12 +25,51 @@ using Intersect.Utilities;
 using Intersect.Server.Services;
 using Intersect.Server.Services.Achievements;
 using Intersect.Server.Core.Services;
+using Intersect.Network.Packets.Localization;
 
 namespace Intersect.Server.Entities.Events;
 
 
 public static partial class CommandProcessing
 {
+
+    private static int ResolvePageIndex(Event instance, EventPage page) =>
+        instance.Descriptor.Pages?.FindIndex(candidate => ReferenceEquals(candidate, page)) ?? -1;
+
+    private static Guid ResolveListId(EventPage page, List<EventCommand> commandList)
+    {
+        if (page.CommandLists == null)
+        {
+            return Guid.Empty;
+        }
+
+        foreach (var (listId, commands) in page.CommandLists)
+        {
+            if (ReferenceEquals(commands, commandList))
+            {
+                return listId;
+            }
+        }
+
+        return Guid.Empty;
+    }
+
+    private static LocalizationRequestEntry BuildEventLocalizationRequest(
+        Event instance,
+        CommandInstance stackInfo,
+        Func<int, Guid, int, string> fieldFactory
+    )
+    {
+        var pageIndex = ResolvePageIndex(instance, stackInfo.Page);
+        var listId = ResolveListId(stackInfo.Page, stackInfo.CommandList);
+        var commandIndex = stackInfo.CommandIndex;
+
+        return new LocalizationRequestEntry(
+            LocalizationEntityTypes.Event,
+            instance.Descriptor.Id.ToString(),
+            fieldFactory(pageIndex, listId, commandIndex)
+        );
+    }
 
     public static void ProcessCommand(EventCommand command, Player player, Event instance)
     {
@@ -52,8 +92,17 @@ public static partial class CommandProcessing
         Stack<CommandInstance> callStack
     )
     {
+        var promptLocalizationRequest = BuildEventLocalizationRequest(
+            instance,
+            stackInfo,
+            EventFieldKey.ShowText
+        );
         PacketSender.SendEventDialog(
-            player, ParseEventText(command.Text, player, instance), command.Face, instance.PageInstance.Id
+            player,
+            ParseEventText(command.Text, player, instance),
+            command.Face,
+            instance.PageInstance.Id,
+            promptLocalizationRequest
         );
 
         stackInfo.WaitingForResponse = CommandInstance.EventResponse.Dialogue;
@@ -73,7 +122,30 @@ public static partial class CommandProcessing
         var opt2 = ParseEventText(command.Options[1], player, instance);
         var opt3 = ParseEventText(command.Options[2], player, instance);
         var opt4 = ParseEventText(command.Options[3], player, instance);
-        PacketSender.SendEventDialog(player, txt, opt1, opt2, opt3, opt4, command.Face, instance.PageInstance.Id);
+        var promptLocalizationRequest = BuildEventLocalizationRequest(
+            instance,
+            stackInfo,
+            EventFieldKey.OptionsText
+        );
+        var optionLocalizationRequests = new List<LocalizationRequestEntry>(4)
+        {
+            BuildEventLocalizationRequest(instance, stackInfo, (page, list, commandIndex) => EventFieldKey.Option(page, list, commandIndex, 0)),
+            BuildEventLocalizationRequest(instance, stackInfo, (page, list, commandIndex) => EventFieldKey.Option(page, list, commandIndex, 1)),
+            BuildEventLocalizationRequest(instance, stackInfo, (page, list, commandIndex) => EventFieldKey.Option(page, list, commandIndex, 2)),
+            BuildEventLocalizationRequest(instance, stackInfo, (page, list, commandIndex) => EventFieldKey.Option(page, list, commandIndex, 3)),
+        };
+        PacketSender.SendEventDialog(
+            player,
+            txt,
+            opt1,
+            opt2,
+            opt3,
+            opt4,
+            command.Face,
+            instance.PageInstance.Id,
+            promptLocalizationRequest,
+            optionLocalizationRequests
+        );
         stackInfo.WaitingForResponse = CommandInstance.EventResponse.Dialogue;
         stackInfo.WaitingOnCommand = command;
         stackInfo.BranchIds = command.BranchIds;
@@ -125,7 +197,25 @@ public static partial class CommandProcessing
             return;
         }
 
-        PacketSender.SendInputVariableDialog(player, title, txt, (VariableDataType)type, instance.PageInstance.Id);
+        var titleLocalizationRequest = BuildEventLocalizationRequest(
+            instance,
+            stackInfo,
+            EventFieldKey.InputTitle
+        );
+        var promptLocalizationRequest = BuildEventLocalizationRequest(
+            instance,
+            stackInfo,
+            EventFieldKey.InputText
+        );
+        PacketSender.SendInputVariableDialog(
+            player,
+            title,
+            txt,
+            (VariableDataType)type,
+            instance.PageInstance.Id,
+            titleLocalizationRequest,
+            promptLocalizationRequest
+        );
         stackInfo.WaitingForResponse = CommandInstance.EventResponse.Dialogue;
         stackInfo.WaitingOnCommand = command;
         stackInfo.BranchIds = command.BranchIds;

--- a/Intersect.Server.Core/Networking/PacketSender.cs
+++ b/Intersect.Server.Core/Networking/PacketSender.cs
@@ -1085,9 +1085,15 @@ public static partial class PacketSender
     }
 
     //EventDialogPacket
-    public static void SendEventDialog(Player player, string prompt, string face, Guid eventId)
+    public static void SendEventDialog(
+        Player player,
+        string prompt,
+        string face,
+        Guid eventId,
+        LocalizationRequestEntry? promptLocalizationRequest = null
+    )
     {
-        player.SendPacket(new EventDialogPacket(eventId, prompt, face, 0, null));
+        player.SendPacket(new EventDialogPacket(eventId, prompt, face, 0, null, promptLocalizationRequest));
     }
 
     //EventDialogPacket
@@ -1099,10 +1105,22 @@ public static partial class PacketSender
         string opt3,
         string opt4,
         string face,
-        Guid eventId
+        Guid eventId,
+        LocalizationRequestEntry? promptLocalizationRequest = null,
+        List<LocalizationRequestEntry>? responseLocalizationRequests = null
     )
     {
-        player.SendPacket(new EventDialogPacket(eventId, prompt, face, 1, new string[4] { opt1, opt2, opt3, opt4 }));
+        player.SendPacket(
+            new EventDialogPacket(
+                eventId,
+                prompt,
+                face,
+                1,
+                new string[4] { opt1, opt2, opt3, opt4 },
+                promptLocalizationRequest,
+                responseLocalizationRequests
+            )
+        );
     }
 
     public static void SendInputVariableDialog(
@@ -1110,10 +1128,21 @@ public static partial class PacketSender
         string title,
         string prompt,
         VariableDataType type,
-        Guid eventId
+        Guid eventId,
+        LocalizationRequestEntry? titleLocalizationRequest = null,
+        LocalizationRequestEntry? promptLocalizationRequest = null
     )
     {
-        player.SendPacket(new InputVariablePacket(eventId, title, prompt, type));
+        player.SendPacket(
+            new InputVariablePacket(
+                eventId,
+                title,
+                prompt,
+                type,
+                titleLocalizationRequest,
+                promptLocalizationRequest
+            )
+        );
     }
 
     //MapListPacket


### PR DESCRIPTION
### Motivation
- Add per-field localization metadata to event/dialog packets so prompts, option lists and input prompts can be resolved and refreshed on the client. 
- Produce stable localization keys for event texts using page/list/command/option identifiers so translations remain consistent across runtime instances.

### Description
- Extended `EventDialogPacket` and `InputVariablePacket` to carry `LocalizationRequestEntry` metadata for prompt/title and option entries via new optional fields. 
- Updated `CommandProcessing` to build stable event keys with `EventFieldKey` (now using command-list `Guid` ids) and attach `LocalizationRequestEntry` objects for `ShowTextCommand`, `ShowOptionsCommand` and `InputVariableCommand`. 
- Propagated localization metadata through server senders by adding optional parameters to `PacketSender.SendEventDialog(...)` and `PacketSender.SendInputVariableDialog(...)`. 
- Updated client handlers in `PacketHandler` to resolve incoming texts via `GameLocalization.GetTextOrDefault(...)`, call `GameLocalization.RequestEntries(...)` for missing entries, and preserve metadata/defaults in `Dialog` for later refresh. 
- Subscribed `EventWindow` UI to `GameLocalization.LocalizedTextsUpdated` and implemented a safe refresh/rebuild when localized texts arrive, with proper subscribe/unsubscribe behavior.

### Testing
- Ran `git diff --check` and there were no whitespace/patch issues reported. 
- Attempted to run `dotnet build Broken.sln -v minimal`, but the environment does not have `dotnet` installed so a full build could not be executed here (command failed with `bash: command not found: dotnet`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985534da1ac832b87e98d1019166088)