### PR TITLE
Refine client camera screen shake behavior

### DIFF
--- a/Intersect.Client.Core/Core/Graphics.cs
+++ b/Intersect.Client.Core/Core/Graphics.cs
@@ -80,13 +80,10 @@ public static partial class Graphics
     //Overlay Stuff
     public static Color OverlayColor = Color.Transparent;
 
-    private static float sScreenShakeAmount;
+    public static float CurrentShake;
 
-    private static int sScreenShakeDurationMs;
+    private static float sShakeDecrement = 0.12f;
 
-    private static long sScreenShakeEnd;
-
-    private static readonly Random sShakeRandom = new();
 
     public static ColorF PlayerLightColor = ColorF.White;
 
@@ -127,9 +124,10 @@ public static partial class Graphics
 
     public static void TriggerScreenShake(float shakeAmount, int durationMs)
     {
-        sScreenShakeAmount = Math.Max(sScreenShakeAmount, shakeAmount);
-        sScreenShakeDurationMs = Math.Max(1, durationMs);
-        sScreenShakeEnd = Timing.Global.MillisecondsUtc + sScreenShakeDurationMs;
+        CurrentShake = Math.Max(CurrentShake, shakeAmount);
+
+        var durationFrames = Math.Max(1f, durationMs / 16f);
+        sShakeDecrement = Math.Max(0.01f, shakeAmount / durationFrames);
     }
 
     //Init Functions
@@ -989,7 +987,25 @@ public static partial class Graphics
             var sx = 0;
             var sy = 0;
             CurrentView = new FloatRect(sx, sy, sw / scale, sh / scale);
+            CurrentShake = 0f;
             return;
+        }
+
+        CurrentShake = MathHelper.Clamp(CurrentShake - sShakeDecrement, 0f, 100f);
+        var yShake = CurrentShake;
+        var xShake = CurrentShake;
+
+        if (CurrentShake > 0f)
+        {
+            if (Randomization.Next(0, 2) == 1)
+            {
+                yShake *= -1;
+            }
+
+            if (Randomization.Next(0, 2) == 1)
+            {
+                xShake *= -1;
+            }
         }
 
         var mapWidth = Options.Instance.Map.MapWidth * Options.Instance.Map.TileWidth;
@@ -1036,8 +1052,8 @@ public static partial class Graphics
         var h = y1 - y;
         var restrictView = new FloatRect(x, y, w, h );
         var newView = new FloatRect(
-            (int)Math.Ceiling(en.Center.X - Renderer.ScreenWidth / scale / 2f),
-            (int)Math.Ceiling(en.Center.Y - Renderer.ScreenHeight / scale / 2f),
+            (int)Math.Ceiling(en.Center.X - Renderer.ScreenWidth / scale / 2f) + (int)xShake,
+            (int)Math.Ceiling(en.Center.Y - Renderer.ScreenHeight / scale / 2f) + (int)yShake,
             Renderer.ScreenWidth / scale,
             Renderer.ScreenHeight / scale
         );
@@ -1074,18 +1090,6 @@ public static partial class Graphics
         else if (Options.Instance.Map.GameBorderStyle == GameBorderStyle.Seamed)
         {
             newView.Y = restrictView.Y - (newView.Height - restrictView.Height) / 2;
-        }
-
-        if (Timing.Global.MillisecondsUtc <= sScreenShakeEnd && sScreenShakeAmount > 0f)
-        {
-            var progress = (sScreenShakeEnd - Timing.Global.MillisecondsUtc) / (float)sScreenShakeDurationMs;
-            var currentShake = sScreenShakeAmount * Math.Clamp(progress, 0f, 1f);
-            newView.X += (float)(sShakeRandom.NextDouble() * 2 - 1) * currentShake;
-            newView.Y += (float)(sShakeRandom.NextDouble() * 2 - 1) * currentShake;
-        }
-        else
-        {
-            sScreenShakeAmount = 0f;
         }
 
         CurrentView = new FloatRect(


### PR DESCRIPTION
### Motivation

- Improve the camera screen-shake so it feels more responsive and controllable than the previous time-window approach. 
- Use an intensity-driven, per-frame decay so shake behaves consistently across frames and can be tuned from the `TriggerScreenShake` call. 

### Description

- Replaced the time-windowed fields with a current intensity model by adding `CurrentShake` and `sShakeDecrement` and removing the previous `sScreenShakeAmount`/`sScreenShakeEnd` logic in `Graphics.cs`.
- Updated `TriggerScreenShake` to set `CurrentShake` and compute a per-frame decrement from the requested `durationMs` so shake decays deterministically.
- Applied shake in `UpdateView` by clamping and decrementing `CurrentShake` each frame, randomizing sign per-axis, and offsetting the camera center when building `newView`.
- Reset `CurrentShake` when not in-game to avoid shake persisting across menu/state transitions.

### Testing

- Ran repository file checks and inspected the modified file `Intersect.Client.Core/Core/Graphics.cs` and created a commit for the change.
- Attempted `dotnet build Intersect.Client/Intersect.Client.csproj -v minimal`, which could not be executed here because `dotnet` is not installed in the environment, so a full compile verification was not performed.
- No automated unit tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698aa3cf8f9c832b98f56e3d498b1851)