### PR TITLE
Replace target texture with outline in DrawTarget

### DIFF
--- a/Intersect.Client.Core/Entities/Entity.cs
+++ b/Intersect.Client.Core/Entities/Entity.cs
@@ -2137,6 +2137,8 @@ public partial class Entity : IEntity
 
     public bool ShouldDrawTarget => this is not Projectile && LatestMap != default;
 
+    public virtual bool CanBeAttacked => true;
+
     public void DrawTarget(int priority)
     {
         // Should we draw the target?
@@ -2145,30 +2147,61 @@ public partial class Entity : IEntity
             return;
         }
 
-        var targetTexture = Globals.ContentManager.GetTexture(TextureType.Misc, "target.png");
-        if (targetTexture == null)
+        // Determinar a cor do contorno baseado no tipo de target
+        Color outlineColor;
+        if (priority == (int)Enums.TargetType.Selected)
         {
-            return;
+            // Target selecionado = vermelho vibrante
+            outlineColor = new Color(255, 255, 0, 0);
+        }
+        else // Hover
+        {
+            // Target em hover = amarelo suave
+            outlineColor = new Color(200, 255, 215, 0);
         }
 
-        var srcRectangle = new FloatRect(
-            priority * targetTexture.Width / 2f,
-            0,
-            targetTexture.Width / 2f,
-            targetTexture.Height
+        // Espessura do contorno (em pixels)
+        var outlineThickness = 2;
+
+        // Desenhar retângulo vazado ao redor da entidade
+        var targetRect = WorldPos;
+        
+        // Linha superior
+        Graphics.DrawGameTexture(
+            Graphics.Renderer.WhitePixel,
+            new FloatRect(0, 0, 1, 1),
+            new FloatRect(targetRect.X - outlineThickness, targetRect.Y - outlineThickness, 
+                         targetRect.Width + (outlineThickness * 2), outlineThickness),
+            outlineColor
         );
 
-        var destRectangle = new FloatRect(
-            (float)Math.Ceiling(WorldPos.X + (WorldPos.Width - targetTexture.Width / 2) / 2),
-            (float)Math.Ceiling(WorldPos.Y + (WorldPos.Height - targetTexture.Height) / 2),
-            srcRectangle.Width,
-            srcRectangle.Height
+        // Linha inferior
+        Graphics.DrawGameTexture(
+            Graphics.Renderer.WhitePixel,
+            new FloatRect(0, 0, 1, 1),
+            new FloatRect(targetRect.X - outlineThickness, targetRect.Y + targetRect.Height, 
+                         targetRect.Width + (outlineThickness * 2), outlineThickness),
+            outlineColor
         );
 
-        Graphics.DrawGameTexture(targetTexture, srcRectangle, destRectangle, Color.White);
+        // Linha esquerda
+        Graphics.DrawGameTexture(
+            Graphics.Renderer.WhitePixel,
+            new FloatRect(0, 0, 1, 1),
+            new FloatRect(targetRect.X - outlineThickness, targetRect.Y, 
+                         outlineThickness, targetRect.Height),
+            outlineColor
+        );
+
+        // Linha direita
+        Graphics.DrawGameTexture(
+            Graphics.Renderer.WhitePixel,
+            new FloatRect(0, 0, 1, 1),
+            new FloatRect(targetRect.X + targetRect.Width, targetRect.Y, 
+                         outlineThickness, targetRect.Height),
+            outlineColor
+        );
     }
-
-    public virtual bool CanBeAttacked => true;
 
     //Chatting
     public void AddChatBubble(string text)


### PR DESCRIPTION
### Motivation
- Improve visual clarity and flexibility of entity targeting by replacing a static `target.png` sprite with a programmatic outline so colors and thickness can reflect target priority.
- Reduce dependency on a texture asset and allow simpler drawing logic for selected vs hover states.

### Description
- Replaced usage of `target.png` in `Intersect.Client.Core/Entities/Entity.cs` with an outline rectangle drawn using `Graphics.Renderer.WhitePixel` inside `DrawTarget(int priority)`.
- Outline color is chosen by `priority` (selected vs hover) and a fixed thickness of `2` pixels is used for the rectangle edges.
- Introduced/relocated the virtual property `CanBeAttacked => true` near the target drawing logic.
- Removed the old source/destination rectangle calculations for the texture and instead draw four filled rectangles for the top, bottom, left and right edges around `WorldPos`.

### Testing
- Attempted to build the modified client project with `dotnet build Intersect.Client.Core/Intersect.Client.Core.csproj -v minimal`, but the environment lacks the .NET SDK and the command failed with `dotnet: command not found`.
- The patch was applied to the codebase and a local verification of the changed lines in `Entity.cs` was performed (`nl`/`sed` output) to confirm the modifications succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69923ba719c0832b847126c647d52d83)