### PR TITLE
Guard Game UI initialization race in packet handling

### DIFF
--- a/Framework/Intersect.Framework.Core/Combat/CombatFormulaCalculator.cs
+++ b/Framework/Intersect.Framework.Core/Combat/CombatFormulaCalculator.cs
@@ -1,0 +1,51 @@
+using System;
+
+namespace Intersect.Framework.Core.Combat;
+
+public static class CombatFormulaCalculator
+{
+    private const double MinHitChance = 0.1d;
+    private const double MaxHitChance = 0.98d;
+    private const double BaseHitChance = 0.7d;
+    private const double HitChanceSwingFactor = 0.3d;
+
+    public static double CalculateAccuracyScore(int agility, int attack, int accuracyBonus)
+    {
+        return agility * 0.5d + attack * 0.3d + accuracyBonus;
+    }
+
+    public static double CalculateEvasionScore(int agility, int defense, int evasionBonus)
+    {
+        return agility * 0.7d + defense * 0.2d + evasionBonus;
+    }
+
+    public static double CalculateHitChance(double accuracyScore, double evasionScore)
+    {
+        var statBalance = accuracyScore - evasionScore;
+        var normalization = Math.Max(50d, accuracyScore + evasionScore);
+        var hitChance = BaseHitChance + HitChanceSwingFactor * statBalance / normalization;
+
+        return Math.Clamp(hitChance, MinHitChance, MaxHitChance);
+    }
+
+    public static int CalculateAgilityCriticalContribution(int agility, int agilityPerCritChance)
+    {
+        return agility / Math.Max(1, agilityPerCritChance);
+    }
+
+    public static int CalculateCriticalChance(
+        int baseCritChance,
+        int agility,
+        int agilityPerCritChance,
+        int criticalChanceBonus,
+        int antiCritChance
+    )
+    {
+        var critChance = baseCritChance;
+        critChance += CalculateAgilityCriticalContribution(agility, agilityPerCritChance);
+        critChance += criticalChanceBonus;
+        critChance -= antiCritChance;
+
+        return Math.Max(0, critChance);
+    }
+}

--- a/Framework/Intersect.Framework.Core/GameObjects/NPCs/BossBehaviorProfile.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/NPCs/BossBehaviorProfile.cs
@@ -1,0 +1,191 @@
+using Intersect.Enums;
+
+namespace Intersect.Framework.Core.GameObjects.NPCs;
+
+public enum BossTriggerConditionType
+{
+    HealthPercentAtOrBelow = 0,
+    StatusApplied = 1,
+    CombatTimeAtOrAbove = 2,
+}
+
+public enum BossActionType
+{
+    CastSpell = 0,
+    MoveToPosition = 1,
+    SummonAdds = 2,
+    ChangeTarget = 3,
+    Enrage = 4,
+    CastSpellFromList = 5,
+    SetInternalState = 6,
+}
+
+public enum BossConditionType
+{
+    SelfHealthPercent = 0,
+    TargetHealthPercent = 1,
+    StatusPresent = 2,
+    DistanceToTarget = 3,
+    TimeSinceLastCastMilliseconds = 4,
+    InternalState = 5,
+}
+
+public enum BossComparisonType
+{
+    LessOrEqual = 0,
+    GreaterOrEqual = 1,
+    BetweenInclusive = 2,
+}
+
+public enum BossStatusTargetType
+{
+    Self = 0,
+    CurrentTarget = 1,
+}
+
+public enum BossTargetSelectionType
+{
+    HighestThreat = 0,
+    Tank = 1,
+    Healer = 2,
+    LowestThreat = 3,
+    LowestHealth = 4,
+    LowestHealthPercent = 5,
+}
+
+public class BossBehaviorProfile
+{
+    public const int LatestVersion = 2;
+
+    public int Version { get; set; } = LatestVersion;
+
+    public int EvaluationIntervalMs { get; set; } = 250;
+
+    public int GlobalCooldownMs { get; set; } = 1000;
+
+    /// <summary>
+    /// Wind-up/telegraph delay applied before critical actions are executed.
+    /// </summary>
+    public int TelegraphMs { get; set; } = 0;
+
+    /// <summary>
+    /// Minimum window between actions marked as burst/big skills.
+    /// </summary>
+    public int MinIntervalBetweenBigSkills { get; set; } = 5000;
+
+    /// <summary>
+    /// Maximum number of consecutive control casts allowed before forcing a non-control action.
+    /// </summary>
+    public int MaxConsecutiveControlCasts { get; set; } = 2;
+
+    public List<BossPhase> Phases { get; set; } = [];
+}
+
+public class BossPhase
+{
+    public string Id { get; set; } = string.Empty;
+
+    public int MinimumHealthPercent { get; set; } = 0;
+
+    public int MaximumHealthPercent { get; set; } = 100;
+
+    public int Priority { get; set; }
+
+    public List<BossTrigger> Triggers { get; set; } = [];
+
+    public List<BossAction> Actions { get; set; } = [];
+}
+
+public class BossTrigger
+{
+    public BossTriggerConditionType Condition { get; set; } = BossTriggerConditionType.HealthPercentAtOrBelow;
+
+    public int ThresholdHealthPercent { get; set; }
+
+    public string RequiredAppliedState { get; set; } = string.Empty;
+
+    public int CombatTimeSeconds { get; set; }
+
+    public int CooldownSeconds { get; set; }
+
+    public int Priority { get; set; }
+
+    public List<BossCondition> Conditions { get; set; } = [];
+
+    public List<BossAction> Actions { get; set; } = [];
+}
+
+public class BossAction
+{
+    public BossActionType Action { get; set; } = BossActionType.CastSpell;
+
+    public Guid SpellId { get; set; } = Guid.Empty;
+
+    public List<Guid> SpellIds { get; set; } = [];
+
+    public int DestinationX { get; set; }
+
+    public int DestinationY { get; set; }
+
+    public Guid SummonNpcId { get; set; } = Guid.Empty;
+
+    public int SummonAmount { get; set; }
+
+    public bool TargetHighestThreat { get; set; } = true;
+
+    public int EnragePercentBonus { get; set; }
+
+    public BossTargetSelectionType TargetSelection { get; set; } = BossTargetSelectionType.HighestThreat;
+
+    public string InternalStateKey { get; set; } = string.Empty;
+
+    public bool InternalStateValue { get; set; } = true;
+
+    public int Priority { get; set; }
+
+    public int CooldownMs { get; set; }
+
+    /// <summary>
+    /// Marks this as a control action for anti-chain logic.
+    /// </summary>
+    public bool IsControlSkill { get; set; }
+
+    /// <summary>
+    /// Marks this as a burst/big action for interval throttling.
+    /// </summary>
+    public bool IsBigSkill { get; set; }
+
+    /// <summary>
+    /// Whether the action should show telegraph feedback before execution.
+    /// </summary>
+    public bool IsCriticalSkill { get; set; }
+
+    /// <summary>
+    /// Optional warning message used in telegraph feedback.
+    /// </summary>
+    public string TelegraphMessage { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Optional animation shown when telegraphing.
+    /// </summary>
+    public Guid TelegraphAnimationId { get; set; } = Guid.Empty;
+}
+
+public class BossCondition
+{
+    public BossConditionType Type { get; set; } = BossConditionType.SelfHealthPercent;
+
+    public BossComparisonType Comparison { get; set; } = BossComparisonType.LessOrEqual;
+
+    public int Value { get; set; }
+
+    public int MinimumValue { get; set; }
+
+    public int MaximumValue { get; set; }
+
+    public SpellEffect StatusEffect { get; set; } = SpellEffect.None;
+
+    public BossStatusTargetType StatusTarget { get; set; } = BossStatusTargetType.Self;
+
+    public string InternalStateKey { get; set; } = string.Empty;
+}

--- a/Framework/Intersect.Framework.Core/GameObjects/NPCs/NPCDescriptor.cs
+++ b/Framework/Intersect.Framework.Core/GameObjects/NPCs/NPCDescriptor.cs
@@ -35,6 +35,30 @@ public partial class NPCDescriptor : DatabaseObject<NPCDescriptor>, IFolderable
 
     public bool HiddenUntilDefeated { get; set; } = false;
 
+    public bool IsBoss { get; set; } = false;
+
+    public int BossRespawnMinutes { get; set; } = 0;
+
+    public bool BossAnnounceOnKill { get; set; } = false;
+
+    public bool BossAnnounceOnRespawn { get; set; } = false;
+
+    [NotMapped]
+    public BossBehaviorProfile BossBehaviorProfile { get; set; }
+
+    [Column("BossBehaviorProfile")]
+    [JsonIgnore]
+    public string BossBehaviorProfileJson
+    {
+        get => JsonConvert.SerializeObject(BossBehaviorProfile);
+        set => BossBehaviorProfile = string.IsNullOrWhiteSpace(value)
+            ? null
+            : JsonConvert.DeserializeObject<BossBehaviorProfile>(value);
+    }
+
+    [NotMapped]
+    public bool UsesDefaultAiBehavior => !IsBoss || BossBehaviorProfile is null || BossBehaviorProfile.Phases.Count == 0;
+
     [NotMapped]
     public Dictionary<BestiaryUnlock, int> BestiaryRequirements { get; set; } = new();
 

--- a/Framework/Intersect.Framework.Core/Network/Packets/Server/NpcEntityPacket.cs
+++ b/Framework/Intersect.Framework.Core/Network/Packets/Server/NpcEntityPacket.cs
@@ -14,4 +14,7 @@ public partial class NpcEntityPacket : EntityPacket
 
     [Key(24)]
     public NpcAggression Aggression { get; set; }
+
+    [Key(25)]
+    public bool IsBoss { get; set; }
 }

--- a/Intersect.Client.Core/Entities/Entity.cs
+++ b/Intersect.Client.Core/Entities/Entity.cs
@@ -233,6 +233,8 @@ public partial class Entity : IEntity
 
     public NpcAggression Aggression { get; set; }
 
+    public bool IsBossEntity { get; set; }
+
     public long[] Vital { get; set; } = new long[Enum.GetValues<Vital>().Length];
 
     IReadOnlyDictionary<Vital, long> IEntity.Vitals =>
@@ -1747,24 +1749,16 @@ public partial class Entity : IEntity
             return;
         }
 
-        // Detectar se é um BOSS e remover a tag do nome
+        // El estilo visual de boss depende únicamente del flag serializado por el servidor.
         var displayName = Name;
-        var isBoss = Name.Contains("[BOSS]", StringComparison.OrdinalIgnoreCase);
+        var isBoss = IsBossEntity;
 
         if (isBoss)
         {
-            // Remover a tag [BOSS] do nome exibido (case-insensitive)
-            displayName = System.Text.RegularExpressions.Regex.Replace(
-                Name,
-                @"\[BOSS\]",
-                "",
-                System.Text.RegularExpressions.RegexOptions.IgnoreCase
-            ).Trim();
-
-            // Aplicar cores de BOSS
-            textColor = new Color(255, 255, 0, 0);        // Vermelho puro
-            backgroundColor = new Color(255, 0, 0, 0);    // Preto sólido
-            borderColor = new Color(255, 0, 0, 0);        // Borda preta
+            // Aplicar cores de BOSS (ARGB)
+            textColor = new Color(255, 255, 0, 255);      // Amarelo sólido (ARGB: 255, 255, 0, 255)
+            borderColor = new Color(0, 0, 0, 255);        // Preto sólido (ARGB: 0, 0, 0, 255)
+            backgroundColor = new Color(0, 0, 0, 255);    // Preto sólido (ARGB: 0, 0, 0, 255)
         }
 
         if (cachedNameColor == null || lastPlayerLevel != player.Level)

--- a/Intersect.Client.Core/Entities/Player.cs
+++ b/Intersect.Client.Core/Entities/Player.cs
@@ -22,6 +22,7 @@ using Intersect.Config.Guilds;
 using Intersect.Configuration;
 using Intersect.Core;
 using Intersect.Enums;
+using Intersect.Framework.Core.Combat;
 using Intersect.Extensions;
 using Intersect.Framework.Core;
 using Intersect.Framework.Core.GameObjects.Events;
@@ -2728,12 +2729,13 @@ public partial class Player : Entity, IPlayer
 
     public int CalculateCriticalChance(int baseCritChance)
     {
-        var agilityPerCrit = Math.Max(1, Options.Instance.Combat.AgilityPerCritChance);
-        var agilityContribution = Stat[(int)Enums.Stat.Agility] / agilityPerCrit;
-        var equipmentBonus = GetEquipmentEffect(ItemEffect.CriticalChance);
-
-        var total = baseCritChance + agilityContribution + equipmentBonus;
-        return Math.Max(0, total);
+        return CombatFormulaCalculator.CalculateCriticalChance(
+            baseCritChance,
+            Stat[(int)Enums.Stat.Agility],
+            Options.Instance.Combat.AgilityPerCritChance,
+            GetEquipmentEffect(ItemEffect.CriticalChance),
+            antiCritChance: 0
+        );
     }
 
 

--- a/Intersect.Client.Core/Interface/Game/Bank/BankWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Bank/BankWindow.cs
@@ -364,6 +364,7 @@ public partial class BankWindow : Window
             }
 
             requests.Add(new LocalizationRequestEntry(descriptor.Type.ToString(), descriptor.Id.ToString(), "Name"));
+            requests.Add(new LocalizationRequestEntry(descriptor.Type.ToString(), descriptor.Id.ToString(), "Description"));
         }
 
         if (requests.Count > 0)

--- a/Intersect.Client.Core/Interface/Game/Character/CharacterWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Character/CharacterWindow.cs
@@ -2,6 +2,7 @@ using Intersect.Client.Core;
 using Intersect.Client.Entities;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using Intersect.Client.Framework.File_Management;
 using Intersect.Client.Framework.Gwen;
@@ -9,10 +10,12 @@ using Intersect.Client.Framework.Gwen.Control;
 using Intersect.Client.Framework.Gwen.Control.EventArguments;
 using Intersect.Client.General;
 using Intersect.Client.Interface.Game.Breaking;
+using Intersect.Client.Interface.Game.DescriptionWindows;
 using Intersect.Client.Interface;
 using Intersect.Client.Localization;
 using Intersect.Client.Networking;
 using Intersect.Enums;
+using Intersect.Framework.Core.Combat;
 using Intersect.Framework.Core.GameObjects.Items;
 using Intersect.Framework.Core.GameObjects.PlayerClass;
 
@@ -23,11 +26,14 @@ public partial class CharacterWindow : Window
     private const int WindowWidth = 700;
     private const int WindowHeight = 520;
     private const int Margin = 16;
+    private const int CharacterInfoHeight = 150;
+    private const int TopSectionHeight = 308;
 
-    private const int StatRowHeight = 24;
-    private const int StatLabelWidth = 230;
-    private const int EffectLabelWidth = 420; // más ancho porque ahora es 1 sola columna
+    private const int StatRowHeight = 22;
+    private const int StatIconSize = 18;
     private const int EffectRowHeight = 20;
+    private const int EffectIconSize = 16;
+    private const int IconSpacing = 8;
 
     private const string TitleFont = "sourcesansproblack";
     private const string BodyFont = "source-sans-pro";
@@ -190,13 +196,58 @@ public partial class CharacterWindow : Window
         return button;
     }
 
+    private ImagePanel CreateIconPanel(
+        Base parent,
+        string name,
+        int x,
+        int y,
+        string? iconName,
+        int rowHeight = StatRowHeight,
+        int iconSize = StatIconSize
+    )
+    {
+        var icon = new ImagePanel(parent, name);
+        icon.SetSize(iconSize, iconSize);
+        icon.SetPosition(x, y + Math.Max(0, (rowHeight - iconSize) / 2));
+        icon.Texture = StatEffectIconProvider.GetIconTexture(iconName);
+        icon.IsHidden = icon.Texture == null;
+
+        return icon;
+    }
+
+    private Label CreateLabelWithIcon(
+        Base parent,
+        string name,
+        string? iconName,
+        int x,
+        int y,
+        int width,
+        int rowHeight = StatRowHeight,
+        int iconSize = StatIconSize
+    )
+    {
+        if (!string.IsNullOrWhiteSpace(iconName))
+        {
+            CreateIconPanel(parent, $"{name}Icon", x, y, iconName, rowHeight, iconSize);
+            x += iconSize + IconSpacing;
+        }
+
+        return CreateBodyLabel(parent, name, x, y, width, rowHeight);
+    }
+
     private int Stack(Base ctrl, int x, int y, int spacing = 4)
     {
         ctrl.SetPosition(x, y);
         return y + ctrl.Height + spacing;
     }
 
-    private string FormatEffectValue(int value) => value == 0 ? "0" : $"{value}%";
+    private static string FormatPercentBonus(int value) => value == 0 ? "0%" : $"{(value > 0 ? "+" : string.Empty)}{value}%";
+
+    private static string FormatRatingValue(double value) => FormatScore(value);
+
+    private static string FormatRatingBonus(int value) => value == 0 ? "0" : $"{(value > 0 ? "+" : string.Empty)}{value}";
+
+    private static string FormatScore(double value) => value.ToString("0.##", CultureInfo.InvariantCulture);
 
     // -------------------------
     // Init
@@ -217,14 +268,13 @@ public partial class CharacterWindow : Window
 
         var leftW = 420;
         var rightW = WindowWidth - (Margin * 2) - leftW;
-        var topH = 250;
-        var bottomH = WindowHeight - (Margin * 2) - topH;
+        var bottomH = WindowHeight - (Margin * 2) - TopSectionHeight;
 
         // Containers
-        mCharacterInfoContainer = CreateContainer("CharacterInfoContainer", contentX, contentY, leftW, 150);
-        mStatsContainer = CreateContainer("StatsContainer", contentX, contentY + 150, leftW, topH - 150);
-        mEquipmentContainer = CreateContainer("EquipmentContainer", contentX + leftW, contentY, rightW, topH);
-        mExtraBuffsContainer = CreateContainer("ExtraBuffsContainer", contentX, contentY + topH, WindowWidth - (Margin * 2), bottomH);
+        mCharacterInfoContainer = CreateContainer("CharacterInfoContainer", contentX, contentY, leftW, CharacterInfoHeight);
+        mStatsContainer = CreateContainer("StatsContainer", contentX, contentY + CharacterInfoHeight, leftW, TopSectionHeight - CharacterInfoHeight);
+        mEquipmentContainer = CreateContainer("EquipmentContainer", contentX + leftW, contentY, rightW, TopSectionHeight);
+        mExtraBuffsContainer = CreateContainer("ExtraBuffsContainer", contentX, contentY + TopSectionHeight, WindowWidth - (Margin * 2), bottomH);
 
         BuildCharacterInfoSection();
         BuildEquipmentSection();
@@ -346,53 +396,122 @@ public partial class CharacterWindow : Window
     {
         var header = CreateSectionTitle(mStatsContainer, "StatsHeader", 0, 0, "Atributos");
 
-        var x = 0;
-        var y = header.Height + 6;
+        var startY = header.Height + 6;
+        var leftX = 0;
+        var rightX = (mStatsContainer.Width / 2) + 8;
+        var leftLabelWidth = 152;
+        var rightLabelWidth = mStatsContainer.Width - rightX - StatIconSize - IconSpacing;
+        var buttonX = leftX + StatIconSize + IconSpacing + leftLabelWidth + 8;
 
-        // Attack
-        mAttackLabel = CreateBodyLabel(mStatsContainer, "AttackLabel", x, y, StatLabelWidth);
-        mAddAttackBtn = CreateStatButton(mStatsContainer, "IncreaseAttackButton", x + StatLabelWidth + 8, y);
+        var leftY = startY;
+        mAttackLabel = CreateLabelWithIcon(
+            mStatsContainer,
+            "AttackLabel",
+            StatEffectIconProvider.GetIconForStat(Stat.Attack),
+            leftX,
+            leftY,
+            leftLabelWidth
+        );
+        mAddAttackBtn = CreateStatButton(mStatsContainer, "IncreaseAttackButton", buttonX, leftY);
         mAddAttackBtn.Clicked += _addAttackBtn_Clicked;
-        y += StatRowHeight;
+        leftY += StatRowHeight;
 
-        // Ability Power
-        mAbilityPwrLabel = CreateBodyLabel(mStatsContainer, "AbilityPowerLabel", x, y, StatLabelWidth);
-        mAddAbilityPwrBtn = CreateStatButton(mStatsContainer, "IncreaseAbilityPowerButton", x + StatLabelWidth + 8, y);
+        mAbilityPwrLabel = CreateLabelWithIcon(
+            mStatsContainer,
+            "AbilityPowerLabel",
+            StatEffectIconProvider.GetIconForStat(Stat.Intelligence),
+            leftX,
+            leftY,
+            leftLabelWidth
+        );
+        mAddAbilityPwrBtn = CreateStatButton(mStatsContainer, "IncreaseAbilityPowerButton", buttonX, leftY);
         mAddAbilityPwrBtn.Clicked += _addAbilityPwrBtn_Clicked;
-        y += StatRowHeight;
+        leftY += StatRowHeight;
 
-        // Defense
-        mDefenseLabel = CreateBodyLabel(mStatsContainer, "DefenseLabel", x, y, StatLabelWidth);
-        mAddDefenseBtn = CreateStatButton(mStatsContainer, "IncreaseDefenseButton", x + StatLabelWidth + 8, y);
+        mDefenseLabel = CreateLabelWithIcon(
+            mStatsContainer,
+            "DefenseLabel",
+            StatEffectIconProvider.GetIconForStat(Stat.Defense),
+            leftX,
+            leftY,
+            leftLabelWidth
+        );
+        mAddDefenseBtn = CreateStatButton(mStatsContainer, "IncreaseDefenseButton", buttonX, leftY);
         mAddDefenseBtn.Clicked += _addDefenseBtn_Clicked;
-        y += StatRowHeight;
+        leftY += StatRowHeight;
 
-        // Vitality (Magic Resist label en tu UI, pero realmente es Vitality)
-        mMagicRstLabel = CreateBodyLabel(mStatsContainer, "MagicResistLabel", x, y, StatLabelWidth);
-        mAddMagicResistBtn = CreateStatButton(mStatsContainer, "IncreaseMagicResistButton", x + StatLabelWidth + 8, y);
+        mMagicRstLabel = CreateLabelWithIcon(
+            mStatsContainer,
+            "MagicResistLabel",
+            StatEffectIconProvider.GetIconForStat(Stat.Vitality),
+            leftX,
+            leftY,
+            leftLabelWidth
+        );
+        mAddMagicResistBtn = CreateStatButton(mStatsContainer, "IncreaseMagicResistButton", buttonX, leftY);
         mAddMagicResistBtn.Clicked += _addMagicResistBtn_Clicked;
-        y += StatRowHeight;
+        leftY += StatRowHeight;
 
-        // Speed
-        mAgilityLabel = CreateBodyLabel(mStatsContainer, "AgilityLabel", x, y, StatLabelWidth);
-
-        mAddAgilityBtn = CreateStatButton(mStatsContainer, "IncreaseSpeedButton", x + StatLabelWidth + 8, y);
+        mAgilityLabel = CreateLabelWithIcon(
+            mStatsContainer,
+            "AgilityLabel",
+            StatEffectIconProvider.GetIconForStat(Stat.Agility),
+            leftX,
+            leftY,
+            leftLabelWidth
+        );
+        mAddAgilityBtn = CreateStatButton(mStatsContainer, "IncreaseSpeedButton", buttonX, leftY);
         mAddAgilityBtn.Clicked += _addSpeedBtn_Clicked;
-        y += StatRowHeight;
 
-        // Read-only stats
-        mSpeedLabel = CreateBodyLabel(mStatsContainer, "SpeedLabel", x, y, StatLabelWidth); y += StatRowHeight;
-        mDamageLabel = CreateBodyLabel(mStatsContainer, "DamageLabel", x, y, StatLabelWidth); y += StatRowHeight;
-        mCureLabel = CreateBodyLabel(mStatsContainer, "CureLabel", x, y, StatLabelWidth); y += StatRowHeight;
-        mCritChanceLabel = CreateBodyLabel(mStatsContainer, "CritLabel", x, y, StatLabelWidth); y += StatRowHeight;
-        mPointsLabel = CreateBodyLabel(mStatsContainer, "PointsLabel", x, y, StatLabelWidth + 40); y += StatRowHeight;
+        var rightY = startY;
+        mSpeedLabel = CreateLabelWithIcon(
+            mStatsContainer,
+            "SpeedLabel",
+            StatEffectIconProvider.GetIconForStat(Stat.Speed),
+            rightX,
+            rightY,
+            rightLabelWidth
+        );
+        rightY += StatRowHeight;
+
+        mDamageLabel = CreateLabelWithIcon(
+            mStatsContainer,
+            "DamageLabel",
+            StatEffectIconProvider.GetIconForItemEffect(ItemEffect.Damages),
+            rightX,
+            rightY,
+            rightLabelWidth
+        );
+        rightY += StatRowHeight;
+
+        mCureLabel = CreateLabelWithIcon(
+            mStatsContainer,
+            "CureLabel",
+            StatEffectIconProvider.GetIconForItemEffect(ItemEffect.Cures),
+            rightX,
+            rightY,
+            rightLabelWidth
+        );
+        rightY += StatRowHeight;
+
+        mCritChanceLabel = CreateLabelWithIcon(
+            mStatsContainer,
+            "CritLabel",
+            StatEffectIconProvider.GetIconForItemEffect(ItemEffect.CriticalChance),
+            rightX,
+            rightY,
+            rightLabelWidth
+        );
+        rightY += StatRowHeight;
+
+        mPointsLabel = CreateBodyLabel(mStatsContainer, "PointsLabel", rightX, rightY, rightLabelWidth, StatRowHeight);
 
         mBasicAttackDamageLabel = CreateBodyLabel(
             mStatsContainer,
             "BasicAttackDamageLabel",
-            x,
-            y,
-            StatLabelWidth + 120,
+            0,
+            startY + (StatRowHeight * 5) + 8,
+            mStatsContainer.Width,
             StatRowHeight + 4
         );
     }
@@ -410,36 +529,35 @@ public partial class CharacterWindow : Window
         mExtraBuffsList.SetPosition(0, 0);
         mExtraBuffsList.SetSize(mExtraBuffsScroll.Width - 20, 10);
 
-        int y = 0;
+        var labelWidth = mExtraBuffsList.Width - EffectIconSize - IconSpacing;
+        var y = 0;
 
-        // Apilado 1 por 1 (una sola columna)
-        mHpRegen = CreateBodyLabel(mExtraBuffsList, "HpRegen", 0, y, EffectLabelWidth, EffectRowHeight); y += EffectRowHeight;
-        mManaRegen = CreateBodyLabel(mExtraBuffsList, "ManaRegen", 0, y, EffectLabelWidth, EffectRowHeight); y += EffectRowHeight;
-        mLifeSteal = CreateBodyLabel(mExtraBuffsList, "Lifesteal", 0, y, EffectLabelWidth, EffectRowHeight); y += EffectRowHeight;
-        mAttackSpeed = CreateBodyLabel(mExtraBuffsList, "AttackSpeed", 0, y, EffectLabelWidth, EffectRowHeight); y += EffectRowHeight;
+        mHpRegen = CreateLabelWithIcon(mExtraBuffsList, "HpRegen", StatEffectIconProvider.GetIconForVital(Vital.Health), 0, y, labelWidth, EffectRowHeight, EffectIconSize); y += EffectRowHeight;
+        mManaRegen = CreateLabelWithIcon(mExtraBuffsList, "ManaRegen", StatEffectIconProvider.GetIconForVital(Vital.Mana), 0, y, labelWidth, EffectRowHeight, EffectIconSize); y += EffectRowHeight;
+        mLifeSteal = CreateLabelWithIcon(mExtraBuffsList, "Lifesteal", StatEffectIconProvider.GetIconForItemEffect(ItemEffect.Lifesteal), 0, y, labelWidth, EffectRowHeight, EffectIconSize); y += EffectRowHeight;
+        mAttackSpeed = CreateLabelWithIcon(mExtraBuffsList, "AttackSpeed", StatEffectIconProvider.GetIconForItemEffect(ItemEffect.CooldownReduction), 0, y, labelWidth, EffectRowHeight, EffectIconSize); y += EffectRowHeight;
 
-        mSpeedBuff = CreateBodyLabel(mExtraBuffsList, "SpeedBuff", 0, y, EffectLabelWidth, EffectRowHeight); y += EffectRowHeight;
-        mDamageBuff = CreateBodyLabel(mExtraBuffsList, "DamageBuff", 0, y, EffectLabelWidth, EffectRowHeight); y += EffectRowHeight;
-        mCureBuff = CreateBodyLabel(mExtraBuffsList, "CureBuff", 0, y, EffectLabelWidth, EffectRowHeight); y += EffectRowHeight;
+        mSpeedBuff = CreateLabelWithIcon(mExtraBuffsList, "SpeedBuff", StatEffectIconProvider.GetIconForStat(Stat.Speed), 0, y, labelWidth, EffectRowHeight, EffectIconSize); y += EffectRowHeight;
+        mDamageBuff = CreateLabelWithIcon(mExtraBuffsList, "DamageBuff", StatEffectIconProvider.GetIconForItemEffect(ItemEffect.Damages), 0, y, labelWidth, EffectRowHeight, EffectIconSize); y += EffectRowHeight;
+        mCureBuff = CreateLabelWithIcon(mExtraBuffsList, "CureBuff", StatEffectIconProvider.GetIconForItemEffect(ItemEffect.Cures), 0, y, labelWidth, EffectRowHeight, EffectIconSize); y += EffectRowHeight;
 
-        mExtraExp = CreateBodyLabel(mExtraBuffsList, "ExtraExp", 0, y, EffectLabelWidth, EffectRowHeight); y += EffectRowHeight;
-        mLuck = CreateBodyLabel(mExtraBuffsList, "Luck", 0, y, EffectLabelWidth, EffectRowHeight); y += EffectRowHeight;
-        mTenacity = CreateBodyLabel(mExtraBuffsList, "Tenacity", 0, y, EffectLabelWidth, EffectRowHeight); y += EffectRowHeight;
-        mCooldownReduction = CreateBodyLabel(mExtraBuffsList, "CooldownReduction", 0, y, EffectLabelWidth, EffectRowHeight); y += EffectRowHeight;
-        mManaSteal = CreateBodyLabel(mExtraBuffsList, "Manasteal", 0, y, EffectLabelWidth, EffectRowHeight); y += EffectRowHeight;
+        mExtraExp = CreateLabelWithIcon(mExtraBuffsList, "ExtraExp", StatEffectIconProvider.GetIconForItemEffect(ItemEffect.EXP), 0, y, labelWidth, EffectRowHeight, EffectIconSize); y += EffectRowHeight;
+        mLuck = CreateLabelWithIcon(mExtraBuffsList, "Luck", StatEffectIconProvider.GetIconForItemEffect(ItemEffect.Luck), 0, y, labelWidth, EffectRowHeight, EffectIconSize); y += EffectRowHeight;
+        mTenacity = CreateLabelWithIcon(mExtraBuffsList, "Tenacity", StatEffectIconProvider.GetIconForItemEffect(ItemEffect.Tenacity), 0, y, labelWidth, EffectRowHeight, EffectIconSize); y += EffectRowHeight;
+        mCooldownReduction = CreateLabelWithIcon(mExtraBuffsList, "CooldownReduction", StatEffectIconProvider.GetIconForItemEffect(ItemEffect.CooldownReduction), 0, y, labelWidth, EffectRowHeight, EffectIconSize); y += EffectRowHeight;
+        mManaSteal = CreateLabelWithIcon(mExtraBuffsList, "Manasteal", StatEffectIconProvider.GetIconForItemEffect(ItemEffect.Manasteal), 0, y, labelWidth, EffectRowHeight, EffectIconSize); y += EffectRowHeight;
 
-        mAccuracy = CreateBodyLabel(mExtraBuffsList, "Accuracy", 0, y, EffectLabelWidth, EffectRowHeight); y += EffectRowHeight;
-        mEvasion = CreateBodyLabel(mExtraBuffsList, "Evasion", 0, y, EffectLabelWidth, EffectRowHeight); y += EffectRowHeight;
-        mCritBonus = CreateBodyLabel(mExtraBuffsList, "CriticalBonus", 0, y, EffectLabelWidth, EffectRowHeight); y += EffectRowHeight;
-        mAntiCrit = CreateBodyLabel(mExtraBuffsList, "AntiCritical", 0, y, EffectLabelWidth, EffectRowHeight); y += EffectRowHeight;
-        mArmorPenetration = CreateBodyLabel(mExtraBuffsList, "ArmorPenetration", 0, y, EffectLabelWidth, EffectRowHeight); y += EffectRowHeight;
-        mDamageReduction = CreateBodyLabel(mExtraBuffsList, "DamageReduction", 0, y, EffectLabelWidth, EffectRowHeight); y += EffectRowHeight;
-        mDamageReflect = CreateBodyLabel(mExtraBuffsList, "DamageReflect", 0, y, EffectLabelWidth, EffectRowHeight); y += EffectRowHeight;
+        mAccuracy = CreateLabelWithIcon(mExtraBuffsList, "Accuracy", StatEffectIconProvider.GetIconForItemEffect(ItemEffect.Accuracy), 0, y, labelWidth, EffectRowHeight, EffectIconSize); y += EffectRowHeight;
+        mEvasion = CreateLabelWithIcon(mExtraBuffsList, "Evasion", StatEffectIconProvider.GetIconForItemEffect(ItemEffect.Evasion), 0, y, labelWidth, EffectRowHeight, EffectIconSize); y += EffectRowHeight;
+        mCritBonus = CreateLabelWithIcon(mExtraBuffsList, "CriticalBonus", StatEffectIconProvider.GetIconForItemEffect(ItemEffect.CriticalChance), 0, y, labelWidth, EffectRowHeight, EffectIconSize); y += EffectRowHeight;
+        mAntiCrit = CreateLabelWithIcon(mExtraBuffsList, "AntiCritical", StatEffectIconProvider.GetIconForItemEffect(ItemEffect.AntiCritChance), 0, y, labelWidth, EffectRowHeight, EffectIconSize); y += EffectRowHeight;
+        mArmorPenetration = CreateLabelWithIcon(mExtraBuffsList, "ArmorPenetration", StatEffectIconProvider.GetIconForItemEffect(ItemEffect.ArmorPenetration), 0, y, labelWidth, EffectRowHeight, EffectIconSize); y += EffectRowHeight;
+        mDamageReduction = CreateLabelWithIcon(mExtraBuffsList, "DamageReduction", StatEffectIconProvider.GetIconForItemEffect(ItemEffect.DamageReduction), 0, y, labelWidth, EffectRowHeight, EffectIconSize); y += EffectRowHeight;
+        mDamageReflect = CreateLabelWithIcon(mExtraBuffsList, "DamageReflect", StatEffectIconProvider.GetIconForItemEffect(ItemEffect.DamageReflect), 0, y, labelWidth, EffectRowHeight, EffectIconSize); y += EffectRowHeight;
 
-        mFlatDamage = CreateBodyLabel(mExtraBuffsList, "FlatDamage", 0, y, EffectLabelWidth, EffectRowHeight); y += EffectRowHeight;
-        mFlatCures = CreateBodyLabel(mExtraBuffsList, "FlatCures", 0, y, EffectLabelWidth, EffectRowHeight); y += EffectRowHeight;
+        mFlatDamage = CreateLabelWithIcon(mExtraBuffsList, "FlatDamage", StatEffectIconProvider.GetIconForItemEffect(ItemEffect.Damages), 0, y, labelWidth, EffectRowHeight, EffectIconSize); y += EffectRowHeight;
+        mFlatCures = CreateLabelWithIcon(mExtraBuffsList, "FlatCures", StatEffectIconProvider.GetIconForItemEffect(ItemEffect.Cures), 0, y, labelWidth, EffectRowHeight, EffectIconSize); y += EffectRowHeight;
 
-        // Ajusta el alto del list para que el scroll funcione bien
         mExtraBuffsList.SetSize(mExtraBuffsList.Width, y + 4);
     }
 
@@ -672,8 +790,8 @@ public partial class CharacterWindow : Window
 
         // Effects
         UpdateExtraBuffs();
-        mDamageLabel.SetText(Strings.Character.FlatDamage.ToString(FormatEffectValue(_flatDamage)));
-        mCureLabel.SetText(Strings.Character.FlatCures.ToString(FormatEffectValue(_flatCures)));
+        mDamageLabel.SetText(Strings.Character.FlatDamage.ToString(FormatPercentBonus(_flatDamage)));
+        mCureLabel.SetText(Strings.Character.FlatCures.ToString(FormatPercentBonus(_flatCures)));
 
         UpdateEquippedItems(true);
     }
@@ -758,6 +876,10 @@ public partial class CharacterWindow : Window
         _flatDamage = default;
         _flatCures = default;
 
+        mAttackSpeed.SetText(Strings.Character.AttackSpeed.ToString(0f));
+        mSpeedBuff.SetText(Strings.Character.StatLabelValue.ToString(Strings.Combat.Stats[Stat.Speed], 0));
+        mBasicAttackDamageLabel.SetText(Strings.Character.BasicAttackDamage.ToString(0, 0, 0));
+
         if (player != null)
         {
             foreach (var descriptor in GetEquippedDescriptors(player))
@@ -836,20 +958,31 @@ public partial class CharacterWindow : Window
         mCooldownReduction.SetText(Strings.Character.CooldownReduction.ToString(CooldownAmount));
         mManaSteal.SetText(Strings.Character.Manasteal.ToString(ManaStealAmount));
 
-        mDamageBuff.SetText(Strings.Character.FlatDamage.ToString(FormatEffectValue(_flatDamage)));
-        mCureBuff.SetText(Strings.Character.FlatCures.ToString(FormatEffectValue(_flatCures)));
+        mDamageBuff.SetText(Strings.Character.FlatDamage.ToString(FormatPercentBonus(_flatDamage)));
+        mCureBuff.SetText(Strings.Character.FlatCures.ToString(FormatPercentBonus(_flatCures)));
 
-        mAccuracy.SetText($"{Strings.ItemDescription.BonusEffects[(int)ItemEffect.Accuracy]} {FormatEffectValue(_accuracy)}");
-        mEvasion.SetText($"{Strings.ItemDescription.BonusEffects[(int)ItemEffect.Evasion]} {FormatEffectValue(_evasion)}");
-        mCritBonus.SetText($"{Strings.ItemDescription.BonusEffects[(int)ItemEffect.CriticalChance]} {FormatEffectValue(_critBonus)}");
-        mAntiCrit.SetText($"{Strings.ItemDescription.BonusEffects[(int)ItemEffect.AntiCritChance]} {FormatEffectValue(_antiCrit)}");
-        mArmorPenetration.SetText($"{Strings.ItemDescription.BonusEffects[(int)ItemEffect.ArmorPenetration]} {FormatEffectValue(_armorPenetration)}");
-        mDamageReduction.SetText($"{Strings.ItemDescription.BonusEffects[(int)ItemEffect.DamageReduction]} {FormatEffectValue(_damageReduction)}");
-        mDamageReflect.SetText($"{Strings.ItemDescription.BonusEffects[(int)ItemEffect.DamageReflect]} {FormatEffectValue(_damageReflect)}");
+        var agility = player?.Stat[(int)Stat.Agility] ?? 0;
+        var attack = player?.Stat[(int)Stat.Attack] ?? 0;
+        var defense = player?.Stat[(int)Stat.Defense] ?? 0;
+
+        var accuracyScore = CombatFormulaCalculator.CalculateAccuracyScore(agility, attack, _accuracy);
+        var evasionScore = CombatFormulaCalculator.CalculateEvasionScore(agility, defense, _evasion);
+
+        mAccuracy.SetText(
+            $"{Strings.ItemDescription.BonusEffects[(int)ItemEffect.Accuracy]} rating final {FormatRatingValue(accuracyScore)} (Agi {FormatScore(agility * 0.5d)} + Atk {FormatScore(attack * 0.3d)} + Eq {FormatRatingBonus(_accuracy)})"
+        );
+        mEvasion.SetText(
+            $"{Strings.ItemDescription.BonusEffects[(int)ItemEffect.Evasion]} rating final {FormatRatingValue(evasionScore)} (Agi {FormatScore(agility * 0.7d)} + Def {FormatScore(defense * 0.2d)} + Eq {FormatRatingBonus(_evasion)})"
+        );
+        mCritBonus.SetText($"{Strings.ItemDescription.BonusEffects[(int)ItemEffect.CriticalChance]} {FormatPercentBonus(_critBonus)}");
+        mAntiCrit.SetText($"{Strings.ItemDescription.BonusEffects[(int)ItemEffect.AntiCritChance]} {FormatPercentBonus(_antiCrit)}");
+        mArmorPenetration.SetText($"{Strings.ItemDescription.BonusEffects[(int)ItemEffect.ArmorPenetration]} {FormatPercentBonus(_armorPenetration)}");
+        mDamageReduction.SetText($"{Strings.ItemDescription.BonusEffects[(int)ItemEffect.DamageReduction]} {FormatPercentBonus(_damageReduction)}");
+        mDamageReflect.SetText($"{Strings.ItemDescription.BonusEffects[(int)ItemEffect.DamageReflect]} {FormatPercentBonus(_damageReflect)}");
 
         // Estos dos son “flat” pero los estás mostrando también acá
-        mFlatDamage.SetText($"{Strings.ItemDescription.BonusEffects[(int)ItemEffect.Damages]} {FormatEffectValue(_flatDamage)}");
-        mFlatCures.SetText($"{Strings.ItemDescription.BonusEffects[(int)ItemEffect.Cures]} {FormatEffectValue(_flatCures)}");
+        mFlatDamage.SetText($"{Strings.ItemDescription.BonusEffects[(int)ItemEffect.Damages]} {FormatPercentBonus(_flatDamage)}");
+        mFlatCures.SetText($"{Strings.ItemDescription.BonusEffects[(int)ItemEffect.Cures]} {FormatPercentBonus(_flatCures)}");
 
         // Reajusta alto del listado por si cambiaste fuentes/escala
         if (mExtraBuffsList != null)

--- a/Intersect.Client.Core/Interface/Game/Character/CharacterWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Character/CharacterWindow.cs
@@ -2,7 +2,6 @@ using Intersect.Client.Core;
 using Intersect.Client.Entities;
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using Intersect.Client.Framework.File_Management;
 using Intersect.Client.Framework.Gwen;
@@ -18,6 +17,9 @@ using Intersect.Enums;
 using Intersect.Framework.Core.Combat;
 using Intersect.Framework.Core.GameObjects.Items;
 using Intersect.Framework.Core.GameObjects.PlayerClass;
+using System.Globalization;
+using Intersect.Client.Entities;
+
 
 namespace Intersect.Client.Interface.Game.Character;
 
@@ -113,7 +115,6 @@ public partial class CharacterWindow : Window
     private Player? _player;
     private ItemProperties mItemProperties = null;
     private ClassDescriptor mClassDescriptor;
-
     public Player? DisplayedPlayer => _player ?? Globals.Me;
 
     long HpRegenAmount;
@@ -585,13 +586,16 @@ public partial class CharacterWindow : Window
 
     private IEnumerable<ItemDescriptor> GetEquippedDescriptors(Player player)
     {
+        var entity = (Entity)player;
+
         if (player == Globals.Me)
         {
-            foreach (var (_, equipmentSlots) in player.MyEquipment)
+            foreach (var equipmentEntry in entity.MyEquipment)
             {
+                var equipmentSlots = equipmentEntry.Value;
                 foreach (var slotIndex in equipmentSlots)
                 {
-                    var invItem = player.Inventory.ElementAtOrDefault(slotIndex);
+                    var invItem = entity.Inventory.ElementAtOrDefault(slotIndex);
                     if (invItem?.ItemId == null || invItem.ItemId == Guid.Empty)
                         continue;
 
@@ -603,8 +607,9 @@ public partial class CharacterWindow : Window
         }
         else
         {
-            foreach (var (_, equippedItems) in player.Equipment)
+            foreach (var equipmentEntry in entity.Equipment)
             {
+                var equippedItems = equipmentEntry.Value;
                 foreach (var id in equippedItems)
                 {
                     if (id == Guid.Empty)
@@ -625,6 +630,8 @@ public partial class CharacterWindow : Window
         out int scalingPercent
     )
     {
+        var entity = (Entity)player;
+
         baseDamage = 0;
         scalingStat = Stat.Attack;
         scalingPercent = 0;
@@ -644,12 +651,12 @@ public partial class CharacterWindow : Window
 
         if (player == Globals.Me)
         {
-            if (player.MyEquipment.TryGetValue(weaponSlotIndex, out var list) && list.Count > 0)
+            if (entity.MyEquipment.TryGetValue(weaponSlotIndex, out var list) && list.Count > 0)
             {
                 var invIndex = list[0];
                 if (invIndex >= 0 && invIndex < Options.Instance.Player.MaxInventory)
                 {
-                    var inventorySlot = player.Inventory.ElementAtOrDefault(invIndex);
+                    var inventorySlot = entity.Inventory.ElementAtOrDefault(invIndex);
                     if (inventorySlot != null)
                     {
                         weaponId = inventorySlot.ItemId;
@@ -659,7 +666,7 @@ public partial class CharacterWindow : Window
         }
         else
         {
-            if (player.Equipment.TryGetValue(weaponSlotIndex, out var list) && list.Count > 0)
+            if (entity.Equipment.TryGetValue(weaponSlotIndex, out var list) && list.Count > 0)
             {
                 weaponId = list[0];
             }
@@ -715,11 +722,10 @@ public partial class CharacterWindow : Window
                         var inventoryIndex = equippedList[0];
                         if (inventoryIndex >= 0 && inventoryIndex < Options.Instance.Player.MaxInventory)
                         {
-                            var itemNum = player.Inventory[inventoryIndex].ItemId;
-
-                            if (ItemDescriptor.TryGet(itemNum, out var itemDescriptor))
+                            var equippedItem = player.Inventory[inventoryIndex];
+                            if (equippedItem != null && ItemDescriptor.TryGet(equippedItem.ItemId, out var itemDescriptor))
                             {
-                                paperdoll = player.Gender == 0 ? itemDescriptor.MalePaperdoll : itemDescriptor.FemalePaperdoll;
+                                paperdoll = player.Gender == Gender.Male ? itemDescriptor.MalePaperdoll : itemDescriptor.FemalePaperdoll;
                                 PaperdollPanels[z].RenderColor = itemDescriptor.Color;
                             }
                         }
@@ -802,6 +808,7 @@ public partial class CharacterWindow : Window
         if (player is null)
             return;
 
+        var entity = (Entity)player;
         int itemIndex = 0;
         for (var slotIndex = 0; slotIndex < Options.Instance.Equipment.EquipmentSlots.Count; slotIndex++)
         {
@@ -809,7 +816,7 @@ public partial class CharacterWindow : Window
 
             if (player == Globals.Me)
             {
-                var itemSlots = player.MyEquipment.GetValueOrDefault(slotIndex) ?? new List<int>();
+                var itemSlots = entity.MyEquipment.GetValueOrDefault(slotIndex) ?? new List<int>();
                 for (var i = 0; i < slot.MaxItems; i++)
                 {
                     if (itemIndex >= Items.Count)
@@ -820,7 +827,7 @@ public partial class CharacterWindow : Window
 
                     if (i < itemSlots.Count && itemSlots[i] >= 0 && itemSlots[i] < Options.Instance.Player.MaxInventory)
                     {
-                        var invItem = player.Inventory[itemSlots[i]];
+                        var invItem = entity.Inventory[itemSlots[i]];
                         if (invItem.ItemId != Guid.Empty)
                         {
                             itemIds.Add(invItem.ItemId);
@@ -834,7 +841,7 @@ public partial class CharacterWindow : Window
             }
             else
             {
-                var equippedIds = player.Equipment.GetValueOrDefault(slotIndex) ?? new List<Guid>();
+                var equippedIds = entity.Equipment.GetValueOrDefault(slotIndex) ?? new List<Guid>();
                 for (var i = 0; i < slot.MaxItems; i++)
                 {
                     if (itemIndex >= Items.Count)
@@ -855,6 +862,7 @@ public partial class CharacterWindow : Window
     {
         var player = DisplayedPlayer;
         mClassDescriptor = ClassDescriptor.Get(player?.Class ?? Guid.Empty);
+        var entity = player as Entity;
 
         HpRegenAmount = mClassDescriptor?.VitalRegen[(int)Vital.Health] ?? 0;
         ManaRegenAmount = mClassDescriptor?.VitalRegen[(int)Vital.Mana] ?? 0;
@@ -919,7 +927,7 @@ public partial class CharacterWindow : Window
 
             mSpeedBuff.SetText(Strings.Character.StatLabelValue.ToString(
                 Strings.Combat.Stats[Stat.Speed],
-                player.Stat[(int)Stat.Speed]
+                entity?.Stat[(int)Stat.Speed] ?? 0
             ));
 
             int sourceBaseDamage;
@@ -933,7 +941,7 @@ public partial class CharacterWindow : Window
                 sourceScalingPercent = mClassDescriptor?.Scaling ?? 0;
             }
 
-            var statValue = player.Stat[(int)sourceScalingStat];
+            var statValue = entity?.Stat[(int)sourceScalingStat] ?? 0;
             var scaledBase = sourceBaseDamage + statValue * (sourceScalingPercent / 100f);
             var afterBonuses = scaledBase * (1f + _flatDamage / 100f);
 
@@ -961,9 +969,9 @@ public partial class CharacterWindow : Window
         mDamageBuff.SetText(Strings.Character.FlatDamage.ToString(FormatPercentBonus(_flatDamage)));
         mCureBuff.SetText(Strings.Character.FlatCures.ToString(FormatPercentBonus(_flatCures)));
 
-        var agility = player?.Stat[(int)Stat.Agility] ?? 0;
-        var attack = player?.Stat[(int)Stat.Attack] ?? 0;
-        var defense = player?.Stat[(int)Stat.Defense] ?? 0;
+        var agility = entity?.Stat[(int)Stat.Agility] ?? 0;
+        var attack = entity?.Stat[(int)Stat.Attack] ?? 0;
+        var defense = entity?.Stat[(int)Stat.Defense] ?? 0;
 
         var accuracyScore = CombatFormulaCalculator.CalculateAccuracyScore(agility, attack, _accuracy);
         var evasionScore = CombatFormulaCalculator.CalculateEvasionScore(agility, defense, _evasion);

--- a/Intersect.Client.Core/Interface/Game/Crafting/CraftingWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Crafting/CraftingWindow.cs
@@ -384,6 +384,51 @@ public partial class CraftingWindow : Window
         GameLocalization.RequestEntries(requests);
     }
 
+    private void RequestRecipeItemLocalization(IEnumerable<CraftingRecipeDescriptor> recipes)
+    {
+        if (recipes == null)
+        {
+            return;
+        }
+
+        var itemIds = new HashSet<Guid>();
+        foreach (var recipe in recipes)
+        {
+            if (recipe == null)
+            {
+                continue;
+            }
+
+            itemIds.Add(recipe.ItemId);
+            foreach (var ingredient in recipe.Ingredients)
+            {
+                itemIds.Add(ingredient.ItemId);
+            }
+        }
+
+        if (itemIds.Count == 0)
+        {
+            return;
+        }
+
+        var requests = new List<LocalizationRequestEntry>();
+        foreach (var itemId in itemIds)
+        {
+            if (!ItemDescriptor.TryGet(itemId, out var descriptor))
+            {
+                continue;
+            }
+
+            requests.Add(new LocalizationRequestEntry(descriptor.Type.ToString(), descriptor.Id.ToString(), "Name"));
+            requests.Add(new LocalizationRequestEntry(descriptor.Type.ToString(), descriptor.Id.ToString(), "Description"));
+        }
+
+        if (requests.Count > 0)
+        {
+            GameLocalization.RequestEntries(requests);
+        }
+    }
+
     private static string GetLocalizedRecipeName(CraftingRecipeDescriptor recipe) =>
         recipe == null
             ? string.Empty
@@ -622,6 +667,7 @@ public partial class CraftingWindow : Window
         }
 
         RequestRecipeLocalization(descriptors!);
+        RequestRecipeItemLocalization(descriptors!);
 
         CraftingRecipeDescriptor? first = null;
         CraftingRecipeDescriptor? selected = null;

--- a/Intersect.Client.Core/Interface/Game/DescriptionWindows/Components/KeyValueRowComponent.cs
+++ b/Intersect.Client.Core/Interface/Game/DescriptionWindows/Components/KeyValueRowComponent.cs
@@ -33,6 +33,16 @@ public partial class KeyValueRowComponent : ComponentBase
     /// <param name="color">The <see cref="Color"/> to draw the value text in.</param>
     public void SetValueTextColor(Color color) => _valueLabel.SetTextColor(color, ComponentState.Normal);
 
+    public void SetKeyText(string key) => _keyLabel.SetText(key);
+
+    public void SetValueText(string value) => _valueLabel.SetText(value);
+
+    public void SetText(string key, string value)
+    {
+        SetKeyText(key);
+        SetValueText(value);
+    }
+
     public void SetIcon(IGameTexture? texture)
     {
         _icon.Texture = texture;

--- a/Intersect.Client.Core/Interface/Game/DescriptionWindows/ItemDescriptionWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/DescriptionWindows/ItemDescriptionWindow.cs
@@ -17,7 +17,7 @@ using Intersect.Network.Packets.Localization;
 
 namespace Intersect.Client.Interface.Game.DescriptionWindows;
 
-public partial class ItemDescriptionWindow() : DescriptionWindowBase(Interface.GameUi.GameCanvas, "DescriptionWindow")
+public partial class ItemDescriptionWindow : DescriptionWindowBase
 {
     private const string AttackSpeedIconName = "attack_speed.png";
     private const string BlockIconName = "block.png";
@@ -30,6 +30,11 @@ public partial class ItemDescriptionWindow() : DescriptionWindowBase(Interface.G
     private int _amount;
     private string? _valueLabel;
     private bool _localizationSubscribed;
+
+    public ItemDescriptionWindow() : base(Interface.GameUi.GameCanvas, "DescriptionWindow")
+    {
+        base.Hide();
+    }
 
     public void Show(
         ItemDescriptor item,
@@ -102,18 +107,14 @@ public partial class ItemDescriptionWindow() : DescriptionWindowBase(Interface.G
 
     public override void Hide()
     {
-        if (Interface.GameUi.ItemDescriptionWindow == this)
-        {
-            Interface.GameUi.GameCanvas.RemoveChild(Interface.GameUi.ItemDescriptionWindow, true);
-            Interface.GameUi.ItemDescriptionWindow = default;
-        }
-
         UnsubscribeFromLocalizationUpdates();
-        if (Interface.GameUi.SpellDescriptionWindow != default)
-        {
-            Interface.GameUi.GameCanvas.RemoveChild(Interface.GameUi.SpellDescriptionWindow, true);
-            Interface.GameUi.SpellDescriptionWindow = default;
-        }
+        _itemDescriptor = null;
+        _itemProperties = null;
+        _valueLabel = null;
+        _amount = 0;
+
+        Interface.GameUi.ExistingSpellDescriptionWindow?.Hide();
+        base.Hide();
     }
 
     protected void SetupDescriptionWindow()

--- a/Intersect.Client.Core/Interface/Game/DescriptionWindows/SpellDescriptionWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/DescriptionWindows/SpellDescriptionWindow.cs
@@ -12,7 +12,7 @@ using Intersect.Network.Packets.Localization;
 
 namespace Intersect.Client.Interface.Game.DescriptionWindows;
 
-public partial class SpellDescriptionWindow() : DescriptionWindowBase(Interface.GameUi.GameCanvas, "DescriptionWindow")
+public partial class SpellDescriptionWindow : DescriptionWindowBase
 {
     private const string CooldownIconName = "effect_cooldown_reduction.png";
     private const string CritIconName = "crit.png";
@@ -22,6 +22,11 @@ public partial class SpellDescriptionWindow() : DescriptionWindowBase(Interface.
     private SpellProperties? _spellProperties;
     private SpellProperties? _effectiveProps;
     private bool _localizationSubscribed;
+
+    public SpellDescriptionWindow() : base(Interface.GameUi.GameCanvas, "DescriptionWindow")
+    {
+        base.Hide();
+    }
 
     public void Show(Guid spellId, ItemDescriptionWindow? itemDecriptionContainer = default)
     {
@@ -57,13 +62,11 @@ public partial class SpellDescriptionWindow() : DescriptionWindowBase(Interface.
 
     public override void Hide()
     {
-        if (Interface.GameUi.SpellDescriptionWindow == this)
-        {
-            Interface.GameUi.GameCanvas.RemoveChild(Interface.GameUi.SpellDescriptionWindow, true);
-            Interface.GameUi.SpellDescriptionWindow = default;
-        }
-
         UnsubscribeFromLocalizationUpdates();
+        _spellDescriptor = null;
+        _spellProperties = null;
+        _effectiveProps = null;
+        base.Hide();
     }
 
     protected void SetupDescriptionWindow()

--- a/Intersect.Client.Core/Interface/Game/EventWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/EventWindow.cs
@@ -10,6 +10,7 @@ using Intersect.Client.Framework.Input;
 using Intersect.Client.General;
 using Intersect.Client.Interface.Game.Typewriting;
 using Intersect.Client.Localization;
+using Intersect.Network.Packets.Localization;
 using Intersect.Client.Networking;
 using Intersect.Client.Utilities;
 using Intersect.Configuration;
@@ -134,6 +135,7 @@ public partial class EventWindow : Panel
         };
 
         CreateOptionButtons();
+        GameLocalization.LocalizedTextsUpdated += OnLocalizedTextsUpdated;
 
         try
         {
@@ -259,6 +261,79 @@ public partial class EventWindow : Panel
         }
     }
 
+    private void OnLocalizedTextsUpdated(string language, IReadOnlyCollection<LocalizationRequestEntry> requests)
+    {
+        if (!IsVisibleInTree || requests.Count < 1)
+        {
+            return;
+        }
+
+        static bool RequestsMatch(LocalizationRequestEntry? expectedRequest, IReadOnlyCollection<LocalizationRequestEntry> updatedRequests)
+        {
+            if (expectedRequest == null)
+            {
+                return false;
+            }
+
+            return updatedRequests.Any(
+                request => request.EntityType == expectedRequest.EntityType &&
+                           request.EntityId == expectedRequest.EntityId &&
+                           request.Field == expectedRequest.Field
+            );
+        }
+
+        var promptRequestMatched = RequestsMatch(_dialog.PromptLocalizationRequest, requests);
+        var optionsRequestMatched = _dialog.OptionLocalizationRequests.Any(optionRequest => RequestsMatch(optionRequest, requests));
+        if (!promptRequestMatched && !optionsRequestMatched)
+        {
+            return;
+        }
+
+        if (_dialog.PromptLocalizationRequest is { } promptLocalizationRequest)
+        {
+            if (Guid.TryParse(promptLocalizationRequest.EntityId, out var promptEntityId))
+            {
+                _dialog.Prompt = GameLocalization.GetTextOrDefault(
+                    promptLocalizationRequest.EntityType,
+                    promptEntityId,
+                    promptLocalizationRequest.Field,
+                    _dialog.PromptDefault ?? string.Empty
+                );
+            }
+        }
+
+        for (var optionIndex = 0; optionIndex < _dialog.OptionLocalizationRequests.Length; optionIndex++)
+        {
+            if (optionIndex >= _dialog.Options.Length)
+            {
+                break;
+            }
+
+            var optionRequest = _dialog.OptionLocalizationRequests[optionIndex];
+            if (optionRequest == null)
+            {
+                continue;
+            }
+
+            var optionFallback = _dialog.OptionDefaults.ElementAtOrDefault(optionIndex) ?? string.Empty;
+            if (!Guid.TryParse(optionRequest.EntityId, out var optionEntityId))
+            {
+                _dialog.Options[optionIndex] = optionFallback;
+                continue;
+            }
+
+            _dialog.Options[optionIndex] = GameLocalization.GetTextOrDefault(
+                optionRequest.EntityType,
+                optionEntityId,
+                optionRequest.Field,
+                optionFallback
+            );
+        }
+
+        ApplyPromptAndTypewriter();
+        CreateOptionButtons();
+    }
+
     private void Update()
     {
         if (!IsVisibleInTree || !_typewriting || _writer is null)
@@ -367,6 +442,7 @@ public partial class EventWindow : Panel
 
     protected override void Dispose(bool disposing)
     {
+        GameLocalization.LocalizedTextsUpdated -= OnLocalizedTextsUpdated;
         EnsureControlRestored();
         base.Dispose(disposing);
     }

--- a/Intersect.Client.Core/Interface/Game/GameInterface.cs
+++ b/Intersect.Client.Core/Interface/Game/GameInterface.cs
@@ -178,17 +178,23 @@ public partial class GameInterface : MutableInterface
         set => _itemDescriptionWindow = value;
     }
 
+    public ItemDescriptionWindow? ExistingItemDescriptionWindow => _itemDescriptionWindow;
+
     public ChatItemDescriptionWindow? ChatItemDescriptionWindow
     {
         get => _chatItemDescriptionWindow ??= new ChatItemDescriptionWindow();
         set => _chatItemDescriptionWindow = value;
     }
 
+    public ChatItemDescriptionWindow? ExistingChatItemDescriptionWindow => _chatItemDescriptionWindow;
+
     public SpellDescriptionWindow? SpellDescriptionWindow
     {
         get => _spellDescriptionWindow ??= new SpellDescriptionWindow();
         set => _spellDescriptionWindow = value;
     }
+
+    public SpellDescriptionWindow? ExistingSpellDescriptionWindow => _spellDescriptionWindow;
 
     public MenuContainer GameMenu { get; private set; }
 

--- a/Intersect.Client.Core/Interface/Game/Inventory/InventoryWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Inventory/InventoryWindow.cs
@@ -635,6 +635,7 @@ public partial class InventoryWindow : Window
             }
 
             requests.Add(new LocalizationRequestEntry(descriptor.Type.ToString(), descriptor.Id.ToString(), "Name"));
+            requests.Add(new LocalizationRequestEntry(descriptor.Type.ToString(), descriptor.Id.ToString(), "Description"));
         }
 
         if (requests.Count > 0)
@@ -662,7 +663,10 @@ public partial class InventoryWindow : Window
         }
 
         GameLocalization.RequestEntries(
-            [new LocalizationRequestEntry(descriptor.Type.ToString(), descriptor.Id.ToString(), "Name")]
+            [
+                new LocalizationRequestEntry(descriptor.Type.ToString(), descriptor.Id.ToString(), "Name"),
+                new LocalizationRequestEntry(descriptor.Type.ToString(), descriptor.Id.ToString(), "Description")
+            ]
         );
     }
 

--- a/Intersect.Client.Core/Interface/Game/Job/JobsWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Job/JobsWindow.cs
@@ -39,6 +39,7 @@ namespace Intersect.Client.Interface.Game.Job
         private List<RecipeItem> mItems = new List<RecipeItem>();
         private RecipeItem mCombinedItem;
         private readonly HashSet<Guid> _visibleRecipeIds = new();
+        private readonly Dictionary<Guid, Label> _recipeNameLabels = new();
         private bool _localizationSubscribed;
 
         private JobType SelectedJob = JobType.None;
@@ -322,20 +323,40 @@ namespace Intersect.Client.Interface.Game.Job
             }
         }
 
+        private void ReleaseHoverFromRecipePanel()
+        {
+            if (InputHandler.HoveredControl is not { } hoveredControl)
+            {
+                return;
+            }
+
+            for (var current = hoveredControl; current != null; current = current.Parent)
+            {
+                if (current == mRecipePanel)
+                {
+                    InputHandler.HoveredControl = null;
+                    return;
+                }
+            }
+        }
+
+        private void ResetRecipePanel()
+        {
+            Interface.GameUi.ItemDescriptionWindow?.Hide();
+            mRecipePanel.ClearChildren(dispose: true);
+            mItems.Clear();
+            _recipeNameLabels.Clear();
+        }
+
         private void LoadRecipes(JobType jobType)
         {  // Record current scroll position before clearing to preserve it
             ReleaseMouseFocusFromRecipePanel();
+            ReleaseHoverFromRecipePanel();
 
             var currentScroll = mRecipePanel.VerticalScrollBar.ScrollAmount;
+            ResetRecipePanel();
             // 🔄 Limpiar visual y lógicamente las recetas anteriores
-            foreach (var craftedItem in mItems)
-            {
-                if (craftedItem.Container is { } container)
-                {
-                    container.Dispose(); // Para evitar fugas visuales
-                }
-                Interface.GameUi.ItemDescriptionWindow?.Hide();
-            }
+            Interface.GameUi.ItemDescriptionWindow?.Hide();
 
             // Limpiar visualmente y en memoria
             mRecipePanel.ClearChildren(); // ✅ Limpia todo visual
@@ -394,6 +415,7 @@ namespace Intersect.Client.Interface.Game.Job
                     TextColorOverride = Color.White
                 };
                 nameLbl.SetPosition(50, 5);
+                _recipeNameLabels[recipe.Id] = nameLbl;
 
                 // XP
                 var estimatedExperience = CraftingExperiencePolicy.CalculateAwardedExperience(recipe, playerJobLevel);
@@ -559,15 +581,28 @@ namespace Intersect.Client.Interface.Game.Job
             }
 
             var entityType = GameObjectType.Crafts.ToString();
-            if (requests.Any(
-                    request => request != null &&
-                               request.EntityType == entityType &&
-                               request.Field == "Name" &&
-                               Guid.TryParse(request.EntityId, out var recipeId) &&
-                               _visibleRecipeIds.Contains(recipeId)
-                ))
+            var updatedRecipeNames = false;
+            foreach (var request in requests)
             {
-                LoadRecipes(SelectedJob);
+                if (request == null ||
+                    request.EntityType != entityType ||
+                    request.Field != "Name" ||
+                    !Guid.TryParse(request.EntityId, out var recipeId) ||
+                    !_visibleRecipeIds.Contains(recipeId) ||
+                    !_recipeNameLabels.TryGetValue(recipeId, out var label) ||
+                    !CraftingRecipeDescriptor.TryGet(recipeId, out var recipe))
+                {
+                    continue;
+                }
+
+                label.Text = GetLocalizedRecipeName(recipe);
+                label.SizeToChildren(false, true);
+                updatedRecipeNames = true;
+            }
+
+            if (updatedRecipeNames)
+            {
+                mRecipePanel.UpdateScrollBars();
             }
         }
     }

--- a/Intersect.Client.Core/Interface/Game/Job/JobsWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Job/JobsWindow.cs
@@ -372,7 +372,11 @@ namespace Intersect.Client.Interface.Game.Job
             if (table == null)
                 return;
 
-            var inventoryItemsByDescriptorId = Globals.Me.Inventory
+            var me = Globals.Me as Intersect.Client.Entities.Entity;
+            if (me == null)
+                return;
+
+            var inventoryItemsByDescriptorId = me.Inventory
                 .Where(i => i != null)
                 .GroupBy(i => i.ItemId)
                 .ToDictionary(g => g.Key, g => g.Sum(i => i.Quantity));

--- a/Intersect.Client.Core/Interface/Game/Market/SellMarketWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Market/SellMarketWindow.cs
@@ -502,6 +502,7 @@ namespace Intersect.Client.Interface.Game.Market
                 }
 
                 requests.Add(new LocalizationRequestEntry(descriptor.Type.ToString(), descriptor.Id.ToString(), "Name"));
+                requests.Add(new LocalizationRequestEntry(descriptor.Type.ToString(), descriptor.Id.ToString(), "Description"));
             }
 
             if (requests.Count > 0)
@@ -529,7 +530,10 @@ namespace Intersect.Client.Interface.Game.Market
             }
 
             GameLocalization.RequestEntries(
-                [new LocalizationRequestEntry(descriptor.Type.ToString(), descriptor.Id.ToString(), "Name")]
+                [
+                    new LocalizationRequestEntry(descriptor.Type.ToString(), descriptor.Id.ToString(), "Name"),
+                    new LocalizationRequestEntry(descriptor.Type.ToString(), descriptor.Id.ToString(), "Description")
+                ]
             );
         }
 

--- a/Intersect.Client.Core/Interface/Game/QuestOfferWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/QuestOfferWindow.cs
@@ -11,6 +11,7 @@ using Intersect.Client.Localization;
 using Intersect.Client.Networking;
 using Intersect.Config;
 using Intersect.Enums;
+using Intersect.Framework.Core.GameObjects.Items;
 using Intersect.Framework.Core.Localization;
 using Intersect.GameObjects;
 using Intersect.Network.Packets.Localization;
@@ -218,12 +219,27 @@ namespace Intersect.Client.Interface.Game
         private void RequestLocalization(QuestDescriptor quest)
         {
             var entityType = GetQuestEntityType(quest);
-            GameLocalization.RequestEntries(
-                [
-                    new LocalizationRequestEntry(entityType, quest.Id.ToString(), QuestFieldKey.Name),
-                    new LocalizationRequestEntry(entityType, quest.Id.ToString(), QuestFieldKey.StartDescription)
-                ]
-            );
+            var requests = new List<LocalizationRequestEntry>
+            {
+                new LocalizationRequestEntry(entityType, quest.Id.ToString(), QuestFieldKey.Name),
+                new LocalizationRequestEntry(entityType, quest.Id.ToString(), QuestFieldKey.StartDescription)
+            };
+
+            if (Globals.QuestRewards.TryGetValue(quest.Id, out var rewards))
+            {
+                foreach (var rewardItemId in rewards.Keys)
+                {
+                    if (!ItemDescriptor.TryGet(rewardItemId, out var descriptor))
+                    {
+                        continue;
+                    }
+
+                    requests.Add(new LocalizationRequestEntry(descriptor.Type.ToString(), descriptor.Id.ToString(), "Name"));
+                    requests.Add(new LocalizationRequestEntry(descriptor.Type.ToString(), descriptor.Id.ToString(), "Description"));
+                }
+            }
+
+            GameLocalization.RequestEntries(requests);
         }
 
         private static string GetLocalizedQuestField(QuestDescriptor quest, string field, string fallback) =>

--- a/Intersect.Client.Core/Interface/Game/QuestOfferWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/QuestOfferWindow.cs
@@ -217,16 +217,20 @@ namespace Intersect.Client.Interface.Game
 
         private void RequestLocalization(QuestDescriptor quest)
         {
+            var entityType = GetQuestEntityType(quest);
             GameLocalization.RequestEntries(
                 [
-                    new LocalizationRequestEntry(quest.Type.ToString(), quest.Id.ToString(), QuestFieldKey.Name),
-                    new LocalizationRequestEntry(quest.Type.ToString(), quest.Id.ToString(), QuestFieldKey.StartDescription)
+                    new LocalizationRequestEntry(entityType, quest.Id.ToString(), QuestFieldKey.Name),
+                    new LocalizationRequestEntry(entityType, quest.Id.ToString(), QuestFieldKey.StartDescription)
                 ]
             );
         }
 
         private static string GetLocalizedQuestField(QuestDescriptor quest, string field, string fallback) =>
-            GameLocalization.GetTextOrDefault(quest.Type.ToString(), quest.Id, field, fallback);
+            GameLocalization.GetTextOrDefault(GetQuestEntityType(quest), quest.Id, field, fallback);
+
+        private static string GetQuestEntityType(QuestDescriptor quest) =>
+            LocalizationEntityTypes.FromGameObjectType(quest.Type);
 
         private void SubscribeToLocalizationUpdates()
         {
@@ -251,7 +255,7 @@ namespace Intersect.Client.Interface.Game
                 return;
             }
 
-            var entityType = quest.Type.ToString();
+            var entityType = GetQuestEntityType(quest);
             var entityId = quest.Id.ToString();
             if (requests.Any(
                     request => request.EntityType == entityType &&

--- a/Intersect.Client.Core/Interface/Game/QuestsWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/QuestsWindow.cs
@@ -440,7 +440,7 @@ namespace Intersect.Client.Interface.Game
         {
             var requests = quests
                 .Select(
-                    quest => new LocalizationRequestEntry(quest.Type.ToString(), quest.Id.ToString(), QuestFieldKey.Name)
+                    quest => new LocalizationRequestEntry(GetQuestEntityType(quest), quest.Id.ToString(), QuestFieldKey.Name)
                 )
                 .ToList();
 
@@ -449,18 +449,19 @@ namespace Intersect.Client.Interface.Game
 
         private void RequestQuestLocalization(QuestDescriptor quest)
         {
+            var entityType = GetQuestEntityType(quest);
             var entries = new List<LocalizationRequestEntry>
             {
-                new LocalizationRequestEntry(quest.Type.ToString(), quest.Id.ToString(), QuestFieldKey.Name),
-                new LocalizationRequestEntry(quest.Type.ToString(), quest.Id.ToString(), QuestFieldKey.BeforeDescription),
-                new LocalizationRequestEntry(quest.Type.ToString(), quest.Id.ToString(), QuestFieldKey.InProgressDescription),
-                new LocalizationRequestEntry(quest.Type.ToString(), quest.Id.ToString(), QuestFieldKey.EndDescription)
+                new LocalizationRequestEntry(entityType, quest.Id.ToString(), QuestFieldKey.Name),
+                new LocalizationRequestEntry(entityType, quest.Id.ToString(), QuestFieldKey.BeforeDescription),
+                new LocalizationRequestEntry(entityType, quest.Id.ToString(), QuestFieldKey.InProgressDescription),
+                new LocalizationRequestEntry(entityType, quest.Id.ToString(), QuestFieldKey.EndDescription)
             };
 
             foreach (var task in quest.Tasks)
             {
                 entries.Add(new LocalizationRequestEntry(
-                    quest.Type.ToString(),
+                    entityType,
                     quest.Id.ToString(),
                     GetQuestTaskLocalizationField(task)
                 ));
@@ -470,7 +471,10 @@ namespace Intersect.Client.Interface.Game
         }
 
         private static string GetLocalizedQuestField(QuestDescriptor quest, string field, string fallback) =>
-            GameLocalization.GetTextOrDefault(quest.Type.ToString(), quest.Id, field, fallback);
+            GameLocalization.GetTextOrDefault(GetQuestEntityType(quest), quest.Id, field, fallback);
+
+        private static string GetQuestEntityType(QuestDescriptor quest) =>
+            LocalizationEntityTypes.FromGameObjectType(quest.Type);
 
         private static string GetQuestTaskLocalizationField(QuestTaskDescriptor task) =>
             QuestFieldKey.TaskDescription(task.Id);
@@ -481,7 +485,7 @@ namespace Intersect.Client.Interface.Game
             string fallback
         ) =>
             GameLocalization.GetTextOrDefault(
-                quest.Type.ToString(),
+                GetQuestEntityType(quest),
                 quest.Id,
                 GetQuestTaskLocalizationField(task),
                 fallback
@@ -518,7 +522,7 @@ namespace Intersect.Client.Interface.Game
 
             if (mSelectedQuest != null)
             {
-                var entityType = mSelectedQuest.Type.ToString();
+                var entityType = GetQuestEntityType(mSelectedQuest);
                 var entityId = mSelectedQuest.Id.ToString();
                 if (requests.Any(
                         request => request.EntityType == entityType &&

--- a/Intersect.Client.Core/Interface/Game/QuestsWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/QuestsWindow.cs
@@ -465,6 +465,36 @@ namespace Intersect.Client.Interface.Game
                     quest.Id.ToString(),
                     GetQuestTaskLocalizationField(task)
                 ));
+
+                switch (task.Objective)
+                {
+                    case QuestObjective.GatherItems when ItemDescriptor.TryGet(task.TargetId, out var item):
+                        entries.Add(new LocalizationRequestEntry(item.Type.ToString(), item.Id.ToString(), "Name"));
+                        entries.Add(new LocalizationRequestEntry(item.Type.ToString(), item.Id.ToString(), "Description"));
+                        break;
+
+                    case QuestObjective.KillNpcs when NPCDescriptor.TryGet(task.TargetId, out var npc):
+                        entries.Add(new LocalizationRequestEntry(
+                            LocalizationEntityTypes.Npc,
+                            npc.Id.ToString(),
+                            "Name"
+                        ));
+                        break;
+                }
+            }
+
+            if (Globals.QuestRewards.TryGetValue(quest.Id, out var rewards))
+            {
+                foreach (var rewardItemId in rewards.Keys)
+                {
+                    if (!ItemDescriptor.TryGet(rewardItemId, out var rewardDescriptor))
+                    {
+                        continue;
+                    }
+
+                    entries.Add(new LocalizationRequestEntry(rewardDescriptor.Type.ToString(), rewardDescriptor.Id.ToString(), "Name"));
+                    entries.Add(new LocalizationRequestEntry(rewardDescriptor.Type.ToString(), rewardDescriptor.Id.ToString(), "Description"));
+                }
             }
 
             GameLocalization.RequestEntries(entries);
@@ -501,6 +531,21 @@ namespace Intersect.Client.Interface.Game
             return GameLocalization.GetTextOrDefault(item.Type.ToString(), item.Id, "Name", item.Name);
         }
 
+        private static string GetLocalizedNpcName(Guid npcId)
+        {
+            if (!NPCDescriptor.TryGet(npcId, out var npc) || npc == null)
+            {
+                return NPCDescriptor.GetName(npcId);
+            }
+
+            return GameLocalization.GetTextOrDefault(
+                LocalizationEntityTypes.Npc,
+                npc.Id,
+                "Name",
+                npc.Name
+            );
+        }
+
         private void SubscribeToLocalizationUpdates()
         {
             if (_localizationSubscribed)
@@ -525,14 +570,21 @@ namespace Intersect.Client.Interface.Game
                 var entityType = GetQuestEntityType(mSelectedQuest);
                 var entityId = mSelectedQuest.Id.ToString();
                 if (requests.Any(
-                        request => request.EntityType == entityType &&
-                                   request.EntityId == entityId &&
-                                   (request.Field == QuestFieldKey.Name ||
-                                    request.Field == QuestFieldKey.BeforeDescription ||
-                                    request.Field == QuestFieldKey.InProgressDescription ||
-                                    request.Field == QuestFieldKey.EndDescription ||
-                                    request.Field.StartsWith("Task:", StringComparison.Ordinal))
-                    ))
+                        request =>
+                            (request.EntityType == entityType &&
+                             request.EntityId == entityId &&
+                             (request.Field == QuestFieldKey.Name ||
+                              request.Field == QuestFieldKey.BeforeDescription ||
+                              request.Field == QuestFieldKey.InProgressDescription ||
+                              request.Field == QuestFieldKey.EndDescription ||
+                              request.Field.StartsWith("Task:", StringComparison.Ordinal))) ||
+                            (request.EntityType == GameObjectType.Item.ToString() &&
+                             (mSelectedQuest.Tasks.Any(task => task.Objective == QuestObjective.GatherItems && task.TargetId.ToString() == request.EntityId) ||
+                              (Globals.QuestRewards.TryGetValue(mSelectedQuest.Id, out var rewards) &&
+                               rewards.Keys.Any(itemId => itemId.ToString() == request.EntityId)))) ||
+                            (request.EntityType == LocalizationEntityTypes.Npc &&
+                             mSelectedQuest.Tasks.Any(task => task.Objective == QuestObjective.KillNpcs && task.TargetId.ToString() == request.EntityId))
+                     ))
                 {
                     UpdateSelectedQuest();
                 }
@@ -725,13 +777,13 @@ namespace Intersect.Client.Interface.Game
                             else if (mSelectedQuest.Tasks[i].Objective == QuestObjective.KillNpcs)
                             {
                                 mQuestCurrentTaskLabel.AddText(
-                                    Strings.QuestLog.TaskNpc.ToString(
-                                        Globals.Me.QuestProgress[mSelectedQuest.Id].TaskProgress,
-                                        mSelectedQuest.Tasks[i].Quantity,
-                                        NPCDescriptor.GetName(mSelectedQuest.Tasks[i].TargetId)
-                                    ),
-                                    mQuestDescTemplateLabel
-                                );
+                                        Strings.QuestLog.TaskNpc.ToString(
+                                            Globals.Me.QuestProgress[mSelectedQuest.Id].TaskProgress,
+                                            mSelectedQuest.Tasks[i].Quantity,
+                                            GetLocalizedNpcName(mSelectedQuest.Tasks[i].TargetId)
+                                        ),
+                                        mQuestDescTemplateLabel
+                                    );
                             }
                         }
                     }
@@ -1190,7 +1242,7 @@ namespace Intersect.Client.Interface.Game
 
                     case QuestObjective.KillNpcs:
                         desc = Strings.QuestLog.TaskNpc.ToString(
-                            progress, task.Quantity, NPCDescriptor.GetName(task.TargetId));
+                            progress, task.Quantity, GetLocalizedNpcName(task.TargetId));
                         break;
                 }
 

--- a/Intersect.Client.Core/Interface/Game/Shops/PlayerShopBrowseWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Shops/PlayerShopBrowseWindow.cs
@@ -237,6 +237,7 @@ namespace Intersect.Client.Interface.Game.Shops
                 }
 
                 requests.Add(new LocalizationRequestEntry(descriptor.Type.ToString(), descriptor.Id.ToString(), "Name"));
+                requests.Add(new LocalizationRequestEntry(descriptor.Type.ToString(), descriptor.Id.ToString(), "Description"));
             }
 
             if (requests.Count > 0)

--- a/Intersect.Client.Core/Interface/Game/Spells/SpellsWindow.cs
+++ b/Intersect.Client.Core/Interface/Game/Spells/SpellsWindow.cs
@@ -393,6 +393,7 @@ public partial class SpellsWindow : Window
             }
 
             requests.Add(new LocalizationRequestEntry(spell.Type.ToString(), spellId.ToString(), "Name"));
+            requests.Add(new LocalizationRequestEntry(spell.Type.ToString(), spellId.ToString(), "Description"));
         }
 
         if (requests.Count > 0)

--- a/Intersect.Client.Core/Interface/Interface.cs
+++ b/Intersect.Client.Core/Interface/Interface.cs
@@ -47,19 +47,13 @@ public static partial class Interface
 
     public static bool HasMainMenuUI => _uiMainMenu != null;
 
-    public static GameInterface GameUi
+    public static GameInterface? GameUi
     {
-        get
-        {
-            if (_uiInGame == null)
-            {
-                throw new InvalidOperationException("In-game UI not initialized");
-            }
-
-            return _uiInGame;
-        }
+        get => _uiInGame;
         private set => _uiInGame = value;
     }
+
+    public static bool IsGameUiReady => _uiInGame != null;
 
     public static MenuGuiBase MenuUi
     {
@@ -151,7 +145,7 @@ public static partial class Interface
             return;
         }
 
-        PendingActionsForInGameInterface.Enqueue(() => action(GameUi));
+        PendingActionsForInGameInterface.Enqueue(() => action(_uiInGame!));
     }
 
     public static void EnqueueInGame<TArg0, TArg1>(Action<GameInterface> action, Action<TArg0, TArg1> onDeferred, TArg0 arg0, TArg1 arg1)
@@ -162,7 +156,7 @@ public static partial class Interface
             return;
         }
 
-        PendingActionsForInGameInterface.Enqueue(() => action(GameUi));
+        PendingActionsForInGameInterface.Enqueue(() => action(_uiInGame!));
         onDeferred(arg0, arg1);
     }
 
@@ -339,7 +333,7 @@ public static partial class Interface
         }
         else if (Globals.GameState == GameStates.InGame)
         {
-            GameUi.Update(elapsed, total);
+            GameUi?.Update(elapsed, total);
         }
 
         //Do not allow hiding of UI under several conditions
@@ -379,7 +373,7 @@ public static partial class Interface
                     _canvasInGame.Show();
                 }
 
-                GameUi.Draw(elapsed, total);
+                GameUi?.Draw(elapsed, total);
             }
         }
     }

--- a/Intersect.Client.Core/Localization/GameLocalization.cs
+++ b/Intersect.Client.Core/Localization/GameLocalization.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Threading;
 using Intersect.Client.General;
 using Intersect.Network.Packets.Localization;
 using Intersect.Client.Networking;
+using Intersect.Core;
 
 namespace Intersect.Client.Localization;
 
@@ -15,6 +17,14 @@ public static class GameLocalization
     private static readonly ConcurrentDictionary<LocalizationCacheKey, LocalizationCacheEntry> Cache = new();
     private static readonly ConcurrentDictionary<LocalizationCacheKey, DateTime> PendingRequests = new();
 
+    private static readonly object StatsSync = new();
+    private static readonly TimeSpan StatsLogThrottle = TimeSpan.FromSeconds(30);
+    private static DateTime NextStatsLogUtc = DateTime.UtcNow + StatsLogThrottle;
+
+    private static long CacheHits;
+    private static long CacheMisses;
+    private static long RequestsDispatched;
+
     public static event Action<string, IReadOnlyCollection<LocalizationRequestEntry>>? LocalizedTextsUpdated;
 
     public static string GetTextOrDefault(string entityType, Guid entityId, string field, string fallback)
@@ -25,8 +35,13 @@ public static class GameLocalization
         {
             if (cacheEntry.State == LocalizationCacheState.Resolved)
             {
+                Interlocked.Increment(ref CacheHits);
+                LogStatsIfNeeded();
                 return string.IsNullOrWhiteSpace(cacheEntry.Text) ? fallback : cacheEntry.Text;
             }
+
+            Interlocked.Increment(ref CacheMisses);
+            LogStatsIfNeeded();
 
             RequestMissingEntries(
                 language,
@@ -37,6 +52,9 @@ public static class GameLocalization
 
             return fallback;
         }
+
+        Interlocked.Increment(ref CacheMisses);
+        LogStatsIfNeeded();
 
         RequestMissingEntries(
             language,
@@ -90,6 +108,13 @@ public static class GameLocalization
     {
         Cache.Clear();
         PendingRequests.Clear();
+        Interlocked.Exchange(ref CacheHits, 0);
+        Interlocked.Exchange(ref CacheMisses, 0);
+        Interlocked.Exchange(ref RequestsDispatched, 0);
+        lock (StatsSync)
+        {
+            NextStatsLogUtc = DateTime.UtcNow + StatsLogThrottle;
+        }
     }
 
     private static void RequestMissingEntries(string language, IEnumerable<LocalizationRequestEntry> requests)
@@ -141,7 +166,40 @@ public static class GameLocalization
 
         if (pendingRequests.Count > 0)
         {
+            Interlocked.Add(ref RequestsDispatched, pendingRequests.Count);
             PacketSender.SendLocalizedTextRequest(language, pendingRequests);
+            LogStatsIfNeeded();
+        }
+    }
+
+
+    private static void LogStatsIfNeeded()
+    {
+        var now = DateTime.UtcNow;
+        lock (StatsSync)
+        {
+            if (now < NextStatsLogUtc)
+            {
+                return;
+            }
+
+            var hits = Interlocked.Exchange(ref CacheHits, 0);
+            var misses = Interlocked.Exchange(ref CacheMisses, 0);
+            var dispatched = Interlocked.Exchange(ref RequestsDispatched, 0);
+            NextStatsLogUtc = now + StatsLogThrottle;
+
+            if (hits + misses + dispatched <= 0)
+            {
+                return;
+            }
+
+            ApplicationContext.Context.Value?.Logger.LogDebug(
+                "Localization cache stats (last {WindowSeconds}s): hits={Hits}, misses={Misses}, requestsDispatched={RequestsDispatched}.",
+                (int)StatsLogThrottle.TotalSeconds,
+                hits,
+                misses,
+                dispatched
+            );
         }
     }
 

--- a/Intersect.Client.Core/Localization/GameLocalization.cs
+++ b/Intersect.Client.Core/Localization/GameLocalization.cs
@@ -6,6 +6,7 @@ using Intersect.Client.General;
 using Intersect.Network.Packets.Localization;
 using Intersect.Client.Networking;
 using Intersect.Core;
+using Microsoft.Extensions.Logging;
 
 namespace Intersect.Client.Localization;
 

--- a/Intersect.Client.Core/Networking/PacketHandler.cs
+++ b/Intersect.Client.Core/Networking/PacketHandler.cs
@@ -1397,14 +1397,22 @@ internal sealed partial class PacketHandler
     {
         Fade.FadeIn(ClientConfiguration.Instance.FadeDurationMs);
         Globals.WaitingOnServer = false;
-        if (Interface.Interface.GameUi?.mMarketWindow != null && Interface.Interface.GameUi.mMarketWindow.IsWaitingSearch)
+
+        if (
+            Interface.Interface.HasInGameUI &&
+            Interface.Interface.GameUi.mMarketWindow != null &&
+            Interface.Interface.GameUi.mMarketWindow.IsWaitingSearch
+        )
         {
             Interface.Interface.GameUi.mMarketWindow.SearchFailed(packet.Error);
+            return;
         }
-        else
+
+        Interface.Interface.ShowAlert(packet.Error, packet.Header, alertType: AlertType.Error);
+
+        if (Interface.Interface.HasMainMenuUI)
         {
-            Interface.Interface.ShowAlert(packet.Error, packet.Header, alertType: AlertType.Error);
-            Interface.Interface.MenuUi?.Reset();
+            Interface.Interface.MenuUi.Reset();
         }
     }
 

--- a/Intersect.Client.Core/Networking/PacketHandler.cs
+++ b/Intersect.Client.Core/Networking/PacketHandler.cs
@@ -199,6 +199,12 @@ internal sealed partial class PacketHandler
             return false;
         }
 
+        var isInGameUiInitializationWindow = Globals.GameState is GameStates.Loading or GameStates.InGame;
+        if (!isInGameUiInitializationWindow)
+        {
+            return false;
+        }
+
         return packet is ErrorMessagePacket;
     }
 

--- a/Intersect.Client.Core/Networking/PacketHandler.cs
+++ b/Intersect.Client.Core/Networking/PacketHandler.cs
@@ -32,9 +32,12 @@ using Intersect.Framework.Core.GameObjects.Mapping.Tilesets;
 using Intersect.Framework.Core.GameObjects.Maps;
 using Intersect.Framework.Core.GameObjects.Maps.Attributes;
 using Intersect.Framework.Core.GameObjects.Maps.MapList;
+using Intersect.Framework.Core.GameObjects.NPCs;
+using Intersect.Framework.Core.GameObjects.Quests;
 using Intersect.Framework.Core.Security;
 using Intersect.Framework.Threading;
 using Intersect.Localization;
+using Intersect.Framework.Core.Localization;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
@@ -2026,6 +2029,7 @@ internal sealed partial class PacketHandler
         {
             Globals.ActiveCraftingTable = new CraftingTableDescriptor();
             Globals.ActiveCraftingTable.Load(packet.TableData);
+            PrefetchCraftingLocalization(Globals.ActiveCraftingTable);
             Interface.Interface.EnqueueInGame(gameInterface => gameInterface.NotifyOpenCraftingTable(packet.JournalMode));
         }
         else
@@ -2278,6 +2282,120 @@ internal sealed partial class PacketHandler
         en.AddChatBubble(packet.Text);
     }
 
+    private static void PrefetchQuestLocalization(Guid questId)
+    {
+        if (!QuestDescriptor.TryGet(questId, out var quest) || quest == null)
+        {
+            return;
+        }
+
+        var entityType = LocalizationEntityTypes.FromGameObjectType(quest.Type);
+        var requests = new List<LocalizationRequestEntry>
+        {
+            new LocalizationRequestEntry(entityType, quest.Id.ToString(), QuestFieldKey.Name),
+            new LocalizationRequestEntry(entityType, quest.Id.ToString(), QuestFieldKey.StartDescription),
+            new LocalizationRequestEntry(entityType, quest.Id.ToString(), QuestFieldKey.BeforeDescription),
+            new LocalizationRequestEntry(entityType, quest.Id.ToString(), QuestFieldKey.InProgressDescription),
+            new LocalizationRequestEntry(entityType, quest.Id.ToString(), QuestFieldKey.EndDescription)
+        };
+
+        foreach (var task in quest.Tasks)
+        {
+            requests.Add(new LocalizationRequestEntry(
+                entityType,
+                quest.Id.ToString(),
+                QuestFieldKey.TaskDescription(task.Id)
+            ));
+
+            switch (task.Objective)
+            {
+                case QuestObjective.GatherItems when ItemDescriptor.TryGet(task.TargetId, out var item):
+                    requests.Add(new LocalizationRequestEntry(item.Type.ToString(), item.Id.ToString(), "Name"));
+                    requests.Add(new LocalizationRequestEntry(item.Type.ToString(), item.Id.ToString(), "Description"));
+                    break;
+
+                case QuestObjective.KillNpcs when NPCDescriptor.TryGet(task.TargetId, out var npc):
+                    requests.Add(new LocalizationRequestEntry(
+                        LocalizationEntityTypes.Npc,
+                        npc.Id.ToString(),
+                        "Name"
+                    ));
+                    break;
+            }
+        }
+
+        if (Globals.QuestRewards.TryGetValue(questId, out var rewards))
+        {
+            foreach (var rewardItemId in rewards.Keys)
+            {
+                if (!ItemDescriptor.TryGet(rewardItemId, out var rewardDescriptor))
+                {
+                    continue;
+                }
+
+                requests.Add(new LocalizationRequestEntry(rewardDescriptor.Type.ToString(), rewardDescriptor.Id.ToString(), "Name"));
+                requests.Add(new LocalizationRequestEntry(rewardDescriptor.Type.ToString(), rewardDescriptor.Id.ToString(), "Description"));
+            }
+        }
+
+        if (requests.Count > 0)
+        {
+            GameLocalization.RequestEntries(requests);
+        }
+    }
+
+    private static void PrefetchCraftingLocalization(CraftingTableDescriptor? table)
+    {
+        if (table == null)
+        {
+            return;
+        }
+
+        var requests = new List<LocalizationRequestEntry>
+        {
+            new LocalizationRequestEntry(
+                LocalizationEntityTypes.FromGameObjectType(table.Type),
+                table.Id.ToString(),
+                "Name"
+            )
+        };
+
+        foreach (var recipeId in table.Crafts)
+        {
+            if (!CraftingRecipeDescriptor.TryGet(recipeId, out var recipe) || recipe == null)
+            {
+                continue;
+            }
+
+            requests.Add(new LocalizationRequestEntry(
+                LocalizationEntityTypes.FromGameObjectType(recipe.Type),
+                recipe.Id.ToString(),
+                "Name"
+            ));
+
+            var itemIds = new HashSet<Guid>(recipe.Ingredients.Select(ingredient => ingredient.ItemId))
+            {
+                recipe.ItemId
+            };
+
+            foreach (var itemId in itemIds)
+            {
+                if (!ItemDescriptor.TryGet(itemId, out var descriptor))
+                {
+                    continue;
+                }
+
+                requests.Add(new LocalizationRequestEntry(descriptor.Type.ToString(), descriptor.Id.ToString(), "Name"));
+                requests.Add(new LocalizationRequestEntry(descriptor.Type.ToString(), descriptor.Id.ToString(), "Description"));
+            }
+        }
+
+        if (requests.Count > 0)
+        {
+            GameLocalization.RequestEntries(requests);
+        }
+    }
+
     //QuestOfferPacket
     public void HandlePacket(IPacketSender packetSender, QuestOfferPacket packet)
     {
@@ -2291,6 +2409,7 @@ internal sealed partial class PacketHandler
         Globals.QuestJobExperience[packet.QuestId] = packet.QuestRewardJobExperience;
         Globals.QuestGuildExperience[packet.QuestId] = packet.QuestRewardGuildExperience;
         Globals.QuestFactionHonor[packet.QuestId] = packet.QuestRewardFactionHonor;
+        PrefetchQuestLocalization(packet.QuestId);
     }
 
     //QuestProgressPacket
@@ -2351,6 +2470,16 @@ internal sealed partial class PacketHandler
             foreach (var honor in packet.QuestRewardFactionHonor)
             {
                 Globals.QuestFactionHonor[honor.Key] = honor.Value;
+            }
+
+            var localizedQuestIds = packet.Quests.Keys
+                .Concat(packet.QuestRewardItems.Keys)
+                .Distinct()
+                .ToList();
+
+            foreach (var questId in localizedQuestIds)
+            {
+                PrefetchQuestLocalization(questId);
             }
 
             Globals.Me.HiddenQuests = packet.HiddenQuests;

--- a/Intersect.Client.Core/Networking/PacketHandler.cs
+++ b/Intersect.Client.Core/Networking/PacketHandler.cs
@@ -51,6 +51,10 @@ namespace Intersect.Client.Networking;
 
 internal sealed partial class PacketHandler
 {
+    private readonly Queue<IPacket> _pendingGameUiPackets = new();
+    private readonly object _pendingGameUiPacketsLock = new();
+    private bool _isFlushingPendingGameUiPackets;
+
     private sealed partial class VirtualPacketSender : IPacketSender
     {
         public IApplicationContext ApplicationContext { get; }
@@ -109,6 +113,9 @@ internal sealed partial class PacketHandler
 
     public bool HandlePacket(IPacket packet)
     {
+        Logger.LogDebug("[PACKET RECEIVED] {PacketType}", packet.GetType().Name);
+        Logger.LogDebug("[UI STATE] Ready: {IsGameUiReady}", Interface.Interface.IsGameUiReady);
+
         if (packet is AbstractTimedPacket timedPacket)
         {
             Timing.Global.Synchronize(timedPacket.UTC, timedPacket.Offset);
@@ -130,6 +137,23 @@ internal sealed partial class PacketHandler
 
             return false;
         }
+
+        if (ShouldDelayUntilGameUiReady(packet))
+        {
+            lock (_pendingGameUiPacketsLock)
+            {
+                _pendingGameUiPackets.Enqueue(packet);
+            }
+
+            Logger.LogWarning(
+                "[PACKET QUEUED] UI not ready for packet: {PacketType}",
+                packet.GetType().Name
+            );
+
+            return true;
+        }
+
+        FlushPendingGameUiPackets();
 
         if (Registry.TryGetPreprocessors(packet, out var preprocessors))
         {
@@ -166,6 +190,63 @@ internal sealed partial class PacketHandler
         }
 
         return true;
+    }
+
+    private bool ShouldDelayUntilGameUiReady(IPacket packet)
+    {
+        if (Interface.Interface.IsGameUiReady)
+        {
+            return false;
+        }
+
+        return packet is ErrorMessagePacket;
+    }
+
+    private void FlushPendingGameUiPackets()
+    {
+        if (!Interface.Interface.IsGameUiReady)
+        {
+            return;
+        }
+
+        lock (_pendingGameUiPacketsLock)
+        {
+            if (_isFlushingPendingGameUiPackets || _pendingGameUiPackets.Count < 1)
+            {
+                return;
+            }
+
+            _isFlushingPendingGameUiPackets = true;
+        }
+
+        try
+        {
+            while (true)
+            {
+                IPacket? pendingPacket;
+                lock (_pendingGameUiPacketsLock)
+                {
+                    if (!_pendingGameUiPackets.TryDequeue(out pendingPacket))
+                    {
+                        break;
+                    }
+                }
+
+                Logger.LogDebug(
+                    "[PACKET REPLAY] Processing queued packet now that UI is ready: {PacketType}",
+                    pendingPacket.GetType().Name
+                );
+
+                HandlePacket(pendingPacket);
+            }
+        }
+        finally
+        {
+            lock (_pendingGameUiPacketsLock)
+            {
+                _isFlushingPendingGameUiPackets = false;
+            }
+        }
     }
 
     //PingPacket
@@ -1397,6 +1478,14 @@ internal sealed partial class PacketHandler
     {
         Fade.FadeIn(ClientConfiguration.Instance.FadeDurationMs);
         Globals.WaitingOnServer = false;
+
+        if (!Interface.Interface.IsGameUiReady)
+        {
+            Logger.LogWarning(
+                "[UI NOT READY] Error received before UI initialization: {ErrorMessage}",
+                packet.Error
+            );
+        }
 
         if (
             Interface.Interface.HasInGameUI &&

--- a/Intersect.Client.Core/Networking/PacketHandler.cs
+++ b/Intersect.Client.Core/Networking/PacketHandler.cs
@@ -44,6 +44,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Intersect.Framework.Core.GameObjects.Spells;
+using Intersect.Framework.Core.GameObjects.Items;
 
 namespace Intersect.Client.Networking;
 

--- a/Intersect.Client.Core/Networking/PacketHandler.cs
+++ b/Intersect.Client.Core/Networking/PacketHandler.cs
@@ -392,12 +392,14 @@ internal sealed partial class PacketHandler
         {
             en.Load(packet);
             en.Aggression = packet.Aggression;
+            en.IsBossEntity = packet.IsBoss;
         }
         else
         {
             var entity = new Entity(packet.EntityId, packet, EntityType.GlobalEntity)
             {
                 Aggression = packet.Aggression,
+                IsBossEntity = packet.IsBoss,
             };
             Globals.Entities.Add(entity.Id, entity);
         }

--- a/Intersect.Editor/Forms/Editors/Events/frmEvent.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/Events/frmEvent.Designer.cs
@@ -1114,7 +1114,7 @@ namespace Intersect.Editor.Forms.Editors.Events
             btnReindexTranslations.Padding = new Padding(6);
             btnReindexTranslations.Size = new Size(160, 24);
             btnReindexTranslations.TabIndex = 8;
-            btnReindexTranslations.Text = "Reindex Translations";
+            btnReindexTranslations.Text = "Reindexar localización Quest/Event";
             btnReindexTranslations.Click += btnReindexTranslations_Click;
             // 
             // commandMenu

--- a/Intersect.Editor/Forms/Editors/Events/frmEvent.cs
+++ b/Intersect.Editor/Forms/Editors/Events/frmEvent.cs
@@ -878,6 +878,7 @@ public partial class FrmEvent : Form
         MinimumSize = default;
 
         FrmEvent_Move(sender, e);
+        LocalizationReindexService.EnsureInitialQuestEventReindexIfNeeded(this);
     }
 
     private void FrmEvent_Move(object? sender, EventArgs e)
@@ -1020,6 +1021,7 @@ public partial class FrmEvent : Form
         btnPaste.Text = Strings.EventEditor.pastecommand;
         btnSave.Text = Strings.EventEditor.save;
         btnCancel.Text = Strings.EventEditor.cancel;
+        btnReindexTranslations.Text = "Reindexar localización Quest/Event";
 
         for (var i = 0; i < lstCommands.Nodes.Count; i++)
         {
@@ -1194,7 +1196,7 @@ public partial class FrmEvent : Form
 
         if (MyEvent != null)
         {
-            TranslationSourceUpdater.UpdateEventEnglishSources(MyEvent);
+            LocalizationReindexService.UpdateIncrementalEventSources(MyEvent);
         }
 
         if (MyEvent.CommonEvent && MyEvent.Id != Guid.Empty)
@@ -1208,28 +1210,7 @@ public partial class FrmEvent : Form
 
     private void btnReindexTranslations_Click(object sender, EventArgs e)
     {
-        var entries = new List<TranslationUpsertEntry>();
-        foreach (var eventDescriptor in EventDescriptor.Lookup.Values)
-        {
-            if (eventDescriptor == null)
-            {
-                continue;
-            }
-
-            entries.AddRange(TranslationSourceUpdater.GetEventEnglishSources((EventDescriptor)eventDescriptor));
-        }
-
-        foreach (var quest in QuestDescriptor.Lookup.Values)
-        {
-            if (quest == null)
-            {
-                continue;
-            }
-
-            entries.AddRange(TranslationSourceUpdater.GetQuestAndRelatedEventSources((QuestDescriptor)quest));
-        }
-
-        TranslationSourceUpdater.QueueBatchEnglishSources(entries);
+        LocalizationReindexService.ReindexQuestAndEventLocalization(this, "Acción manual desde editor de eventos");
     }
 
     #endregion

--- a/Intersect.Editor/Forms/Editors/Quest/frmQuest.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/Quest/frmQuest.Designer.cs
@@ -79,6 +79,7 @@ namespace Intersect.Editor.Forms.Editors.Quest
             this.lblOnStart = new System.Windows.Forms.Label();
             this.btnCancel = new DarkUI.Controls.DarkButton();
             this.btnSave = new DarkUI.Controls.DarkButton();
+            this.btnReindexQuestEventLocalization = new DarkUI.Controls.DarkButton();
             this.toolStrip = new DarkUI.Controls.DarkToolStrip();
             this.toolStripItemNew = new System.Windows.Forms.ToolStripButton();
             this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
@@ -692,6 +693,17 @@ namespace Intersect.Editor.Forms.Editors.Quest
             this.btnSave.Text = "Save";
             this.btnSave.Click += new System.EventHandler(this.btnSave_Click);
             // 
+            // btnReindexQuestEventLocalization
+            // 
+            this.btnReindexQuestEventLocalization.Location = new System.Drawing.Point(404, 414);
+            this.btnReindexQuestEventLocalization.Name = "btnReindexQuestEventLocalization";
+            this.btnReindexQuestEventLocalization.Padding = new System.Windows.Forms.Padding(5);
+            this.btnReindexQuestEventLocalization.Size = new System.Drawing.Size(190, 27);
+            this.btnReindexQuestEventLocalization.TabIndex = 40;
+            this.btnReindexQuestEventLocalization.Text = "Reindexar localización Quest/Event";
+            this.btnReindexQuestEventLocalization.Click += new System.EventHandler(this.btnReindexQuestEventLocalization_Click);
+            // 
+            // 
             // toolStrip
             // 
             this.toolStrip.AutoSize = false;
@@ -853,6 +865,7 @@ namespace Intersect.Editor.Forms.Editors.Quest
             this.Controls.Add(this.toolStrip);
             this.Controls.Add(this.btnCancel);
             this.Controls.Add(this.btnSave);
+            this.Controls.Add(this.btnReindexQuestEventLocalization);
             this.Controls.Add(this.grpQuests);
             this.Controls.Add(this.pnlContainer);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
@@ -898,6 +911,7 @@ namespace Intersect.Editor.Forms.Editors.Quest
         private System.Windows.Forms.Panel pnlContainer;
         private DarkButton btnSave;
         private DarkButton btnCancel;
+        private DarkButton btnReindexQuestEventLocalization;
         private DarkGroupBox grpQuestReqs;
         private DarkCheckBox chkRepeatable;
         private DarkCheckBox chkQuittable;

--- a/Intersect.Editor/Forms/Editors/Quest/frmQuest.cs
+++ b/Intersect.Editor/Forms/Editors/Quest/frmQuest.cs
@@ -40,6 +40,12 @@ public partial class FrmQuest : EditorForm
         UpdateEditor();
     }
 
+    protected override void OnShown(EventArgs e)
+    {
+        base.OnShown(e);
+        LocalizationReindexService.EnsureInitialQuestEventReindexIfNeeded(this);
+    }
+
     private void AssignEditorItem(Guid id)
     {
         mEditorItem = QuestDescriptor.Get(id);
@@ -112,6 +118,7 @@ public partial class FrmQuest : EditorForm
 
         btnSave.Text = Strings.QuestEditor.save;
         btnCancel.Text = Strings.QuestEditor.cancel;
+        btnReindexQuestEventLocalization.Text = "Reindexar localización Quest/Event";
     }
 
     protected override void GameObjectUpdatedDelegate(GameObjectType type)
@@ -178,8 +185,7 @@ public partial class FrmQuest : EditorForm
                     return;
                 }
 
-                var translationEntries = TranslationSourceUpdater.GetQuestAndRelatedEventSources(item);
-                TranslationSourceUpdater.QueueBatchSources(translationEntries);
+                LocalizationReindexService.UpdateIncrementalQuestAndEventSources(item);
 
                 foreach (var id in item.OriginalTaskEventIds.Keys)
                 {
@@ -228,6 +234,12 @@ public partial class FrmQuest : EditorForm
         Hide();
         Globals.CurrentEditor = -1;
         Dispose();
+    }
+
+
+    private void btnReindexQuestEventLocalization_Click(object sender, EventArgs e)
+    {
+        LocalizationReindexService.ReindexQuestAndEventLocalization(this, "Acción manual desde editor de quests");
     }
 
     private void UpdateEditor()

--- a/Intersect.Editor/Forms/Editors/frmNpc.Designer.cs
+++ b/Intersect.Editor/Forms/Editors/frmNpc.Designer.cs
@@ -83,6 +83,26 @@ namespace Intersect.Editor.Forms.Editors
             lblHP = new Label();
             lblExp = new Label();
             pnlContainer = new Panel();
+            grpBoss = new DarkGroupBox();
+            grpBossAi = new DarkGroupBox();
+            lblBossActions = new Label();
+            lblBossTriggers = new Label();
+            lblBossPhases = new Label();
+            btnBossPreset = new DarkButton();
+            btnBossActionRemove = new DarkButton();
+            btnBossActionAdd = new DarkButton();
+            btnBossTriggerRemove = new DarkButton();
+            btnBossTriggerAdd = new DarkButton();
+            btnBossPhaseRemove = new DarkButton();
+            btnBossPhaseAdd = new DarkButton();
+            lstBossActions = new ListBox();
+            lstBossTriggers = new ListBox();
+            lstBossPhases = new ListBox();
+            chkBossAnnounceOnRespawn = new DarkCheckBox();
+            chkBossAnnounceOnKill = new DarkCheckBox();
+            nudBossRespawnMinutes = new DarkNumericUpDown();
+            lblBossRespawnMinutes = new Label();
+            chkIsBoss = new DarkCheckBox();
             grpImmunities = new DarkGroupBox();
             nudTenacity = new DarkNumericUpDown();
             lblTenacity = new Label();
@@ -113,8 +133,6 @@ namespace Intersect.Editor.Forms.Editors
             lblCritChance = new Label();
             cmbAttackAnimation = new DarkComboBox();
             lblAttackAnimation = new Label();
-            cmbDeathAnimation = new DarkComboBox();
-            lblDeathAnimation = new Label();
             lblDamage = new Label();
             grpCommonEvents = new DarkGroupBox();
             cmbOnDeathEventParty = new DarkComboBox();
@@ -162,6 +180,8 @@ namespace Intersect.Editor.Forms.Editors
             lstAggro = new ListBox();
             chkAttackAllies = new DarkCheckBox();
             chkEnabled = new DarkCheckBox();
+            label1 = new Label();
+            darkComboBox1 = new DarkComboBox();
             grpSpells = new DarkGroupBox();
             cmbSpell = new DarkComboBox();
             cmbFreq = new DarkComboBox();
@@ -170,6 +190,9 @@ namespace Intersect.Editor.Forms.Editors
             btnRemove = new DarkButton();
             btnAdd = new DarkButton();
             lstSpells = new ListBox();
+            DeathNpcGrp = new DarkGroupBox();
+            lblDeathAnimation = new Label();
+            cmbDeathAnimation = new DarkComboBox();
             grpBestiary = new DarkGroupBox();
             lstBestiary = new ListBox();
             cmbBestiary = new DarkComboBox();
@@ -191,9 +214,6 @@ namespace Intersect.Editor.Forms.Editors
             toolStripItemPaste = new ToolStripButton();
             toolStripSeparator3 = new ToolStripSeparator();
             toolStripItemUndo = new ToolStripButton();
-            label1 = new Label();
-            darkComboBox1 = new DarkComboBox();
-            DeathNpcGrp = new DarkGroupBox();
             grpNpcs.SuspendLayout();
             grpGeneral.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)nudRgbaA).BeginInit();
@@ -217,6 +237,9 @@ namespace Intersect.Editor.Forms.Editors
             ((System.ComponentModel.ISupportInitialize)nudMag).BeginInit();
             ((System.ComponentModel.ISupportInitialize)nudStr).BeginInit();
             pnlContainer.SuspendLayout();
+            grpBoss.SuspendLayout();
+            grpBossAi.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)nudBossRespawnMinutes).BeginInit();
             grpImmunities.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)nudTenacity).BeginInit();
             grpCombat.SuspendLayout();
@@ -240,10 +263,10 @@ namespace Intersect.Editor.Forms.Editors
             ((System.ComponentModel.ISupportInitialize)nudDropChance).BeginInit();
             grpNpcVsNpc.SuspendLayout();
             grpSpells.SuspendLayout();
+            DeathNpcGrp.SuspendLayout();
             grpBestiary.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)nudBestiaryAmount).BeginInit();
             toolStrip.SuspendLayout();
-            DeathNpcGrp.SuspendLayout();
             SuspendLayout();
             // 
             // grpNpcs
@@ -893,13 +916,14 @@ namespace Intersect.Editor.Forms.Editors
             lblExp.Location = new System.Drawing.Point(124, 175);
             lblExp.Margin = new Padding(4, 0, 4, 0);
             lblExp.Name = "lblExp";
-            lblExp.Size = new Size(29, 15);
+            lblExp.Size = new Size(28, 15);
             lblExp.TabIndex = 11;
             lblExp.Text = "Exp:";
             // 
             // pnlContainer
             // 
             pnlContainer.AutoScroll = true;
+            pnlContainer.Controls.Add(grpBoss);
             pnlContainer.Controls.Add(grpImmunities);
             pnlContainer.Controls.Add(grpCombat);
             pnlContainer.Controls.Add(grpCommonEvents);
@@ -918,6 +942,241 @@ namespace Intersect.Editor.Forms.Editors
             pnlContainer.Size = new Size(1138, 642);
             pnlContainer.TabIndex = 17;
             pnlContainer.Paint += pnlContainer_Paint;
+            // 
+            // grpBoss
+            // 
+            grpBoss.BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
+            grpBoss.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            grpBoss.Controls.Add(grpBossAi);
+            grpBoss.Controls.Add(chkBossAnnounceOnRespawn);
+            grpBoss.Controls.Add(chkBossAnnounceOnKill);
+            grpBoss.Controls.Add(nudBossRespawnMinutes);
+            grpBoss.Controls.Add(lblBossRespawnMinutes);
+            grpBoss.Controls.Add(chkIsBoss);
+            grpBoss.ForeColor = System.Drawing.Color.Gainsboro;
+            grpBoss.Location = new System.Drawing.Point(8, 855);
+            grpBoss.Margin = new Padding(2);
+            grpBoss.Name = "grpBoss";
+            grpBoss.Padding = new Padding(2);
+            grpBoss.Size = new Size(596, 356);
+            grpBoss.TabIndex = 34;
+            grpBoss.TabStop = false;
+            grpBoss.Text = "Boss";
+            // 
+            // grpBossAi
+            // 
+            grpBossAi.BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
+            grpBossAi.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            grpBossAi.Controls.Add(lblBossActions);
+            grpBossAi.Controls.Add(lblBossTriggers);
+            grpBossAi.Controls.Add(lblBossPhases);
+            grpBossAi.Controls.Add(btnBossPreset);
+            grpBossAi.Controls.Add(btnBossActionRemove);
+            grpBossAi.Controls.Add(btnBossActionAdd);
+            grpBossAi.Controls.Add(btnBossTriggerRemove);
+            grpBossAi.Controls.Add(btnBossTriggerAdd);
+            grpBossAi.Controls.Add(btnBossPhaseRemove);
+            grpBossAi.Controls.Add(btnBossPhaseAdd);
+            grpBossAi.Controls.Add(lstBossActions);
+            grpBossAi.Controls.Add(lstBossTriggers);
+            grpBossAi.Controls.Add(lstBossPhases);
+            grpBossAi.ForeColor = System.Drawing.Color.Gainsboro;
+            grpBossAi.Location = new System.Drawing.Point(15, 123);
+            grpBossAi.Margin = new Padding(2);
+            grpBossAi.Name = "grpBossAi";
+            grpBossAi.Padding = new Padding(2);
+            grpBossAi.Size = new Size(566, 220);
+            grpBossAi.TabIndex = 92;
+            grpBossAi.TabStop = false;
+            grpBossAi.Text = "Boss AI";
+            // 
+            // lblBossActions
+            // 
+            lblBossActions.AutoSize = true;
+            lblBossActions.Location = new System.Drawing.Point(386, 24);
+            lblBossActions.Name = "lblBossActions";
+            lblBossActions.Size = new Size(47, 15);
+            lblBossActions.TabIndex = 12;
+            lblBossActions.Text = "Actions";
+            // 
+            // lblBossTriggers
+            // 
+            lblBossTriggers.AutoSize = true;
+            lblBossTriggers.Location = new System.Drawing.Point(198, 24);
+            lblBossTriggers.Name = "lblBossTriggers";
+            lblBossTriggers.Size = new Size(49, 15);
+            lblBossTriggers.TabIndex = 11;
+            lblBossTriggers.Text = "Triggers";
+            // 
+            // lblBossPhases
+            // 
+            lblBossPhases.AutoSize = true;
+            lblBossPhases.Location = new System.Drawing.Point(10, 24);
+            lblBossPhases.Name = "lblBossPhases";
+            lblBossPhases.Size = new Size(43, 15);
+            lblBossPhases.TabIndex = 10;
+            lblBossPhases.Text = "Phases";
+            // 
+            // btnBossPreset
+            // 
+            btnBossPreset.Location = new System.Drawing.Point(10, 187);
+            btnBossPreset.Name = "btnBossPreset";
+            btnBossPreset.Padding = new Padding(5);
+            btnBossPreset.Size = new Size(172, 23);
+            btnBossPreset.TabIndex = 9;
+            btnBossPreset.Text = "Apply 30% Heal+Enrage";
+            btnBossPreset.Click += btnBossPreset_Click;
+            // 
+            // btnBossActionRemove
+            // 
+            btnBossActionRemove.Location = new System.Drawing.Point(478, 187);
+            btnBossActionRemove.Name = "btnBossActionRemove";
+            btnBossActionRemove.Padding = new Padding(5);
+            btnBossActionRemove.Size = new Size(78, 23);
+            btnBossActionRemove.TabIndex = 8;
+            btnBossActionRemove.Text = "Remove";
+            btnBossActionRemove.Click += btnBossActionRemove_Click;
+            // 
+            // btnBossActionAdd
+            // 
+            btnBossActionAdd.Location = new System.Drawing.Point(389, 187);
+            btnBossActionAdd.Name = "btnBossActionAdd";
+            btnBossActionAdd.Padding = new Padding(5);
+            btnBossActionAdd.Size = new Size(78, 23);
+            btnBossActionAdd.TabIndex = 7;
+            btnBossActionAdd.Text = "Add";
+            btnBossActionAdd.Click += btnBossActionAdd_Click;
+            // 
+            // btnBossTriggerRemove
+            // 
+            btnBossTriggerRemove.Location = new System.Drawing.Point(289, 187);
+            btnBossTriggerRemove.Name = "btnBossTriggerRemove";
+            btnBossTriggerRemove.Padding = new Padding(5);
+            btnBossTriggerRemove.Size = new Size(78, 23);
+            btnBossTriggerRemove.TabIndex = 6;
+            btnBossTriggerRemove.Text = "Remove";
+            btnBossTriggerRemove.Click += btnBossTriggerRemove_Click;
+            // 
+            // btnBossTriggerAdd
+            // 
+            btnBossTriggerAdd.Location = new System.Drawing.Point(200, 187);
+            btnBossTriggerAdd.Name = "btnBossTriggerAdd";
+            btnBossTriggerAdd.Padding = new Padding(5);
+            btnBossTriggerAdd.Size = new Size(78, 23);
+            btnBossTriggerAdd.TabIndex = 5;
+            btnBossTriggerAdd.Text = "Add";
+            btnBossTriggerAdd.Click += btnBossTriggerAdd_Click;
+            // 
+            // btnBossPhaseRemove
+            // 
+            btnBossPhaseRemove.Location = new System.Drawing.Point(99, 158);
+            btnBossPhaseRemove.Name = "btnBossPhaseRemove";
+            btnBossPhaseRemove.Padding = new Padding(5);
+            btnBossPhaseRemove.Size = new Size(83, 23);
+            btnBossPhaseRemove.TabIndex = 4;
+            btnBossPhaseRemove.Text = "Remove";
+            btnBossPhaseRemove.Click += btnBossPhaseRemove_Click;
+            // 
+            // btnBossPhaseAdd
+            // 
+            btnBossPhaseAdd.Location = new System.Drawing.Point(10, 158);
+            btnBossPhaseAdd.Name = "btnBossPhaseAdd";
+            btnBossPhaseAdd.Padding = new Padding(5);
+            btnBossPhaseAdd.Size = new Size(83, 23);
+            btnBossPhaseAdd.TabIndex = 3;
+            btnBossPhaseAdd.Text = "Add";
+            btnBossPhaseAdd.Click += btnBossPhaseAdd_Click;
+            // 
+            // lstBossActions
+            // 
+            lstBossActions.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            lstBossActions.ForeColor = System.Drawing.Color.Gainsboro;
+            lstBossActions.FormattingEnabled = true;
+            lstBossActions.ItemHeight = 15;
+            lstBossActions.Location = new System.Drawing.Point(389, 42);
+            lstBossActions.Name = "lstBossActions";
+            lstBossActions.Size = new Size(167, 139);
+            lstBossActions.TabIndex = 2;
+            // 
+            // lstBossTriggers
+            // 
+            lstBossTriggers.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            lstBossTriggers.ForeColor = System.Drawing.Color.Gainsboro;
+            lstBossTriggers.FormattingEnabled = true;
+            lstBossTriggers.ItemHeight = 15;
+            lstBossTriggers.Location = new System.Drawing.Point(200, 42);
+            lstBossTriggers.Name = "lstBossTriggers";
+            lstBossTriggers.Size = new Size(167, 139);
+            lstBossTriggers.TabIndex = 1;
+            lstBossTriggers.SelectedIndexChanged += lstBossTriggers_SelectedIndexChanged;
+            // 
+            // lstBossPhases
+            // 
+            lstBossPhases.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            lstBossPhases.ForeColor = System.Drawing.Color.Gainsboro;
+            lstBossPhases.FormattingEnabled = true;
+            lstBossPhases.ItemHeight = 15;
+            lstBossPhases.Location = new System.Drawing.Point(10, 42);
+            lstBossPhases.Name = "lstBossPhases";
+            lstBossPhases.Size = new Size(172, 109);
+            lstBossPhases.TabIndex = 0;
+            lstBossPhases.SelectedIndexChanged += lstBossPhases_SelectedIndexChanged;
+            // 
+            // chkBossAnnounceOnRespawn
+            // 
+            chkBossAnnounceOnRespawn.AutoSize = true;
+            chkBossAnnounceOnRespawn.Location = new System.Drawing.Point(150, 98);
+            chkBossAnnounceOnRespawn.Margin = new Padding(4, 3, 4, 3);
+            chkBossAnnounceOnRespawn.Name = "chkBossAnnounceOnRespawn";
+            chkBossAnnounceOnRespawn.Size = new Size(139, 19);
+            chkBossAnnounceOnRespawn.TabIndex = 91;
+            chkBossAnnounceOnRespawn.Text = "Announce on Respawn";
+            chkBossAnnounceOnRespawn.CheckedChanged += chkBossAnnounceOnRespawn_CheckedChanged;
+            // 
+            // chkBossAnnounceOnKill
+            // 
+            chkBossAnnounceOnKill.AutoSize = true;
+            chkBossAnnounceOnKill.Location = new System.Drawing.Point(15, 98);
+            chkBossAnnounceOnKill.Margin = new Padding(4, 3, 4, 3);
+            chkBossAnnounceOnKill.Name = "chkBossAnnounceOnKill";
+            chkBossAnnounceOnKill.Size = new Size(116, 19);
+            chkBossAnnounceOnKill.TabIndex = 90;
+            chkBossAnnounceOnKill.Text = "Announce on Kill";
+            chkBossAnnounceOnKill.CheckedChanged += chkBossAnnounceOnKill_CheckedChanged;
+            // 
+            // nudBossRespawnMinutes
+            // 
+            nudBossRespawnMinutes.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            nudBossRespawnMinutes.ForeColor = System.Drawing.Color.Gainsboro;
+            nudBossRespawnMinutes.Location = new System.Drawing.Point(15, 68);
+            nudBossRespawnMinutes.Margin = new Padding(4, 3, 4, 3);
+            nudBossRespawnMinutes.Maximum = new decimal(new int[] { 10080, 0, 0, 0 });
+            nudBossRespawnMinutes.Name = "nudBossRespawnMinutes";
+            nudBossRespawnMinutes.Size = new Size(275, 23);
+            nudBossRespawnMinutes.TabIndex = 89;
+            nudBossRespawnMinutes.Value = new decimal(new int[] { 0, 0, 0, 0 });
+            nudBossRespawnMinutes.ValueChanged += nudBossRespawnMinutes_ValueChanged;
+            // 
+            // lblBossRespawnMinutes
+            // 
+            lblBossRespawnMinutes.AutoSize = true;
+            lblBossRespawnMinutes.Location = new System.Drawing.Point(12, 50);
+            lblBossRespawnMinutes.Margin = new Padding(4, 0, 4, 0);
+            lblBossRespawnMinutes.Name = "lblBossRespawnMinutes";
+            lblBossRespawnMinutes.Size = new Size(141, 15);
+            lblBossRespawnMinutes.TabIndex = 88;
+            lblBossRespawnMinutes.Text = "Respawn Time (minutes):";
+            // 
+            // chkIsBoss
+            // 
+            chkIsBoss.AutoSize = true;
+            chkIsBoss.Location = new System.Drawing.Point(15, 24);
+            chkIsBoss.Margin = new Padding(4, 3, 4, 3);
+            chkIsBoss.Name = "chkIsBoss";
+            chkIsBoss.Size = new Size(63, 19);
+            chkIsBoss.TabIndex = 87;
+            chkIsBoss.Text = "Is Boss";
+            chkIsBoss.CheckedChanged += chkIsBoss_CheckedChanged;
             // 
             // grpImmunities
             // 
@@ -963,7 +1222,7 @@ namespace Intersect.Editor.Forms.Editors
             lblTenacity.Location = new System.Drawing.Point(6, 141);
             lblTenacity.Margin = new Padding(4, 0, 4, 0);
             lblTenacity.Name = "lblTenacity";
-            lblTenacity.Size = new Size(74, 15);
+            lblTenacity.Size = new Size(75, 15);
             lblTenacity.TabIndex = 79;
             lblTenacity.Text = "Tenacity (%):";
             // 
@@ -973,7 +1232,7 @@ namespace Intersect.Editor.Forms.Editors
             chkTaunt.Location = new System.Drawing.Point(205, 110);
             chkTaunt.Margin = new Padding(4, 3, 4, 3);
             chkTaunt.Name = "chkTaunt";
-            chkTaunt.Size = new Size(55, 19);
+            chkTaunt.Size = new Size(56, 19);
             chkTaunt.TabIndex = 86;
             chkTaunt.Text = "Taunt";
             chkTaunt.CheckedChanged += chkTaunt_CheckedChanged;
@@ -995,7 +1254,7 @@ namespace Intersect.Editor.Forms.Editors
             chkTransform.Location = new System.Drawing.Point(205, 83);
             chkTransform.Margin = new Padding(4, 3, 4, 3);
             chkTransform.Name = "chkTransform";
-            chkTransform.Size = new Size(79, 19);
+            chkTransform.Size = new Size(80, 19);
             chkTransform.TabIndex = 84;
             chkTransform.Text = "Transform";
             chkTransform.CheckedChanged += chkTransform_CheckedChanged;
@@ -1178,7 +1437,7 @@ namespace Intersect.Editor.Forms.Editors
             lblCritMultiplier.Location = new System.Drawing.Point(12, 119);
             lblCritMultiplier.Margin = new Padding(4, 0, 4, 0);
             lblCritMultiplier.Name = "lblCritMultiplier";
-            lblCritMultiplier.Size = new Size(156, 15);
+            lblCritMultiplier.Size = new Size(155, 15);
             lblCritMultiplier.TabIndex = 62;
             lblCritMultiplier.Text = "Crit Multiplier (Default 1.5x):";
             // 
@@ -1292,7 +1551,7 @@ namespace Intersect.Editor.Forms.Editors
             lblDamageType.Location = new System.Drawing.Point(10, 167);
             lblDamageType.Margin = new Padding(4, 0, 4, 0);
             lblDamageType.Name = "lblDamageType";
-            lblDamageType.Size = new Size(81, 15);
+            lblDamageType.Size = new Size(82, 15);
             lblDamageType.TabIndex = 53;
             lblDamageType.Text = "Damage Type:";
             // 
@@ -1337,38 +1596,6 @@ namespace Intersect.Editor.Forms.Editors
             lblAttackAnimation.Size = new Size(103, 15);
             lblAttackAnimation.TabIndex = 49;
             lblAttackAnimation.Text = "Attack Animation:";
-            // 
-            // cmbDeathAnimation
-            // 
-            cmbDeathAnimation.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
-            cmbDeathAnimation.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
-            cmbDeathAnimation.BorderStyle = ButtonBorderStyle.Solid;
-            cmbDeathAnimation.ButtonColor = System.Drawing.Color.FromArgb(43, 43, 43);
-            cmbDeathAnimation.DrawDropdownHoverOutline = false;
-            cmbDeathAnimation.DrawFocusRectangle = false;
-            cmbDeathAnimation.DrawMode = DrawMode.OwnerDrawFixed;
-            cmbDeathAnimation.DropDownStyle = ComboBoxStyle.DropDownList;
-            cmbDeathAnimation.FlatStyle = FlatStyle.Flat;
-            cmbDeathAnimation.ForeColor = System.Drawing.Color.Gainsboro;
-            cmbDeathAnimation.FormattingEnabled = true;
-            cmbDeathAnimation.Location = new System.Drawing.Point(20, 41);
-            cmbDeathAnimation.Margin = new Padding(4, 3, 4, 3);
-            cmbDeathAnimation.Name = "cmbDeathAnimation";
-            cmbDeathAnimation.Size = new Size(234, 24);
-            cmbDeathAnimation.TabIndex = 49;
-            cmbDeathAnimation.Text = null;
-            cmbDeathAnimation.TextPadding = new Padding(2);
-            cmbDeathAnimation.SelectedIndexChanged += cmbDeathAnimation_SelectedIndexChanged;
-            // 
-            // lblDeathAnimation
-            // 
-            lblDeathAnimation.AutoSize = true;
-            lblDeathAnimation.Location = new System.Drawing.Point(20, 19);
-            lblDeathAnimation.Margin = new Padding(4, 0, 4, 0);
-            lblDeathAnimation.Name = "lblDeathAnimation";
-            lblDeathAnimation.Size = new Size(100, 15);
-            lblDeathAnimation.TabIndex = 48;
-            lblDeathAnimation.Text = "Death Animation:";
             // 
             // lblDamage
             // 
@@ -1876,7 +2103,7 @@ namespace Intersect.Editor.Forms.Editors
             lblDropMaxAmount.Location = new System.Drawing.Point(163, 156);
             lblDropMaxAmount.Margin = new Padding(4, 0, 4, 0);
             lblDropMaxAmount.Name = "lblDropMaxAmount";
-            lblDropMaxAmount.Size = new Size(80, 15);
+            lblDropMaxAmount.Size = new Size(79, 15);
             lblDropMaxAmount.TabIndex = 15;
             lblDropMaxAmount.Text = "Max Amount:";
             // 
@@ -2012,6 +2239,38 @@ namespace Intersect.Editor.Forms.Editors
             chkEnabled.Text = "Enabled?";
             chkEnabled.CheckedChanged += chkEnabled_CheckedChanged;
             // 
+            // label1
+            // 
+            label1.AutoSize = true;
+            label1.Location = new System.Drawing.Point(102, 42);
+            label1.Margin = new Padding(4, 0, 4, 0);
+            label1.Name = "label1";
+            label1.Size = new Size(100, 15);
+            label1.TabIndex = 48;
+            label1.Text = "Death Animation:";
+            // 
+            // darkComboBox1
+            // 
+            darkComboBox1.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            darkComboBox1.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            darkComboBox1.BorderStyle = ButtonBorderStyle.Solid;
+            darkComboBox1.ButtonColor = System.Drawing.Color.FromArgb(43, 43, 43);
+            darkComboBox1.DrawDropdownHoverOutline = false;
+            darkComboBox1.DrawFocusRectangle = false;
+            darkComboBox1.DrawMode = DrawMode.OwnerDrawFixed;
+            darkComboBox1.DropDownStyle = ComboBoxStyle.DropDownList;
+            darkComboBox1.FlatStyle = FlatStyle.Flat;
+            darkComboBox1.ForeColor = System.Drawing.Color.Gainsboro;
+            darkComboBox1.FormattingEnabled = true;
+            darkComboBox1.Location = new System.Drawing.Point(106, 59);
+            darkComboBox1.Margin = new Padding(4, 3, 4, 3);
+            darkComboBox1.Name = "darkComboBox1";
+            darkComboBox1.Size = new Size(276, 24);
+            darkComboBox1.TabIndex = 49;
+            darkComboBox1.Text = null;
+            darkComboBox1.TextPadding = new Padding(2);
+            darkComboBox1.SelectedIndexChanged += cmbDeathAnimation_SelectedIndexChanged;
+            // 
             // grpSpells
             // 
             grpSpells.BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
@@ -2134,6 +2393,54 @@ namespace Intersect.Editor.Forms.Editors
             lstSpells.TabIndex = 29;
             lstSpells.SelectedIndexChanged += lstSpells_SelectedIndexChanged;
             // 
+            // DeathNpcGrp
+            // 
+            DeathNpcGrp.BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
+            DeathNpcGrp.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            DeathNpcGrp.Controls.Add(lblDeathAnimation);
+            DeathNpcGrp.Controls.Add(cmbDeathAnimation);
+            DeathNpcGrp.ForeColor = System.Drawing.Color.Gainsboro;
+            DeathNpcGrp.Location = new System.Drawing.Point(261, 744);
+            DeathNpcGrp.Margin = new Padding(2);
+            DeathNpcGrp.Name = "DeathNpcGrp";
+            DeathNpcGrp.Padding = new Padding(2);
+            DeathNpcGrp.Size = new Size(266, 87);
+            DeathNpcGrp.TabIndex = 34;
+            DeathNpcGrp.TabStop = false;
+            DeathNpcGrp.Text = "Death Animation";
+            // 
+            // lblDeathAnimation
+            // 
+            lblDeathAnimation.AutoSize = true;
+            lblDeathAnimation.Location = new System.Drawing.Point(20, 19);
+            lblDeathAnimation.Margin = new Padding(4, 0, 4, 0);
+            lblDeathAnimation.Name = "lblDeathAnimation";
+            lblDeathAnimation.Size = new Size(100, 15);
+            lblDeathAnimation.TabIndex = 48;
+            lblDeathAnimation.Text = "Death Animation:";
+            // 
+            // cmbDeathAnimation
+            // 
+            cmbDeathAnimation.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
+            cmbDeathAnimation.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
+            cmbDeathAnimation.BorderStyle = ButtonBorderStyle.Solid;
+            cmbDeathAnimation.ButtonColor = System.Drawing.Color.FromArgb(43, 43, 43);
+            cmbDeathAnimation.DrawDropdownHoverOutline = false;
+            cmbDeathAnimation.DrawFocusRectangle = false;
+            cmbDeathAnimation.DrawMode = DrawMode.OwnerDrawFixed;
+            cmbDeathAnimation.DropDownStyle = ComboBoxStyle.DropDownList;
+            cmbDeathAnimation.FlatStyle = FlatStyle.Flat;
+            cmbDeathAnimation.ForeColor = System.Drawing.Color.Gainsboro;
+            cmbDeathAnimation.FormattingEnabled = true;
+            cmbDeathAnimation.Location = new System.Drawing.Point(20, 41);
+            cmbDeathAnimation.Margin = new Padding(4, 3, 4, 3);
+            cmbDeathAnimation.Name = "cmbDeathAnimation";
+            cmbDeathAnimation.Size = new Size(234, 24);
+            cmbDeathAnimation.TabIndex = 49;
+            cmbDeathAnimation.Text = null;
+            cmbDeathAnimation.TextPadding = new Padding(2);
+            cmbDeathAnimation.SelectedIndexChanged += cmbDeathAnimation_SelectedIndexChanged;
+            // 
             // grpBestiary
             // 
             grpBestiary.BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
@@ -2150,7 +2457,7 @@ namespace Intersect.Editor.Forms.Editors
             grpBestiary.Margin = new Padding(2);
             grpBestiary.Name = "grpBestiary";
             grpBestiary.Padding = new Padding(2);
-            grpBestiary.Size = new Size(266, 157);
+            grpBestiary.Size = new Size(266, 134);
             grpBestiary.TabIndex = 34;
             grpBestiary.TabStop = false;
             grpBestiary.Text = "Bestiary";
@@ -2165,7 +2472,7 @@ namespace Intersect.Editor.Forms.Editors
             lstBestiary.Location = new System.Drawing.Point(7, 22);
             lstBestiary.Margin = new Padding(4, 3, 4, 3);
             lstBestiary.Name = "lstBestiary";
-            lstBestiary.Size = new Size(120, 92);
+            lstBestiary.Size = new Size(120, 77);
             lstBestiary.TabIndex = 0;
             lstBestiary.SelectedIndexChanged += lstBestiary_SelectedIndexChanged;
             // 
@@ -2226,7 +2533,7 @@ namespace Intersect.Editor.Forms.Editors
             // 
             // btnBestiaryAdd
             // 
-            btnBestiaryAdd.Location = new System.Drawing.Point(7, 126);
+            btnBestiaryAdd.Location = new System.Drawing.Point(7, 105);
             btnBestiaryAdd.Margin = new Padding(4, 3, 4, 3);
             btnBestiaryAdd.Name = "btnBestiaryAdd";
             btnBestiaryAdd.Padding = new Padding(6);
@@ -2237,7 +2544,7 @@ namespace Intersect.Editor.Forms.Editors
             // 
             // btnBestiaryRemove
             // 
-            btnBestiaryRemove.Location = new System.Drawing.Point(73, 126);
+            btnBestiaryRemove.Location = new System.Drawing.Point(75, 105);
             btnBestiaryRemove.Margin = new Padding(4, 3, 4, 3);
             btnBestiaryRemove.Name = "btnBestiaryRemove";
             btnBestiaryRemove.Padding = new Padding(6);
@@ -2380,54 +2687,6 @@ namespace Intersect.Editor.Forms.Editors
             toolStripItemUndo.Text = "Undo";
             toolStripItemUndo.Click += toolStripItemUndo_Click;
             // 
-            // label1
-            // 
-            label1.AutoSize = true;
-            label1.Location = new System.Drawing.Point(102, 42);
-            label1.Margin = new Padding(4, 0, 4, 0);
-            label1.Name = "label1";
-            label1.Size = new Size(100, 15);
-            label1.TabIndex = 48;
-            label1.Text = "Death Animation:";
-            // 
-            // darkComboBox1
-            // 
-            darkComboBox1.BackColor = System.Drawing.Color.FromArgb(69, 73, 74);
-            darkComboBox1.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
-            darkComboBox1.BorderStyle = ButtonBorderStyle.Solid;
-            darkComboBox1.ButtonColor = System.Drawing.Color.FromArgb(43, 43, 43);
-            darkComboBox1.DrawDropdownHoverOutline = false;
-            darkComboBox1.DrawFocusRectangle = false;
-            darkComboBox1.DrawMode = DrawMode.OwnerDrawFixed;
-            darkComboBox1.DropDownStyle = ComboBoxStyle.DropDownList;
-            darkComboBox1.FlatStyle = FlatStyle.Flat;
-            darkComboBox1.ForeColor = System.Drawing.Color.Gainsboro;
-            darkComboBox1.FormattingEnabled = true;
-            darkComboBox1.Location = new System.Drawing.Point(106, 59);
-            darkComboBox1.Margin = new Padding(4, 3, 4, 3);
-            darkComboBox1.Name = "darkComboBox1";
-            darkComboBox1.Size = new Size(276, 24);
-            darkComboBox1.TabIndex = 49;
-            darkComboBox1.Text = null;
-            darkComboBox1.TextPadding = new Padding(2);
-            darkComboBox1.SelectedIndexChanged += cmbDeathAnimation_SelectedIndexChanged;
-            // 
-            // DeathNpcGrp
-            // 
-            DeathNpcGrp.BackColor = System.Drawing.Color.FromArgb(45, 45, 48);
-            DeathNpcGrp.BorderColor = System.Drawing.Color.FromArgb(90, 90, 90);
-            DeathNpcGrp.Controls.Add(lblDeathAnimation);
-            DeathNpcGrp.Controls.Add(cmbDeathAnimation);
-            DeathNpcGrp.ForeColor = System.Drawing.Color.Gainsboro;
-            DeathNpcGrp.Location = new System.Drawing.Point(261, 744);
-            DeathNpcGrp.Margin = new Padding(2);
-            DeathNpcGrp.Name = "DeathNpcGrp";
-            DeathNpcGrp.Padding = new Padding(2);
-            DeathNpcGrp.Size = new Size(266, 87);
-            DeathNpcGrp.TabIndex = 34;
-            DeathNpcGrp.TabStop = false;
-            DeathNpcGrp.Text = "Death Animation";
-            // 
             // FrmNpc
             // 
             AutoScaleDimensions = new SizeF(7F, 15F);
@@ -2477,6 +2736,11 @@ namespace Intersect.Editor.Forms.Editors
             ((System.ComponentModel.ISupportInitialize)nudMag).EndInit();
             ((System.ComponentModel.ISupportInitialize)nudStr).EndInit();
             pnlContainer.ResumeLayout(false);
+            grpBoss.ResumeLayout(false);
+            grpBoss.PerformLayout();
+            grpBossAi.ResumeLayout(false);
+            grpBossAi.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)nudBossRespawnMinutes).EndInit();
             grpImmunities.ResumeLayout(false);
             grpImmunities.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)nudTenacity).EndInit();
@@ -2509,13 +2773,13 @@ namespace Intersect.Editor.Forms.Editors
             grpNpcVsNpc.PerformLayout();
             grpSpells.ResumeLayout(false);
             grpSpells.PerformLayout();
+            DeathNpcGrp.ResumeLayout(false);
+            DeathNpcGrp.PerformLayout();
             grpBestiary.ResumeLayout(false);
             grpBestiary.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)nudBestiaryAmount).EndInit();
             toolStrip.ResumeLayout(false);
             toolStrip.PerformLayout();
-            DeathNpcGrp.ResumeLayout(false);
-            DeathNpcGrp.PerformLayout();
             ResumeLayout(false);
         }
 
@@ -2653,6 +2917,7 @@ namespace Intersect.Editor.Forms.Editors
         private DarkCheckBox chkIndividualLoot;
         private Controls.GameObjectList lstGameObjects;
         private DarkGroupBox grpImmunities;
+        private DarkGroupBox grpBoss;
         private DarkNumericUpDown nudTenacity;
         private System.Windows.Forms.Label lblTenacity;
         private DarkCheckBox chkTaunt;
@@ -2663,6 +2928,25 @@ namespace Intersect.Editor.Forms.Editors
         private DarkCheckBox chkStun;
         private DarkCheckBox chkSilence;
         private DarkCheckBox chkKnockback;
+        private DarkCheckBox chkIsBoss;
+        private Label lblBossRespawnMinutes;
+        private DarkNumericUpDown nudBossRespawnMinutes;
+        private DarkCheckBox chkBossAnnounceOnKill;
+        private DarkCheckBox chkBossAnnounceOnRespawn;
+        private DarkGroupBox grpBossAi;
+        private Label lblBossActions;
+        private Label lblBossTriggers;
+        private Label lblBossPhases;
+        private DarkButton btnBossPreset;
+        private DarkButton btnBossActionRemove;
+        private DarkButton btnBossActionAdd;
+        private DarkButton btnBossTriggerRemove;
+        private DarkButton btnBossTriggerAdd;
+        private DarkButton btnBossPhaseRemove;
+        private DarkButton btnBossPhaseAdd;
+        private ListBox lstBossActions;
+        private ListBox lstBossTriggers;
+        private ListBox lstBossPhases;
         private DarkNumericUpDown nudDropMinAmount;
         private Label lblDropMinAmount;
         private DarkNumericUpDown nudDmg;

--- a/Intersect.Editor/Forms/Editors/frmNpc.cs
+++ b/Intersect.Editor/Forms/Editors/frmNpc.cs
@@ -38,6 +38,8 @@ public partial class FrmNpc : EditorForm
 
     private BindingList<NotifiableBestiaryUnlock> _bestiaryUnlocks = [];
 
+    private bool _isUpdatingBossAiUi;
+
 
     public FrmNpc()
     {
@@ -86,6 +88,11 @@ public partial class FrmNpc : EditorForm
 
     private void btnSave_Click(object sender, EventArgs e)
     {
+        if (!ValidateBossBehaviorProfiles())
+        {
+            return;
+        }
+
         //Send Changed items
         foreach (var item in mChanged)
         {
@@ -290,6 +297,23 @@ public partial class FrmNpc : EditorForm
         chkSleep.Text = Strings.NpcEditor.Immunities[SpellEffect.Sleep];
         lblTenacity.Text = Strings.NpcEditor.Tenacity;
 
+        grpBoss.Text = Strings.NpcEditor.boss;
+        chkIsBoss.Text = Strings.NpcEditor.isboss;
+        lblBossRespawnMinutes.Text = Strings.NpcEditor.bossrespawnminutes;
+        chkBossAnnounceOnKill.Text = Strings.NpcEditor.bossannounceonkill;
+        chkBossAnnounceOnRespawn.Text = Strings.NpcEditor.bossannounceonrespawn;
+        grpBossAi.Text = Strings.NpcEditor.bossai;
+        lblBossPhases.Text = Strings.NpcEditor.bossaiphases;
+        lblBossTriggers.Text = Strings.NpcEditor.bossaitriggers;
+        lblBossActions.Text = Strings.NpcEditor.bossaiactions;
+        btnBossPhaseAdd.Text = Strings.NpcEditor.add;
+        btnBossPhaseRemove.Text = Strings.NpcEditor.remove;
+        btnBossTriggerAdd.Text = Strings.NpcEditor.add;
+        btnBossTriggerRemove.Text = Strings.NpcEditor.remove;
+        btnBossActionAdd.Text = Strings.NpcEditor.add;
+        btnBossActionRemove.Text = Strings.NpcEditor.remove;
+        btnBossPreset.Text = Strings.NpcEditor.bossaipreset30;
+
         btnSave.Text = Strings.NpcEditor.save;
         btnCancel.Text = Strings.NpcEditor.cancel;
     }
@@ -413,6 +437,13 @@ public partial class FrmNpc : EditorForm
 
             // Tenacity and immunities
             nudTenacity.Value = (decimal)mEditorItem.Tenacity;
+
+            // Boss settings
+            chkIsBoss.Checked = mEditorItem.IsBoss;
+            nudBossRespawnMinutes.Value = mEditorItem.BossRespawnMinutes;
+            chkBossAnnounceOnKill.Checked = mEditorItem.BossAnnounceOnKill;
+            chkBossAnnounceOnRespawn.Checked = mEditorItem.BossAnnounceOnRespawn;
+            LoadBossBehaviorProfile();
 
             UpdateImmunities();
         }
@@ -1301,6 +1332,317 @@ public partial class FrmNpc : EditorForm
     private void nudTenacity_ValueChanged(object sender, EventArgs e)
     {
         mEditorItem.Tenacity = (double)nudTenacity.Value;
+    }
+
+    private BossBehaviorProfile EnsureBossBehaviorProfile()
+    {
+        mEditorItem.BossBehaviorProfile ??= new BossBehaviorProfile();
+        mEditorItem.BossBehaviorProfile.Phases ??= [];
+
+        foreach (var phase in mEditorItem.BossBehaviorProfile.Phases)
+        {
+            phase.Triggers ??= [];
+            if (phase.Actions?.Count > 0 && phase.Triggers.Count > 0 && phase.Triggers.All(trigger => trigger.Actions.Count == 0))
+            {
+                phase.Triggers[0].Actions = [.. phase.Actions];
+            }
+
+            foreach (var trigger in phase.Triggers)
+            {
+                trigger.Actions ??= [];
+            }
+        }
+
+        return mEditorItem.BossBehaviorProfile;
+    }
+
+    private void LoadBossBehaviorProfile()
+    {
+        _isUpdatingBossAiUi = true;
+        lstBossPhases.Items.Clear();
+        lstBossTriggers.Items.Clear();
+        lstBossActions.Items.Clear();
+
+        var profile = EnsureBossBehaviorProfile();
+        foreach (var phase in profile.Phases)
+        {
+            lstBossPhases.Items.Add($"{phase.Id} ({phase.MinimumHealthPercent}-{phase.MaximumHealthPercent}%)");
+        }
+
+        if (lstBossPhases.Items.Count > 0)
+        {
+            lstBossPhases.SelectedIndex = 0;
+        }
+
+        _isUpdatingBossAiUi = false;
+    }
+
+    private void LoadBossTriggers()
+    {
+        if (_isUpdatingBossAiUi || lstBossPhases.SelectedIndex < 0)
+        {
+            return;
+        }
+
+        _isUpdatingBossAiUi = true;
+        lstBossTriggers.Items.Clear();
+        lstBossActions.Items.Clear();
+
+        var phase = EnsureBossBehaviorProfile().Phases[lstBossPhases.SelectedIndex];
+        for (var i = 0; i < phase.Triggers.Count; i++)
+        {
+            var trigger = phase.Triggers[i];
+            lstBossTriggers.Items.Add($"{trigger.Condition} ({trigger.CooldownSeconds}s)");
+        }
+
+        if (lstBossTriggers.Items.Count > 0)
+        {
+            lstBossTriggers.SelectedIndex = 0;
+        }
+
+        _isUpdatingBossAiUi = false;
+    }
+
+    private void LoadBossActions()
+    {
+        if (_isUpdatingBossAiUi || lstBossPhases.SelectedIndex < 0 || lstBossTriggers.SelectedIndex < 0)
+        {
+            return;
+        }
+
+        _isUpdatingBossAiUi = true;
+        lstBossActions.Items.Clear();
+
+        var trigger = EnsureBossBehaviorProfile().Phases[lstBossPhases.SelectedIndex].Triggers[lstBossTriggers.SelectedIndex];
+        foreach (var action in trigger.Actions)
+        {
+            var display = action.Action == BossActionType.CastSpell
+                ? $"{action.Action}: {SpellDescriptor.GetName(action.SpellId)}"
+                : action.Action.ToString();
+            lstBossActions.Items.Add(display);
+        }
+
+        _isUpdatingBossAiUi = false;
+    }
+
+    private bool ValidateBossBehaviorProfiles()
+    {
+        foreach (var item in mChanged)
+        {
+            if (item?.IsBoss != true)
+            {
+                continue;
+            }
+
+            var phases = item.BossBehaviorProfile?.Phases ?? [];
+            for (var i = 0; i < phases.Count; i++)
+            {
+                var phase = phases[i];
+                for (var j = i + 1; j < phases.Count; j++)
+                {
+                    var other = phases[j];
+                    var overlaps = phase.MinimumHealthPercent <= other.MaximumHealthPercent && other.MinimumHealthPercent <= phase.MaximumHealthPercent;
+                    if (overlaps)
+                    {
+                        DarkMessageBox.ShowError(Strings.NpcEditor.bossaivalidationhpoverlap, Strings.NpcEditor.bossaivalidationtitle, DarkDialogButton.Ok, Icon);
+                        return false;
+                    }
+                }
+
+                foreach (var trigger in phase.Triggers)
+                {
+                    if (trigger.CooldownSeconds <= 0 && trigger.Condition != BossTriggerConditionType.HealthPercentAtOrBelow)
+                    {
+                        DarkMessageBox.ShowError(Strings.NpcEditor.bossaivalidationcooldown, Strings.NpcEditor.bossaivalidationtitle, DarkDialogButton.Ok, Icon);
+                        return false;
+                    }
+
+                    if (trigger.Actions.Count == 0)
+                    {
+                        DarkMessageBox.ShowError(Strings.NpcEditor.bossaivalidationactions, Strings.NpcEditor.bossaivalidationtitle, DarkDialogButton.Ok, Icon);
+                        return false;
+                    }
+
+                    foreach (var action in trigger.Actions.Where(a => a.Action == BossActionType.CastSpell))
+                    {
+                        if (action.SpellId == Guid.Empty || SpellDescriptor.Get(action.SpellId) == null)
+                        {
+                            DarkMessageBox.ShowError(Strings.NpcEditor.bossaivalidationspell, Strings.NpcEditor.bossaivalidationtitle, DarkDialogButton.Ok, Icon);
+                            return false;
+                        }
+                    }
+                }
+            }
+        }
+
+        return true;
+    }
+
+    private void lstBossPhases_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        LoadBossTriggers();
+    }
+
+    private void lstBossTriggers_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        LoadBossActions();
+    }
+
+    private void btnBossPhaseAdd_Click(object sender, EventArgs e)
+    {
+        var profile = EnsureBossBehaviorProfile();
+        var index = profile.Phases.Count + 1;
+        profile.Phases.Add(new BossPhase
+        {
+            Id = $"Phase {index}",
+            MinimumHealthPercent = 0,
+            MaximumHealthPercent = 100,
+            Priority = index,
+            Triggers =
+            [
+                new BossTrigger
+                {
+                    Condition = BossTriggerConditionType.HealthPercentAtOrBelow,
+                    ThresholdHealthPercent = 30,
+                    CooldownSeconds = 1,
+                    Actions =
+                    [
+                        new BossAction { Action = BossActionType.Enrage, EnragePercentBonus = 20 },
+                    ],
+                },
+            ],
+        });
+
+        LoadBossBehaviorProfile();
+        lstBossPhases.SelectedIndex = profile.Phases.Count - 1;
+    }
+
+    private void btnBossPhaseRemove_Click(object sender, EventArgs e)
+    {
+        if (lstBossPhases.SelectedIndex < 0)
+        {
+            return;
+        }
+
+        EnsureBossBehaviorProfile().Phases.RemoveAt(lstBossPhases.SelectedIndex);
+        LoadBossBehaviorProfile();
+    }
+
+    private void btnBossTriggerAdd_Click(object sender, EventArgs e)
+    {
+        if (lstBossPhases.SelectedIndex < 0)
+        {
+            return;
+        }
+
+        var trigger = new BossTrigger
+        {
+            Condition = BossTriggerConditionType.HealthPercentAtOrBelow,
+            ThresholdHealthPercent = 50,
+            CooldownSeconds = 1,
+            Actions =
+            [
+                new BossAction { Action = BossActionType.Enrage, EnragePercentBonus = 10 },
+            ],
+        };
+
+        EnsureBossBehaviorProfile().Phases[lstBossPhases.SelectedIndex].Triggers.Add(trigger);
+        LoadBossTriggers();
+    }
+
+    private void btnBossTriggerRemove_Click(object sender, EventArgs e)
+    {
+        if (lstBossPhases.SelectedIndex < 0 || lstBossTriggers.SelectedIndex < 0)
+        {
+            return;
+        }
+
+        EnsureBossBehaviorProfile().Phases[lstBossPhases.SelectedIndex].Triggers.RemoveAt(lstBossTriggers.SelectedIndex);
+        LoadBossTriggers();
+    }
+
+    private void btnBossActionAdd_Click(object sender, EventArgs e)
+    {
+        if (lstBossPhases.SelectedIndex < 0 || lstBossTriggers.SelectedIndex < 0)
+        {
+            return;
+        }
+
+        var trigger = EnsureBossBehaviorProfile().Phases[lstBossPhases.SelectedIndex].Triggers[lstBossTriggers.SelectedIndex];
+        var selectedSpell = cmbSpell.SelectedIndex >= 0 && cmbSpell.SelectedIndex < SpellDescriptor.Lookup.Count
+            ? SpellDescriptor.Get(SpellDescriptor.IdFromList(cmbSpell.SelectedIndex))
+            : SpellDescriptor.Lookup.Values.FirstOrDefault();
+
+        trigger.Actions.Add(new BossAction
+        {
+            Action = selectedSpell != null ? BossActionType.CastSpell : BossActionType.Enrage,
+            SpellId = selectedSpell?.Id ?? Guid.Empty,
+            EnragePercentBonus = 15,
+        });
+
+        LoadBossActions();
+    }
+
+    private void btnBossActionRemove_Click(object sender, EventArgs e)
+    {
+        if (lstBossPhases.SelectedIndex < 0 || lstBossTriggers.SelectedIndex < 0 || lstBossActions.SelectedIndex < 0)
+        {
+            return;
+        }
+
+        var trigger = EnsureBossBehaviorProfile().Phases[lstBossPhases.SelectedIndex].Triggers[lstBossTriggers.SelectedIndex];
+        trigger.Actions.RemoveAt(lstBossActions.SelectedIndex);
+        LoadBossActions();
+    }
+
+    private void btnBossPreset_Click(object sender, EventArgs e)
+    {
+        var profile = EnsureBossBehaviorProfile();
+        var healSpell = SpellDescriptor.Lookup.Values.FirstOrDefault();
+        var phase = new BossPhase
+        {
+            Id = "Phase 30%",
+            MinimumHealthPercent = 0,
+            MaximumHealthPercent = 30,
+            Priority = 1,
+            Triggers =
+            [
+                new BossTrigger
+                {
+                    Condition = BossTriggerConditionType.HealthPercentAtOrBelow,
+                    ThresholdHealthPercent = 30,
+                    CooldownSeconds = 10,
+                    Actions =
+                    [
+                        new BossAction { Action = BossActionType.CastSpell, SpellId = healSpell?.Id ?? Guid.Empty },
+                        new BossAction { Action = BossActionType.Enrage, EnragePercentBonus = 25 },
+                    ],
+                },
+            ],
+        };
+
+        profile.Phases.Add(phase);
+        LoadBossBehaviorProfile();
+    }
+
+    private void chkIsBoss_CheckedChanged(object sender, EventArgs e)
+    {
+        mEditorItem.IsBoss = chkIsBoss.Checked;
+    }
+
+    private void nudBossRespawnMinutes_ValueChanged(object sender, EventArgs e)
+    {
+        mEditorItem.BossRespawnMinutes = (int)nudBossRespawnMinutes.Value;
+    }
+
+    private void chkBossAnnounceOnKill_CheckedChanged(object sender, EventArgs e)
+    {
+        mEditorItem.BossAnnounceOnKill = chkBossAnnounceOnKill.Checked;
+    }
+
+    private void chkBossAnnounceOnRespawn_CheckedChanged(object sender, EventArgs e)
+    {
+        mEditorItem.BossAnnounceOnRespawn = chkBossAnnounceOnRespawn.Checked;
     }
 
     private void pnlContainer_Paint(object sender, PaintEventArgs e)

--- a/Intersect.Editor/Forms/Editors/frmNpc.resx
+++ b/Intersect.Editor/Forms/Editors/frmNpc.resx
@@ -124,58 +124,57 @@
   <data name="toolStripItemNew.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAACMSURBVDhP7Y3BCYAwFEM7h1M4Q/fy2rUEp3AFT1UovSrR
-        /22orQpeDTxqNS8aToxxVeTVu7A4dM35DKRyHxbzUyr1oASmsd8lBXf9JtVyUGCxdCd8CKEV9QgXaqK1
-        dsc5h3t5RKX8nP1yUh1BUcn/ng/wiOgpLKLIMoNv6Ih2zT+QBu54HHiD1L/EmA2wn/hWQ4oVCwAAAABJ
-        RU5ErkJggg==
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAACDSURBVDhPY2BAAt++ffsPw8jiBAGyxkO1UnA20QYha0Sn
+        0dViAJhNL2/sB2uCYRCfKFfAbINhbHwk/P7Lly8GGAbAMC6NTk5OYNzW1obbEHS/w+gP7z/CMU5D0F2B
+        zEc3ANkQFFegGwRSiKwZ3SCQGnT9cDBqAMIAfJigAcRgdH1kAQCwn/hWq+E7AwAAAABJRU5ErkJggg==
 </value>
   </data>
   <data name="toolStripItemDelete.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAFbSURBVDhPrZK9SgNBFIV9AcEHSJHKwkpIZZfOSkhtZeED
-        BPQBVh9A7S2CjaYQJI2VEEyRQoTFRhEEkUCCWExk/8rxfpOZxVlmY+OBC8Pcc879mVn5NxRF0cyyLJLo
-        KqXW7LUH7iXfkxgSotkzCTm0vz9n+un8zESSJO9VExF05rOpejw51h+jO53neVxycEV4sb5qYnx0AOGG
-        HCQ5n07jB33d3tCDnS2NUZqmm0YMqgYEVeQ+opvnfk9fthomMKIbK13AjYC7M4DMHd1UTLtW5oOFhEzc
-        mS7o1NLDCJkQ94f7/tLqsMxAqg8tLQw2/fX2+tcI4fmZje3+FmBEN7y7M4PjPR+oE/PWkuswO9W55x/M
-        JxP/k/E0TkhgRGWeljxkisAjd7u7XX4yA9eiE9MNy7TpEsxPji7QlBznvEzsQFeMxogvg6vFd0YgLSlC
-        qkSWWwvhN9mLhIySxz9ZBc31XkEs1QAAAABJRU5ErkJggg==
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAFTSURBVDhPrZOxSgNBEIbzAoIPYGFlYSVY2aWzEqytLHyA
+        gD6A+gBqbxFs1EKQNFaCaGEhQrBRBEEkkCAWF7nMbLnyrcy5u5xn4w8Dx+7Mv/8/M9dq/Recc7Misi0i
+        naIopvN7wLmIdEXkinDOrYcL51z7833kHw4PQpRl+ZqTiMjqeDQs7vd2/dvNpVfVfpUDK4VHc1Mhbnc2
+        STi3V1V1f9i/82fted9bWfIQTSaThZg9ISB4BUuoeTzt+uPFmRAQoeZHW2QBdiMgmTPUZKSdpNhAQ+pI
+        7BsVKM3rEtSRENdbG2nTfkMTAWPL8xPQ6Y+X578s1PvHG92NCyBCDXM3MnKS8TUVM2vGhXde55w9GA8G
+        6ZIxmtivjY/Rcm/rSx53F2vL1ZIFmMRYZrXjEfBv20hNlWPMTcUGVGENi0+9k+91pkBVC4LVzYty8NfS
+        F1UNu/EFWQXN9cDO9sIAAAAASUVORK5CYII=
 </value>
   </data>
   <data name="btnAlphabetical.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAABrSURBVDhPnc9BCoAwDETR3rM37omyU1KcMFGJGQf+JtCH
-        Dp+ZHdw+KvNHc87dHfsqAI8BgFUl0O0V2EdlANB17s8f8X8pBeAxALAqATioJSCpylj8DfAXKAWw1koA
-        wKoS6BbAQ1XGogaMcQIneCosACuo6QAAAABJRU5ErkJggg==
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAABfSURBVDhP1ZBBCsAgDAT3n/lxXpRbi4IlsUFX7aULAxJw
+        wgYAYGaXp8yWUj6JSKWXzXgETeLfM4YCllQQ+jFJrStp2z+r4IUjgmBn+0vw8yOq6tkRewFLWiH0Y5Ja
+        ydwneCos5rLhuQAAAABJRU5ErkJggg==
 </value>
   </data>
   <data name="toolStripItemCopy.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAABVSURBVDhP7YxBCgAgCAR9m///S3XxWghGUWJLdGxhkHId
-        8iIiFcHqe3TJzCGQIKfi8l6gD4RQoJ8RkKAXVr5gHOjsXAlW7BwXWH3PM0HEUYBg9SlEDZN0dAOhJqHd
-        AAAAAElFTkSuQmCC
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAABWSURBVDhPY2DAAr59+/afGIyuDw5Akk5OTngxUQZ8eP8R
+        K6a+Aeh+w4XxGoDuR3RMlAHoTkXXgM4fiQaAaBgmywB0TLIBcA3ogGoG4MMEDSAGo+sDAQCTdHQDUSJx
+        NAAAAABJRU5ErkJggg==
 </value>
   </data>
   <data name="toolStripItemPaste.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAACKSURBVDhP7Y3LDYAgEEQpwVKsgSoojl4swSbUCwc0Aa7q
-        4BJN+IjGo5O8ZJndGVhKxpjWWts551aih0fre+0BLaVchRAezPB2NXSSV/gVwXGYPJiVUt6ns1ghCDjn
-        UQG86w3FToVgDcWCWS9Fvi/Ao0RVAcwUjwpyhzmf4n8BFApS5HZRwRuONGMbrIJ1JIN8O2QAAAAASUVO
-        RK5CYII=
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAACMSURBVDhP7Y/BDYAgDEUdwVGcgSkYjl0cwSXUC4dqAr1i
+        SsSQQgkxHv3JT8jn90GHoSLn3OS9nxEx3F4o4z1RiAjGmKC1jqYzZQAw8m6h9CoNbuseTWdrbcx5/1H2
+        3aCUKgCU5R0+HwFU6nETcMDZ9PeAfK+auwB8x3zXboBUlPIfUAHULN0VgDdO8xesgnUk+GYkMwAAAABJ
+        RU5ErkJggg==
 </value>
   </data>
   <data name="toolStripItemUndo.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAEfSURBVDhPjVK7DgFBFN0/4A/4AvEJfkAi0ZLoNArR6hUq
-        tUgkElGJ1jYaDYVsI9Fq2EYyin2Ua864d9g1u/YkJ5nHOfcxcy2G53nVIAiEZBSGYdn3/TnviQJnuCPL
-        BzDf3aeoDNZaPFweo0J7EVnNmSLWOMMd9GR9AyaYIXQfT702kZKIWCUIwIJSd6XX9dE2sk9XRaz5HJWg
-        HbLHAzCn9pnbURklHQ6CdnBGdnMAsDXZKSF6lhkbqITvlIdhCvBthuZvAAO1WQhRlPv0FrKAIBCjIs7+
-        84hpkF9VS5qN32iCFHSSM4FAGLifQUpCltc3mZE5j3l+uNxiYzzeODA7f8um1xa96V6baaAc3JEsG/zq
-        PMaoKLeZQa+f46ss6wVeddKu0bn3NAAAAABJRU5ErkJggg==
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAEdSURBVDhPjVKxagJBEL0/MH8QvyDkE/yBgGAbIV2aFJI2
+        fQoraxECgqQKaWOTxkYL2SaQNk1yjbBX3MyUK2/ZWXLrevpgYG5m3tuZuSmKgLqur5nZMrMTkS4Rveh3
+        MIsYcsqJAPmvrOzV41ssflpsXGc4d8Vg5g0+YsihviEAEsgoLHdV9HMWHrGNTiCgBZf3r9G/ef5wy+2P
+        N/gaRycYJyugNl1+6Tj+RWY2KoJxEGsVgN1OPuPMRNRHJ5rznDaB/2TUnBTIWCRbay9aR2iD3gc60tcP
+        lngMItJLydnfmIOI3KU3ASEc3MEhpSCiUY6cvcIUmG39/ds44/G7AdmcbDts2z5MV5EcDsogl9ZnoVvX
+        M0ZHZ5MVYftn/ao9XnXSrn/EHrsAAAAASUVORK5CYII=
 </value>
   </data>
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">

--- a/Intersect.Editor/Localization/LocalizationReindexService.cs
+++ b/Intersect.Editor/Localization/LocalizationReindexService.cs
@@ -1,0 +1,269 @@
+using DarkUI.Forms;
+using Intersect.Editor.Core;
+using Intersect.Editor.Forms;
+using Intersect.Framework.Core.Localization;
+using Intersect.Framework.Core.Network.Packets;
+using Intersect.GameObjects;
+using Microsoft.Extensions.Logging;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Intersect.Editor.Localization;
+
+public static class LocalizationReindexService
+{
+    private const string ReindexVersionKey = "LocalizationQuestEventReindexVersion";
+    private const string PendingVersionKey = "LocalizationQuestEventReindexPending";
+    private const string SchemaChecksumKey = "LocalizationQuestEventSchemaChecksum";
+    private const string FormatChecksumKey = "LocalizationQuestEventFormatChecksum";
+
+    private const string CurrentReindexVersion = "quest-event-reindex-v1";
+    private static readonly string CurrentSchemaChecksum = BuildChecksum(
+        string.Join(
+            "|",
+            QuestFieldKey.Name,
+            QuestFieldKey.BeforeDescription,
+            QuestFieldKey.StartDescription,
+            QuestFieldKey.InProgressDescription,
+            QuestFieldKey.EndDescription,
+            EventFieldKey.PageDescription(0),
+            EventFieldKey.ShowText(0, Guid.Empty, 0),
+            EventFieldKey.ChatboxText(0, Guid.Empty, 0),
+            EventFieldKey.OptionsText(0, Guid.Empty, 0),
+            EventFieldKey.Option(0, Guid.Empty, 0, 0),
+            EventFieldKey.InputTitle(0, Guid.Empty, 0),
+            EventFieldKey.InputText(0, Guid.Empty, 0),
+            EventFieldKey.PlayerLabel(0, Guid.Empty, 0)
+        )
+    );
+
+    private static readonly string CurrentFormatChecksum = BuildChecksum("translation_upsert:entity_type,entity_id,field,source,language,translated,status");
+    private static bool _initialReindexCheckDone;
+
+    public static void EnsureInitialQuestEventReindexIfNeeded(IWin32Window owner)
+    {
+        if (_initialReindexCheckDone)
+        {
+            return;
+        }
+
+        _initialReindexCheckDone = true;
+
+        var pendingVersion = string.Equals(Preferences.LoadPreference(PendingVersionKey), "true", StringComparison.OrdinalIgnoreCase);
+        var storedVersion = Preferences.LoadPreference(ReindexVersionKey);
+        var storedSchemaChecksum = Preferences.LoadPreference(SchemaChecksumKey);
+        var storedFormatChecksum = Preferences.LoadPreference(FormatChecksumKey);
+
+        var requiresReindex = pendingVersion ||
+                              !string.Equals(storedVersion, CurrentReindexVersion, StringComparison.Ordinal) ||
+                              !string.Equals(storedSchemaChecksum, CurrentSchemaChecksum, StringComparison.Ordinal) ||
+                              !string.Equals(storedFormatChecksum, CurrentFormatChecksum, StringComparison.Ordinal);
+
+        if (!requiresReindex)
+        {
+            return;
+        }
+
+        Preferences.SavePreference(PendingVersionKey, true.ToString());
+
+        var response = DarkMessageBox.ShowWarning(
+            "Se detectó una marca pendiente o cambios en el esquema/formato de localización de Quest/Event. ¿Deseas ejecutar una reindexación inicial ahora?",
+            "Reindexación inicial de localización",
+            DarkDialogButton.YesNo,
+            Program.Icon
+        );
+
+        if (response != DialogResult.Yes)
+        {
+            return;
+        }
+
+        ReindexQuestAndEventLocalization(owner, "Apertura del editor");
+    }
+
+    public static void UpdateIncrementalEventSources(EventDescriptor eventDescriptor)
+    {
+        var entries = TranslationSourceUpdater.GetEventSources(eventDescriptor);
+        QueueEntries(entries, logSummary: true, operationName: "Incremental event save");
+    }
+
+    public static void UpdateIncrementalQuestAndEventSources(QuestDescriptor quest)
+    {
+        var entries = TranslationSourceUpdater.GetQuestAndRelatedEventSources(quest);
+        QueueEntries(entries, logSummary: true, operationName: "Incremental quest save");
+    }
+
+    public static void ReindexQuestAndEventLocalization(IWin32Window owner, string reason)
+    {
+        using var progress = new FrmProgress();
+        progress.SetTitle("Reindexar localización Quest/Event");
+        progress.Show(owner as Form);
+        progress.SetProgress($"Iniciando reindexación ({reason})...", 0, false);
+
+        var collectedEntries = new List<TranslationUpsertEntry>();
+
+        var eventDescriptors = EventDescriptor.Lookup.Values.OfType<EventDescriptor>().ToList();
+        var questDescriptors = QuestDescriptor.Lookup.Values.OfType<QuestDescriptor>().ToList();
+        var totalSteps = Math.Max(1, eventDescriptors.Count + questDescriptors.Count);
+        var currentStep = 0;
+
+        foreach (var eventDescriptor in eventDescriptors)
+        {
+            collectedEntries.AddRange(TranslationSourceUpdater.GetEventSources(eventDescriptor));
+            currentStep++;
+            progress.SetProgress($"Reindexando eventos ({currentStep}/{totalSteps})...", (int)(currentStep * 100f / totalSteps), false);
+        }
+
+        foreach (var questDescriptor in questDescriptors)
+        {
+            collectedEntries.AddRange(TranslationSourceUpdater.GetQuestAndRelatedEventSources(questDescriptor));
+            currentStep++;
+            progress.SetProgress($"Reindexando quests ({currentStep}/{totalSteps})...", (int)(currentStep * 100f / totalSteps), false);
+        }
+
+        var summary = QueueEntries(collectedEntries, logSummary: true, operationName: $"Bulk reindex ({reason})");
+
+        progress.SetProgress("Finalizando reindexación...", 100, false);
+        progress.NotifyClose();
+
+        if (summary.DiscardedEntries > 0)
+        {
+            DarkMessageBox.ShowWarning(BuildSummaryMessage(summary), "Reindexación completada con descartes", DarkDialogButton.Ok, Program.Icon);
+        }
+        else
+        {
+            DarkMessageBox.ShowInformation(BuildSummaryMessage(summary), "Reindexación completada", DarkDialogButton.Ok, Program.Icon);
+        }
+
+        if (summary.DiscardedEntries == 0)
+        {
+            SaveCurrentReindexMarkers();
+        }
+    }
+
+    private static ReindexSummary QueueEntries(IEnumerable<TranslationUpsertEntry> entries, bool logSummary, string operationName)
+    {
+        var sentByEntityType = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        var validEntries = new List<TranslationUpsertEntry>();
+        var errors = new List<string>();
+
+        foreach (var entry in entries ?? Enumerable.Empty<TranslationUpsertEntry>())
+        {
+            if (!IsValidEntry(entry, out var error))
+            {
+                errors.Add(error);
+                continue;
+            }
+
+            validEntries.Add(entry);
+            sentByEntityType[entry.EntityType] = sentByEntityType.TryGetValue(entry.EntityType, out var total)
+                ? total + 1
+                : 1;
+        }
+
+        TranslationSourceUpdater.QueueBatchSources(validEntries);
+
+        var summary = new ReindexSummary(validEntries.Count + errors.Count, validEntries.Count, errors.Count, sentByEntityType, errors);
+
+        if (logSummary)
+        {
+            LogSummary(summary, operationName);
+        }
+
+        return summary;
+    }
+
+    private static bool IsValidEntry(TranslationUpsertEntry entry, out string error)
+    {
+        if (entry == null)
+        {
+            error = "Entry nula descartada.";
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(entry.EntityType))
+        {
+            error = $"Entry descartada por entity_type vacío (field={entry.Field ?? "<null>"}).";
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(entry.EntityId))
+        {
+            error = $"Entry descartada por entity_id vacío (entity_type={entry.EntityType}, field={entry.Field ?? "<null>"}).";
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(entry.Field))
+        {
+            error = $"Entry descartada por field vacío (entity_type={entry.EntityType}, entity_id={entry.EntityId}).";
+            return false;
+        }
+
+        error = string.Empty;
+        return true;
+    }
+
+    private static void LogSummary(ReindexSummary summary, string operationName)
+    {
+        var logger = ApplicationContext.Context.Value?.Logger;
+        if (logger == null)
+        {
+            return;
+        }
+
+        var entitySummary = summary.SentByEntityType.Count == 0
+            ? "none"
+            : string.Join(", ", summary.SentByEntityType.OrderBy(pair => pair.Key).Select(pair => $"{pair.Key}={pair.Value}"));
+
+        logger.LogInformation(
+            "{OperationName}: total_entries={TotalEntries}, sent_entries={SentEntries}, discarded_entries={DiscardedEntries}, sent_by_entity_type={SentByEntityType}",
+            operationName,
+            summary.TotalEntries,
+            summary.SentEntries,
+            summary.DiscardedEntries,
+            entitySummary
+        );
+
+        foreach (var error in summary.Errors.Take(10))
+        {
+            logger.LogWarning("Localization reindex discarded entry: {Error}", error);
+        }
+    }
+
+    private static string BuildSummaryMessage(ReindexSummary summary)
+    {
+        var details = summary.SentByEntityType.Count == 0
+            ? "(sin entradas enviadas)"
+            : string.Join(Environment.NewLine, summary.SentByEntityType.OrderBy(pair => pair.Key).Select(pair => $"- {pair.Key}: {pair.Value}"));
+
+        var discardedInfo = summary.DiscardedEntries == 0
+            ? "Sin entradas descartadas."
+            : $"Entradas descartadas: {summary.DiscardedEntries}.{Environment.NewLine}{string.Join(Environment.NewLine, summary.Errors.Take(5).Select(error => $"  • {error}"))}";
+
+        return $"Total detectadas: {summary.TotalEntries}{Environment.NewLine}" +
+               $"Total enviadas: {summary.SentEntries}{Environment.NewLine}" +
+               $"Resumen por entity_type:{Environment.NewLine}{details}{Environment.NewLine}{discardedInfo}";
+    }
+
+    private static string BuildChecksum(string text)
+    {
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(text ?? string.Empty));
+        return Convert.ToHexString(bytes);
+    }
+
+    private static void SaveCurrentReindexMarkers()
+    {
+        Preferences.SavePreference(PendingVersionKey, false.ToString());
+        Preferences.SavePreference(ReindexVersionKey, CurrentReindexVersion);
+        Preferences.SavePreference(SchemaChecksumKey, CurrentSchemaChecksum);
+        Preferences.SavePreference(FormatChecksumKey, CurrentFormatChecksum);
+    }
+
+    private sealed record ReindexSummary(
+        int TotalEntries,
+        int SentEntries,
+        int DiscardedEntries,
+        IReadOnlyDictionary<string, int> SentByEntityType,
+        IReadOnlyList<string> Errors
+    );
+}

--- a/Intersect.Editor/Localization/LocalizationReindexService.cs
+++ b/Intersect.Editor/Localization/LocalizationReindexService.cs
@@ -1,9 +1,11 @@
 using DarkUI.Forms;
 using Intersect.Editor.Core;
 using Intersect.Editor.Forms;
+using Intersect.Framework.Core.GameObjects.Events;
 using Intersect.Framework.Core.Localization;
 using Intersect.Framework.Core.Network.Packets;
 using Intersect.GameObjects;
+using Intersect.Network.Packets.Editor;
 using Microsoft.Extensions.Logging;
 using System.Security.Cryptography;
 using System.Text;
@@ -205,7 +207,7 @@ public static class LocalizationReindexService
 
     private static void LogSummary(ReindexSummary summary, string operationName)
     {
-        var logger = ApplicationContext.Context.Value?.Logger;
+        var logger = Intersect.Core.ApplicationContext.Context.Value?.Logger;
         if (logger == null)
         {
             return;

--- a/Intersect.Editor/Localization/Strings.cs
+++ b/Intersect.Editor/Localization/Strings.cs
@@ -4818,6 +4818,40 @@ Tick timer saved in server config.json.";
 
         public static LocalizedString behavior = @"Behavior:";
 
+        public static LocalizedString boss = @"Boss";
+
+        public static LocalizedString isboss = @"Is Boss";
+
+        public static LocalizedString bossrespawnminutes = @"Respawn Time (minutes):";
+
+        public static LocalizedString bossannounceonkill = @"Announce on Kill";
+
+        public static LocalizedString bossannounceonrespawn = @"Announce on Respawn";
+
+        public static LocalizedString bossai = @"Boss AI";
+
+        public static LocalizedString bossaiphases = @"Phases";
+
+        public static LocalizedString bossaitriggers = @"Triggers";
+
+        public static LocalizedString bossaiactions = @"Actions";
+
+        public static LocalizedString bossaipreset30 = @"Fase 30%: heal + enrage";
+
+        public static LocalizedString add = @"Add";
+
+        public static LocalizedString remove = @"Remove";
+
+        public static LocalizedString bossaivalidationtitle = @"Boss AI Validation";
+
+        public static LocalizedString bossaivalidationhpoverlap = @"Boss AI phases cannot have overlapping HP ranges.";
+
+        public static LocalizedString bossaivalidationspell = @"Boss AI has a Cast Spell action with an invalid spell.";
+
+        public static LocalizedString bossaivalidationcooldown = @"Boss AI triggers with timed/status conditions require cooldown > 0.";
+
+        public static LocalizedString bossaivalidationactions = @"Each Boss AI trigger must contain at least one action.";
+
         public static LocalizedString cancel = @"Cancel";
 
         public static LocalizedString combat = @"Combat";

--- a/Intersect.Server.Core/Core/Bootstrapper.cs
+++ b/Intersect.Server.Core/Core/Bootstrapper.cs
@@ -19,6 +19,7 @@ using Intersect.Plugins;
 using Intersect.Plugins.Contexts;
 using Intersect.Plugins.Helpers;
 using Intersect.Server.Database;
+using Intersect.Server.Entities.BossSystem;
 using Intersect.Server.Database.PlayerData;
 using Intersect.Server.Database.PlayerData.Players;
 using Intersect.Server.Entities;
@@ -305,6 +306,8 @@ internal static class Bootstrapper
 
 
         Time.Update();
+
+        BossManager.Instance.Initialize();
 
         Console.WriteLine();
         Console.WriteLine(Strings.Commandoutput.ServerInfo);

--- a/Intersect.Server.Core/Core/LogicService.LogicThread.cs
+++ b/Intersect.Server.Core/Core/LogicService.LogicThread.cs
@@ -19,6 +19,7 @@ using Intersect.Server.Core.Services;
 using System;
 using System.Threading.Tasks;
 using Serilog;
+using Intersect.Server.Entities.BossSystem;
 
 namespace Intersect.Server.Core;
 

--- a/Intersect.Server.Core/Core/ServerContext.cs
+++ b/Intersect.Server.Core/Core/ServerContext.cs
@@ -12,6 +12,7 @@ using Intersect.Server.Plugins;
 using Intersect.Plugins.Interfaces;
 using Intersect.Rsa;
 using Intersect.Server.Database.PlayerData.Players;
+using Intersect.Server.Entities.BossSystem;
 using Microsoft.Extensions.Logging;
 
 namespace Intersect.Server.Core;
@@ -110,6 +111,9 @@ internal partial class ServerContext : ApplicationContext<ServerContext, ServerC
             // Except this line, this line is fine.
             ApplicationContext.Context.Value?.Logger.LogInformation("Disposing network..." + $" ({stopwatch.ElapsedMilliseconds}ms)");
             Network.Dispose();
+
+            ApplicationContext.Context.Value?.Logger.LogInformation("Shutting down boss manager..." + $" ({stopwatch.ElapsedMilliseconds}ms)");
+            BossManager.Instance.Shutdown();
 
             ApplicationContext.Context.Value?.Logger.LogInformation("Saving updated server variable values");
             DbInterface.SaveUpdatedServerVariables();

--- a/Intersect.Server.Core/Entities/BossSystem/BossAiDebugSettings.cs
+++ b/Intersect.Server.Core/Entities/BossSystem/BossAiDebugSettings.cs
@@ -1,0 +1,32 @@
+using System.Collections.Concurrent;
+
+namespace Intersect.Server.Entities.BossSystem;
+
+internal static class BossAiDebugSettings
+{
+    private static readonly ConcurrentDictionary<Guid, bool> BossDebugFlags = new();
+
+    public static bool IsEnabled(Guid bossId)
+    {
+        return BossDebugFlags.TryGetValue(bossId, out var isEnabled) && isEnabled;
+    }
+
+    public static bool SetEnabled(Guid bossId, bool enabled)
+    {
+        if (enabled)
+        {
+            BossDebugFlags[bossId] = true;
+            return true;
+        }
+
+        BossDebugFlags.TryRemove(bossId, out _);
+        return false;
+    }
+
+    public static bool Toggle(Guid bossId)
+    {
+        var next = !IsEnabled(bossId);
+        SetEnabled(bossId, next);
+        return next;
+    }
+}

--- a/Intersect.Server.Core/Entities/BossSystem/BossAiDecisionSelector.cs
+++ b/Intersect.Server.Core/Entities/BossSystem/BossAiDecisionSelector.cs
@@ -1,0 +1,129 @@
+using System.Linq;
+using Intersect.Framework.Core.GameObjects.NPCs;
+
+namespace Intersect.Server.Entities.BossSystem;
+
+internal sealed class BossAiDecisionSelector
+{
+    public BossAiSelectionResult BuildCandidates(
+        BossBehaviorProfile profile,
+        int healthPercent,
+        long now,
+        Func<string, BossTrigger, int, bool> isTriggerActive,
+        Func<BossAction, bool> canUseAction,
+        Func<BossAction, bool> isActionOnCooldown,
+        Action<string>? debugLog = null
+    )
+    {
+        var candidates = new List<BossAiActionCandidate>();
+        var runningIndex = 0;
+
+        foreach (var phase in profile.Phases.OrderByDescending(p => p.Priority))
+        {
+            var inRange = healthPercent >= phase.MinimumHealthPercent && healthPercent <= phase.MaximumHealthPercent;
+            if (!inRange)
+            {
+                debugLog?.Invoke(
+                    $"Fase '{phase.Id}' descartada por umbral de vida. hp={healthPercent}% rango={phase.MinimumHealthPercent}-{phase.MaximumHealthPercent}%"
+                );
+                continue;
+            }
+
+            debugLog?.Invoke($"Fase '{phase.Id}' activa para hp={healthPercent}%.");
+
+            foreach (var action in phase.Actions)
+            {
+                if (!canUseAction(action))
+                {
+                    debugLog?.Invoke($"Acción {action.Action} descartada en fase '{phase.Id}': restricciones de uso.");
+                    runningIndex++;
+                    continue;
+                }
+
+                if (isActionOnCooldown(action))
+                {
+                    debugLog?.Invoke($"Acción {action.Action} descartada en fase '{phase.Id}': cooldown activo.");
+                    runningIndex++;
+                    continue;
+                }
+
+                candidates.Add(new BossAiActionCandidate(action, phase.Id, phase.Priority + action.Priority, runningIndex++, 0, string.Empty));
+            }
+
+            for (var triggerIndex = 0; triggerIndex < phase.Triggers.Count; triggerIndex++)
+            {
+                var trigger = phase.Triggers[triggerIndex];
+                var triggerCooldownKey = $"{phase.Id}:{triggerIndex}";
+                if (!isTriggerActive(phase.Id, trigger, triggerIndex))
+                {
+                    debugLog?.Invoke($"Trigger evaluado en fase '{phase.Id}' idx={triggerIndex}: inactivo.");
+                    runningIndex += trigger.Actions.Count;
+                    continue;
+                }
+
+                debugLog?.Invoke($"Trigger evaluado en fase '{phase.Id}' idx={triggerIndex}: activo.");
+
+                foreach (var action in trigger.Actions)
+                {
+                    if (!canUseAction(action))
+                    {
+                        debugLog?.Invoke($"Acción {action.Action} de trigger {triggerIndex} descartada: restricciones de uso.");
+                        runningIndex++;
+                        continue;
+                    }
+
+                    if (isActionOnCooldown(action))
+                    {
+                        debugLog?.Invoke($"Acción {action.Action} de trigger {triggerIndex} descartada: cooldown activo.");
+                        runningIndex++;
+                        continue;
+                    }
+
+                    var priority = phase.Priority + trigger.Priority + action.Priority;
+                    candidates.Add(
+                        new BossAiActionCandidate(
+                            action,
+                            phase.Id,
+                            priority,
+                            runningIndex++,
+                            trigger.CooldownSeconds * 1000,
+                            triggerCooldownKey
+                        )
+                    );
+                }
+            }
+        }
+
+        var selected = candidates
+            .OrderByDescending(c => c.Priority)
+            .ThenBy(c => c.Index)
+            .FirstOrDefault();
+
+        if (selected != null)
+        {
+            debugLog?.Invoke(
+                $"Acción elegida: {selected.Action.Action} (fase='{selected.PhaseId}', prioridad={selected.Priority}, índice={selected.Index})."
+            );
+        }
+        else
+        {
+            debugLog?.Invoke("No se seleccionó ninguna acción de IA para esta evaluación.");
+        }
+
+        return new BossAiSelectionResult(candidates, selected);
+    }
+}
+
+internal sealed record BossAiActionCandidate(
+    BossAction Action,
+    string PhaseId,
+    int Priority,
+    int Index,
+    int TriggerCooldownMs,
+    string TriggerCooldownKey
+);
+
+internal sealed record BossAiSelectionResult(
+    IReadOnlyList<BossAiActionCandidate> Candidates,
+    BossAiActionCandidate? Selected
+);

--- a/Intersect.Server.Core/Entities/BossSystem/BossAiExecutor.cs
+++ b/Intersect.Server.Core/Entities/BossSystem/BossAiExecutor.cs
@@ -1,0 +1,530 @@
+using System.Linq;
+using Intersect;
+using Intersect.Core;
+using Intersect.Enums;
+using Intersect.Framework.Core.GameObjects.Animations;
+using Intersect.Framework.Core.GameObjects.NPCs;
+using Intersect.Server.Entities;
+using Intersect.Server.Networking;
+using Intersect.Utilities;
+using Microsoft.Extensions.Logging;
+
+namespace Intersect.Server.Entities.BossSystem;
+
+internal sealed class BossAiExecutor
+{
+    private readonly BossAiRuntimeState _runtime = new();
+    private readonly BossAiDecisionSelector _selector = new();
+
+    public bool TryExecute(Npc npc, long now)
+    {
+        if (npc.Descriptor.BossBehaviorProfile is not { Phases.Count: > 0 } profile)
+        {
+            return false;
+        }
+
+        if (TryExecutePendingAction(npc, now))
+        {
+            return true;
+        }
+
+        var evaluationInterval = Math.Max(100, profile.EvaluationIntervalMs);
+        if (_runtime.LastEvaluationAt + evaluationInterval > now)
+        {
+            return false;
+        }
+
+        _runtime.LastEvaluationAt = now;
+
+        if (_runtime.GlobalCooldownUntil > now)
+        {
+            return false;
+        }
+
+        var target = npc.Target;
+        var bossId = npc.Descriptor.Id;
+        var debugEnabled = BossAiDebugSettings.IsEnabled(bossId);
+        var selection = BuildCandidates(npc, profile, target, now, debugEnabled);
+        if (selection.Candidates.Count == 0 || selection.Selected == null)
+        {
+            return TryFallbackAction(npc, target);
+        }
+
+        var selected = selection.Selected;
+        if (!string.Equals(_runtime.CurrentPhaseId, selected.PhaseId, StringComparison.Ordinal))
+        {
+            LogDebug(
+                debugEnabled,
+                npc,
+                "Cambio de fase detectado: '{PreviousPhase}' -> '{NextPhase}'.",
+                string.IsNullOrWhiteSpace(_runtime.CurrentPhaseId) ? "<none>" : _runtime.CurrentPhaseId,
+                selected.PhaseId
+            );
+            _runtime.CurrentPhaseId = selected.PhaseId;
+        }
+
+        if (ShouldTelegraphAction(selected.Action, profile) &&
+            TryStartTelegraph(npc, selected.Action, target, profile, now))
+        {
+            return true;
+        }
+
+        if (!TryExecuteAction(npc, selected.Action, target, now))
+        {
+            return TryFallbackAction(npc, target);
+        }
+
+        var actionKey = BuildActionCooldownKey(selected.Action);
+        if (selected.Action.CooldownMs > 0)
+        {
+            _runtime.ActionCooldowns[actionKey] = now + selected.Action.CooldownMs;
+        }
+
+        if (selected.TriggerCooldownMs > 0)
+        {
+            _runtime.TriggerCooldowns[selected.TriggerCooldownKey] = now + selected.TriggerCooldownMs;
+        }
+
+        var globalCooldownMs = selected.Action.CooldownMs > 0
+            ? Math.Max(profile.GlobalCooldownMs, selected.Action.CooldownMs)
+            : profile.GlobalCooldownMs;
+
+        if (globalCooldownMs > 0)
+        {
+            _runtime.GlobalCooldownUntil = now + globalCooldownMs;
+        }
+
+        return true;
+    }
+
+    private BossAiSelectionResult BuildCandidates(Npc npc, BossBehaviorProfile profile, Entity target, long now, bool debugEnabled)
+    {
+        var healthPercent = GetHealthPercent(npc);
+        return _selector.BuildCandidates(
+            profile,
+            healthPercent,
+            now,
+            (phaseId, trigger, triggerIndex) =>
+            {
+                var triggerCooldownKey = $"{phaseId}:{triggerIndex}";
+                if (trigger.CooldownSeconds > 0 &&
+                    _runtime.TriggerCooldowns.TryGetValue(triggerCooldownKey, out var triggerCooldownUntil) &&
+                    triggerCooldownUntil > now)
+                {
+                    LogDebug(debugEnabled, npc, "Trigger evaluado idx={TriggerIndex}: en cooldown hasta {CooldownUntil}.", triggerIndex, triggerCooldownUntil);
+                    return false;
+                }
+
+                return IsTriggerActive(npc, trigger, target, now, debugEnabled, triggerIndex);
+            },
+            action => CanUseAction(action, profile, now),
+            action => IsActionOnCooldown(action, now),
+            message => LogDebug(debugEnabled, npc, message)
+        );
+    }
+
+    private bool IsTriggerActive(Npc npc, BossTrigger trigger, Entity target, long now, bool debugEnabled, int triggerIndex)
+    {
+        if (!EvaluateLegacyTriggerCondition(npc, trigger, target, now))
+        {
+            LogDebug(debugEnabled, npc, "Trigger evaluado idx={TriggerIndex}: condición legacy no cumplida.", triggerIndex);
+            return false;
+        }
+
+        foreach (var condition in trigger.Conditions)
+        {
+            if (!EvaluateCondition(npc, condition, target, now))
+            {
+                LogDebug(debugEnabled, npc, "Trigger evaluado idx={TriggerIndex}: condición {ConditionType} no cumplida.", triggerIndex, condition.Type);
+                return false;
+            }
+        }
+
+        LogDebug(debugEnabled, npc, "Trigger evaluado idx={TriggerIndex}: activo.", triggerIndex);
+        return true;
+    }
+
+    private static bool EvaluateLegacyTriggerCondition(Npc npc, BossTrigger trigger, Entity target, long now)
+    {
+        return trigger.Condition switch
+        {
+            BossTriggerConditionType.HealthPercentAtOrBelow =>
+                trigger.ThresholdHealthPercent <= 0 || GetHealthPercent(npc) <= trigger.ThresholdHealthPercent,
+            BossTriggerConditionType.StatusApplied =>
+                string.IsNullOrWhiteSpace(trigger.RequiredAppliedState) || HasStatusByName(target, trigger.RequiredAppliedState),
+            BossTriggerConditionType.CombatTimeAtOrAbove =>
+                trigger.CombatTimeSeconds <= 0 || now >= npc.CombatTimer + trigger.CombatTimeSeconds * 1000L,
+            _ => true,
+        };
+    }
+
+    private bool EvaluateCondition(Npc npc, BossCondition condition, Entity target, long now)
+    {
+        switch (condition.Type)
+        {
+            case BossConditionType.SelfHealthPercent:
+                return Compare(GetHealthPercent(npc), condition);
+            case BossConditionType.TargetHealthPercent:
+                return target != null && Compare(GetHealthPercent(target), condition);
+            case BossConditionType.StatusPresent:
+            {
+                var statusTarget = condition.StatusTarget == BossStatusTargetType.CurrentTarget ? target : npc;
+                if (statusTarget == null)
+                {
+                    return false;
+                }
+
+                return statusTarget.HasStatusEffect(condition.StatusEffect);
+            }
+            case BossConditionType.DistanceToTarget:
+                return target != null && Compare(npc.GetDistanceTo(target), condition);
+            case BossConditionType.TimeSinceLastCastMilliseconds:
+            {
+                var elapsed = Math.Max(0, now - _runtime.LastCastAt);
+                return Compare(elapsed, condition);
+            }
+            case BossConditionType.InternalState:
+                return _runtime.InternalStates.TryGetValue(condition.InternalStateKey ?? string.Empty, out var state) && state;
+            default:
+                return false;
+        }
+    }
+
+    private static bool Compare(long actualValue, BossCondition condition)
+    {
+        return condition.Comparison switch
+        {
+            BossComparisonType.LessOrEqual => actualValue <= condition.Value,
+            BossComparisonType.GreaterOrEqual => actualValue >= condition.Value,
+            BossComparisonType.BetweenInclusive => actualValue >= condition.MinimumValue && actualValue <= condition.MaximumValue,
+            _ => false,
+        };
+    }
+
+    private bool TryExecuteAction(Npc npc, BossAction action, Entity target, long now)
+    {
+        if (!CanUseAction(action, npc.Descriptor.BossBehaviorProfile, now))
+        {
+            return false;
+        }
+
+        switch (action.Action)
+        {
+            case BossActionType.CastSpell:
+                if (action.SpellId == Guid.Empty)
+                {
+                    return false;
+                }
+
+                if (npc.TryCastSpellById(action.SpellId, target))
+                {
+                    OnSuccessfulCast(action, now);
+                    return true;
+                }
+
+                return false;
+            case BossActionType.CastSpellFromList:
+            {
+                var spellIds = action.SpellIds?.Where(id => id != Guid.Empty).ToArray();
+                if (spellIds is not { Length: > 0 })
+                {
+                    return false;
+                }
+
+                var startIndex = Randomization.Next(0, spellIds.Length);
+                for (var index = 0; index < spellIds.Length; index++)
+                {
+                    var spellId = spellIds[(startIndex + index) % spellIds.Length];
+                    if (!npc.TryCastSpellById(spellId, target))
+                    {
+                        continue;
+                    }
+
+                    OnSuccessfulCast(action, now);
+                    return true;
+                }
+
+                return false;
+            }
+            case BossActionType.ChangeTarget:
+                if (TrySelectTarget(npc, action.TargetSelection, out var selectedTarget))
+                {
+                    npc.AssignTarget(selectedTarget);
+                    return true;
+                }
+
+                return false;
+            case BossActionType.Enrage:
+            case BossActionType.SetInternalState:
+                if (string.IsNullOrWhiteSpace(action.InternalStateKey))
+                {
+                    return false;
+                }
+
+                _runtime.InternalStates[action.InternalStateKey] = action.InternalStateValue;
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private static bool TrySelectTarget(Npc npc, BossTargetSelectionType selection, out Entity selected)
+    {
+        selected = null;
+        var candidates = npc.DamageMap
+            .Where(entry =>
+                entry.Key != null &&
+                !entry.Key.IsDisposed &&
+                !entry.Key.IsDead &&
+                entry.Key.MapInstanceId == npc.MapInstanceId &&
+                npc.CanTarget(entry.Key)
+            )
+            .Select(entry => (Entity: entry.Key, Threat: entry.Value))
+            .ToArray();
+
+        if (candidates.Length == 0)
+        {
+            return false;
+        }
+
+        selected = selection switch
+        {
+            BossTargetSelectionType.HighestThreat => npc.DamageMapHighest,
+            BossTargetSelectionType.Tank => candidates
+                .OrderByDescending(candidate => candidate.Entity.GetMaxVital(Vital.Health))
+                .Select(candidate => candidate.Entity)
+                .FirstOrDefault(),
+            BossTargetSelectionType.Healer => candidates
+                .OrderByDescending(candidate => candidate.Entity.Stat[(int)Stat.Intelligence].Value())
+                .Select(candidate => candidate.Entity)
+                .FirstOrDefault(),
+            BossTargetSelectionType.LowestThreat => candidates
+                .OrderBy(candidate => candidate.Threat)
+                .Select(candidate => candidate.Entity)
+                .FirstOrDefault(),
+            BossTargetSelectionType.LowestHealth => candidates
+                .OrderBy(candidate => candidate.Entity.GetVital(Vital.Health))
+                .Select(candidate => candidate.Entity)
+                .FirstOrDefault(),
+            BossTargetSelectionType.LowestHealthPercent => candidates
+                .OrderBy(candidate => GetHealthPercent(candidate.Entity))
+                .ThenBy(candidate => candidate.Entity.GetVital(Vital.Health))
+                .Select(candidate => candidate.Entity)
+                .FirstOrDefault(),
+            _ => npc.DamageMapHighest,
+        };
+
+        if (selected != null)
+        {
+            return true;
+        }
+
+        selected = candidates[0].Entity;
+        return true;
+    }
+
+    private bool IsActionOnCooldown(BossAction action, long now)
+    {
+        var actionKey = BuildActionCooldownKey(action);
+        return _runtime.ActionCooldowns.TryGetValue(actionKey, out var actionCooldownUntil) && actionCooldownUntil > now;
+    }
+
+    private static string BuildActionCooldownKey(BossAction action)
+    {
+        return action.Action switch
+        {
+            BossActionType.CastSpell => $"cast:{action.SpellId}",
+            BossActionType.CastSpellFromList => $"cast-list:{string.Join(',', action.SpellIds?.Where(id => id != Guid.Empty) ?? Enumerable.Empty<Guid>())}",
+            BossActionType.ChangeTarget => $"target:{action.TargetSelection}",
+            BossActionType.SetInternalState or BossActionType.Enrage => $"state:{action.InternalStateKey}",
+            _ => action.Action.ToString(),
+        };
+    }
+
+    private static bool HasStatusByName(Entity target, string statusName)
+    {
+        if (target == null || string.IsNullOrWhiteSpace(statusName))
+        {
+            return false;
+        }
+
+        if (!Enum.TryParse<SpellEffect>(statusName, true, out var spellEffect))
+        {
+            return false;
+        }
+
+        return target.HasStatusEffect(spellEffect);
+    }
+
+    private bool CanUseAction(BossAction action, BossBehaviorProfile profile, long now)
+    {
+        profile ??= new BossBehaviorProfile();
+
+        if (IsControlAction(action) &&
+            profile.MaxConsecutiveControlCasts > 0 &&
+            _runtime.ConsecutiveControlCasts >= profile.MaxConsecutiveControlCasts)
+        {
+            return false;
+        }
+
+        if (IsBigSkill(action) &&
+            profile.MinIntervalBetweenBigSkills > 0 &&
+            _runtime.LastBigSkillAt + profile.MinIntervalBetweenBigSkills > now)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private void OnSuccessfulCast(BossAction action, long now)
+    {
+        _runtime.LastCastAt = now;
+        _runtime.ConsecutiveControlCasts = IsControlAction(action) ? _runtime.ConsecutiveControlCasts + 1 : 0;
+
+        if (IsBigSkill(action))
+        {
+            _runtime.LastBigSkillAt = now;
+        }
+    }
+
+    private static bool IsControlAction(BossAction action)
+    {
+        return action.IsControlSkill;
+    }
+
+    private static bool IsBigSkill(BossAction action)
+    {
+        return action.IsBigSkill;
+    }
+
+    private bool TryExecutePendingAction(Npc npc, long now)
+    {
+        var pending = _runtime.PendingAction;
+        if (pending == null)
+        {
+            return false;
+        }
+
+        if (pending.ExecuteAt > now)
+        {
+            return true;
+        }
+
+        _runtime.PendingAction = null;
+        if (TryExecuteAction(npc, pending.Action, pending.Target, now))
+        {
+            return true;
+        }
+
+        return TryFallbackAction(npc, npc.Target);
+    }
+
+    private bool TryStartTelegraph(Npc npc, BossAction action, Entity target, BossBehaviorProfile profile, long now)
+    {
+        if (profile.TelegraphMs <= 0)
+        {
+            return false;
+        }
+
+        var telegraphMessage = string.IsNullOrWhiteSpace(action.TelegraphMessage)
+            ? $"{npc.Name} prepara una habilidad crítica..."
+            : action.TelegraphMessage;
+
+        PacketSender.SendActionMsg(npc, telegraphMessage, new Color(255, 255, 215, 0));
+        PacketSender.SendChatBubble(npc.Id, npc.MapInstanceId, EntityType.GlobalEntity, telegraphMessage, npc.MapId);
+
+        var telegraphAnimation = action.TelegraphAnimationId;
+        if (telegraphAnimation != Guid.Empty)
+        {
+            PacketSender.SendAnimationToProximity(
+                telegraphAnimation,
+                1,
+                npc.Id,
+                npc.MapId,
+                0,
+                0,
+                npc.Dir,
+                npc.MapInstanceId,
+                AnimationSourceType.SpellCast,
+                Guid.Empty
+            );
+        }
+
+        var executeAt = now + profile.TelegraphMs;
+        _runtime.PendingAction = new BossAiRuntimeState.PendingBossAction
+        {
+            Action = action,
+            Target = target,
+            ExecuteAt = executeAt,
+        };
+
+        _runtime.GlobalCooldownUntil = Math.Max(_runtime.GlobalCooldownUntil, executeAt);
+        return true;
+    }
+
+    private static bool ShouldTelegraphAction(BossAction action, BossBehaviorProfile profile)
+    {
+        return action.IsCriticalSkill && profile.TelegraphMs > 0;
+    }
+
+    private static bool TryFallbackAction(Npc npc, Entity target)
+    {
+        if (target != null && !target.IsDead && npc.CanAttack(target,null))
+        {
+            npc.TryAttack(target);
+            return true;
+        }
+
+        var directions = new[]
+        {
+            Direction.Up,
+            Direction.Down,
+            Direction.Left,
+            Direction.Right,
+            Direction.UpLeft,
+            Direction.UpRight,
+            Direction.DownRight,
+            Direction.DownLeft,
+        };
+
+        var proposedDirection = directions[Randomization.Next(0, directions.Length)];
+        if (!npc.CanMoveInDirection(proposedDirection, out var blockerType, out _) &&
+             blockerType != MovementBlockerType.Slide)
+        {
+            return false;
+        }
+
+        npc.Move(proposedDirection, null);
+        return true;
+    }
+
+    private static int GetHealthPercent(Entity entity)
+    {
+        var maxHealth = entity.GetMaxVital(Vital.Health);
+        if (maxHealth <= 0)
+        {
+            return 0;
+        }
+
+        return (int)Math.Clamp(entity.GetVital(Vital.Health) * 100 / maxHealth, 0, 100);
+    }
+
+    private static void LogDebug(bool enabled, Npc npc, string message, params object[] args)
+    {
+        if (!enabled)
+        {
+            return;
+        }
+
+        var logArgs = new object[args.Length + 2];
+        logArgs[0] = npc.Name;
+        logArgs[1] = npc.Descriptor.Id;
+        Array.Copy(args, 0, logArgs, 2, args.Length);
+
+        ApplicationContext.Context.Value?.Logger.LogDebug(
+            "[BossAI:{BossName}/{BossId}] " + message,
+            logArgs
+        );
+    }
+}

--- a/Intersect.Server.Core/Entities/BossSystem/BossAiRuntimeState.cs
+++ b/Intersect.Server.Core/Entities/BossSystem/BossAiRuntimeState.cs
@@ -1,0 +1,37 @@
+using System.Collections.Concurrent;
+using Intersect.Framework.Core.GameObjects.NPCs;
+using Intersect.Server.Entities;
+
+namespace Intersect.Server.Entities.BossSystem;
+
+internal sealed class BossAiRuntimeState
+{
+    public sealed class PendingBossAction
+    {
+        public required BossAction Action { get; init; }
+
+        public required Entity? Target { get; init; }
+
+        public required long ExecuteAt { get; init; }
+    }
+
+    public long LastEvaluationAt { get; set; }
+
+    public long GlobalCooldownUntil { get; set; }
+
+    public long LastCastAt { get; set; }
+
+    public long LastBigSkillAt { get; set; }
+
+    public int ConsecutiveControlCasts { get; set; }
+
+    public string CurrentPhaseId { get; set; } = string.Empty;
+
+    public PendingBossAction? PendingAction { get; set; }
+
+    public ConcurrentDictionary<string, long> ActionCooldowns { get; } = new();
+
+    public ConcurrentDictionary<string, bool> InternalStates { get; } = new();
+
+    public ConcurrentDictionary<string, long> TriggerCooldowns { get; } = new();
+}

--- a/Intersect.Server.Core/Entities/BossSystem/BossCatalogEntry.cs
+++ b/Intersect.Server.Core/Entities/BossSystem/BossCatalogEntry.cs
@@ -1,0 +1,12 @@
+using Intersect.Framework.Core.GameObjects.Maps;
+
+namespace Intersect.Server.Entities.BossSystem;
+
+public sealed record BossCatalogEntry(
+    Guid NpcId,
+    Guid MapId,
+    NpcSpawn Spawn,
+    int RespawnMinutes,
+    bool AnnounceOnKill,
+    bool AnnounceOnRespawn
+);

--- a/Intersect.Server.Core/Entities/BossSystem/BossManager.cs
+++ b/Intersect.Server.Core/Entities/BossSystem/BossManager.cs
@@ -1,0 +1,411 @@
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Intersect.Core;
+using Intersect.Enums;
+using Intersect.Framework.Core;
+using Intersect.Framework.Core.GameObjects.Maps;
+using Intersect.Framework.Core.GameObjects.NPCs;
+using Intersect.Server.Database.PlayerData.Players;
+using Intersect.Server.Maps;
+using Intersect.Server.Networking;
+using Intersect.Utilities;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+
+namespace Intersect.Server.Entities.BossSystem;
+
+public static class BossManager
+{
+    public static BossManagerService Instance { get; } = new();
+
+    public static void InitializeCatalog() => Instance.Initialize();
+
+    public static void RegisterSpawn(Npc npc) => Instance.RegisterSpawn(npc);
+
+    public static void HandleDeath(Npc npc) => Instance.HandleDeath(npc);
+
+    public static void Update(long now) => Instance.CheckRespawns(now);
+
+    public static string ExportDebugJson() => Instance.ExportDebugJson();
+}
+
+public sealed class BossManagerService
+{
+    private readonly ConcurrentDictionary<Guid, BossCatalogEntry> _catalog = new();
+    private readonly ConcurrentDictionary<Guid, BossRuntimeState> _runtime = new();
+    private readonly SemaphoreSlim _respawnSemaphore = new(1, 1);
+    private readonly object _timerLock = new();
+
+    private Timer? _respawnTimer;
+    private int _initialized;
+
+    public void Initialize()
+    {
+        _catalog.Clear();
+        _runtime.Clear();
+
+        var bosses = NPCDescriptor.Lookup.Values
+            .OfType<NPCDescriptor>()
+            .Where(npc => npc?.IsBoss == true)
+            .ToArray();
+
+        foreach (var boss in bosses)
+        {
+            if (!TryResolveSpawn(boss.Id, out var mapId, out var spawn))
+            {
+                ApplicationContext.Context.Value?.Logger.LogWarning(
+                    "Boss config inválida: npc {BossId} ({BossName}) marcado como boss pero sin spawn válido en mapa.",
+                    boss.Id,
+                    boss.Name
+                );
+
+                continue;
+            }
+
+            _catalog[boss.Id] = new BossCatalogEntry(
+                boss.Id,
+                mapId,
+                new NpcSpawn(spawn),
+                boss.BossRespawnMinutes,
+                boss.BossAnnounceOnKill,
+                boss.BossAnnounceOnRespawn
+            );
+
+            _runtime[boss.Id] = new BossRuntimeState
+            {
+                NpcId = boss.Id,
+                IsAlive = false,
+                NextRespawnAt = null,
+                AliveEntityId = null,
+                MapId = mapId,
+                MapInstanceId = Guid.Empty,
+            };
+        }
+
+        StartRespawnTimer();
+        Interlocked.Exchange(ref _initialized, 1);
+
+        ApplicationContext.Context.Value?.Logger.LogInformation(
+            "BossManager inicializado. Bosses en catálogo: {BossCount}",
+            _catalog.Count
+        );
+    }
+
+    public void Shutdown()
+    {
+        StopRespawnTimer();
+        Interlocked.Exchange(ref _initialized, 0);
+
+        ApplicationContext.Context.Value?.Logger.LogInformation("BossManager apagado correctamente.");
+    }
+
+    public bool IsBoss(Guid npcId)
+    {
+        EnsureInitialized();
+        return _catalog.ContainsKey(npcId);
+    }
+
+    public async Task OnBossKilled(Guid npcId, Player player)
+    {
+        EnsureInitialized();
+
+        if (!_catalog.TryGetValue(npcId, out var catalogEntry))
+        {
+            ApplicationContext.Context.Value?.Logger.LogWarning(
+                "OnBossKilled ignorado: npc {BossId} no existe en catálogo.",
+                npcId
+            );
+
+            return;
+        }
+
+        if (_runtime.TryGetValue(npcId, out var state))
+        {
+            ApplicationContext.Context.Value?.Logger.LogInformation(
+                "Boss kill registrado: {BossId} por {PlayerName} ({PlayerId}). Próximo respawn: {NextRespawnAt}.",
+                npcId,
+                player?.Name,
+                player?.Id,
+                state.NextRespawnAt
+            );
+        }
+        else
+        {
+            ApplicationContext.Context.Value?.Logger.LogWarning(
+                "Boss kill registrado sin estado runtime: {BossId} por {PlayerName} ({PlayerId}).",
+                npcId,
+                player?.Name,
+                player?.Id
+            );
+        }
+
+        if (catalogEntry.AnnounceOnKill)
+        {
+            PacketSender.SendGlobalMsg($"Boss defeated: {NPCDescriptor.Get(npcId)?.Name ?? npcId.ToString()}");
+        }
+
+        await Task.CompletedTask;
+    }
+
+    public void RegisterSpawn(Npc npc)
+    {
+        EnsureInitialized();
+
+        var descriptor = npc?.Descriptor;
+        if (descriptor?.IsBoss != true || !_catalog.ContainsKey(descriptor.Id))
+        {
+            return;
+        }
+
+        _runtime.AddOrUpdate(
+            descriptor.Id,
+            _ => new BossRuntimeState
+            {
+                NpcId = descriptor.Id,
+                IsAlive = true,
+                NextRespawnAt = null,
+                AliveEntityId = npc.Id,
+                MapId = npc.MapId,
+                MapInstanceId = npc.MapInstanceId,
+            },
+            (_, state) =>
+            {
+                state.IsAlive = true;
+                state.NextRespawnAt = null;
+                state.AliveEntityId = npc.Id;
+                state.MapId = npc.MapId;
+                state.MapInstanceId = npc.MapInstanceId;
+
+                return state;
+            }
+        );
+
+        ApplicationContext.Context.Value?.Logger.LogInformation(
+            "Boss spawn detectado: {BossId} ({BossName}) en mapa {MapId} instancia {MapInstanceId} entidad {EntityId}.",
+            descriptor.Id,
+            descriptor.Name,
+            npc.MapId,
+            npc.MapInstanceId,
+            npc.Id
+        );
+    }
+
+    public void HandleDeath(Npc npc)
+    {
+        EnsureInitialized();
+
+        var descriptor = npc?.Descriptor;
+        if (descriptor?.IsBoss != true || !_catalog.TryGetValue(descriptor.Id, out var catalogEntry))
+        {
+            return;
+        }
+
+        var nextRespawnAt = Timing.Global.Milliseconds + GetRespawnDelayMs(descriptor, catalogEntry);
+
+        _runtime.AddOrUpdate(
+            descriptor.Id,
+            _ => new BossRuntimeState
+            {
+                NpcId = descriptor.Id,
+                IsAlive = false,
+                NextRespawnAt = nextRespawnAt,
+                AliveEntityId = null,
+                MapId = npc.MapId,
+                MapInstanceId = npc.MapInstanceId,
+            },
+            (_, state) =>
+            {
+                state.IsAlive = false;
+                state.NextRespawnAt = nextRespawnAt;
+                state.AliveEntityId = null;
+                state.MapId = npc.MapId;
+                state.MapInstanceId = npc.MapInstanceId;
+
+                return state;
+            }
+        );
+
+        ApplicationContext.Context.Value?.Logger.LogInformation(
+            "Boss death registrado: {BossId} ({BossName}) en mapa {MapId}/{MapInstanceId}. Respawn en {NextRespawnAt}.",
+            descriptor.Id,
+            descriptor.Name,
+            npc.MapId,
+            npc.MapInstanceId,
+            nextRespawnAt
+        );
+    }
+
+    public void CheckRespawns(long now)
+    {
+        EnsureInitialized();
+
+        if (!_respawnSemaphore.Wait(0))
+        {
+            return;
+        }
+
+        try
+        {
+            foreach (var (bossId, state) in _runtime)
+            {
+                if (state.IsAlive || !state.NextRespawnAt.HasValue || state.NextRespawnAt.Value > now)
+                {
+                    continue;
+                }
+
+                if (!_catalog.TryGetValue(bossId, out var catalogEntry))
+                {
+                    ApplicationContext.Context.Value?.Logger.LogWarning(
+                        "Respawn omitido: {BossId} no está en catálogo.",
+                        bossId
+                    );
+
+                    continue;
+                }
+
+                if (!MapController.TryGetInstanceFromMap(state.MapId, state.MapInstanceId, out var mapInstance))
+                {
+                    ApplicationContext.Context.Value?.Logger.LogWarning(
+                        "Respawn fallido: boss {BossId} no encontró mapa/instancia {MapId}/{MapInstanceId}.",
+                        bossId,
+                        state.MapId,
+                        state.MapInstanceId
+                    );
+
+                    continue;
+                }
+
+                ResolveSpawnPosition(mapInstance, catalogEntry.Spawn, out var x, out var y, out var direction);
+                var spawnedNpc = mapInstance.SpawnNpc((byte)x, (byte)y, direction, bossId);
+                if (spawnedNpc == null)
+                {
+                    ApplicationContext.Context.Value?.Logger.LogWarning(
+                        "Respawn fallido: SpawnNpc devolvió null para boss {BossId} en mapa {MapId}/{MapInstanceId}.",
+                        bossId,
+                        state.MapId,
+                        state.MapInstanceId
+                    );
+
+                    continue;
+                }
+
+                RegisterSpawn(spawnedNpc);
+                ApplicationContext.Context.Value?.Logger.LogInformation(
+                    "Boss respawneado: {BossId} ({BossName}) en {MapId}/{MapInstanceId} entidad {EntityId}.",
+                    bossId,
+                    spawnedNpc.Name,
+                    state.MapId,
+                    state.MapInstanceId,
+                    spawnedNpc.Id
+                );
+
+                if (catalogEntry.AnnounceOnRespawn)
+                {
+                    PacketSender.SendGlobalMsg($"Boss respawned: {spawnedNpc.Name}");
+                }
+            }
+        }
+        catch (Exception exception)
+        {
+            ApplicationContext.Context.Value?.Logger.LogError(exception, "Error al ejecutar ciclo de respawn de bosses.");
+        }
+        finally
+        {
+            _respawnSemaphore.Release();
+        }
+    }
+
+    public string ExportDebugJson()
+    {
+        EnsureInitialized();
+        return JsonConvert.SerializeObject(_runtime.Values.OrderBy(state => state.NpcId).ToArray(), Formatting.Indented);
+    }
+
+    private void EnsureInitialized()
+    {
+        if (Volatile.Read(ref _initialized) != 1)
+        {
+            Initialize();
+        }
+    }
+
+    private void StartRespawnTimer()
+    {
+        lock (_timerLock)
+        {
+            _respawnTimer?.Dispose();
+            _respawnTimer = new Timer(_ => CheckRespawns(Timing.Global.Milliseconds), null, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1));
+        }
+    }
+
+    private void StopRespawnTimer()
+    {
+        lock (_timerLock)
+        {
+            _respawnTimer?.Dispose();
+            _respawnTimer = null;
+        }
+    }
+
+    private static bool TryResolveSpawn(Guid npcId, out Guid mapId, out NpcSpawn spawn)
+    {
+        foreach (var map in MapController.Lookup.Values.OfType<MapController>())
+        {
+            var resolvedSpawn = map.Spawns.FirstOrDefault(existingSpawn => existingSpawn.NpcId == npcId);
+            if (resolvedSpawn == null)
+            {
+                continue;
+            }
+
+            mapId = map.Id;
+            spawn = resolvedSpawn;
+
+            return true;
+        }
+
+        mapId = Guid.Empty;
+        spawn = new NpcSpawn();
+
+        return false;
+    }
+
+    private static long GetRespawnDelayMs(NPCDescriptor descriptor, BossCatalogEntry catalogEntry) =>
+        catalogEntry.RespawnMinutes > 0
+            ? catalogEntry.RespawnMinutes * 60000L
+            : Math.Max(descriptor.SpawnDuration, 0);
+
+    private static void ResolveSpawnPosition(MapInstance mapInstance, NpcSpawn spawn, out int x, out int y, out Direction direction)
+    {
+        direction = spawn.Direction != NpcSpawnDirection.Random
+            ? (Direction)(spawn.Direction - 1)
+            : Randomization.NextDirection();
+
+        if (spawn.X >= 0 && spawn.Y >= 0)
+        {
+            x = spawn.X;
+            y = spawn.Y;
+            return;
+        }
+
+        var mapController = MapController.Get(mapInstance.MapId);
+        x = 0;
+        y = 0;
+
+        for (var i = 0; i < 100; i++)
+        {
+            x = Randomization.Next(0, Options.Instance.Map.MapWidth);
+            y = Randomization.Next(0, Options.Instance.Map.MapHeight);
+
+            if (mapController?.Attributes[x, y] == null ||
+                mapController.Attributes[x, y].Type == (int)MapAttributeType.Walkable)
+            {
+                return;
+            }
+        }
+
+        x = 0;
+        y = 0;
+    }
+}

--- a/Intersect.Server.Core/Entities/BossSystem/BossRuntimeState.cs
+++ b/Intersect.Server.Core/Entities/BossSystem/BossRuntimeState.cs
@@ -1,0 +1,16 @@
+namespace Intersect.Server.Entities.BossSystem;
+
+public sealed class BossRuntimeState
+{
+    public Guid NpcId { get; init; }
+
+    public bool IsAlive { get; set; }
+
+    public long? NextRespawnAt { get; set; }
+
+    public Guid? AliveEntityId { get; set; }
+
+    public Guid MapId { get; set; }
+
+    public Guid MapInstanceId { get; set; }
+}

--- a/Intersect.Server.Core/Entities/Combat/CombatResolver.cs
+++ b/Intersect.Server.Core/Entities/Combat/CombatResolver.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Intersect.Enums;
+using Intersect.Framework.Core.Combat;
 using Intersect.Framework.Core.GameObjects.Items;
 using Intersect.Server.Entities;
 using Intersect.Server.General;
@@ -27,26 +28,19 @@ public static class CombatResolver
         CombatantEffects defenderEffects
     )
     {
-        const double minChance = 0.1d;
-        const double maxChance = 0.98d;
-        const double baseChance = 0.7d;
-        const double swingFactor = 0.3d;
+        var accuracy = CombatFormulaCalculator.CalculateAccuracyScore(
+            attacker.Stat[(int)Enums.Stat.Agility].Value(),
+            attacker.Stat[(int)Enums.Stat.Attack].Value(),
+            attackerEffects.GetTotalEffectValue(ItemEffect.Accuracy)
+        );
 
-        var accuracy =
-            attacker.Stat[(int)Enums.Stat.Agility].Value() * 0.5d +
-            attacker.Stat[(int)Enums.Stat.Attack].Value() * 0.3d +
-            attackerEffects.GetTotalEffectValue(ItemEffect.Accuracy);
+        var evasion = CombatFormulaCalculator.CalculateEvasionScore(
+            defender.Stat[(int)Enums.Stat.Agility].Value(),
+            defender.Stat[(int)Enums.Stat.Defense].Value(),
+            defenderEffects.GetTotalEffectValue(ItemEffect.Evasion)
+        );
 
-        var evasion =
-            defender.Stat[(int)Enums.Stat.Agility].Value() * 0.7d +
-            defender.Stat[(int)Enums.Stat.Defense].Value() * 0.2d +
-            defenderEffects.GetTotalEffectValue(ItemEffect.Evasion);
-
-        var statBalance = accuracy - evasion;
-        var normalization = Math.Max(50d, accuracy + evasion);
-        var hitChance = baseChance + swingFactor * statBalance / normalization;
-
-        return Math.Clamp(hitChance, minChance, maxChance);
+        return CombatFormulaCalculator.CalculateHitChance(accuracy, evasion);
     }
 
     public static int CalculateCriticalChance(
@@ -55,16 +49,13 @@ public static class CombatResolver
         CombatantEffects defenderEffects
     )
     {
-        var critChance = baseCritChance;
-
-        var agilityPerCrit = Math.Max(1, Options.Instance.Combat.AgilityPerCritChance);
-        critChance += attackerEffects.Entity.Stat[(int)Enums.Stat.Agility].Value() / agilityPerCrit;
-        critChance += attackerEffects.GetTotalEffectValue(ItemEffect.CriticalChance);
-
-        var antiCrit = defenderEffects.GetTotalEffectValue(ItemEffect.AntiCritChance);
-        critChance -= antiCrit;
-
-        return Math.Max(0, critChance);
+        return CombatFormulaCalculator.CalculateCriticalChance(
+            baseCritChance,
+            attackerEffects.Entity.Stat[(int)Enums.Stat.Agility].Value(),
+            Options.Instance.Combat.AgilityPerCritChance,
+            attackerEffects.GetTotalEffectValue(ItemEffect.CriticalChance),
+            defenderEffects.GetTotalEffectValue(ItemEffect.AntiCritChance)
+        );
     }
 
     public static IReadOnlyDictionary<string, object>? BuildDefenseOverrides(

--- a/Intersect.Server.Core/Entities/Entity.cs
+++ b/Intersect.Server.Core/Entities/Entity.cs
@@ -3465,44 +3465,32 @@ public abstract partial class Entity : IEntity
             return;
         }
 
-        // Find tiles to spawn items.
+        // Find tiles to spawn items around the source entity on this map only.
         var range = Math.Max(0, Options.ItemDropRange);
-        var tiles = new List<(TileHelper Tile, int Distance)>();
-        for (var x = X - range; x <= X + range; x++)
+        var hasMapInstance = MapController.TryGetInstanceFromMap(MapId, MapInstanceId, out var mapInstance);
+        var tiles = new List<(int X, int Y, int Distance)>();
+        if (hasMapInstance)
         {
-            for (var y = Y - range; y <= Y + range; y++)
+            var minX = Math.Max(0, X - range);
+            var maxX = Math.Min(Options.Instance.Map.MapWidth - 1, X + range);
+            var minY = Math.Max(0, Y - range);
+            var maxY = Math.Min(Options.Instance.Map.MapHeight - 1, Y + range);
+
+            for (var x = minX; x <= maxX; x++)
             {
-                // Use a radial selection (Manhattan distance) rather than a full square area.
-                var distance = Math.Abs(x - X) + Math.Abs(y - Y);
-                if (distance > range)
+                for (var y = minY; y <= maxY; y++)
                 {
-                    continue;
-                }
+                    // Use Chebyshev distance so immediate diagonals are considered "around" the entity.
+                    var distance = Math.Max(Math.Abs(x - X), Math.Abs(y - Y));
+                    if (distance == 0 || distance > range)
+                    {
+                        continue;
+                    }
 
-                var tileHelper = new TileHelper(MapId, x, y);
-                if (!tileHelper.TryFix())
-                {
-                    continue;
-                }
-
-                var mapId = tileHelper.GetMapId();
-
-                // Drops should stay on the current map unless explicitly intended otherwise.
-                if (mapId != MapId)
-                {
-                    continue;
-                }
-
-                if (!MapController.TryGetInstanceFromMap(mapId, MapInstanceId, out var mapInstance))
-                {
-                    continue;
-                }
-
-                var tileX = tileHelper.GetX();
-                var tileY = tileHelper.GetY();
-                if (!mapInstance.TileBlocked(tileX, tileY))
-                {
-                    tiles.Add((tileHelper, distance));
+                    if (!mapInstance.TileBlocked(x, y))
+                    {
+                        tiles.Add((x, y, distance));
+                    }
                 }
             }
         }
@@ -3512,7 +3500,7 @@ public abstract partial class Entity : IEntity
             .ThenBy(_ => Randomization.Next())
             .ToList();
 
-        var closestTilePoolCount = Math.Min(5, orderedTiles.Count);
+        var closestTilePoolCount = Math.Min(8, orderedTiles.Count);
 
         // Drop items
         foreach (var slot in Items)
@@ -3540,15 +3528,11 @@ public abstract partial class Entity : IEntity
             }
 
             // Spawn the actual item!
-            if (closestTilePoolCount > 0)
+            if (closestTilePoolCount > 0 && hasMapInstance)
             {
-                var tile = orderedTiles[Randomization.Next(closestTilePoolCount)].Tile;
-                var mapId = tile.GetMapId();
-                if (MapController.TryGetInstanceFromMap(mapId, MapInstanceId, out var tileInstance))
-                {
-                    var itemSource = this.AsItemSource();
-                    tileInstance.SpawnItem(itemSource, tile.GetX(), tile.GetY(), drop, drop.Quantity, lootOwner, sendUpdate);
-                }
+                var tile = orderedTiles[Randomization.Next(closestTilePoolCount)];
+                var itemSource = this.AsItemSource();
+                mapInstance.SpawnItem(itemSource, tile.X, tile.Y, drop, drop.Quantity, lootOwner, sendUpdate);
             }
             else if (MapController.TryGetInstanceFromMap(MapId, MapInstanceId, out var instance))
             {

--- a/Intersect.Server.Core/Entities/Events/CommandInstance.cs
+++ b/Intersect.Server.Core/Entities/Events/CommandInstance.cs
@@ -43,6 +43,8 @@ public partial class CommandInstance
 
     public EventPage Page;
 
+    public int PageIndex;
+
     public EventResponse WaitingForResponse = EventResponse.None;
 
     public Guid WaitingForRoute;
@@ -51,24 +53,60 @@ public partial class CommandInstance
 
     public EventCommand WaitingOnCommand = null;
 
-    public CommandInstance(EventPage page, int listIndex = 0)
+    public CommandInstance(EventPage page, int listIndex = 0, int pageIndex = -1)
     {
         Page = page;
-        CommandList = page.CommandLists.Values.First();
+        PageIndex = pageIndex;
+
+        if (page.CommandLists?.Any() == true)
+        {
+            var firstList = page.CommandLists.First();
+            CommandListId = firstList.Key;
+            CommandList = firstList.Value;
+        }
+
         CommandIndex = listIndex;
     }
 
-    public CommandInstance(EventPage page, List<EventCommand> commandList, int listIndex = 0)
+    public CommandInstance(
+        EventPage page,
+        List<EventCommand> commandList,
+        int listIndex = 0,
+        int pageIndex = -1,
+        Guid commandListId = default
+    )
     {
         Page = page;
+        PageIndex = pageIndex;
         CommandList = commandList;
+        CommandListId = commandListId;
+
+        if (CommandListId == Guid.Empty && commandList != null && page.CommandLists != null)
+        {
+            foreach (var (listId, commands) in page.CommandLists)
+            {
+                if (commands == commandList)
+                {
+                    CommandListId = listId;
+                    break;
+                }
+            }
+        }
+
         CommandIndex = listIndex;
     }
 
-    public CommandInstance(EventPage page, Guid commandListId, int listIndex = 0)
+    public CommandInstance(EventPage page, Guid commandListId, int listIndex = 0, int pageIndex = -1)
     {
         Page = page;
-        CommandList = page.CommandLists[commandListId];
+        PageIndex = pageIndex;
+        CommandListId = commandListId;
+
+        if (page.CommandLists != null && page.CommandLists.TryGetValue(commandListId, out var commandList))
+        {
+            CommandList = commandList;
+        }
+
         CommandIndex = listIndex;
     }
 
@@ -78,7 +116,9 @@ public partial class CommandInstance
         set
         {
             commandIndex = value;
-            Command = commandIndex >= 0 && commandIndex < CommandList.Count ? CommandList[commandIndex] : null;
+            Command = CommandList != null && commandIndex >= 0 && commandIndex < CommandList.Count
+                ? CommandList[commandIndex]
+                : null;
         }
     }
 

--- a/Intersect.Server.Core/Entities/Events/CommandProcessing.cs
+++ b/Intersect.Server.Core/Entities/Events/CommandProcessing.cs
@@ -26,6 +26,8 @@ using Intersect.Utilities;
 using Intersect.Server.Services;
 using Intersect.Server.Core.Services;
 using Intersect.Network.Packets.Localization;
+using Intersect.Core;
+using Microsoft.Extensions.Logging;
 
 namespace Intersect.Server.Entities.Events;
 

--- a/Intersect.Server.Core/Entities/Events/CommandProcessing.cs
+++ b/Intersect.Server.Core/Entities/Events/CommandProcessing.cs
@@ -32,37 +32,28 @@ namespace Intersect.Server.Entities.Events;
 
 public static partial class CommandProcessing
 {
-
-    private static int ResolvePageIndex(Event instance, EventPage page) =>
-        instance.Descriptor.Pages?.FindIndex(candidate => ReferenceEquals(candidate, page)) ?? -1;
-
-    private static Guid ResolveListId(EventPage page, List<EventCommand> commandList)
-    {
-        if (page.CommandLists == null)
-        {
-            return Guid.Empty;
-        }
-
-        foreach (var (listId, commands) in page.CommandLists)
-        {
-            if (ReferenceEquals(commands, commandList))
-            {
-                return listId;
-            }
-        }
-
-        return Guid.Empty;
-    }
-
-    private static LocalizationRequestEntry BuildEventLocalizationRequest(
+    private static LocalizationRequestEntry? BuildEventLocalizationRequest(
         Event instance,
         CommandInstance stackInfo,
         Func<int, Guid, int, string> fieldFactory
     )
     {
-        var pageIndex = ResolvePageIndex(instance, stackInfo.Page);
-        var listId = ResolveListId(stackInfo.Page, stackInfo.CommandList);
+        var pageIndex = stackInfo.PageIndex;
+        var listId = stackInfo.CommandListId;
         var commandIndex = stackInfo.CommandIndex;
+
+        if (pageIndex < 0 || listId == Guid.Empty)
+        {
+            ApplicationContext.Context.Value?.Logger.LogWarning(
+                "Unable to build event localization key because command metadata is invalid. eventId={EventId}, commandIndex={CommandIndex}, pageIndex={PageIndex}, listId={ListId}",
+                instance.Descriptor.Id,
+                commandIndex,
+                pageIndex,
+                listId
+            );
+
+            return null;
+        }
 
         return new LocalizationRequestEntry(
             LocalizationEntityTypes.Event,
@@ -127,13 +118,17 @@ public static partial class CommandProcessing
             stackInfo,
             EventFieldKey.OptionsText
         );
-        var optionLocalizationRequests = new List<LocalizationRequestEntry>(4)
-        {
-            BuildEventLocalizationRequest(instance, stackInfo, (page, list, commandIndex) => EventFieldKey.Option(page, list, commandIndex, 0)),
-            BuildEventLocalizationRequest(instance, stackInfo, (page, list, commandIndex) => EventFieldKey.Option(page, list, commandIndex, 1)),
-            BuildEventLocalizationRequest(instance, stackInfo, (page, list, commandIndex) => EventFieldKey.Option(page, list, commandIndex, 2)),
-            BuildEventLocalizationRequest(instance, stackInfo, (page, list, commandIndex) => EventFieldKey.Option(page, list, commandIndex, 3)),
-        };
+        var optionLocalizationRequests = Enumerable.Range(0, 4)
+            .Select(
+                optionIndex => BuildEventLocalizationRequest(
+                    instance,
+                    stackInfo,
+                    (page, list, commandIndex) => EventFieldKey.Option(page, list, commandIndex, optionIndex)
+                )
+            )
+             .Where(entry => entry != null)
+            .Select(entry => entry!)
+            .ToList();
         PacketSender.SendEventDialog(
             player,
             txt,
@@ -144,7 +139,7 @@ public static partial class CommandProcessing
             command.Face,
             instance.PageInstance.Id,
             promptLocalizationRequest,
-            optionLocalizationRequests
+            optionLocalizationRequests.Count > 0 ? optionLocalizationRequests : null
         );
         stackInfo.WaitingForResponse = CommandInstance.EventResponse.Dialogue;
         stackInfo.WaitingOnCommand = command;
@@ -192,7 +187,7 @@ public static partial class CommandProcessing
         }
         else if (type == -1)
         {
-            var tmpStack = new CommandInstance(stackInfo.Page, command.BranchIds[1]);
+            var tmpStack = new CommandInstance(stackInfo.Page, command.BranchIds[1], pageIndex: stackInfo.PageIndex);
             callStack.Push(tmpStack);
             return;
         }
@@ -236,15 +231,18 @@ public static partial class CommandProcessing
             stackInfo,
             EventFieldKey.ChatboxText
         );
-        var localizedText = LocalizationRepository.Default.Get(
-            promptLocalizationRequest.EntityType,
-            promptLocalizationRequest.EntityId,
-            promptLocalizationRequest.Field,
-            Options.Instance.Language
-        );
-        if (!string.IsNullOrWhiteSpace(localizedText))
+        if (promptLocalizationRequest != null)
         {
-            txt = ParseEventText(localizedText, player, instance);
+            var localizedText = LocalizationRepository.Default.Get(
+                promptLocalizationRequest.EntityType,
+                promptLocalizationRequest.EntityId,
+                promptLocalizationRequest.Field,
+                Options.Instance.Language
+            );
+            if (!string.IsNullOrWhiteSpace(localizedText))
+            {
+                txt = ParseEventText(localizedText, player, instance);
+            }
         }
 
         var color = Color.FromName(command.Color, Strings.Colors.Presets);
@@ -370,11 +368,9 @@ public static partial class CommandProcessing
 
         if (newCommandList != null)
         {
-            var tmpStack = new CommandInstance(stackInfo.Page)
-            {
-                CommandList = newCommandList,
-                CommandIndex = 0,
-            };
+            var newCommandListId = success ? command.BranchIds[0] : command.BranchIds[1];
+            var tmpStack = new CommandInstance(stackInfo.Page, newCommandList, pageIndex: stackInfo.PageIndex, commandListId: newCommandListId);
+            tmpStack.CommandIndex = 0;
 
             callStack.Push(tmpStack);
         }
@@ -414,7 +410,7 @@ public static partial class CommandProcessing
     )
     {
         //Recursively search through commands for the label, and create a brand new call stack based on where that label is located.
-        var newCallStack = LoadLabelCallstack(command.Label, stackInfo.Page);
+        var newCallStack = LoadLabelCallstack(command.Label, stackInfo.Page, stackInfo.PageIndex);
         if (newCallStack != null)
         {
             newCallStack.Reverse();
@@ -450,7 +446,7 @@ public static partial class CommandProcessing
         {
             if (Conditions.CanSpawnPage(page, player, instance))
             {
-                var commonEventStack = new CommandInstance(page);
+                var commonEventStack = new CommandInstance(page, pageIndex: commonEvent.Pages?.IndexOf(page) ?? -1);
                 callStack.Push(commonEventStack);
             }
         }
@@ -628,11 +624,9 @@ public static partial class CommandProcessing
             newCommandList = stackInfo.Page.CommandLists[command.BranchIds[1]];
         }
 
-        var tmpStack = new CommandInstance(stackInfo.Page)
-        {
-            CommandList = newCommandList,
-            CommandIndex = 0,
-        };
+        var newCommandListId = success ? command.BranchIds[0] : command.BranchIds[1];
+        var tmpStack = new CommandInstance(stackInfo.Page, newCommandList, pageIndex: stackInfo.PageIndex, commandListId: newCommandListId);
+        tmpStack.CommandIndex = 0;
 
         callStack.Push(tmpStack);
     }
@@ -705,11 +699,9 @@ public static partial class CommandProcessing
             newCommandList = stackInfo.Page.CommandLists[command.BranchIds[1]];
         }
 
-        var tmpStack = new CommandInstance(stackInfo.Page)
-        {
-            CommandList = newCommandList,
-            CommandIndex = 0,
-        };
+        var newCommandListId = success ? command.BranchIds[0] : command.BranchIds[1];
+        var tmpStack = new CommandInstance(stackInfo.Page, newCommandList, pageIndex: stackInfo.PageIndex, commandListId: newCommandListId);
+        tmpStack.CommandIndex = 0;
 
         callStack.Push(tmpStack);
     }
@@ -1520,11 +1512,9 @@ public static partial class CommandProcessing
             newCommandList = stackInfo.Page.CommandLists[command.BranchIds[1]];
         }
 
-        var tmpStack = new CommandInstance(stackInfo.Page)
-        {
-            CommandList = newCommandList,
-            CommandIndex = 0,
-        };
+        var newCommandListId = success ? command.BranchIds[0] : command.BranchIds[1];
+        var tmpStack = new CommandInstance(stackInfo.Page, newCommandList, pageIndex: stackInfo.PageIndex, commandListId: newCommandListId);
+        tmpStack.CommandIndex = 0;
 
         callStack.Push(tmpStack);
     }
@@ -1600,11 +1590,9 @@ public static partial class CommandProcessing
             newCommandList = stackInfo.Page.CommandLists[command.BranchIds[1]];
         }
 
-        var tmpStack = new CommandInstance(stackInfo.Page)
-        {
-            CommandList = newCommandList,
-            CommandIndex = 0,
-        };
+        var newCommandListId = success ? command.BranchIds[0] : command.BranchIds[1];
+        var tmpStack = new CommandInstance(stackInfo.Page, newCommandList, pageIndex: stackInfo.PageIndex, commandListId: newCommandListId);
+        tmpStack.CommandIndex = 0;
 
         callStack.Push(tmpStack);
     }
@@ -1659,11 +1647,9 @@ public static partial class CommandProcessing
             newCommandList = stackInfo.Page.CommandLists[command.BranchIds[1]];
         }
 
-        var tmpStack = new CommandInstance(stackInfo.Page)
-        {
-            CommandList = newCommandList,
-            CommandIndex = 0,
-        };
+        var newCommandListId = success ? command.BranchIds[0] : command.BranchIds[1];
+        var tmpStack = new CommandInstance(stackInfo.Page, newCommandList, pageIndex: stackInfo.PageIndex, commandListId: newCommandListId);
+        tmpStack.CommandIndex = 0;
 
         callStack.Push(tmpStack);
     }
@@ -1796,10 +1782,10 @@ public static partial class CommandProcessing
         }
     }
 
-    private static Stack<CommandInstance> LoadLabelCallstack(string label, EventPage currentPage)
+    private static Stack<CommandInstance> LoadLabelCallstack(string label, EventPage currentPage, int currentPageIndex)
     {
         var newStack = new Stack<CommandInstance>();
-        newStack.Push(new CommandInstance(currentPage)); //Start from the top
+        newStack.Push(new CommandInstance(currentPage, pageIndex: currentPageIndex)); //Start from the top
         if (FindLabelResursive(newStack, currentPage, newStack.Peek().CommandList, label))
         {
             return newStack;
@@ -1862,9 +1848,8 @@ public static partial class CommandProcessing
                 {
                     if (page.CommandLists.ContainsKey(branch))
                     {
-                        var tmpStack = new CommandInstance(page)
+                        var tmpStack = new CommandInstance(page, page.CommandLists[branch], pageIndex: stack.Peek().PageIndex, commandListId: branch)
                         {
-                            CommandList = page.CommandLists[branch],
                             CommandIndex = 0,
                         };
 

--- a/Intersect.Server.Core/Entities/Events/Event.cs
+++ b/Intersect.Server.Core/Entities/Events/Event.cs
@@ -275,7 +275,7 @@ public partial class Event
                 {
                     if (PageInstance.Trigger == EventTrigger.Autorun && WaitTimer < Timing.Global.Milliseconds)
                     {
-                        var newStack = new CommandInstance(PageInstance.MyPage);
+                        var newStack = new CommandInstance(PageInstance.MyPage, pageIndex: PageIndex);
                         CallStack.Push(newStack);
                     }
                 }

--- a/Intersect.Server.Core/Entities/Npc.cs
+++ b/Intersect.Server.Core/Entities/Npc.cs
@@ -21,6 +21,8 @@ using Intersect.Utilities;
 using Microsoft.Extensions.Logging;
 using System.Linq;
 using Stat = Intersect.Enums.Stat;
+using Intersect.Server.General;
+using Intersect.Server.Entities.BossSystem;
 
 namespace Intersect.Server.Entities;
 
@@ -30,6 +32,8 @@ public partial class Npc : Entity
 
     //Spell casting
     public long CastFreq;
+
+    private readonly BossAiExecutor _bossAiExecutor;
 
     /// <summary>
     /// Damage Map - Keep track of who is doing the most damage to this npc and focus accordingly
@@ -118,6 +122,7 @@ public partial class Npc : Entity
         Immunities = npcDescriptor.Immunities;
         Descriptor = npcDescriptor;
         Despawnable = despawnable;
+        _bossAiExecutor = new BossAiExecutor();
 
         for (var i = 0; i < Enum.GetValues<Stat>().Length; i++)
         {
@@ -264,6 +269,11 @@ public partial class Npc : Entity
                 {
                     PacketSender.SendUnlockedBestiaryEntries(player);
                 }
+
+                if (BossManager.Instance.IsBoss(Id))
+                {
+                    BossManager.Instance.OnBossKilled(Id, player).GetAwaiter().GetResult();
+                }
             }
 
 
@@ -278,6 +288,8 @@ public partial class Npc : Entity
             }
             PacketSender.SendEntityDie(this);
             PacketSender.SendEntityLeave(this);
+
+            BossManager.HandleDeath(this);
         }
     }
 
@@ -742,49 +754,73 @@ public partial class Npc : Entity
         return blockerType == MovementBlockerType.NotBlocked;
     }
 
+    public bool TryCastSpellById(Guid spellId, Entity explicitTarget = null)
+    {
+        if (spellId == Guid.Empty)
+        {
+            return false;
+        }
+
+        var spellIndex = Descriptor.Spells.IndexOf(spellId);
+        if (spellIndex < 0)
+        {
+            return false;
+        }
+
+        if (!SpellDescriptor.TryGet(spellId, out var spellDescriptor))
+        {
+            return false;
+        }
+
+        var target = explicitTarget ?? Target;
+        return TryBeginSpellCast(spellDescriptor, spellIndex, target);
+    }
+
     private void TryCastSpells()
     {
-        var target = Target;
-
-        if (target == null || mPathFinder.GetTarget() == null)
-        {
-            return;
-        }
-
-        // Check if NPC is stunned/sleeping
-        if (IsStunnedOrSleeping)
-        {
-            return;
-        }
-
-        //Check if NPC is casting a spell
-        if (IsCasting)
-        {
-            return; //can't move while casting
-        }
-
-        if (CastFreq >= Timing.Global.Milliseconds)
-        {
-            return;
-        }
-
-        // Check if the NPC is able to cast spells
-        if (IsUnableToCastSpells)
-        {
-            return;
-        }
-
         if (Descriptor.Spells is not { Count: > 0 })
         {
             return;
         }
 
-        // Pick a random spell
         var spellIndex = Randomization.Next(0, Spells.Count);
         var spellId = Descriptor.Spells[spellIndex];
-        if (!SpellDescriptor.TryGet(spellId, out var spellBase))
+        if (!SpellDescriptor.TryGet(spellId, out var spellDescriptor))
         {
             return;
+        }
+
+        _ = TryBeginSpellCast(spellDescriptor, spellIndex, Target);
+    }
+
+    private bool TryBeginSpellCast(SpellDescriptor spellBase, int spellIndex, Entity target)
+    {
+        if (target == null || mPathFinder.GetTarget() == null)
+        {
+            return false;
+        }
+
+        // Check if NPC is stunned/sleeping
+        if (IsStunnedOrSleeping)
+        {
+            return false;
+        }
+
+        //Check if NPC is casting a spell
+        if (IsCasting)
+        {
+            return false; //can't move while casting
+        }
+
+        if (CastFreq >= Timing.Global.Milliseconds)
+        {
+            return false;
+        }
+
+        // Check if the NPC is able to cast spells
+        if (IsUnableToCastSpells)
+        {
+            return false;
         }
 
         if (spellBase.Combat == null)
@@ -792,16 +828,10 @@ public partial class Npc : Entity
             ApplicationContext.Context.Value?.Logger.LogWarning($"Combat data missing for {spellBase.Id}.");
         }
 
-        //TODO: try cast spell to find out hidden targets?
-        // if (target.HasStatusEffect(SpellEffect.Stealth) /* && spellBase.Combat.TargetType != SpellTargetType.AoE*/)
-        // {
-        //     return;
-        // }
-
         // Check if we are even allowed to cast this spell.
         if (!CanCastSpell(spellBase, target, true, SoftRetargetOnSelfCast, out _))
         {
-            return;
+            return false;
         }
 
         var targetType = spellBase.Combat?.TargetType ?? SpellTargetType.Single;
@@ -817,14 +847,14 @@ public partial class Npc : Entity
             {
                 if (LastRandomMove >= Timing.Global.Milliseconds)
                 {
-                    return;
+                    return false;
                 }
 
                 //Face the target -- next frame fire -- then go on with life
                 ChangeDir(dirToEnemy); // Gotta get dir to enemy
                 LastRandomMove = Timing.Global.Milliseconds + Randomization.Next(1000, 3000);
 
-                return;
+                return false;
             }
         }
 
@@ -843,27 +873,22 @@ public partial class Npc : Entity
         {
             case 0:
                 CastFreq = Timing.Global.Milliseconds + 30000;
-
                 break;
 
             case 1:
                 CastFreq = Timing.Global.Milliseconds + 15000;
-
                 break;
 
             case 2:
                 CastFreq = Timing.Global.Milliseconds + 8000;
-
                 break;
 
             case 3:
                 CastFreq = Timing.Global.Milliseconds + 4000;
-
                 break;
 
             case 4:
                 CastFreq = Timing.Global.Milliseconds + 2000;
-
                 break;
         }
 
@@ -883,11 +908,10 @@ public partial class Npc : Entity
                 AnimationSourceType.SpellCast,
                 spellBase.Id
             );
-
-            //Target Type 1 will be global entity
         }
 
-        PacketSender.SendEntityCastTime(this, spellId);
+        PacketSender.SendEntityCastTime(this, spellBase.Id);
+        return true;
     }
 
     public bool IsFleeing()
@@ -1051,7 +1075,16 @@ public partial class Npc : Entity
 
                     if (mPathFinder.GetTarget() != null && Descriptor.Movement != (int)NpcMovement.Static)
                     {
-                        TryCastSpells();
+                        var bossActionExecuted = false;
+                        if (Descriptor.IsBoss && !Descriptor.UsesDefaultAiBehavior)
+                        {
+                            bossActionExecuted = _bossAiExecutor.TryExecute(this, timeMs);
+                        }
+
+                        if (!bossActionExecuted)
+                        {
+                            TryCastSpells();
+                        }
                         // TODO: Make resetting mobs actually return to their starting location.
                         if ((!mResetting && !IsOneBlockAway(
                             mPathFinder.GetTarget().TargetMapId, mPathFinder.GetTarget().TargetX,
@@ -1826,6 +1859,7 @@ public partial class Npc : Entity
         var pkt = (NpcEntityPacket)packet;
         pkt.Aggression = GetAggression(forPlayer);
         pkt.Level = Level; // Asegúrate de que el nivel se incluya en el paquete
+        pkt.IsBoss = Descriptor?.IsBoss == true;
 
         return pkt;
     }

--- a/Intersect.Server.Core/Entities/Player.cs
+++ b/Intersect.Server.Core/Entities/Player.cs
@@ -6825,7 +6825,7 @@ public partial class Player : Entity
 
                         if (((StartQuestCommand)stackInfo.WaitingOnCommand).QuestId == questId)
                         {
-                            var tmpStack = new CommandInstance(stackInfo.Page, stackInfo.BranchIds[0]);
+                            var tmpStack = new CommandInstance(stackInfo.Page, stackInfo.BranchIds[0], pageIndex: stackInfo.PageIndex);
                             evt.Value.CallStack.Peek().WaitingForResponse = CommandInstance.EventResponse.None;
                             evt.Value.CallStack.Push(tmpStack);
                         }
@@ -6862,7 +6862,7 @@ public partial class Player : Entity
                     if (((StartQuestCommand)stackInfo.WaitingOnCommand).QuestId == questId)
                     {
                         //Run failure branch
-                        var tmpStack = new CommandInstance(stackInfo.Page, stackInfo.BranchIds[1]);
+                        var tmpStack = new CommandInstance(stackInfo.Page, stackInfo.BranchIds[1], pageIndex: stackInfo.PageIndex);
                         stackInfo.WaitingForResponse = CommandInstance.EventResponse.None;
                         evt.Value.CallStack.Push(tmpStack);
                     }
@@ -7230,7 +7230,7 @@ public partial class Player : Entity
                     return;
                 }
 
-                var newStack = new CommandInstance(evt.Value.PageInstance.MyPage);
+                var newStack = new CommandInstance(evt.Value.PageInstance.MyPage, pageIndex: evt.Value.PageIndex);
                 evt.Value.CallStack.Push(newStack);
                 if (!evt.Value.Global)
                 {
@@ -7286,7 +7286,7 @@ public partial class Player : Entity
                     if (stackInfo.WaitingOnCommand != null &&
                         stackInfo.WaitingOnCommand.Type == EventCommandType.ShowOptions)
                     {
-                        var tmpStack = new CommandInstance(stackInfo.Page, stackInfo.BranchIds[responseId - 1]);
+                        var tmpStack = new CommandInstance(stackInfo.Page, stackInfo.BranchIds[responseId - 1], pageIndex: stackInfo.PageIndex);
                         evt.Value.CallStack.Push(tmpStack);
                     }
 
@@ -7497,8 +7497,8 @@ public partial class Player : Entity
                         }
 
                         var tmpStack = success
-                            ? new CommandInstance(stackInfo.Page, stackInfo.BranchIds[0])
-                            : new CommandInstance(stackInfo.Page, stackInfo.BranchIds[1]);
+                            ? new CommandInstance(stackInfo.Page, stackInfo.BranchIds[0], pageIndex: stackInfo.PageIndex)
+                            : new CommandInstance(stackInfo.Page, stackInfo.BranchIds[1], pageIndex: stackInfo.PageIndex);
 
                         evt.Value.CallStack.Push(tmpStack);
                     }
@@ -7701,7 +7701,7 @@ public partial class Player : Entity
                             throw Exceptions.UnreachableInvalidEnum(trigger);
                     }
 
-                    var newStack = new CommandInstance(newEvent.PageInstance.MyPage);
+                    var newStack = new CommandInstance(newEvent.PageInstance.MyPage, pageIndex: newEvent.PageIndex);
                     newEvent.CallStack.Push(newStack);
 
                     break;
@@ -7878,7 +7878,7 @@ public partial class Player : Entity
                             return;
                         }
 
-                        var newStack = new CommandInstance(evt.Value.PageInstance.MyPage);
+                        var newStack = new CommandInstance(evt.Value.PageInstance.MyPage, pageIndex: evt.Value.PageIndex);
                         evt.Value.CallStack.Push(newStack);
                     }
                 }
@@ -7918,7 +7918,7 @@ public partial class Player : Entity
                 return;
             }
 
-            var newStack = new CommandInstance(eventInstance.PageInstance.MyPage);
+            var newStack = new CommandInstance(eventInstance.PageInstance.MyPage, pageIndex: eventInstance.PageIndex);
             eventInstance.CallStack.Push(newStack);
         }
     }

--- a/Intersect.Server.Core/General/NpcExperienceCalculator.cs
+++ b/Intersect.Server.Core/General/NpcExperienceCalculator.cs
@@ -120,32 +120,10 @@ public static partial class NpcExperienceCalculator
     }
 
     /// <summary>
-    /// Verifica se o NPC é um Boss baseado no nome
-    /// </summary>
-    /// <param name="npcName">Nome do NPC</param>
-    /// <returns>True se o NPC tem a tag [BOSS] no nome</returns>
-    private static bool IsBoss(string npcName)
-    {
-        var bossTag = Options.Instance.Npc.Experience.BossTag;
-
-        if (string.IsNullOrWhiteSpace(npcName))
-        {
-            return false;
-        }
-
-        if (string.IsNullOrWhiteSpace(bossTag))
-        {
-            return false;
-        }
-
-        return npcName.Contains(bossTag, StringComparison.OrdinalIgnoreCase);
-    }
-
-    /// <summary>
     /// Calcula a experiência usando a fórmula automática baseada no nível do NPC.
     /// IMPORTANTE: Se AlwaysUseAutomaticCalculation = true, SEMPRE usa o cálculo automático,
     /// ignorando o valor configurado no editor.
-    /// NPCs com [BOSS] no nome recebem multiplicador de XP x30.
+    /// NPCs marcados como Boss recebem multiplicador de XP configurável.
     /// </summary>
     /// <param name="npcDescriptor">Descritor do NPC</param>
     /// <returns>Experiência que o NPC deve dar</returns>
@@ -176,8 +154,8 @@ public static partial class NpcExperienceCalculator
             experience = CalculateExperience(npcDescriptor.Level);
         }
 
-        // Aplicar multiplicador de Boss se o NPC tiver [BOSS] no nome
-        if (IsBoss(npcDescriptor.Name))
+        // Aplicar multiplicador de Boss usando exclusivamente o flag IsBoss do descriptor.
+        if (npcDescriptor.IsBoss)
         {
             experience *= Math.Max(1, experienceOptions.BossExperienceMultiplier);
         }

--- a/Intersect.Server.Core/Localization/LocalizationRepository.cs
+++ b/Intersect.Server.Core/Localization/LocalizationRepository.cs
@@ -5,9 +5,11 @@ using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
+using Intersect.Core;
 using Intersect.Framework.Core.Localization;
 using Intersect.Server.Core;
 using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging;
 
 namespace Intersect.Server.Localization;
 
@@ -308,6 +310,13 @@ public sealed class LocalizationRepository
 
         if (string.IsNullOrWhiteSpace(currentHash))
         {
+            ApplicationContext.Context.Value?.Logger.LogDebug(
+                "Localization source not found for {EntityType}/{EntityId}/{Field}.",
+                entityType,
+                entityId,
+                field
+            );
+            LocalizationStatsTracker.RecordRepositoryLookup(missingSource: true, missingCurrentHashTranslation: false);
             return null;
         }
 
@@ -371,6 +380,15 @@ public sealed class LocalizationRepository
         {
             return translation;
         }
+
+        ApplicationContext.Context.Value?.Logger.LogTrace(
+            "No translation for current hash found for {EntityType}/{EntityId}/{Field} in language '{Language}'.",
+            entityType,
+            entityId,
+            field,
+            normalizedLanguage
+        );
+        LocalizationStatsTracker.RecordRepositoryLookup(missingSource: false, missingCurrentHashTranslation: true);
 
         translation = GetLatestTranslation(normalizedLanguage);
         if (!string.IsNullOrWhiteSpace(translation))

--- a/Intersect.Server.Core/Localization/LocalizationStatsTracker.cs
+++ b/Intersect.Server.Core/Localization/LocalizationStatsTracker.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Intersect.Server.Localization;
+
+public static class LocalizationStatsTracker
+{
+    private static readonly TimeSpan Retention = TimeSpan.FromHours(24);
+    private static readonly ConcurrentQueue<LocalizationStatsEvent> Events = new();
+
+    public static void RecordPacketBatch(
+        int totalRequests,
+        int validRequests,
+        int emptyRequests,
+        int unknownEntityTypeRequests,
+        IReadOnlyDictionary<string, int>? missesByEntityTypeAndField
+    )
+    {
+        Enqueue(
+            new LocalizationStatsEvent(
+                DateTime.UtcNow,
+                totalRequests,
+                validRequests,
+                emptyRequests,
+                unknownEntityTypeRequests,
+                0,
+                0,
+                missesByEntityTypeAndField?.ToDictionary(pair => pair.Key, pair => pair.Value) ?? new Dictionary<string, int>()
+            )
+        );
+    }
+
+    public static void RecordRepositoryLookup(bool missingSource, bool missingCurrentHashTranslation)
+    {
+        if (!missingSource && !missingCurrentHashTranslation)
+        {
+            return;
+        }
+
+        Enqueue(
+            new LocalizationStatsEvent(
+                DateTime.UtcNow,
+                0,
+                0,
+                0,
+                0,
+                missingSource ? 1 : 0,
+                missingCurrentHashTranslation ? 1 : 0,
+                new Dictionary<string, int>()
+            )
+        );
+    }
+
+    public static LocalizationStatsSnapshot GetSnapshot(TimeSpan window)
+    {
+        var now = DateTime.UtcNow;
+        var cutoff = now - (window <= TimeSpan.Zero ? TimeSpan.FromMinutes(5) : window);
+        Prune(now);
+
+        var relevantEvents = Events.Where(@event => @event.TimestampUtc >= cutoff).ToArray();
+        var missesByEntityTypeAndField = new Dictionary<string, long>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var @event in relevantEvents)
+        {
+            foreach (var pair in @event.MissesByEntityTypeAndField)
+            {
+                missesByEntityTypeAndField[pair.Key] =
+                    missesByEntityTypeAndField.TryGetValue(pair.Key, out var count)
+                        ? count + pair.Value
+                        : pair.Value;
+            }
+        }
+
+        return new LocalizationStatsSnapshot(
+            (int)Math.Round((now - cutoff).TotalMinutes),
+            relevantEvents.Sum(@event => (long)@event.TotalRequests),
+            relevantEvents.Sum(@event => (long)@event.ValidRequests),
+            relevantEvents.Sum(@event => (long)@event.EmptyRequests),
+            relevantEvents.Sum(@event => (long)@event.UnknownEntityTypeRequests),
+            relevantEvents.Sum(@event => (long)@event.RepositoryMissingSourceCount),
+            relevantEvents.Sum(@event => (long)@event.RepositoryMissingCurrentHashTranslationCount),
+            missesByEntityTypeAndField
+        );
+    }
+
+    private static void Enqueue(LocalizationStatsEvent @event)
+    {
+        Events.Enqueue(@event);
+        Prune(@event.TimestampUtc);
+    }
+
+    private static void Prune(DateTime now)
+    {
+        var cutoff = now - Retention;
+        while (Events.TryPeek(out var @event) && @event.TimestampUtc < cutoff)
+        {
+            Events.TryDequeue(out _);
+        }
+    }
+
+    private sealed record LocalizationStatsEvent(
+        DateTime TimestampUtc,
+        int TotalRequests,
+        int ValidRequests,
+        int EmptyRequests,
+        int UnknownEntityTypeRequests,
+        int RepositoryMissingSourceCount,
+        int RepositoryMissingCurrentHashTranslationCount,
+        IReadOnlyDictionary<string, int> MissesByEntityTypeAndField
+    );
+}
+
+public sealed record LocalizationStatsSnapshot(
+    int WindowMinutes,
+    long TotalRequests,
+    long ValidRequests,
+    long EmptyRequests,
+    long UnknownEntityTypeRequests,
+    long RepositoryMissingSourceCount,
+    long RepositoryMissingCurrentHashTranslationCount,
+    IReadOnlyDictionary<string, long> MissesByEntityTypeAndField
+);

--- a/Intersect.Server.Core/Maps/MapInstance.cs
+++ b/Intersect.Server.Core/Maps/MapInstance.cs
@@ -16,6 +16,7 @@ using Intersect.Server.Entities.Events;
 using Intersect.Server.Networking;
 using Intersect.Utilities;
 using Intersect.Server.Entities;
+using Intersect.Server.Entities.BossSystem;
 using Intersect.Server.Classes.Maps;
 using Intersect.Server.Core.MapInstancing;
 using Intersect.Server.Framework.Items;
@@ -472,6 +473,10 @@ public partial class MapInstance : IMapInstance
             FindNpcSpawnLocation(spawn, out var x, out var y, out Direction dir);
 
             npcSpawnInstance.Entity = SpawnNpc((byte) x, (byte) y, dir, spawn.NpcId);
+            if (npcSpawnInstance.Entity != null)
+            {
+                BossManager.RegisterSpawn(npcSpawnInstance.Entity);
+            }
         }
     }
 
@@ -1399,6 +1404,11 @@ public partial class MapInstance : IMapInstance
         {
             var spawn = spawns[i];
             if (!NpcSpawnInstances.TryGetValue(spawn, out var spawnInstance) || spawnInstance?.Entity?.Descriptor == default || !spawnInstance.Entity.IsDead)
+            {
+                continue;
+            }
+
+            if (spawnInstance.Entity.Descriptor.IsBoss)
             {
                 continue;
             }

--- a/Intersect.Server.Core/Migrations/Sqlite/Game/20260216022547_AddNpcBossFields.Designer.cs
+++ b/Intersect.Server.Core/Migrations/Sqlite/Game/20260216022547_AddNpcBossFields.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Intersect.Server.Database.GameData;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Intersect.Server.Migrations.Sqlite.Game
 {
     [DbContext(typeof(SqliteGameContext))]
-    partial class SqliteGameContextModelSnapshot : ModelSnapshot
+    [Migration("20260216022547_AddNpcBossFields")]
+    partial class AddNpcBossFields
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "8.0.11");
@@ -470,10 +473,6 @@ namespace Intersect.Server.Migrations.Sqlite.Game
 
                     b.Property<bool>("BossAnnounceOnRespawn")
                         .HasColumnType("INTEGER");
-
-                    b.Property<string>("BossBehaviorProfileJson")
-                        .HasColumnType("TEXT")
-                        .HasColumnName("BossBehaviorProfile");
 
                     b.Property<int>("BossRespawnMinutes")
                         .HasColumnType("INTEGER");

--- a/Intersect.Server.Core/Migrations/Sqlite/Game/20260216022547_AddNpcBossFields.cs
+++ b/Intersect.Server.Core/Migrations/Sqlite/Game/20260216022547_AddNpcBossFields.cs
@@ -1,0 +1,62 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Intersect.Server.Migrations.Sqlite.Game
+{
+    /// <inheritdoc />
+    public partial class AddNpcBossFields : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "BossAnnounceOnKill",
+                table: "Npcs",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "BossAnnounceOnRespawn",
+                table: "Npcs",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<int>(
+                name: "BossRespawnMinutes",
+                table: "Npcs",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsBoss",
+                table: "Npcs",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "BossAnnounceOnKill",
+                table: "Npcs");
+
+            migrationBuilder.DropColumn(
+                name: "BossAnnounceOnRespawn",
+                table: "Npcs");
+
+            migrationBuilder.DropColumn(
+                name: "BossRespawnMinutes",
+                table: "Npcs");
+
+            migrationBuilder.DropColumn(
+                name: "IsBoss",
+                table: "Npcs");
+        }
+    }
+}

--- a/Intersect.Server.Core/Migrations/Sqlite/Game/20260217014630_AddNpcBossbehavior.Designer.cs
+++ b/Intersect.Server.Core/Migrations/Sqlite/Game/20260217014630_AddNpcBossbehavior.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Intersect.Server.Database.GameData;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Intersect.Server.Migrations.Sqlite.Game
 {
     [DbContext(typeof(SqliteGameContext))]
-    partial class SqliteGameContextModelSnapshot : ModelSnapshot
+    [Migration("20260217014630_AddNpcBossbehavior")]
+    partial class AddNpcBossbehavior
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "8.0.11");

--- a/Intersect.Server.Core/Migrations/Sqlite/Game/20260217014630_AddNpcBossbehavior.cs
+++ b/Intersect.Server.Core/Migrations/Sqlite/Game/20260217014630_AddNpcBossbehavior.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Intersect.Server.Migrations.Sqlite.Game
+{
+    /// <inheritdoc />
+    public partial class AddNpcBossbehavior : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "BossBehaviorProfile",
+                table: "Npcs",
+                type: "TEXT",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "BossBehaviorProfile",
+                table: "Npcs");
+        }
+    }
+}

--- a/Intersect.Server.Core/Networking/PacketHandler.cs
+++ b/Intersect.Server.Core/Networking/PacketHandler.cs
@@ -20,6 +20,7 @@ using Intersect.Server.Maps;
 using Intersect.Utilities;
 using System.Collections.Concurrent;
 using System.Diagnostics;
+using System.Linq;
 using System.Text;
 using Intersect.Core;
 using Intersect.Framework.Core;
@@ -521,14 +522,19 @@ internal sealed partial class PacketHandler
         }
 
         var language = string.IsNullOrWhiteSpace(packet.Language) ? "en" : packet.Language;
+        var totalRequests = packet.Requests.Count;
+        var emptyRequests = 0;
+        var unknownEntityTypeRequests = 0;
         var entries = new List<LocalizedTextEntry>();
         var validRequests = new List<LocalizationRequestEntry>(packet.Requests.Count);
         var batchKeys = new List<LocalizationKey>(packet.Requests.Count);
+        var missesByEntityTypeAndField = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
 
         foreach (var request in packet.Requests)
         {
             if (request == null)
             {
+                emptyRequests++;
                 continue;
             }
 
@@ -540,12 +546,14 @@ internal sealed partial class PacketHandler
                     entityType,
                     client.Id
                 );
+                unknownEntityTypeRequests++;
                 entries.Add(new LocalizedTextEntry(request, string.Empty));
                 continue;
             }
 
             if (string.IsNullOrWhiteSpace(request.EntityId) || string.IsNullOrWhiteSpace(request.Field))
             {
+                emptyRequests++;
                 entries.Add(new LocalizedTextEntry(request, string.Empty));
                 continue;
             }
@@ -564,9 +572,38 @@ internal sealed partial class PacketHandler
                     ? localizedText
                     : string.Empty;
 
+                if (string.IsNullOrWhiteSpace(text))
+                {
+                    var missKey = $"{request.EntityType}/{request.Field}";
+                    missesByEntityTypeAndField[missKey] =
+                        missesByEntityTypeAndField.TryGetValue(missKey, out var currentMisses)
+                            ? currentMisses + 1
+                            : 1;
+                }
+
                 entries.Add(new LocalizedTextEntry(request, text));
             }
         }
+
+        ApplicationContext.Context.Value?.Logger.LogDebug(
+            "Localization batch from client {ClientId}: total={TotalRequests}, valid={ValidRequests}, empty={EmptyRequests}, unknownEntityType={UnknownEntityTypeRequests}, missesByEntityTypeField={MissesByEntityTypeField}.",
+            client.Id,
+            totalRequests,
+            validRequests.Count,
+            emptyRequests,
+            unknownEntityTypeRequests,
+            missesByEntityTypeAndField.Count > 0
+                ? string.Join(", ", missesByEntityTypeAndField.Select(pair => $"{pair.Key}:{pair.Value}"))
+                : "none"
+        );
+
+        LocalizationStatsTracker.RecordPacketBatch(
+            totalRequests,
+            validRequests.Count,
+            emptyRequests,
+            unknownEntityTypeRequests,
+            missesByEntityTypeAndField
+        );
 
         if (entries.Count > 0)
         {

--- a/Intersect.Server.Core/Networking/PacketHandler.cs
+++ b/Intersect.Server.Core/Networking/PacketHandler.cs
@@ -13,6 +13,7 @@ using Intersect.Server.Database.PlayerData.Players;
 using Intersect.Server.Database.PlayerData.Security;
 using Intersect.Server.Database.PlayerData.Shops;
 using Intersect.Server.Entities;
+using Intersect.Server.Entities.BossSystem;
 using Intersect.Server.General;
 using Intersect.Server.Localization;
 using Intersect.Server.Maps;
@@ -26,6 +27,7 @@ using Intersect.Framework.Core.GameObjects.Crafting;
 using Intersect.Framework.Core.GameObjects.Events;
 using Intersect.Framework.Core.GameObjects.Items;
 using Intersect.Framework.Core.GameObjects.Maps;
+using Intersect.Framework.Core.GameObjects.NPCs;
 using Intersect.Framework.Core.GameObjects.PlayerClass;
 using Intersect.Framework.Core.Localization;
 using Intersect.Framework.Core.Security;
@@ -1229,6 +1231,66 @@ internal sealed partial class PacketHandler
             {
                 PacketSender.SendChatMsg(player, Strings.Player.Offline, ChatMessageType.PM, CustomColors.Alerts.Error);
             }
+        }
+        else if (cmd == "/bossailog")
+        {
+            if (!(client?.Power.IsAdmin ?? false))
+            {
+                PacketSender.SendChatMsg(player, Strings.Account.NotAllowed, ChatMessageType.Error, CustomColors.Alerts.Error);
+                return;
+            }
+
+            if (msgSplit.Length < 1)
+            {
+                PacketSender.SendChatMsg(player, "Uso: /bossailog <bossId|bossName> [on|off|toggle]", ChatMessageType.Notice);
+                return;
+            }
+
+            var bossKey = msgSplit[0];
+            var mode = msgSplit.Length > 1 ? msgSplit[1].ToLowerInvariant() : "toggle";
+
+            NPCDescriptor? descriptor = null;
+            if (Guid.TryParse(bossKey, out var bossId))
+            {
+                descriptor = NPCDescriptor.Get(bossId);
+            }
+
+            descriptor ??= NPCDescriptor.Lookup.Values
+                .OfType<NPCDescriptor>()
+                .FirstOrDefault(npc => string.Equals(npc.Name, bossKey, StringComparison.OrdinalIgnoreCase));
+
+            if (descriptor == null || !descriptor.IsBoss)
+            {
+                PacketSender.SendChatMsg(player, $"Boss '{bossKey}' no encontrado o no marcado como boss.", ChatMessageType.Error, CustomColors.Alerts.Error);
+                return;
+            }
+
+            bool enabled;
+            switch (mode)
+            {
+                case "on":
+                case "1":
+                case "true":
+                    enabled = BossAiDebugSettings.SetEnabled(descriptor.Id, true);
+                    break;
+                case "off":
+                case "0":
+                case "false":
+                    enabled = BossAiDebugSettings.SetEnabled(descriptor.Id, false);
+                    break;
+                default:
+                    enabled = BossAiDebugSettings.Toggle(descriptor.Id);
+                    break;
+            }
+
+            PacketSender.SendChatMsg(
+                player,
+                $"Boss AI debug para '{descriptor.Name}' ({descriptor.Id}) => {(enabled ? "ON" : "OFF")}",
+                ChatMessageType.Notice,
+                enabled ? CustomColors.Alerts.Success : CustomColors.Alerts.Info
+            );
+
+            return;
         }
         else if (cmd == "/alignment" && msgSplit.Length >= 2 &&
                  string.Equals(msgSplit[0], "set", StringComparison.OrdinalIgnoreCase))

--- a/Intersect.Server.Core/Properties/AssemblyAttributes.cs
+++ b/Intersect.Server.Core/Properties/AssemblyAttributes.cs
@@ -1,0 +1,1 @@
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Intersect.Tests.Server")]

--- a/Intersect.Server/Web/Controllers/Api/V1/LocalizationController.cs
+++ b/Intersect.Server/Web/Controllers/Api/V1/LocalizationController.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Net;
 using Intersect.Framework.Core.Localization;
 using Intersect.Server.Database.PlayerData.Security;
@@ -14,6 +15,28 @@ namespace Intersect.Server.Web.Controllers.Api.V1
     [Authorize(Roles = nameof(ApiRoles.UserManage))]
     public sealed partial class LocalizationController : IntersectController
     {
+
+        [HttpGet("stats")]
+        [ProducesResponseType(typeof(LocalizationStatsResponseBody), (int)HttpStatusCode.OK, ContentTypes.Json)]
+        public IActionResult GetLocalizationStats([FromQuery] int minutes = 5)
+        {
+            var boundedMinutes = Math.Clamp(minutes, 1, 1440);
+            var snapshot = LocalizationStatsTracker.GetSnapshot(TimeSpan.FromMinutes(boundedMinutes));
+
+            return Ok(
+                new LocalizationStatsResponseBody(
+                    snapshot.WindowMinutes,
+                    snapshot.TotalRequests,
+                    snapshot.ValidRequests,
+                    snapshot.EmptyRequests,
+                    snapshot.UnknownEntityTypeRequests,
+                    snapshot.RepositoryMissingSourceCount,
+                    snapshot.RepositoryMissingCurrentHashTranslationCount,
+                    snapshot.MissesByEntityTypeAndField
+                )
+            );
+        }
+
         [HttpPost("translations")]
         [ProducesResponseType(typeof(StatusMessageResponseBody), (int)HttpStatusCode.BadRequest, ContentTypes.Json)]
         [ProducesResponseType(typeof(StatusMessageResponseBody), (int)HttpStatusCode.NotFound, ContentTypes.Json)]

--- a/Intersect.Server/Web/Types/Localization/LocalizationStatsResponseBody.cs
+++ b/Intersect.Server/Web/Types/Localization/LocalizationStatsResponseBody.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+
+namespace Intersect.Server.Web.Types.Localization;
+
+public sealed record LocalizationStatsResponseBody(
+    int WindowMinutes,
+    long TotalRequests,
+    long ValidRequests,
+    long EmptyRequests,
+    long UnknownEntityTypeRequests,
+    long RepositoryMissingSourceCount,
+    long RepositoryMissingCurrentHashTranslationCount,
+    IReadOnlyDictionary<string, long> MissesByEntityTypeAndField
+);

--- a/Intersect.Tests.Server/Entities/BossAiDecisionSelectorTests.cs
+++ b/Intersect.Tests.Server/Entities/BossAiDecisionSelectorTests.cs
@@ -1,0 +1,212 @@
+using System;
+using System.Collections.Generic;
+
+using Intersect.Framework.Core.GameObjects.NPCs;
+using Intersect.Server.Entities.BossSystem;
+using NUnit.Framework;
+
+namespace Intersect.Tests.Server.Entities;
+
+[TestFixture]
+public class BossAiDecisionSelectorTests
+{
+    [Test]
+    public void Hp30PercentTrigger_SelectsExpectedAction()
+    {
+        var selector = new BossAiDecisionSelector();
+        var expectedSpell = Guid.NewGuid();
+        var profile = new BossBehaviorProfile
+        {
+            Phases =
+            [
+                new BossPhase
+                {
+                    Id = "phase-1",
+                    MinimumHealthPercent = 0,
+                    MaximumHealthPercent = 100,
+                    Priority = 1,
+                    Triggers =
+                    [
+                        new BossTrigger
+                        {
+                            Condition = BossTriggerConditionType.HealthPercentAtOrBelow,
+                            ThresholdHealthPercent = 30,
+                            Priority = 50,
+                            Actions =
+                            [
+                                new BossAction
+                                {
+                                    Action = BossActionType.CastSpell,
+                                    SpellId = expectedSpell,
+                                    Priority = 20,
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+        };
+
+        var result = selector.BuildCandidates(
+            profile,
+            30,
+            now: 0,
+            isTriggerActive: (_, trigger, _) => trigger.ThresholdHealthPercent >= 30,
+            canUseAction: _ => true,
+            isActionOnCooldown: _ => false
+        );
+
+        Assert.That(result.Selected, Is.Not.Null);
+        Assert.That(result.Selected!.Action.SpellId, Is.EqualTo(expectedSpell));
+    }
+
+    [Test]
+    public void SpellOnCooldown_IsNotSelected()
+    {
+        var selector = new BossAiDecisionSelector();
+        var onCooldownSpell = Guid.NewGuid();
+        var availableSpell = Guid.NewGuid();
+        var profile = new BossBehaviorProfile
+        {
+            Phases =
+            [
+                new BossPhase
+                {
+                    Id = "phase-1",
+                    Priority = 1,
+                    Actions =
+                    [
+                        new BossAction { Action = BossActionType.CastSpell, SpellId = onCooldownSpell, Priority = 100 },
+                        new BossAction { Action = BossActionType.CastSpell, SpellId = availableSpell, Priority = 10 },
+                    ],
+                },
+            ],
+        };
+
+        var result = selector.BuildCandidates(
+            profile,
+            80,
+            now: 0,
+            isTriggerActive: (_, _, _) => false,
+            canUseAction: _ => true,
+            isActionOnCooldown: action => action.SpellId == onCooldownSpell
+        );
+
+        Assert.That(result.Selected, Is.Not.Null);
+        Assert.That(result.Selected!.Action.SpellId, Is.EqualTo(availableSpell));
+    }
+
+    [Test]
+    public void PhaseChanges_WhenCrossingHealthThreshold()
+    {
+        var selector = new BossAiDecisionSelector();
+        var highPhaseSpell = Guid.NewGuid();
+        var lowPhaseSpell = Guid.NewGuid();
+        var profile = new BossBehaviorProfile
+        {
+            Phases =
+            [
+                new BossPhase
+                {
+                    Id = "high",
+                    MinimumHealthPercent = 51,
+                    MaximumHealthPercent = 100,
+                    Priority = 10,
+                    Actions = [ new BossAction { Action = BossActionType.CastSpell, SpellId = highPhaseSpell, Priority = 10 } ],
+                },
+                new BossPhase
+                {
+                    Id = "low",
+                    MinimumHealthPercent = 0,
+                    MaximumHealthPercent = 50,
+                    Priority = 20,
+                    Actions = [ new BossAction { Action = BossActionType.CastSpell, SpellId = lowPhaseSpell, Priority = 10 } ],
+                },
+            ],
+        };
+
+        var firstEval = selector.BuildCandidates(profile, 70, 0, (_, _, _) => false, _ => true, _ => false);
+        var secondEval = selector.BuildCandidates(profile, 45, 1000, (_, _, _) => false, _ => true, _ => false);
+
+        Assert.That(firstEval.Selected, Is.Not.Null);
+        Assert.That(firstEval.Selected!.PhaseId, Is.EqualTo("high"));
+        Assert.That(secondEval.Selected, Is.Not.Null);
+        Assert.That(secondEval.Selected!.PhaseId, Is.EqualTo("low"));
+    }
+
+    [Test]
+    public void Integration_TwoPhaseCombatFlow_TransitionsAndRespectsCooldowns()
+    {
+        var selector = new BossAiDecisionSelector();
+        var phase1Spell = Guid.NewGuid();
+        var phase2Spell = Guid.NewGuid();
+        var profile = new BossBehaviorProfile
+        {
+            Phases =
+            [
+                new BossPhase
+                {
+                    Id = "phase1",
+                    MinimumHealthPercent = 51,
+                    MaximumHealthPercent = 100,
+                    Priority = 10,
+                    Triggers =
+                    [
+                        new BossTrigger
+                        {
+                            Priority = 50,
+                            CooldownSeconds = 3,
+                            Actions = [ new BossAction { Action = BossActionType.CastSpell, SpellId = phase1Spell, Priority = 10 } ],
+                        },
+                    ],
+                },
+                new BossPhase
+                {
+                    Id = "phase2",
+                    MinimumHealthPercent = 0,
+                    MaximumHealthPercent = 50,
+                    Priority = 20,
+                    Actions = [ new BossAction { Action = BossActionType.CastSpell, SpellId = phase2Spell, Priority = 10 } ],
+                },
+            ],
+        };
+
+        var triggerCooldowns = new Dictionary<string, long>();
+        var timeline = new[]
+        {
+            (now: 0L, hp: 100),
+            (now: 1000L, hp: 95),
+            (now: 3500L, hp: 48),
+        };
+
+        var selectedPhases = new List<string>();
+        foreach (var tick in timeline)
+        {
+            var result = selector.BuildCandidates(
+                profile,
+                tick.hp,
+                tick.now,
+                (phaseId, trigger, triggerIndex) =>
+                {
+                    var key = $"{phaseId}:{triggerIndex}";
+                    return !triggerCooldowns.TryGetValue(key, out var until) || until <= tick.now;
+                },
+                _ => true,
+                _ => false
+            );
+
+            if (result.Selected == null)
+            {
+                continue;
+            }
+
+            selectedPhases.Add(result.Selected.PhaseId);
+            if (result.Selected.TriggerCooldownMs > 0)
+            {
+                triggerCooldowns[result.Selected.TriggerCooldownKey] = tick.now + result.Selected.TriggerCooldownMs;
+            }
+        }
+
+        Assert.That(selectedPhases, Is.EqualTo(new[] { "phase1", "phase2" }));
+    }
+}

--- a/docs/boss-flag-migration-notes.md
+++ b/docs/boss-flag-migration-notes.md
@@ -1,0 +1,22 @@
+# Migración: Boss por flag `IsBoss` (sin prefijo en nombre)
+
+## Cambio aplicado
+A partir de este cambio, la política de boss queda unificada en un único origen de verdad:
+
+- El multiplicador de XP de boss depende **solo** de `NPCDescriptor.IsBoss`.
+- El estilo visual del nombre de boss en cliente depende **solo** del flag `IsBoss` serializado por el servidor.
+
+El prefijo legacy `[BOSS]` en `Name` ya no se usa para lógica de gameplay ni para estilizado visual.
+
+## Acciones recomendadas de migración
+1. Revisar NPCs existentes y asegurarse de marcar `IsBoss = true` en los que correspondan.
+2. Remover el prefijo `[BOSS]` del campo `Name` en todos los NPCs donde aún exista.
+3. Validar en juego:
+   - XP otorgada por boss.
+   - Estilo visual de nombre de boss.
+
+## Checklist rápida
+- [ ] Todos los bosses tienen `IsBoss = true`.
+- [ ] No quedan nombres con prefijo `[BOSS]`.
+- [ ] El multiplicador de XP de boss se aplica correctamente.
+- [ ] El cliente renderiza estilo de boss usando `packet.IsBoss`.


### PR DESCRIPTION
### Motivation
- Prevent crashes caused by server packets (notably `ErrorMessagePacket`) arriving before the in-game UI is initialized due to latency/timing races. 
- Make UI access safe for packet handlers and provide observability to diagnose early-arriving packets. 

### Description
- Make `Interface.GameUi` nullable (`GameInterface?`) and add `Interface.IsGameUiReady` to allow safe readiness checks (file: `Intersect.Client.Core/Interface/Interface.cs`).
- Replace calls that previously threw when UI was missing with null-safe usages and change deferred enqueues to reference the backing field when deferring (file: `Intersect.Client.Core/Interface/Interface.cs`).
- Add packet-level debug logging for received packet types and UI readiness state (file: `Intersect.Client.Core/Networking/PacketHandler.cs`).
- Implement a small defensive queue to enqueue UI-dependent packets (currently `ErrorMessagePacket`) when the UI is not ready and replay them once `IsGameUiReady` is true, plus a warning log in the `ErrorMessagePacket` handler if an error arrives early (file: `Intersect.Client.Core/Networking/PacketHandler.cs`).

### Testing
- Attempted a local project build with `dotnet build Intersect.Client.Core/Intersect.Client.Core.csproj -nologo` but the environment does not have `dotnet` installed so compilation could not be executed here and therefore automated build tests did not run. 
- No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2e0db63f4832b9fcac192dca0388d)