### PR TITLE
Fix NRE when loading character window weapon profile

### DIFF
--- a/Intersect.Client.Core/Interface/Game/Character/CharacterWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Character/CharacterWindow.cs
@@ -531,7 +531,11 @@ public partial class CharacterWindow : Window
                 var invIndex = list[0];
                 if (invIndex >= 0 && invIndex < Options.Instance.Player.MaxInventory)
                 {
-                    weaponId = player.Inventory[invIndex].ItemId;
+                    var inventorySlot = player.Inventory.ElementAtOrDefault(invIndex);
+                    if (inventorySlot != null)
+                    {
+                        weaponId = inventorySlot.ItemId;
+                    }
                 }
             }
         }


### PR DESCRIPTION
### Motivation
- Prevent a `NullReferenceException` during startup when a local player's equipped weapon slot references an empty or null inventory entry.

### Description
- Use `ElementAtOrDefault` on `player.Inventory` and check the resulting `inventorySlot` for null before reading `ItemId` in `CharacterWindow.TryGetEquippedWeaponProfile`, preserving existing behavior for valid equipped items.

### Testing
- Attempted to run `dotnet build Broken_Reborn.sln -v minimal` as automated validation, but the build could not be executed because `dotnet` is not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698aaa0db43c832ba82dc8cc0019e96c)