### PR TITLE
Add boss combat AI execution layer for NPCs

### DIFF
--- a/Framework/Intersect.Framework.Core/GameObjects/NPCs/BossBehaviorProfile.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/NPCs/BossBehaviorProfile.cs
@@ -1,3 +1,5 @@
+using Intersect.Enums;
+
 namespace Intersect.Framework.Core.GameObjects.NPCs;
 
 public enum BossTriggerConditionType
@@ -14,6 +16,38 @@ public enum BossActionType
     SummonAdds = 2,
     ChangeTarget = 3,
     Enrage = 4,
+    CastSpellFromList = 5,
+    SetInternalState = 6,
+}
+
+public enum BossConditionType
+{
+    SelfHealthPercent = 0,
+    TargetHealthPercent = 1,
+    StatusPresent = 2,
+    DistanceToTarget = 3,
+    TimeSinceLastCastMilliseconds = 4,
+    InternalState = 5,
+}
+
+public enum BossComparisonType
+{
+    LessOrEqual = 0,
+    GreaterOrEqual = 1,
+    BetweenInclusive = 2,
+}
+
+public enum BossStatusTargetType
+{
+    Self = 0,
+    CurrentTarget = 1,
+}
+
+public enum BossTargetSelectionType
+{
+    HighestThreat = 0,
+    Tank = 1,
+    Healer = 2,
 }
 
 public class BossBehaviorProfile
@@ -21,6 +55,10 @@ public class BossBehaviorProfile
     public const int LatestVersion = 1;
 
     public int Version { get; set; } = LatestVersion;
+
+    public int EvaluationIntervalMs { get; set; } = 250;
+
+    public int GlobalCooldownMs { get; set; } = 1000;
 
     public List<BossPhase> Phases { get; set; } = [];
 }
@@ -52,6 +90,10 @@ public class BossTrigger
 
     public int CooldownSeconds { get; set; }
 
+    public int Priority { get; set; }
+
+    public List<BossCondition> Conditions { get; set; } = [];
+
     public List<BossAction> Actions { get; set; } = [];
 }
 
@@ -60,6 +102,8 @@ public class BossAction
     public BossActionType Action { get; set; } = BossActionType.CastSpell;
 
     public Guid SpellId { get; set; } = Guid.Empty;
+
+    public List<Guid> SpellIds { get; set; } = [];
 
     public int DestinationX { get; set; }
 
@@ -72,4 +116,33 @@ public class BossAction
     public bool TargetHighestThreat { get; set; } = true;
 
     public int EnragePercentBonus { get; set; }
+
+    public BossTargetSelectionType TargetSelection { get; set; } = BossTargetSelectionType.HighestThreat;
+
+    public string InternalStateKey { get; set; } = string.Empty;
+
+    public bool InternalStateValue { get; set; } = true;
+
+    public int Priority { get; set; }
+
+    public int CooldownMs { get; set; }
+}
+
+public class BossCondition
+{
+    public BossConditionType Type { get; set; } = BossConditionType.SelfHealthPercent;
+
+    public BossComparisonType Comparison { get; set; } = BossComparisonType.LessOrEqual;
+
+    public int Value { get; set; }
+
+    public int MinimumValue { get; set; }
+
+    public int MaximumValue { get; set; }
+
+    public SpellEffect StatusEffect { get; set; } = SpellEffect.None;
+
+    public BossStatusTargetType StatusTarget { get; set; } = BossStatusTargetType.Self;
+
+    public string InternalStateKey { get; set; } = string.Empty;
 }

--- a/Intersect.Server.Core/Entities/BossSystem/BossAiExecutor.cs
+++ b/Intersect.Server.Core/Entities/BossSystem/BossAiExecutor.cs
@@ -1,0 +1,357 @@
+using System.Linq;
+using Intersect.Enums;
+using Intersect.Framework.Core.GameObjects.NPCs;
+using Intersect.Server.Entities;
+using Intersect.Utilities;
+
+namespace Intersect.Server.Entities.BossSystem;
+
+internal sealed class BossAiExecutor
+{
+    private readonly BossAiRuntimeState _runtime = new();
+
+    public bool TryExecute(Npc npc, long now)
+    {
+        if (npc.Descriptor.BossBehaviorProfile is not { Phases.Count: > 0 } profile)
+        {
+            return false;
+        }
+
+        var evaluationInterval = Math.Max(100, profile.EvaluationIntervalMs);
+        if (_runtime.LastEvaluationAt + evaluationInterval > now)
+        {
+            return false;
+        }
+
+        _runtime.LastEvaluationAt = now;
+
+        if (_runtime.GlobalCooldownUntil > now)
+        {
+            return false;
+        }
+
+        var target = npc.Target;
+        var candidates = BuildCandidates(npc, profile, target, now);
+        if (candidates.Count == 0)
+        {
+            return false;
+        }
+
+        var selected = candidates
+            .OrderByDescending(c => c.Priority)
+            .ThenBy(c => c.Index)
+            .First();
+
+        if (!TryExecuteAction(npc, selected.Action, target, now))
+        {
+            return false;
+        }
+
+        var actionKey = BuildActionCooldownKey(selected.Action);
+        if (selected.Action.CooldownMs > 0)
+        {
+            _runtime.ActionCooldowns[actionKey] = now + selected.Action.CooldownMs;
+        }
+
+        if (selected.TriggerCooldownMs > 0)
+        {
+            _runtime.TriggerCooldowns[selected.TriggerCooldownKey] = now + selected.TriggerCooldownMs;
+        }
+
+        var globalCooldownMs = selected.Action.CooldownMs > 0
+            ? Math.Max(profile.GlobalCooldownMs, selected.Action.CooldownMs)
+            : profile.GlobalCooldownMs;
+
+        if (globalCooldownMs > 0)
+        {
+            _runtime.GlobalCooldownUntil = now + globalCooldownMs;
+        }
+
+        return true;
+    }
+
+    private List<ActionCandidate> BuildCandidates(Npc npc, BossBehaviorProfile profile, Entity target, long now)
+    {
+        var candidates = new List<ActionCandidate>();
+        var healthPercent = GetHealthPercent(npc);
+        var runningIndex = 0;
+
+        foreach (var phase in profile.Phases.OrderByDescending(p => p.Priority))
+        {
+            if (healthPercent < phase.MinimumHealthPercent || healthPercent > phase.MaximumHealthPercent)
+            {
+                continue;
+            }
+
+            foreach (var action in phase.Actions)
+            {
+                if (IsActionOnCooldown(action, now))
+                {
+                    runningIndex++;
+                    continue;
+                }
+
+                candidates.Add(new ActionCandidate(action, phase.Priority + action.Priority, runningIndex++, 0, string.Empty));
+            }
+
+            for (var triggerIndex = 0; triggerIndex < phase.Triggers.Count; triggerIndex++)
+            {
+                var trigger = phase.Triggers[triggerIndex];
+                var triggerCooldownKey = $"{phase.Id}:{triggerIndex}";
+                if (trigger.CooldownSeconds > 0 &&
+                    _runtime.TriggerCooldowns.TryGetValue(triggerCooldownKey, out var triggerCooldownUntil) &&
+                    triggerCooldownUntil > now)
+                {
+                    runningIndex += trigger.Actions.Count;
+                    continue;
+                }
+
+                if (!IsTriggerActive(npc, trigger, target, now))
+                {
+                    runningIndex += trigger.Actions.Count;
+                    continue;
+                }
+
+                foreach (var action in trigger.Actions)
+                {
+                    if (IsActionOnCooldown(action, now))
+                    {
+                        runningIndex++;
+                        continue;
+                    }
+
+                    var priority = phase.Priority + trigger.Priority + action.Priority;
+                    candidates.Add(
+                        new ActionCandidate(
+                            action,
+                            priority,
+                            runningIndex++,
+                            trigger.CooldownSeconds * 1000,
+                            triggerCooldownKey
+                        )
+                    );
+                }
+            }
+        }
+
+        return candidates;
+    }
+
+    private bool IsTriggerActive(Npc npc, BossTrigger trigger, Entity target, long now)
+    {
+        if (!EvaluateLegacyTriggerCondition(npc, trigger, target, now))
+        {
+            return false;
+        }
+
+        foreach (var condition in trigger.Conditions)
+        {
+            if (!EvaluateCondition(npc, condition, target, now))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool EvaluateLegacyTriggerCondition(Npc npc, BossTrigger trigger, Entity target, long now)
+    {
+        return trigger.Condition switch
+        {
+            BossTriggerConditionType.HealthPercentAtOrBelow =>
+                trigger.ThresholdHealthPercent <= 0 || GetHealthPercent(npc) <= trigger.ThresholdHealthPercent,
+            BossTriggerConditionType.StatusApplied =>
+                string.IsNullOrWhiteSpace(trigger.RequiredAppliedState) || HasStatusByName(target, trigger.RequiredAppliedState),
+            BossTriggerConditionType.CombatTimeAtOrAbove =>
+                trigger.CombatTimeSeconds <= 0 || now >= npc.CombatTimer + trigger.CombatTimeSeconds * 1000L,
+            _ => true,
+        };
+    }
+
+    private bool EvaluateCondition(Npc npc, BossCondition condition, Entity target, long now)
+    {
+        switch (condition.Type)
+        {
+            case BossConditionType.SelfHealthPercent:
+                return Compare(GetHealthPercent(npc), condition);
+            case BossConditionType.TargetHealthPercent:
+                return target != null && Compare(GetHealthPercent(target), condition);
+            case BossConditionType.StatusPresent:
+            {
+                var statusTarget = condition.StatusTarget == BossStatusTargetType.CurrentTarget ? target : npc;
+                if (statusTarget == null)
+                {
+                    return false;
+                }
+
+                return statusTarget.HasStatusEffect(condition.StatusEffect);
+            }
+            case BossConditionType.DistanceToTarget:
+                return target != null && Compare(npc.GetDistanceTo(target), condition);
+            case BossConditionType.TimeSinceLastCastMilliseconds:
+            {
+                var elapsed = Math.Max(0, now - _runtime.LastCastAt);
+                return Compare(elapsed, condition);
+            }
+            case BossConditionType.InternalState:
+                return _runtime.InternalStates.TryGetValue(condition.InternalStateKey ?? string.Empty, out var state) && state;
+            default:
+                return false;
+        }
+    }
+
+    private static bool Compare(long actualValue, BossCondition condition)
+    {
+        return condition.Comparison switch
+        {
+            BossComparisonType.LessOrEqual => actualValue <= condition.Value,
+            BossComparisonType.GreaterOrEqual => actualValue >= condition.Value,
+            BossComparisonType.BetweenInclusive => actualValue >= condition.MinimumValue && actualValue <= condition.MaximumValue,
+            _ => false,
+        };
+    }
+
+    private bool TryExecuteAction(Npc npc, BossAction action, Entity target, long now)
+    {
+        switch (action.Action)
+        {
+            case BossActionType.CastSpell:
+                if (action.SpellId == Guid.Empty)
+                {
+                    return false;
+                }
+
+                if (npc.TryCastSpellById(action.SpellId, target))
+                {
+                    _runtime.LastCastAt = now;
+                    return true;
+                }
+
+                return false;
+            case BossActionType.CastSpellFromList:
+            {
+                var spellIds = action.SpellIds?.Where(id => id != Guid.Empty).ToArray();
+                if (spellIds is not { Length: > 0 })
+                {
+                    return false;
+                }
+
+                var startIndex = Randomization.Next(0, spellIds.Length);
+                for (var index = 0; index < spellIds.Length; index++)
+                {
+                    var spellId = spellIds[(startIndex + index) % spellIds.Length];
+                    if (!npc.TryCastSpellById(spellId, target))
+                    {
+                        continue;
+                    }
+
+                    _runtime.LastCastAt = now;
+                    return true;
+                }
+
+                return false;
+            }
+            case BossActionType.ChangeTarget:
+                if (TrySelectTarget(npc, action.TargetSelection, out var selectedTarget))
+                {
+                    npc.AssignTarget(selectedTarget);
+                    return true;
+                }
+
+                return false;
+            case BossActionType.Enrage:
+            case BossActionType.SetInternalState:
+                if (string.IsNullOrWhiteSpace(action.InternalStateKey))
+                {
+                    return false;
+                }
+
+                _runtime.InternalStates[action.InternalStateKey] = action.InternalStateValue;
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private static bool TrySelectTarget(Npc npc, BossTargetSelectionType selection, out Entity selected)
+    {
+        selected = null;
+        var candidates = npc.DamageMap.Keys
+            .Where(entity => entity != null && !entity.IsDisposed && !entity.IsDead && npc.CanTarget(entity))
+            .ToArray();
+
+        if (candidates.Length == 0)
+        {
+            return false;
+        }
+
+        selected = selection switch
+        {
+            BossTargetSelectionType.HighestThreat => npc.DamageMapHighest,
+            BossTargetSelectionType.Tank => candidates.OrderByDescending(entity => entity.GetMaxVital(Vital.Health)).FirstOrDefault(),
+            BossTargetSelectionType.Healer => candidates.OrderByDescending(entity => entity.Stat[(int)Stat.Intelligence].Value()).FirstOrDefault(),
+            _ => npc.DamageMapHighest,
+        };
+
+        if (selected != null)
+        {
+            return true;
+        }
+
+        selected = candidates[0];
+        return true;
+    }
+
+    private bool IsActionOnCooldown(BossAction action, long now)
+    {
+        var actionKey = BuildActionCooldownKey(action);
+        return _runtime.ActionCooldowns.TryGetValue(actionKey, out var actionCooldownUntil) && actionCooldownUntil > now;
+    }
+
+    private static string BuildActionCooldownKey(BossAction action)
+    {
+        return action.Action switch
+        {
+            BossActionType.CastSpell => $"cast:{action.SpellId}",
+            BossActionType.CastSpellFromList => $"cast-list:{string.Join(',', action.SpellIds?.Where(id => id != Guid.Empty) ?? Enumerable.Empty<Guid>())}",
+            BossActionType.ChangeTarget => $"target:{action.TargetSelection}",
+            BossActionType.SetInternalState or BossActionType.Enrage => $"state:{action.InternalStateKey}",
+            _ => action.Action.ToString(),
+        };
+    }
+
+    private static bool HasStatusByName(Entity target, string statusName)
+    {
+        if (target == null || string.IsNullOrWhiteSpace(statusName))
+        {
+            return false;
+        }
+
+        if (!Enum.TryParse<SpellEffect>(statusName, true, out var spellEffect))
+        {
+            return false;
+        }
+
+        return target.HasStatusEffect(spellEffect);
+    }
+
+    private static int GetHealthPercent(Entity entity)
+    {
+        var maxHealth = entity.GetMaxVital(Vital.Health);
+        if (maxHealth <= 0)
+        {
+            return 0;
+        }
+
+        return (int)Math.Clamp(entity.GetVital(Vital.Health) * 100 / maxHealth, 0, 100);
+    }
+
+    private readonly record struct ActionCandidate(
+        BossAction Action,
+        int Priority,
+        int Index,
+        int TriggerCooldownMs,
+        string TriggerCooldownKey
+    );
+}

--- a/Intersect.Server.Core/Entities/BossSystem/BossAiRuntimeState.cs
+++ b/Intersect.Server.Core/Entities/BossSystem/BossAiRuntimeState.cs
@@ -1,0 +1,18 @@
+using System.Collections.Concurrent;
+
+namespace Intersect.Server.Entities.BossSystem;
+
+internal sealed class BossAiRuntimeState
+{
+    public long LastEvaluationAt { get; set; }
+
+    public long GlobalCooldownUntil { get; set; }
+
+    public long LastCastAt { get; set; }
+
+    public ConcurrentDictionary<string, long> ActionCooldowns { get; } = new();
+
+    public ConcurrentDictionary<string, bool> InternalStates { get; } = new();
+
+    public ConcurrentDictionary<string, long> TriggerCooldowns { get; } = new();
+}

--- a/Intersect.Server.Core/Entities/Npc.cs
+++ b/Intersect.Server.Core/Entities/Npc.cs
@@ -33,6 +33,8 @@ public partial class Npc : Entity
     //Spell casting
     public long CastFreq;
 
+    private readonly BossAiExecutor _bossAiExecutor;
+
     /// <summary>
     /// Damage Map - Keep track of who is doing the most damage to this npc and focus accordingly
     /// </summary>
@@ -120,6 +122,7 @@ public partial class Npc : Entity
         Immunities = npcDescriptor.Immunities;
         Descriptor = npcDescriptor;
         Despawnable = despawnable;
+        _bossAiExecutor = new BossAiExecutor();
 
         for (var i = 0; i < Enum.GetValues<Stat>().Length; i++)
         {
@@ -751,49 +754,73 @@ public partial class Npc : Entity
         return blockerType == MovementBlockerType.NotBlocked;
     }
 
+    public bool TryCastSpellById(Guid spellId, Entity explicitTarget = null)
+    {
+        if (spellId == Guid.Empty)
+        {
+            return false;
+        }
+
+        var spellIndex = Descriptor.Spells.IndexOf(spellId);
+        if (spellIndex < 0)
+        {
+            return false;
+        }
+
+        if (!SpellDescriptor.TryGet(spellId, out var spellDescriptor))
+        {
+            return false;
+        }
+
+        var target = explicitTarget ?? Target;
+        return TryBeginSpellCast(spellDescriptor, spellIndex, target);
+    }
+
     private void TryCastSpells()
     {
-        var target = Target;
-
-        if (target == null || mPathFinder.GetTarget() == null)
-        {
-            return;
-        }
-
-        // Check if NPC is stunned/sleeping
-        if (IsStunnedOrSleeping)
-        {
-            return;
-        }
-
-        //Check if NPC is casting a spell
-        if (IsCasting)
-        {
-            return; //can't move while casting
-        }
-
-        if (CastFreq >= Timing.Global.Milliseconds)
-        {
-            return;
-        }
-
-        // Check if the NPC is able to cast spells
-        if (IsUnableToCastSpells)
-        {
-            return;
-        }
-
         if (Descriptor.Spells is not { Count: > 0 })
         {
             return;
         }
 
-        // Pick a random spell
         var spellIndex = Randomization.Next(0, Spells.Count);
         var spellId = Descriptor.Spells[spellIndex];
-        if (!SpellDescriptor.TryGet(spellId, out var spellBase))
+        if (!SpellDescriptor.TryGet(spellId, out var spellDescriptor))
         {
             return;
+        }
+
+        _ = TryBeginSpellCast(spellDescriptor, spellIndex, Target);
+    }
+
+    private bool TryBeginSpellCast(SpellDescriptor spellBase, int spellIndex, Entity target)
+    {
+        if (target == null || mPathFinder.GetTarget() == null)
+        {
+            return false;
+        }
+
+        // Check if NPC is stunned/sleeping
+        if (IsStunnedOrSleeping)
+        {
+            return false;
+        }
+
+        //Check if NPC is casting a spell
+        if (IsCasting)
+        {
+            return false; //can't move while casting
+        }
+
+        if (CastFreq >= Timing.Global.Milliseconds)
+        {
+            return false;
+        }
+
+        // Check if the NPC is able to cast spells
+        if (IsUnableToCastSpells)
+        {
+            return false;
         }
 
         if (spellBase.Combat == null)
@@ -801,16 +828,10 @@ public partial class Npc : Entity
             ApplicationContext.Context.Value?.Logger.LogWarning($"Combat data missing for {spellBase.Id}.");
         }
 
-        //TODO: try cast spell to find out hidden targets?
-        // if (target.HasStatusEffect(SpellEffect.Stealth) /* && spellBase.Combat.TargetType != SpellTargetType.AoE*/)
-        // {
-        //     return;
-        // }
-
         // Check if we are even allowed to cast this spell.
         if (!CanCastSpell(spellBase, target, true, SoftRetargetOnSelfCast, out _))
         {
-            return;
+            return false;
         }
 
         var targetType = spellBase.Combat?.TargetType ?? SpellTargetType.Single;
@@ -826,14 +847,14 @@ public partial class Npc : Entity
             {
                 if (LastRandomMove >= Timing.Global.Milliseconds)
                 {
-                    return;
+                    return false;
                 }
 
                 //Face the target -- next frame fire -- then go on with life
                 ChangeDir(dirToEnemy); // Gotta get dir to enemy
                 LastRandomMove = Timing.Global.Milliseconds + Randomization.Next(1000, 3000);
 
-                return;
+                return false;
             }
         }
 
@@ -852,27 +873,22 @@ public partial class Npc : Entity
         {
             case 0:
                 CastFreq = Timing.Global.Milliseconds + 30000;
-
                 break;
 
             case 1:
                 CastFreq = Timing.Global.Milliseconds + 15000;
-
                 break;
 
             case 2:
                 CastFreq = Timing.Global.Milliseconds + 8000;
-
                 break;
 
             case 3:
                 CastFreq = Timing.Global.Milliseconds + 4000;
-
                 break;
 
             case 4:
                 CastFreq = Timing.Global.Milliseconds + 2000;
-
                 break;
         }
 
@@ -892,11 +908,10 @@ public partial class Npc : Entity
                 AnimationSourceType.SpellCast,
                 spellBase.Id
             );
-
-            //Target Type 1 will be global entity
         }
 
-        PacketSender.SendEntityCastTime(this, spellId);
+        PacketSender.SendEntityCastTime(this, spellBase.Id);
+        return true;
     }
 
     public bool IsFleeing()
@@ -1060,7 +1075,16 @@ public partial class Npc : Entity
 
                     if (mPathFinder.GetTarget() != null && Descriptor.Movement != (int)NpcMovement.Static)
                     {
-                        TryCastSpells();
+                        var bossActionExecuted = false;
+                        if (Descriptor.IsBoss && !Descriptor.UsesDefaultAiBehavior)
+                        {
+                            bossActionExecuted = _bossAiExecutor.TryExecute(this, timeMs);
+                        }
+
+                        if (!bossActionExecuted)
+                        {
+                            TryCastSpells();
+                        }
                         // TODO: Make resetting mobs actually return to their starting location.
                         if ((!mResetting && !IsOneBlockAway(
                             mPathFinder.GetTarget().TargetMapId, mPathFinder.GetTarget().TargetX,


### PR DESCRIPTION
### Motivation
- Implementar una capa de IA para bosses que permita evaluar triggers por intervalo corto y seleccionar acciones por prioridad sin romper la IA de mobs normales.
- Soportar condiciones y acciones de boss más avanzadas (HP, estados, distancia, tiempo desde último casteo, cambios de target, estados internos) y controlar spam mediante cooldowns.

### Description
- Añadido `BossAiExecutor` y `BossAiRuntimeState` en `Intersect.Server.Core/Entities/BossSystem` que manejan evaluación periódica, scoring de candidatas y ejecución de la acción seleccionada.
- Extendido el modelo `BossBehaviorProfile` en `Framework/Intersect.Framework.Core/GameObjects/NPCs/BossBehaviorProfile.cs` con nuevos enums y clases para condiciones, comparadores, selección de target, listas de spells, prioridad y cooldowns globales/por-acción.
- Integrada la ejecución de la IA de boss en el loop de combate del `Npc` (`Intersect.Server.Core/Entities/Npc.cs`) con fallback seguro a la lógica existente para mobs normales y disparo condicionado a `Descriptor.IsBoss && !Descriptor.UsesDefaultAiBehavior`.
- Refactor de casteo de NPCs: añadido `TryCastSpellById` y `TryBeginSpellCast` para exponer casteo dirigido por ID y reutilizar validaciones de inicio de casteo; añadido soporte de cooldowns por acción y trigger, y selección de target (highest threat/tank/healer).

### Testing
- Ejecutado `git diff --check` para verificar problemas de formato y no se reportaron errores (éxito).
- Intentado `dotnet build Intersect.Server.Core/Intersect.Server.Core.csproj` pero `dotnet` no está disponible en este entorno, por lo que no se pudo compilar aquí (falló por entorno, no por código).
- Verificado estado de cambios y archivos añadidos mediante `git status --short` y revisado los archivos modificados para revisar la integración (verificados manualmente).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69930c937bbc832b9f01f6bbf0b073ee)