### PR TITLE
Fix action message digit texture fallback for missing digit assets

### DIFF
--- a/Intersect.Client.Core/Maps/ActionMessage.cs
+++ b/Intersect.Client.Core/Maps/ActionMessage.cs
@@ -70,6 +70,11 @@ public partial class ActionMessage : IActionMessage
                 }
             }
 
+            if (_digitTextures.Count != numericText.Length)
+            {
+                _digitTextures.Clear();
+            }
+
             _texturesLoaded = true;
         }
 


### PR DESCRIPTION
### Motivation

- Avoid rendering partially-populated numeric badges when one or more `Misc/<digit>.png` assets are missing, which could display incorrect combat numbers to players.

### Description

- Add a strict check in `Intersect.Client.Core/Maps/ActionMessage.cs` so that after attempting to load digit textures we clear the cached `_digitTextures` list if its count does not match the length of the numeric string, forcing a fallback to text rendering.
- Mark textures as loaded with the existing `_texturesLoaded` flag after the check to avoid repeated work when the fallback is used.
- Change was committed to the repository on the current branch.

### Testing

- Attempted to build with `dotnet build Intersect.Client.Core/Intersect.Client.Core.csproj -v minimal`, which failed in this environment because `dotnet` is not installed; no other automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a8d55a678832b9d3c53e24eda73da)